### PR TITLE
Add sync in device MPI nbwait

### DIFF
--- a/src/gs/bcknd/device/gs_device_mpi.F90
+++ b/src/gs/bcknd/device/gs_device_mpi.F90
@@ -388,6 +388,8 @@ contains
        end do
     end do
 
+    call device_sync()
+
   end subroutine gs_device_mpi_nbwait
 
 end module gs_device_mpi


### PR DESCRIPTION
Without this change, the pressure start residual is sometimes wrong (and maybe other things too), probably due to a race condition. This seems to happen maybe once per run of Tgv32 with 2 ranks. Sometimes it causes divergence, sometimes just a few more pressure iterations.

Adding this sync makes my test case completely deterministic. Over four Tgv32 runs the residuals and iteration counts for the complete run are exactly the same.