### PR TITLE
User deform mesh

### DIFF
--- a/src/common/utils.f90
+++ b/src/common/utils.f90
@@ -85,6 +85,30 @@ contains
     index = (i + lx * ((j - 1) + ly * ((k - 1) + lz * ((l - 1)))))
   end function linear_index
 
+  pure function index_is_on_facet(i, j, k, lx, ly, lz, facet) result(is_on)
+    integer, intent(in) :: i, j, k, lx, ly, lz, facet
+    logical :: is_on
+
+    is_on = .false.
+    select case(facet)
+    case(1)
+       if (i .eq. 1) is_on = .true.
+    case(2)
+       if (i .eq. lx) is_on = .true.
+    case(3)
+       if (j .eq. 1) is_on = .true.
+    case(4)
+       if (j .eq. ly) is_on = .true.
+    case(5)
+       if (k .eq. 1) is_on = .true.
+    case(6)
+       if (k .eq. lz) is_on = .true.
+    end select
+  
+
+  end function index_is_on_facet
+  
+ 
   !> Compute (i,j,k,l) array given linear index
   !! with sizes (1:lx, 1:ly, 1:lz, :)
   pure function nonlinear_index(linear_index,lx,ly,lz) result(index)

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -107,8 +107,24 @@ module mesh
      logical :: lconn = .false.                !< valid connectivity
      logical :: ldist = .false.                !< valid distributed data
      logical :: lnumr = .false.                !< valid numbering
-
+     !< enables user to specify a deformation
+     !! that is applied to all x,y,z coordinates generated with this mesh
+     procedure(mesh_deform), pass(msh), pointer  :: apply_deform => null()
   end type mesh_t
+
+  abstract interface
+     subroutine mesh_deform(msh, x, y, z, lx, ly, lz)
+       import mesh_t       
+       import rp
+       class(mesh_t) :: msh
+       integer, intent(in) :: lx, ly, lz
+       real(kind=rp), intent(inout) :: x(lx, ly, lz, msh%nelv)
+       real(kind=rp), intent(inout) :: y(lx, ly, lz, msh%nelv)
+       real(kind=rp), intent(inout) :: z(lx, ly, lz, msh%nelv)
+     end subroutine mesh_deform
+  end interface
+
+
 
   !> Initialise a mesh
   interface mesh_init

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -107,7 +107,8 @@ module mesh
      logical :: lconn = .false.                !< valid connectivity
      logical :: ldist = .false.                !< valid distributed data
      logical :: lnumr = .false.                !< valid numbering
-     !< enables user to specify a deformation
+     
+     !> enables user to specify a deformation
      !! that is applied to all x,y,z coordinates generated with this mesh
      procedure(mesh_deform), pass(msh), pointer  :: apply_deform => null()
   end type mesh_t

--- a/src/sem/dofmap.f90
+++ b/src/sem/dofmap.f90
@@ -697,6 +697,9 @@ contains
        end if
        end do
     enddo
+    if (associated(msh%apply_deform)) then
+       call msh%apply_deform(this%x, this%y, this%z, Xh%lx, Xh%ly, Xh%lz)
+    end if
   end subroutine dofmap_generate_xyz
 
   subroutine dofmap_xyzlin(Xh, msh, element, x, y, z)


### PR DESCRIPTION
Lets the user define a deformation subroutine that is then applied to the generated dofs in dofmap. 

I feel like this slaughters a few kittens and we should probably add checks and prints when this function is called.