### PR TITLE
Single NaN fix

### DIFF
--- a/src/fluid_plan4.f90
+++ b/src/fluid_plan4.f90
@@ -80,7 +80,8 @@ contains
     class(fluid_plan4_t), intent(inout) :: this
     type(mesh_t), intent(inout) :: msh
     integer, intent(inout) :: lx
-    type(param_t), intent(inout) :: param        
+    type(param_t), intent(inout) :: param     
+    integer :: n   
 
     call this%free()
     
@@ -113,6 +114,16 @@ contains
     allocate(this%abx2(this%Xh%lx,this%Xh%ly,this%Xh%lz,this%msh%nelv))
     allocate(this%aby2(this%Xh%lx,this%Xh%ly,this%Xh%lz,this%msh%nelv))
     allocate(this%abz2(this%Xh%lx,this%Xh%ly,this%Xh%lz,this%msh%nelv))
+    
+    n = this%Xh%lx*this%Xh%ly*this%Xh%lz*this%msh%nelv
+
+    call rzero(this%abx1,n)
+    call rzero(this%aby1,n)
+    call rzero(this%abz1,n)
+    
+    call rzero(this%abx2,n)
+    call rzero(this%aby2,n)
+    call rzero(this%abz2,n)
             
     call field_init(this%u_e, this%dm_Xh, 'u_e')
     call field_init(this%v_e, this%dm_Xh, 'v_e')
@@ -497,7 +508,7 @@ contains
     call rzero(ta3%x,n)
     call opadd2cm (wa1%x, wa2%x, wa3%x, ta1%x, ta2%x, ta3%x, scl, n, gdim)
 
-    work1%x = (one / Re) / rho
+    work1 = (one / Re) / rho
     call opcolv(wa1%x, wa2%x, wa3%x, work1%x, gdim, n)
 
     call Ax%compute(p_res,p%x,c_Xh,p%msh,p%Xh)

--- a/src/opr_cpu.f90
+++ b/src/opr_cpu.f90
@@ -28,7 +28,7 @@ contains
     lxyz = Xh%lx*Xh%ly*Xh%lz
 
     do e=1,msh%nelv
-       if (msh%nelv .eq. 2) then
+       if (msh%gdim .eq. 2) then
           call mxm     (Xh%dx,Xh%lx,u(1,1,1,e),Xh%lx,du(1,1,1,e),lyz)
           call col2    (du(1,1,1,e),dr(1,1,1,e),lxyz)
           call mxm     (U(1,1,1,e),Xh%lx,Xh%dyt,Xh%ly,drst,Xh%ly)


### PR DESCRIPTION
This appears to work for now. but We (I) should look over the entire code thoroughly to find occurrences of the following

- Places where an array is initialized with `x = some_real_number`. From what I saw in DDT this is not deterministic.
- Any place where we allocate an array `allocate(x(n))` and then implciity assume it is set to 0.

Probably more to come.