### PR TITLE
Symmetry facet normal

### DIFF
--- a/src/fluid/bcknd/cpu/pnpn_res_cpu.f90
+++ b/src/fluid/bcknd/cpu/pnpn_res_cpu.f90
@@ -20,7 +20,7 @@ contains
 
   subroutine pnpn_prs_res_cpu_compute(p, p_res, u, v, w, u_e, v_e, w_e, &
        ta1, ta2, ta3, wa1, wa2, wa3, work1, work2, f_Xh, c_Xh, gs_Xh, &
-       bc_prs_surface, Ax, bd, dt, Re, rho)
+       bc_prs_surface,bc_sym_surface, Ax, bd, dt, Re, rho)
     type(field_t), intent(inout) :: p, u, v, w
     type(field_t), intent(inout) :: u_e, v_e, w_e
     type(field_t), intent(inout) :: ta1, ta2, ta3
@@ -31,6 +31,7 @@ contains
     type(coef_t), intent(inout) :: c_Xh
     type(gs_t), intent(inout) :: gs_Xh
     type(facet_normal_t), intent(inout) :: bc_prs_surface
+    type(facet_normal_t), intent(inout) :: bc_sym_surface
     class(Ax_t), intent(inout) :: Ax
     real(kind=rp), intent(inout) :: bd
     real(kind=rp), intent(in) :: dt
@@ -84,6 +85,12 @@ contains
     !
     ! Surface velocity terms
     !
+    do i = 1, n
+       wa1%x(i,1,1,1) = 0.0_rp
+       wa2%x(i,1,1,1) = 0.0_rp
+       wa3%x(i,1,1,1) = 0.0_rp
+    enddo
+    call bc_sym_surface%apply_surfvec(wa1%x,wa2%x,wa3%x,ta1%x, ta2%x, ta3%x, n)
     dtbd = bd / dt
     do i = 1, n
        ta1%x(i,1,1,1) = 0.0_rp
@@ -95,7 +102,8 @@ contains
 
     do i = 1, n
        p_res%x(i,1,1,1) = p_res%x(i,1,1,1) &
-            - (dtbd * (ta1%x(i,1,1,1) + ta2%x(i,1,1,1) + ta3%x(i,1,1,1)))
+            - (dtbd * (ta1%x(i,1,1,1) + ta2%x(i,1,1,1) + ta3%x(i,1,1,1)))&
+            - (wa1%x(i,1,1,1) + wa2%x(i,1,1,1) + wa3%x(i,1,1,1))
     end do
 
   end subroutine pnpn_prs_res_cpu_compute

--- a/src/fluid/bcknd/sx/pnpn_res_sx.f90
+++ b/src/fluid/bcknd/sx/pnpn_res_sx.f90
@@ -20,7 +20,7 @@ contains
 
   subroutine pnpn_prs_res_sx_compute(p, p_res, u, v, w, u_e, v_e, w_e, &
        ta1, ta2, ta3, wa1, wa2, wa3, work1, work2, f_Xh, c_Xh, gs_Xh, &
-       bc_prs_surface, Ax, bd, dt, Re, rho)
+       bc_prs_surface, bc_sym_surface, Ax, bd, dt, Re, rho)
     type(field_t), intent(inout) :: p, u, v, w
     type(field_t), intent(inout) :: u_e, v_e, w_e
     type(field_t), intent(inout) :: ta1, ta2, ta3
@@ -31,6 +31,7 @@ contains
     type(coef_t), intent(inout) :: c_Xh
     type(gs_t), intent(inout) :: gs_Xh
     type(facet_normal_t), intent(inout) :: bc_prs_surface
+    type(facet_normal_t), intent(inout) :: bc_sym_surface
     class(Ax_t), intent(inout) :: Ax
     real(kind=rp), intent(inout) :: bd
     real(kind=rp), intent(in) :: dt
@@ -86,6 +87,12 @@ contains
     !
     ! Surface velocity terms
     !
+    do i = 1, n
+       wa1%x(i,1,1,1) = 0.0_rp
+       wa2%x(i,1,1,1) = 0.0_rp
+       wa3%x(i,1,1,1) = 0.0_rp
+    enddo
+    call bc_sym_surface%apply_surfvec(wa1%x,wa2%x,wa3%x,ta1%x, ta2%x, ta3%x, n)
     dtbd = bd / dt
     do i = 1, n
        ta1%x(i,1,1,1) = 0.0_rp
@@ -97,7 +104,8 @@ contains
 
     do i = 1, n
        p_res%x(i,1,1,1) = p_res%x(i,1,1,1) &
-            - (dtbd * (ta1%x(i,1,1,1) + ta2%x(i,1,1,1) + ta3%x(i,1,1,1)))
+            - (dtbd * (ta1%x(i,1,1,1) + ta2%x(i,1,1,1) + ta3%x(i,1,1,1)))&
+            - (wa1%x(i,1,1,1) + wa2%x(i,1,1,1) + wa3%x(i,1,1,1))
     end do
 
   end subroutine pnpn_prs_res_sx_compute

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -36,6 +36,7 @@ module fluid_pnpn
      type(projection_t) :: proj
 
      type(facet_normal_t) :: bc_prs_surface !< Surface term in pressure rhs
+     type(facet_normal_t) :: bc_sym_surface !< Surface term in pressure rhs
      type(dirichlet_t) :: bc_vel_residual   !< Dirichlet condition vel. res.
      type(bc_list_t) :: bclst_vel_residual  
 
@@ -144,7 +145,11 @@ contains
     call this%bc_prs_surface%mark_zone(msh%inlet)
     call this%bc_prs_surface%finalize()
     call this%bc_prs_surface%set_coef(this%c_Xh)
-
+    ! Initialize symmetry surface terms in pressure rhs
+    call this%bc_sym_surface%init(this%dm_Xh)
+    call this%bc_sym_surface%mark_zone(msh%sympln)
+    call this%bc_sym_surface%finalize()
+    call this%bc_sym_surface%set_coef(this%c_Xh)
     ! Initialize boundary condition for velocity residual
     call this%bc_vel_residual%init(this%dm_Xh)
     call this%bc_vel_residual%mark_zone(msh%inlet)
@@ -170,6 +175,7 @@ contains
     call this%scheme_free()
 
     call this%bc_prs_surface%free()  
+    call this%bc_sym_surface%free()  
     call bc_list_free(this%bclst_vel_residual)
     call this%proj%free()
    
@@ -302,8 +308,8 @@ contains
                            ta1, ta2, ta3, wa1, wa2, wa3, &
                            this%work1, this%work2, f_Xh, &
                            c_Xh, gs_Xh, this%bc_prs_surface, &
-                           Ax, ab_bdf%bd(1), params%dt, &
-                           params%Re, params%rho)
+                           this%bc_sym_surface, Ax, ab_bdf%bd(1), &
+                           params%dt, params%Re, params%rho)
 
       call gs_op(gs_Xh, p_res, GS_OP_ADD) 
       call bc_list_apply_scalar(this%bclst_prs, p_res%x, p%dof%n_dofs)

--- a/src/fluid/pnpn_res.f90
+++ b/src/fluid/pnpn_res.f90
@@ -58,7 +58,7 @@ module pnpn_residual
   abstract interface
      subroutine prs_res(p, p_res, u, v, w, u_e, v_e, w_e, &
        ta1, ta2, ta3, wa1, wa2, wa3, work1, work2, f_Xh, c_xh, gs_Xh, &
-       bc_prs_surface, Ax, bd, dt, Re, rho)
+       bc_prs_surface, bc_sym_surface, Ax, bd, dt, Re, rho)
        import field_t
        import Ax_t
        import gs_t
@@ -76,6 +76,7 @@ module pnpn_residual
        type(coef_t), intent(inout) :: c_Xh
        type(gs_t), intent(inout) :: gs_Xh
        type(facet_normal_t), intent(inout) :: bc_prs_surface
+       type(facet_normal_t), intent(inout) :: bc_sym_surface
        class(Ax_t), intent(inout) :: Ax
        real(kind=rp), intent(inout) :: bd
        real(kind=rp), intent(in) :: dt


### PR DESCRIPTION
Adds the missing facet normal term to the rhs for symmetry boundary conditions. 

Seems to be an issue when two symmetry bcs intersect each other and are perpendicular (e.g. hemi).