### PR TITLE
Device uniform ic

### DIFF
--- a/src/fluid/flow_ic.f90
+++ b/src/fluid/flow_ic.f90
@@ -106,9 +106,12 @@ contains
     v = uinf(2)
     w = uinf(3)
     n = u%dof%n_dofs
-    call cfill(u%x,uinf(1),n)
-    call cfill(v%x,uinf(2),n)
-    call cfill(w%x,uinf(3),n)
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call cfill(u%x,uinf(1),n)
+       call cfill(v%x,uinf(2),n)
+       call cfill(w%x,uinf(3),n)
+    end if
 
   end subroutine set_flow_ic_uniform
 


### PR DESCRIPTION
Unfirom ic was broken on the device. This is a somewhat ugly fix. I am uncertain whether `field = scalar` should only update the device, but I leave this consideration to Niclas.