### PR TITLE
Don't assume rp corresponds to byte size

### DIFF
--- a/src/common/projection.f90
+++ b/src/common/projection.f90
@@ -86,7 +86,7 @@ module projection
      type(c_ptr) :: xx_d_d = C_NULL_PTR
      type(c_ptr) :: bb_d_d = C_NULL_PTR
      integer :: m, L
-     real(kind=rp) :: tol = 1d-7
+     real(kind=rp) :: tol = 1e-7_rp
    contains
      procedure, pass(this) :: project_on => bcknd_project_on
      procedure, pass(this) :: project_back => bcknd_project_back
@@ -103,7 +103,8 @@ contains
     integer :: i
     integer(c_size_t) :: ptr_size
     type(c_ptr) :: ptr
-    
+    real(c_rp) :: dummy
+     
     call this%free()
     
     if (present(L)) then
@@ -128,7 +129,7 @@ contains
          (NEKO_BCKND_OPENCL .eq. 1)) then
        
        call device_map(this%xbar, this%xbar_d,n)
-       call device_alloc(this%alpha_d, int(rp*this%L,c_size_t))
+       call device_alloc(this%alpha_d, int(c_sizeof(dummy)*this%L,c_size_t))
 
        do i = 1, this%L
           this%xx_d(i) = C_NULL_PTR
@@ -137,7 +138,7 @@ contains
           call device_map_r1(this%bb(:,i), this%bb_d(i), n)
        end do
 
-       ptr_size = 8*this%L
+       ptr_size = c_sizeof(C_NULL_PTR) * this%L
        call device_alloc(this%xx_d_d, ptr_size)
        ptr = c_loc(this%xx_d)
        call device_memcpy(ptr,this%xx_d_d, ptr_size, HOST_TO_DEVICE)

--- a/src/fluid/fluid_method.f90
+++ b/src/fluid/fluid_method.f90
@@ -234,14 +234,14 @@ contains
        
     if (params%output_bdry) then       
        call field_init(this%bdry, this%dm_Xh, 'bdry')
-       this%bdry = real(0d0,rp)
+       this%bdry = 0.0_rp
        
        call bdry_mask%init(this%dm_Xh)
        call bdry_mask%mark_zone(msh%wall)
        call bdry_mask%mark_zones_from_list(msh%labeled_zones,&
                       'w', this%params%bc_labels)
        call bdry_mask%finalize()
-       call bdry_mask%set_g(real(1d0,rp))
+       call bdry_mask%set_g(1.0_rp)
        call bdry_mask%apply_scalar(this%bdry%x, this%dm_Xh%n_dofs)
        call bdry_mask%free()
 
@@ -251,7 +251,7 @@ contains
                       'v', this%params%bc_labels)
 
        call bdry_mask%finalize()
-       call bdry_mask%set_g(real(2d0,rp))
+       call bdry_mask%set_g(2.0_rp)
        call bdry_mask%apply_scalar(this%bdry%x, this%dm_Xh%n_dofs)
        call bdry_mask%free()
 
@@ -260,7 +260,7 @@ contains
        call bdry_mask%mark_zones_from_list(msh%labeled_zones,&
                       'o', this%params%bc_labels)
        call bdry_mask%finalize()
-       call bdry_mask%set_g(real(3d0,rp))
+       call bdry_mask%set_g(3.0_rp)
        call bdry_mask%apply_scalar(this%bdry%x, this%dm_Xh%n_dofs)
        call bdry_mask%free()
 
@@ -269,14 +269,14 @@ contains
        call bdry_mask%mark_zones_from_list(msh%labeled_zones,&
                       'sym', this%params%bc_labels)
        call bdry_mask%finalize()
-       call bdry_mask%set_g(real(4d0,rp))
+       call bdry_mask%set_g(4.0_rp)
        call bdry_mask%apply_scalar(this%bdry%x, this%dm_Xh%n_dofs)
        call bdry_mask%free()
 
        call bdry_mask%init(this%dm_Xh)
        call bdry_mask%mark_zone(msh%periodic)
        call bdry_mask%finalize()
-       call bdry_mask%set_g(real(5d0,rp))
+       call bdry_mask%set_g(5.0_rp)
        call bdry_mask%apply_scalar(this%bdry%x, this%dm_Xh%n_dofs)
        call bdry_mask%free()
 
@@ -285,7 +285,7 @@ contains
        call bdry_mask%mark_zones_from_list(msh%labeled_zones,&
                       'on', this%params%bc_labels)
        call bdry_mask%finalize()
-       call bdry_mask%set_g(real(6d0,rp))
+       call bdry_mask%set_g(6.0_rp)
        call bdry_mask%apply_scalar(this%bdry%x, this%dm_Xh%n_dofs)
        call bdry_mask%free()
 
@@ -351,7 +351,7 @@ contains
     end if
 
     call this%bc_prs%finalize()
-    call this%bc_prs%set_g(real(0d0,rp))
+    call this%bc_prs%set_g(0.0_rp)
     call bc_list_add(this%bclst_prs, this%bc_prs)
 
     if (kspv_init) then

--- a/src/gs/bcknd/device/gs_device_mpi.F90
+++ b/src/gs/bcknd/device/gs_device_mpi.F90
@@ -168,7 +168,9 @@ contains
     integer, pointer :: pe(:)
     integer :: i, ndof
     integer(c_size_t) :: sz
-
+    real(c_rp) :: rp_dummy
+    integer(c_int) :: i4_dummy
+ 
     call this%init_order(send_pe, recv_pe)
 
     allocate(this%send_buf(send_pe%size()))
@@ -181,10 +183,10 @@ contains
        ndof = this%send_dof(pe(i))%size()
        ndofs(i) = ndof
 
-       sz = rp * ndof
+       sz = c_sizeof(rp_dummy) * ndof
        call device_alloc(buf_ptrs(i), sz)
 
-       sz = 4 * ndof
+       sz = c_sizeof(i4_dummy) * ndof
        call device_alloc(dof_ptrs(i), sz)
 
        ! %array() breaks on cray
@@ -226,10 +228,10 @@ contains
     do i = 1, recv_pe%size()
        ndof = this%recv_dof(pe(i))%size()
 
-       sz = rp * ndof
+       sz = c_sizeof(rp_dummy) * ndof
        call device_alloc(this%recv_buf(i)%buf_d, sz)
 
-       sz = 4 * ndof
+       sz = c_sizeof(i4_dummy) * ndof
        call device_alloc(this%recv_buf(i)%dof_d, sz)
 
        ! %array() breaks on cray


### PR DESCRIPTION
- Remove uncessary casts
- Don't assume rp corresponds to byte size
