### PR TITLE
Output max sample time instead of rank zero time

### DIFF
--- a/src/common/sampler.f90
+++ b/src/common/sampler.f90
@@ -129,6 +129,7 @@ contains
     class(sampler_t), intent(inout) :: this
     real(kind=rp), intent(in) :: t
     real(kind=dp) :: sample_start_time, sample_end_time
+    real(kind=dp) :: sample_time, max_sample_time
     character(len=LOG_SIZE) :: log_buf
     integer :: i
 
@@ -141,8 +142,10 @@ contains
        sample_end_time = MPI_WTIME()
        this%nsample = this%nsample + 1
 
+       sample_time = sample_end_time - sample_start_time
+       call MPI_Reduce(sample_time, max_sample_time, 1, MPI_DOUBLE_PRECISION, MPI_MAX, 0, NEKO_COMM)
        write(log_buf,'(a23,1x,e15.7,A,F8.4)') 'Sampling fields at time:', t, &
-             ' Sample time (s): ', sample_end_time - sample_start_time
+             ' Sample time (s): ', max_sample_time
        call neko_log%message(log_buf)
 
     end if


### PR DESCRIPTION
Currently, the sample timing only takes the time from rank zero. However, when other distributed storage mediums are used (e.g. local/shared burst buffers) the variance can be high, and rank zero may not be representative of the I/O time. This is also needed to prepare for a bandwidth calculation patch (i.e output both the sample time and I/O bandwidth) later.

- the log module records only messages from pe_rank zero
- use MPI_MAX to get the maximum sample time as overall output time