### PR TITLE
Fix possible race

### DIFF
--- a/src/math/bcknd/device/cuda/schwarz_kernel.h
+++ b/src/math/bcknd/device/cuda/schwarz_kernel.h
@@ -110,6 +110,7 @@ __global__ void schwarz_toext3d_kernel(T * __restrict__ a,
   for(int i = idx; i<nx2*nx2*nx2; i+=blockDim.x){
     a[i+el2] = 0.0;
   }
+  __syncthreads();
   for(int ijk = idx; ijk<nx*nx*nx; ijk+=blockDim.x){
     const int jk = ijk / nx;
     const int i = ijk - jk * nx;

--- a/src/math/bcknd/device/hip/schwarz_kernel.h
+++ b/src/math/bcknd/device/hip/schwarz_kernel.h
@@ -110,6 +110,7 @@ __global__ void schwarz_toext3d_kernel(T * __restrict__ a,
   for(int i = idx; i<nx2*nx2*nx2; i+=blockDim.x){
     a[i+el2] = 0.0;
   }
+  __syncthreads();
   for(int ijk = idx; ijk<nx*nx*nx; ijk+=blockDim.x){
     const int jk = ijk / nx;
     const int i = ijk - jk * nx;


### PR DESCRIPTION
Seems there is something different between Nvidia/AMD with regards to in what order operations are performed within a threadblock.