### PR TITLE
Make application of vel bc more reasonable

### DIFF
--- a/src/fluid/fluid_method.f90
+++ b/src/fluid/fluid_method.f90
@@ -207,8 +207,6 @@ contains
     call this%bc_inflow%mark_zone(msh%inlet)
     call this%bc_inflow%mark_zones_from_list(msh%labeled_zones,&
                         'v', this%params%bc_labels)
-    call this%bc_inflow%mark_zones_from_list(msh%labeled_zones,&
-                        'on', this%params%bc_labels)
     call this%bc_inflow%finalize()
     call this%bc_inflow%set_inflow(params%uinf)
     call bc_list_add(this%bclst_vel, this%bc_inflow)

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -344,8 +344,6 @@ contains
       !> We assume that no change of boundary conditions 
       !! occurs between elements. I.e. we do not apply gsop here like in Nek5000
       !> Apply dirichlet
-      call bc_list_apply_vector(this%bclst_vel_residual,&
-         u%x, v%x, w%x, this%dm_Xh%n_dofs)
       call this%bc_apply_vel()
       
       ! compute pressure


### PR DESCRIPTION
Increases readability, does not impose the specified velocity bc at the ON boundary. Should enable the flow to flow out easier, but from my measurements seems to make 0 difference, another difference is that ON does not take a time dependent inflow into account. Regarding the time dependence we should maybe consider how we want to do with the ON bc.

ON will still not work with tripping close to the boundary since applying zero velocity in the non-normal direction is unphysical when the turbulence hits the ON boundary.