### PR TITLE
Write a checkpoint if job limit is reached before final time step

### DIFF
--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -61,7 +61,13 @@ contains
        call neko_log%end()
        call C%s%sample(t)
     end do
+
+    if (t .lt. C%params%T_end) then
+       call simulation_joblimit_chkp(C, t)
+    end if
+    
     call neko_log%end_section('normal end.')
+    
   end subroutine neko_solve
 
   subroutine simulation_settime(t, dt, ab_bdf, tlag, dtlag, step)
@@ -92,9 +98,10 @@ contains
     
   end subroutine simulation_settime
 
+  !> Restart a case @a C from a given checkpoint
   subroutine simulation_restart(C, t)
     type(case_t), intent(inout) :: C
-    real(kind=rp) :: t
+    real(kind=rp), intent(inout) :: t
     type(file_t) :: chkpf
     character(len=LOG_SIZE) :: log_buf   
 
@@ -113,6 +120,20 @@ contains
 
     call C%s%set_counter(t)
   end subroutine simulation_restart
+
+  !> Write a checkpoint at joblimit
+  subroutine simulation_joblimit_chkp(C, t)
+    type(case_t), intent(inout) :: C
+    real(kind=rp), intent(inout) :: t
+    type(file_t) :: chkpf
+    character(len=LOG_SIZE) :: log_buf
+
+    chkpf = file_t('joblimit.chkp')
+    call chkpf%write(C%fluid%chkp, t)
+    write(log_buf, '(A)') '! saving checkpoint >>>'
+    call neko_log%message(log_buf)
+    
+  end subroutine simulation_joblimit_chkp
 
 end module simulation
 


### PR DESCRIPTION
Automagically write a checkpoint file if job limit is reached before i) a sampling time or ii) end of job

![a](https://media.giphy.com/media/GeimqsH0TLDt4tScGw/giphy-downsized.gif)
