### PR TITLE
Add support for midpoint deformation

### DIFF
--- a/src/comm/mpi_types.f90
+++ b/src/comm/mpi_types.f90
@@ -229,8 +229,8 @@ contains
     end do
 
     len(1) = 1
-    len(2) = 5*8
-    len(3) = 8
+    len(2) = 5*12
+    len(3) = 12
     type(1) = MPI_INTEGER
     type(2) = MPI_DOUBLE_PRECISION
     type(3) = MPI_INTEGER
@@ -358,7 +358,7 @@ contains
     !
     
     call MPI_Get_address(re2v1_data%elem, disp(1), ierr)
-    call MPI_Get_address(re2v1_data%face, disp(2), ierr)
+    call MPI_Get_address(re2v1_data%zone, disp(2), ierr)
     call MPI_Get_address(re2v1_data%point, disp(3), ierr)
     call MPI_Get_address(re2v1_data%type, disp(4), ierr)
 
@@ -383,7 +383,7 @@ contains
     !
     
     call MPI_Get_address(re2v2_data%elem, disp(1), ierr)
-    call MPI_Get_address(re2v2_data%face, disp(2), ierr)
+    call MPI_Get_address(re2v2_data%zone, disp(2), ierr)
     call MPI_Get_address(re2v2_data%point, disp(3), ierr)
     call MPI_Get_address(re2v2_data%type, disp(4), ierr)
 

--- a/src/common/structs.f90
+++ b/src/common/structs.f90
@@ -4,8 +4,8 @@ module structs
   implicit none
   
   type, public :: struct_curve_t
-    real(kind=dp) :: curve_data(5,8)
-    integer :: curve_type(8)
+    real(kind=dp) :: curve_data(5,12)
+    integer :: curve_type(12)
     integer :: el_idx
   end type struct_curve_t
 end module structs

--- a/src/io/format/nmsh.f90
+++ b/src/io/format/nmsh.f90
@@ -38,8 +38,8 @@ module nmsh
    !> Neko curve data
   type, public :: nmsh_curve_el_t
      integer :: e                                !< Element id (global)
-     real(kind=dp), dimension(5,8) :: curve_data !< Save 6 values for each edge
-     integer, dimension(8) :: type               !< type of curve for each edge
+     real(kind=dp), dimension(5,12) :: curve_data !< Save 6 values for each edge
+     integer, dimension(12) :: type               !< type of curve for each edge
   end type nmsh_curve_el_t
   
 

--- a/src/io/format/re2.f90
+++ b/src/io/format/re2.f90
@@ -30,7 +30,7 @@ module re2
   !> NEKTON re2 curve data (version 1)
   type, public :: re2v1_curve_t
      integer :: elem
-     integer :: face
+     integer :: zone
      real(kind=sp), dimension(5) :: point
      character(len=4) :: type
   end type re2v1_curve_t
@@ -64,7 +64,7 @@ module re2
   !> NEKTON re2 curve data (version 2)
   type, public :: re2v2_curve_t
      real(kind=dp) :: elem
-     real(kind=dp) :: face
+     real(kind=dp) :: zone
      real(kind=dp), dimension(5) :: point
      character(len=8) :: type
   end type re2v2_curve_t

--- a/src/io/nmsh_file.f90
+++ b/src/io/nmsh_file.f90
@@ -209,6 +209,7 @@ contains
               el_idx .le. msh%nelv) then             
              call mesh_mark_curve_element(msh, el_idx, nmsh_curve(i)%curve_data, nmsh_curve(i)%type)
           end if
+             
        end do
        
        deallocate(nmsh_curve)

--- a/src/io/re2_file.f90
+++ b/src/io/re2_file.f90
@@ -396,12 +396,12 @@ contains
     real(kind=dp), allocatable :: curve_data(:,:,:)
     integer, allocatable :: curve_type(:,:)
     logical, allocatable :: curve_element(:)
-    character(len=4) :: chtemp
+    character(len=1) :: chtemp
     logical :: curve_skip = .false.
  
-    allocate(curve_data(5,8,msh%nelv))
+    allocate(curve_data(5,12,msh%nelv))
     allocate(curve_element(msh%nelv))
-    allocate(curve_type(8,msh%nelv))
+    allocate(curve_type(12,msh%nelv))
     do i = 1, msh%nelv
        curve_element(i) = .false.
        do j = 1, 8
@@ -425,14 +425,14 @@ contains
     do i = 1, ncurve
        if(v2_format) then
           el_idx = re2v2_data_curve(i)%elem - dist%start_idx()
-          id = re2v2_data_curve(i)%face
+          id = re2v2_data_curve(i)%zone
           chtemp = re2v2_data_curve(i)%type
           do j = 1, 5 
              curve_data(j,id, el_idx) = re2v2_data_curve(i)%point(j)
           enddo
        else 
           el_idx = re2v1_data_curve(i)%elem - dist%start_idx()
-          id = re2v1_data_curve(i)%face
+          id = re2v1_data_curve(i)%zone
           chtemp = re2v1_data_curve(i)%type
           do j = 1, 5 
              curve_data(j,id, el_idx) = real(re2v1_data_curve(i)%point(j),dp) 
@@ -454,6 +454,11 @@ contains
          exit
        case ('C')
          curve_type(id,el_idx) = 3
+       case ('m')
+         curve_type(id,el_idx) = 4
+       case default
+         write(*,*) chtemp,'curve type not supported yet, treating mesh as non-curved', id, el_idx
+         curve_skip = .true.
        end select
     end do
 

--- a/src/mesh/curve.f90
+++ b/src/mesh/curve.f90
@@ -82,8 +82,8 @@ contains
   !> Add a (facet, el) tuple to an unfinalized domain
   subroutine curve_element_add(z, el_idx, curve_data, curve_type )
     class(curve_t), intent(inout) :: z
-    real(kind=dp), dimension(5,8), intent(in) :: curve_data
-    integer, dimension(8), intent(in) :: curve_type
+    real(kind=dp), dimension(5,12), intent(in) :: curve_data
+    integer, dimension(12), intent(in) :: curve_type
     integer, intent(in) :: el_idx
     type(struct_curve_t) :: c_el
 

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -1340,8 +1340,8 @@ contains
   subroutine mesh_mark_curve_element(m, e, curve_data, curve_type)
     type(mesh_t), intent(inout) :: m
     integer, intent(in) :: e
-    real(kind=dp), dimension(5,8), intent(in) :: curve_data 
-    integer, dimension(8), intent(in) :: curve_type 
+    real(kind=dp), dimension(5,12), intent(in) :: curve_data 
+    integer, dimension(12), intent(in) :: curve_type 
 
     if (e .gt. m%nelv) then
        call neko_error('Invalid element index')

--- a/src/sem/dofmap.f90
+++ b/src/sem/dofmap.f90
@@ -648,7 +648,6 @@ contains
 
   end function dofmap_facetidx
 
-
   !> Generate x,y,z-coordinates for all dofs
   !! @note Assumes \f$ X_{h_x} = X_{h_y} = X_{h_z} \f$
   subroutine dofmap_generate_xyz(this)
@@ -656,67 +655,34 @@ contains
     integer :: i,j,k, el_idx
     type(mesh_t), pointer :: msh
     type(space_t), pointer :: Xh
-    real(kind=rp) :: xyzb(2,2,2,3), zgml(this%Xh%lx, 3)
-    real(kind=rp) :: jx(this%Xh%lx*2), jy(this%Xh%lx*2), jz(this%Xh%lx*2)
-    real(kind=rp) :: jxt(this%Xh%lx*2), jyt(this%Xh%lx*2), jzt(this%Xh%lx*2)
-    real(kind=rp) :: w(4*this%Xh%lx**3), tmp(this%Xh%lx, this%Xh%lx, this%Xh%lx)
-    real(kind=rp) :: rp_curve_data(5)
-    real(kind=rp), dimension(2), parameter :: zlin = (/-1d0, 1d0/)
-    
+    real(kind=rp) :: rp_curve_data(5), curve_data_tot(5,12)
+    logical :: midpoint
+    integer :: n_edge, curve_type(12)
+
+    if (msh%gdim .eq. 3) then
+       n_edge = 12
+    else
+       n_edge = 4
+    end if
 
     msh => this%msh
     Xh => this%Xh
-    zgml = 0d0
-    xyzb = 0d0
     do i = 1, msh%nelv       
-
-       w = 0d0
-       call copy(zgml(1,1), Xh%zg(1,1), Xh%lx)                               
-       call copy(zgml(1,2), Xh%zg(1,2), Xh%ly)
-       if (msh%gdim .gt. 2) then
-          call copy(zgml(1,3), Xh%zg(1,3), Xh%lz)
-       end if
-       
-       k = 1
-       do j = 1, Xh%lx
-          call fd_weights_full(zgml(j,1),zlin,1,0,jxt(k))
-          call fd_weights_full(zgml(j,2),zlin,1,0,jyt(k))
-          if (msh%gdim .gt. 2) then
-             call fd_weights_full(zgml(j,3),zlin,1,0,jzt(k))
-          end if
-          k = k + 2
-       end do
-       call trsp(jx, Xh%lx, jxt, 2)
-
-       if (msh%gdim .eq. 2) then
-          jzt = 1d0
-       end if
-
-       do j = 1, msh%gdim
-          xyzb(1,1,1,j) = msh%elements(i)%e%pts(1)%p%x(j)
-          xyzb(2,1,1,j) = msh%elements(i)%e%pts(2)%p%x(j)
-          xyzb(1,2,1,j) = msh%elements(i)%e%pts(4)%p%x(j)
-          xyzb(2,2,1,j) = msh%elements(i)%e%pts(3)%p%x(j)
-
-          if (msh%gdim .gt. 2) then
-             xyzb(1,1,2,j) = msh%elements(i)%e%pts(5)%p%x(j)
-             xyzb(2,1,2,j) = msh%elements(i)%e%pts(6)%p%x(j)
-             xyzb(1,2,2,j) = msh%elements(i)%e%pts(8)%p%x(j)
-             xyzb(2,2,2,j) = msh%elements(i)%e%pts(7)%p%x(j)
+       call dofmap_xyzlin(Xh,msh, msh%elements(i)%e,this%x(1,1,1,i),this%y(1,1,1,i), this%z(1,1,1,i)) 
+    end do
+    do i =1, msh%curve%size 
+       el_idx = msh%curve%curve_el(i)%el_idx
+       curve_type = msh%curve%curve_el(i)%curve_type
+       curve_data_tot = msh%curve%curve_el(i)%curve_data
+       do j = 1, n_edge
+          if (curve_type(j) .eq. 4) then
+             midpoint = .true.
           end if
        end do
-       if (msh%gdim .eq. 3) then
-          call tensr3(tmp, Xh%lx, xyzb(1,1,1,1), 2, jx, jyt, jzt, w)
-          call copy(this%x(1,1,1,i), tmp, Xh%lx*Xh%ly*Xh%lz)
-          call tensr3(tmp, Xh%ly, xyzb(1,1,1,2), 2, jx, jyt, jzt, w)
-          call copy(this%y(1,1,1,i), tmp, Xh%lx*Xh%ly*Xh%lz)
-          call tensr3(tmp, Xh%lz, xyzb(1,1,1,3), 2, jx, jyt, jzt, w)
-          call copy(this%z(1,1,1,i), tmp, Xh%lx*Xh%ly*Xh%lz)
-       else
-          call tnsr2d_el(tmp, Xh%lx, xyzb(1,1,1,1), 2, jx, jyt)
-          call copy(this%x(1,1,1,i), tmp, Xh%lx*Xh%ly*Xh%lz)
-          call tnsr2d_el(tmp, Xh%ly, xyzb(1,1,1,2), 2, jx, jyt)
-          call copy(this%y(1,1,1,i), tmp, Xh%lx*Xh%ly*Xh%lz)
+       if (midpoint .and. Xh%lx .gt. 2) then
+          call dofmap_xyzquad(Xh, msh, msh%elements(el_idx)%e, &
+                              this%x(1,1,1,el_idx), this%y(1,1,1,el_idx),&
+                              this%z(1,1,1,el_idx),curve_type, curve_data_tot)
        end if
     end do
     do i =1, msh%curve%size 
@@ -731,7 +697,358 @@ contains
        end do
     enddo
   end subroutine dofmap_generate_xyz
+
+  subroutine dofmap_xyzlin(Xh, msh, element, x, y, z)
+    type(mesh_t), pointer, intent(in) :: msh
+    type(space_t), intent(in) :: Xh
+    class(element_t), intent(in) :: element
+    real(kind=rp), intent(inout) :: x(Xh%lx,Xh%ly,Xh%lz), y(Xh%lx,Xh%ly,Xh%lz), z(Xh%lx,Xh%ly,Xh%lz)
+    real(kind=rp) :: xyzb(2,2,2,3), zgml(Xh%lx, 3)
+    real(kind=rp) :: jx(Xh%lx*2), jy(Xh%lx*2), jz(Xh%lx*2)
+    real(kind=rp) :: jxt(Xh%lx*2), jyt(Xh%lx*2), jzt(Xh%lx*2)
+    real(kind=rp) :: w(4*Xh%lx**3), tmp(Xh%lx, Xh%lx, Xh%lx)
+    real(kind=rp), dimension(2), parameter :: zlin = (/-1d0, 1d0/)
+    
+    integer :: j, k
+
+    zgml = 0d0
+    xyzb = 0d0
  
+    w = 0d0
+    call copy(zgml(1,1), Xh%zg(1,1), Xh%lx)                               
+    call copy(zgml(1,2), Xh%zg(1,2), Xh%ly)
+    if (msh%gdim .gt. 2) then
+       call copy(zgml(1,3), Xh%zg(1,3), Xh%lz)
+    end if
+    
+    k = 1
+    do j = 1, Xh%lx
+       call fd_weights_full(zgml(j,1),zlin,1,0,jxt(k))
+       call fd_weights_full(zgml(j,2),zlin,1,0,jyt(k))
+       if (msh%gdim .gt. 2) then
+          call fd_weights_full(zgml(j,3),zlin,1,0,jzt(k))
+       end if
+       k = k + 2
+    end do
+    call trsp(jx, Xh%lx, jxt, 2)
+
+    if (msh%gdim .eq. 2) then
+       jzt = 1d0
+    end if
+
+    do j = 1, msh%gdim
+       xyzb(1,1,1,j) = element%pts(1)%p%x(j)
+       xyzb(2,1,1,j) = element%pts(2)%p%x(j)
+       xyzb(1,2,1,j) = element%pts(4)%p%x(j)
+       xyzb(2,2,1,j) = element%pts(3)%p%x(j)
+
+       if (msh%gdim .gt. 2) then
+          xyzb(1,1,2,j) = element%pts(5)%p%x(j)
+          xyzb(2,1,2,j) = element%pts(6)%p%x(j)
+          xyzb(1,2,2,j) = element%pts(8)%p%x(j)
+          xyzb(2,2,2,j) = element%pts(7)%p%x(j)
+       end if
+    end do
+    if (msh%gdim .eq. 3) then
+       call tensr3(tmp, Xh%lx, xyzb(1,1,1,1), 2, jx, jyt, jzt, w)
+       call copy(x, tmp, Xh%lx*Xh%ly*Xh%lz)
+       call tensr3(tmp, Xh%ly, xyzb(1,1,1,2), 2, jx, jyt, jzt, w)
+       call copy(y, tmp, Xh%lx*Xh%ly*Xh%lz)
+       call tensr3(tmp, Xh%lz, xyzb(1,1,1,3), 2, jx, jyt, jzt, w)
+       call copy(z, tmp, Xh%lx*Xh%ly*Xh%lz)
+    else
+       call tnsr2d_el(tmp, Xh%lx, xyzb(1,1,1,1), 2, jx, jyt)
+       call copy(x, tmp, Xh%lx*Xh%ly*Xh%lz)
+       call tnsr2d_el(tmp, Xh%ly, xyzb(1,1,1,2), 2, jx, jyt)
+       call copy(y, tmp, Xh%lx*Xh%ly*Xh%lz)
+    end if
+  end subroutine dofmap_xyzlin
+
+  subroutine dofmap_xyzquad(Xh, msh, element, x, y, z, curve_type, curve_data)
+    type(mesh_t), pointer, intent(in) :: msh
+    type(space_t), intent(in) :: Xh
+    class(element_t), intent(in) :: element
+    real(kind=rp), intent(inout) :: x(Xh%lx,Xh%ly,Xh%lz), y(Xh%lx,Xh%ly,Xh%lz), z(Xh%lx,Xh%ly,Xh%lz)
+    integer :: curve_type(12), eindx(12)
+    real(kind=rp) :: curve_data(5,12), x3(3,3,3), y3(3,3,3), z3(3,3,3)
+    type(space_t), target :: Xh3
+    real(kind=rp), dimension(3), parameter :: zquad = (/-1d0, 0d0,1d0/)
+    real(kind=rp) :: zg(3)
+    real(kind=rp), dimension(Xh%lx,Xh%lx,Xh%lx) :: tmp
+    real(kind=rp) :: jx(Xh%lx*3), jy(Xh%lx*3), jz(Xh%lx*3)
+    real(kind=rp) :: jxt(Xh%lx*3), jyt(Xh%lx*3), jzt(Xh%lx*3)
+    real(kind=rp) :: w(4*Xh%lxyz,2)
+    real(kind=rp), dimension(Xh%lx,3) :: zgml
+    integer :: j, k, n, n_edges
+    eindx = (/2 ,  6 ,  8 ,  4, &
+              20 , 24 , 26 , 22, &
+              10 , 12 , 18 , 16 /)
+
+    w = 0d0
+    if (msh%gdim .eq. 3) then
+       n_edges = 12
+       call space_init(Xh3, GLL, 3, 3, 3)
+    else
+       n_edges = 4
+       call space_init(Xh3, GLL, 3, 3)
+    end if
+    call dofmap_xyzlin(Xh3, msh, element, x3, y3, z3)
+
+    do k = 1, n_edges
+       if (curve_type(k) .eq. 4) then
+          x3(eindx(k),1,1) = curve_data(1,k)
+          y3(eindx(k),1,1) = curve_data(2,k)
+          z3(eindx(k),1,1) = curve_data(3,k)
+       end if
+    end do 
+    zg(1) = -1
+    zg(2) =  0 
+    zg(3) =  1
+    if (msh%gdim .eq. 3) then
+       call gh_face_extend_3d(x3,zg,3,2,w(1,1),w(1,2)) ! 2 --> edge extend
+       call gh_face_extend_3d(y3,zg,3,2,w(1,1),w(1,2))
+       call gh_face_extend_3d(z3,zg,3,2,w(1,1),w(1,2))
+    else
+       call neko_warning(' m deformation not supported for 2d yet')
+       call gh_face_extend_2d(x3,zg,3,2,w(1,1),w(1,2)) ! 2 --> edge extend
+       call gh_face_extend_2d(y3,zg,3,2,w(1,1),w(1,2))
+    endif
+    k =1 
+    do j = 1, Xh%lx
+       call fd_weights_full(Xh%zg(j,1),zquad,2,0,jxt(k))
+       call fd_weights_full(Xh%zg(j,2),zquad,2,0,jyt(k))
+       if (msh%gdim .gt. 2) then
+          call fd_weights_full(Xh%zg(j,3),zquad,2,0,jzt(k))
+       end if
+       k = k + 3
+    end do
+    call trsp(jx, Xh%lx, jxt, 3)
+    if (msh%gdim .eq. 3) then
+       call tensr3(tmp, Xh%lx, x3, 3, jx, jyt, jzt, w)
+       call copy(x, tmp, Xh%lx*Xh%ly*Xh%lz)
+       call tensr3(tmp, Xh%ly, y3, 3, jx, jyt, jzt, w)
+       call copy(y, tmp, Xh%lx*Xh%ly*Xh%lz)
+       call tensr3(tmp, Xh%lz, z3, 3, jx, jyt, jzt, w)
+       call copy(z, tmp, Xh%lx*Xh%ly*Xh%lz)
+    else
+       call tnsr2d_el(tmp, Xh%lx, x3, 3, jx, jyt)
+       call copy(x, tmp, Xh%lx*Xh%ly*Xh%lz)
+       call tnsr2d_el(tmp, Xh%ly, y3, 3, jx, jyt)
+       call copy(y, tmp, Xh%lx*Xh%ly*Xh%lz)
+    end if
+
+    call space_free(Xh3)
+  end subroutine dofmap_xyzquad
+ !> Extend faces into interior via gordon hall
+ !! gh_type:  1 - vertex only                   
+ !!           2 - vertex and edges
+ !!           3 - vertex, edges, and faces      
+ !! Original in Nek5000/core/navier5.f
+    
+ subroutine gh_face_extend_3d(x,zg,n,gh_type,e,v)
+   integer, intent(in) :: n
+   real(kind=rp), intent(inout) ::  x(n,n,n)
+   real(kind=rp), intent(in) ::  zg(n)
+   real(kind=rp), intent(inout) ::  e(n,n,n)
+   real(kind=rp), intent(inout) ::  v(n,n,n)
+   integer :: gh_type, ntot, kk, jj, ii, k, j, i
+   real(kind=rp) :: si, sj, sk, hi, hj, hk
+   
+!
+!  Build vertex interpolant
+!
+   ntot=n*n*n
+   call rzero(v,ntot)
+   do kk=1,n,n-1
+   do jj=1,n,n-1
+   do ii=1,n,n-1
+      do k=1,n
+      do j=1,n
+      do i=1,n
+         si       = 0.5*((n-ii)*(1-zg(i))+(ii-1)*(1+zg(i)))/(n-1)
+         sj       = 0.5*((n-jj)*(1-zg(j))+(jj-1)*(1+zg(j)))/(n-1)
+         sk       = 0.5*((n-kk)*(1-zg(k))+(kk-1)*(1+zg(k)))/(n-1)
+         v(i,j,k) = v(i,j,k) + si*sj*sk*x(ii,jj,kk)
+      enddo
+      enddo
+      enddo
+   enddo
+   enddo
+   enddo
+   if (gh_type.eq.1) then
+      call copy(x,v,ntot)
+      return
+   endif
+!
+!
+!  Extend 12 edges
+   call rzero(e,ntot)
+!
+!  x-edges
+!
+   do kk=1,n,n-1
+   do jj=1,n,n-1
+      do k=1,n
+      do j=1,n
+      do i=1,n
+         hj       = 0.5*((n-jj)*(1-zg(j))+(jj-1)*(1+zg(j)))/(n-1)
+         hk       = 0.5*((n-kk)*(1-zg(k))+(kk-1)*(1+zg(k)))/(n-1)
+         e(i,j,k) = e(i,j,k) + hj*hk*(x(i,jj,kk)-v(i,jj,kk))
+      enddo
+      enddo
+      enddo
+   enddo
+   enddo
+!
+!  y-edges
+!
+   do kk=1,n,n-1
+   do ii=1,n,n-1
+      do k=1,n
+      do j=1,n
+      do i=1,n
+         hi       = 0.5*((n-ii)*(1-zg(i))+(ii-1)*(1+zg(i)))/(n-1)
+         hk       = 0.5*((n-kk)*(1-zg(k))+(kk-1)*(1+zg(k)))/(n-1)
+         e(i,j,k) = e(i,j,k) + hi*hk*(x(ii,j,kk)-v(ii,j,kk))
+      enddo
+      enddo
+      enddo
+   enddo
+   enddo
+!
+!  z-edges
+!
+   do jj=1,n,n-1
+   do ii=1,n,n-1
+      do k=1,n
+      do j=1,n
+      do i=1,n
+         hi       = 0.5*((n-ii)*(1-zg(i))+(ii-1)*(1+zg(i)))/(n-1)
+         hj       = 0.5*((n-jj)*(1-zg(j))+(jj-1)*(1+zg(j)))/(n-1)
+         e(i,j,k) = e(i,j,k) + hi*hj*(x(ii,jj,k)-v(ii,jj,k))
+      enddo
+      enddo
+      enddo
+   enddo
+   enddo
+   call add2(e,v,ntot)
+   if (gh_type.eq.2) then
+      call copy(x,e,ntot)
+      return
+   endif
+!
+!  Extend faces
+!
+   call rzero(v,ntot)
+!
+!  x-edges
+!
+   do ii=1,n,n-1
+      do k=1,n
+      do j=1,n
+      do i=1,n
+         hi       = 0.5*((n-ii)*(1-zg(i))+(ii-1)*(1+zg(i)))/(n-1)
+         v(i,j,k) = v(i,j,k) + hi*(x(ii,j,k)-e(ii,j,k))
+      enddo
+      enddo
+      enddo
+   enddo
+!
+! y-edges
+!
+   do jj=1,n,n-1
+      do k=1,n
+      do j=1,n
+      do i=1,n
+         hj       = 0.5*((n-jj)*(1-zg(j))+(jj-1)*(1+zg(j)))/(n-1)
+         v(i,j,k) = v(i,j,k) + hj*(x(i,jj,k)-e(i,jj,k))
+      enddo
+      enddo
+      enddo
+   enddo
+! 
+!  z-edges
+! 
+   do kk=1,n,n-1
+      do k=1,n
+      do j=1,n
+      do i=1,n
+         hk       = 0.5*((n-kk)*(1-zg(k))+(kk-1)*(1+zg(k)))/(n-1)
+         v(i,j,k) = v(i,j,k) + hk*(x(i,j,kk)-e(i,j,kk))
+      enddo
+      enddo
+      enddo
+   enddo
+   call add2(v,e,ntot)
+   call copy(x,v,ntot)
+
+  end subroutine gh_face_extend_3d
+
+  !> Extend 2D faces into interior via gordon hall
+  !! gh_type:  1 - vertex only
+  !!           2 - vertex and faces
+  subroutine gh_face_extend_2d(x,zg,n,gh_type,e,v)
+    integer, intent(in) :: n
+    real(kind=rp), intent(inout) :: x(n,n)
+    real(kind=rp), intent(in) :: zg(n)
+    real(kind=rp), intent(inout) :: e(n,n)
+    real(kind=rp), intent(inout) :: v(n,n)
+    integer, intent(in) :: gh_type
+    integer :: i,j , jj, ii, ntot
+    real(kind=rp) :: si, sj, hi, hj 
+
+    !Build vertex interpolant
+
+    ntot=n*n
+    call rzero(v,ntot)
+    do jj=1,n,n-1
+    do ii=1,n,n-1
+       do j=1,n
+       do i=1,n
+          si     = 0.5*((n-ii)*(1-zg(i))+(ii-1)*(1+zg(i)))/(n-1)
+          sj     = 0.5*((n-jj)*(1-zg(j))+(jj-1)*(1+zg(j)))/(n-1)
+          v(i,j) = v(i,j) + si*sj*x(ii,jj)
+       enddo
+       enddo
+    enddo
+    enddo
+    if (gh_type.eq.1) then
+       call copy(x,v,ntot)
+       return
+    endif
+
+
+    !Extend 4 edges
+    call rzero(e,ntot)
+
+    !x-edges
+
+    do jj=1,n,n-1
+       do j=1,n
+       do i=1,n
+          hj     = 0.5*((n-jj)*(1-zg(j))+(jj-1)*(1+zg(j)))/(n-1)
+          e(i,j) = e(i,j) + hj*(x(i,jj)-v(i,jj))
+       enddo
+       enddo
+    enddo
+
+    !y-edges
+
+    do ii=1,n,n-1
+       do j=1,n
+       do i=1,n
+          hi     = 0.5*((n-ii)*(1-zg(i))+(ii-1)*(1+zg(i)))/(n-1)
+          e(i,j) = e(i,j) + hi*(x(ii,j)-v(ii,j))
+       enddo
+       enddo
+    enddo
+
+    call add3(x,e,v,ntot)
+
+  end subroutine gh_face_extend_2d
+
+
+
   subroutine arc_surface(isid,curve_data,x,y,z, Xh, element, gdim)
     integer, intent(in) :: isid, gdim
     type(space_t), intent(in) :: Xh


### PR DESCRIPTION
Adds support for midpoint deformation. Rerun rea2nbin for old neko meshes with deformations.

There should be initial 2d support, but this I did not test very thoroughly.

This is adds a lot of backwards compatibility with re2 meshes generated from gmsh, but a lot of the conventions form Nek5000 is maintained. We should maybe look over how we want to deal with deformations in the future.