### PR TITLE
Offload (most of) coef. calc. to device

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -18,7 +18,9 @@ math/mathops.o : math/mathops.f90 config/num_types.o
 math/fast3d.o : math/fast3d.f90 math/math.o sem/speclib.o config/num_types.o 
 sem/space.o : sem/space.f90 math/math.o math/fast3d.o common/utils.o device/device.o sem/speclib.o config/num_types.o config/neko_config.o 
 sem/dofmap.o : sem/dofmap.f90 math/math.o math/tensor.o math/fast3d.o common/utils.o config/num_types.o adt/tuple.o sem/space.o mesh/mesh.o 
-sem/coef.o : sem/coef.f90 math/mxm_wrapper.o device/device.o mesh/mesh.o math/math.o sem/space.o config/num_types.o config/neko_config.o gs/gather_scatter.o 
+sem/coef.o : sem/coef.f90 math/mxm_wrapper.o sem/bcknd/device/device_coef.o device/device.o mesh/mesh.o math/math.o sem/space.o config/num_types.o config/neko_config.o gs/gather_scatter.o 
+sem/interpolation.o : sem/interpolation.f90 sem/space.o math/tensor.o math/fast3d.o math/math.o common/utils.o device/device.o sem/speclib.o 
+sem/bcknd/device/device_coef.o : sem/bcknd/device/device_coef.F90 common/utils.o config/num_types.o 
 gs/gs_bcknd.o : gs/gs_bcknd.f90 config/num_types.o 
 gs/bcknd/cpu/gs_cpu.o : gs/bcknd/cpu/gs_cpu.f90 gs/gs_ops.o gs/gs_bcknd.o config/num_types.o 
 gs/bcknd/sx/gs_sx.o : gs/bcknd/sx/gs_sx.f90 gs/gs_ops.o gs/gs_bcknd.o config/num_types.o 
@@ -156,7 +158,6 @@ math/bcknd/device/ax_helm_device.o : math/bcknd/device/ax_helm_device.F90 config
 common/projection.o : common/projection.f90 math/bcknd/device/device_math.o device/device.o config/neko_config.o gs/gather_scatter.o comm/comm.o bc/bc.o math/ax.o sem/coef.o math/math.o config/num_types.o 
 comm/parmetis.o : comm/parmetis.F90 mesh/mesh.o field/mesh_field.o config/num_types.o common/utils.o mesh/point.o comm/comm.o 
 comm/redist.o : comm/redist.f90 mesh/zone.o io/format/nmsh.o mesh/mesh.o comm/comm.o mesh/curve.o adt/stack.o mesh/point.o adt/htable.o comm/mpi_types.o field/mesh_field.o 
-sem/interpolation.o : sem/interpolation.f90 sem/space.o math/tensor.o math/fast3d.o math/math.o common/utils.o device/device.o sem/speclib.o 
 krylov/pc_hsmg.o : krylov/pc_hsmg.f90 math/bcknd/device/device_math.o device/device.o krylov/bcknd/device/pc_jacobi_device.o krylov/bcknd/sx/pc_jacobi_sx.o krylov/bcknd/cpu/pc_jacobi.o math/tensor.o math/schwarz.o math/fdm.o bc/dirichlet.o bc/bc.o sem/interpolation.o math/fast3d.o gs/gather_scatter.o krylov/krylov_fctry.o math/ax_helm_fctry.o math/ax.o krylov/precon.o common/utils.o math/math.o config/neko_config.o 
 common/signal.o : common/signal.f90 common/utils.o 
 common/jobctrl.o : common/jobctrl.f90 common/log.o comm/comm.o common/utils.o common/signal.o config/num_types.o 

--- a/src/.depends
+++ b/src/.depends
@@ -17,7 +17,7 @@ math/math.o : math/math.f90 comm/comm.o config/num_types.o
 math/mathops.o : math/mathops.f90 config/num_types.o 
 math/fast3d.o : math/fast3d.f90 math/math.o sem/speclib.o config/num_types.o 
 sem/space.o : sem/space.f90 math/math.o math/fast3d.o common/utils.o device/device.o sem/speclib.o config/num_types.o config/neko_config.o 
-sem/dofmap.o : sem/dofmap.f90 math/math.o math/tensor.o math/fast3d.o common/utils.o config/num_types.o adt/tuple.o sem/space.o mesh/mesh.o 
+sem/dofmap.o : sem/dofmap.f90 math/math.o device/device.o math/tensor.o math/fast3d.o common/utils.o config/num_types.o adt/tuple.o sem/space.o mesh/mesh.o config/neko_config.o 
 sem/coef.o : sem/coef.f90 math/mxm_wrapper.o sem/bcknd/device/device_coef.o device/device.o mesh/mesh.o math/math.o sem/space.o config/num_types.o config/neko_config.o gs/gather_scatter.o 
 sem/interpolation.o : sem/interpolation.f90 sem/space.o math/tensor.o math/fast3d.o math/math.o common/utils.o device/device.o sem/speclib.o 
 sem/bcknd/device/device_coef.o : sem/bcknd/device/device_coef.F90 common/utils.o config/num_types.o 

--- a/src/.depends_device
+++ b/src/.depends_device
@@ -11,8 +11,6 @@ math/bcknd/device/hip/schwarz.o : math/bcknd/device/hip/schwarz.hip math/bcknd/d
 math/bcknd/device/hip/tensor.o : math/bcknd/device/hip/tensor.hip math/bcknd/device/hip/tensor_kernel.h
 math/bcknd/device/hip/fdm.o : math/bcknd/device/hip/fdm.hip math/bcknd/device/hip/fdm_kernel.h
 krylov/bcknd/device/hip/pc_jacobi.o : krylov/bcknd/device/hip/pc_jacobi.hip
-krylov/bcknd/device/cuda/pipecg_aux.o : krylov/bcknd/device/cuda/pipecg_aux.cu krylov/bcknd/device/cuda/pipecg_kernel.h
-krylov/bcknd/device/cuda/gmres_aux.o : krylov/bcknd/device/cuda/gmres_aux.cu krylov/bcknd/device/cuda/gmres_kernel.h
 krylov/bcknd/device/hip/pipecg_aux.o : krylov/bcknd/device/hip/pipecg_aux.hip krylov/bcknd/device/hip/pipecg_kernel.h
 krylov/bcknd/device/hip/gmres_aux.o : krylov/bcknd/device/hip/gmres_aux.hip krylov/bcknd/device/hip/gmres_kernel.h
 gs/bcknd/device/hip/gs.o : gs/bcknd/device/hip/gs.hip gs/bcknd/device/hip/gs_kernels.h
@@ -39,6 +37,7 @@ math/bcknd/device/cuda/tensor.o : math/bcknd/device/cuda/tensor.cu math/bcknd/de
 math/bcknd/device/cuda/fdm.o : math/bcknd/device/cuda/fdm.cu math/bcknd/device/cuda/fdm_kernel.h
 krylov/bcknd/device/cuda/pc_jacobi.o : krylov/bcknd/device/cuda/pc_jacobi.cu
 krylov/bcknd/device/cuda/pipecg_aux.o : krylov/bcknd/device/cuda/pipecg_aux.cu krylov/bcknd/device/cuda/pipecg_kernel.h
+krylov/bcknd/device/cuda/gmres_aux.o : krylov/bcknd/device/cuda/gmres_aux.cu krylov/bcknd/device/cuda/gmres_kernel.h
 gs/bcknd/device/cuda/gs.o : gs/bcknd/device/cuda/gs.cu gs/bcknd/device/cuda/gs_kernels.h 
 bc/bcknd/device/cuda/dirichlet.o : bc/bcknd/device/cuda/dirichlet.cu bc/bcknd/device/cuda/dirichlet_kernel.h
 bc/bcknd/device/cuda/inflow.o : bc/bcknd/device/cuda/inflow.cu bc/bcknd/device/cuda/inflow_kernel.h
@@ -49,6 +48,7 @@ bc/bcknd/device/cuda/inhom_dirichlet.o : bc/bcknd/device/cuda/inhom_dirichlet.cu
 bc/bcknd/device/cuda/dong_outflow.o : bc/bcknd/device/cuda/dong_outflow.cu bc/bcknd/device/cuda/dong_outflow_kernel.h
 fluid/bcknd/device/cuda/fluid_abbdf.o : fluid/bcknd/device/cuda/fluid_abbdf.cu fluid/bcknd/device/cuda/sumab_kernel.h fluid/bcknd/device/cuda/makeabf_kernel.h fluid/bcknd/device/cuda/makebdf_kernel.h
 fluid/bcknd/device/cuda/pnpn_res.o : fluid/bcknd/device/cuda/pnpn_res.cu fluid/bcknd/device/cuda/vel_res_update_kernel.h fluid/bcknd/device/cuda/prs_res_kernel.h 
+sem/bcknd/device/cuda/coef.o : sem/bcknd/device/cuda/coef.cu sem/bcknd/device/cuda/coef_kernel.h
 device/opencl/check.o : device/opencl/check.c device/opencl/check.h
 device/opencl/jit.o : device/opencl/jit.c device/opencl/jit.h
 math/bcknd/device/opencl/math.o : math/bcknd/device/opencl/math.c math/bcknd/device/opencl/math_kernel.cl.h 

--- a/src/.depends_device
+++ b/src/.depends_device
@@ -23,6 +23,7 @@ bc/bcknd/device/hip/inhom_dirichlet.o : bc/bcknd/device/hip/inhom_dirichlet.hip 
 bc/bcknd/device/hip/dong_outflow.o : bc/bcknd/device/hip/dong_outflow.hip bc/bcknd/device/hip/dong_outflow_kernel.h
 fluid/bcknd/device/hip/fluid_abbdf.o : fluid/bcknd/device/hip/fluid_abbdf.hip fluid/bcknd/device/hip/sumab_kernel.h fluid/bcknd/device/hip/makeabf_kernel.h fluid/bcknd/device/hip/makebdf_kernel.h
 fluid/bcknd/device/hip/pnpn_res.o : fluid/bcknd/device/hip/pnpn_res.hip fluid/bcknd/device/hip/vel_res_update_kernel.h fluid/bcknd/device/hip/prs_res_kernel.h 
+sem/bcknd/device/hip/coef.o : sem/bcknd/device/hip/coef.hip sem/bcknd/device/hip/coef_kernel.h
 device/cuda/check.o : device/cuda/check.cu device/cuda/check.h
 math/bcknd/device/cuda/math.o : math/bcknd/device/cuda/math.cu math/bcknd/device/cuda/math_kernel.h
 math/bcknd/device/cuda/mathops.o : math/bcknd/device/cuda/mathops.cu math/bcknd/device/cuda/mathops_kernel.h

--- a/src/.depends_device
+++ b/src/.depends_device
@@ -74,3 +74,4 @@ bc/bcknd/device/opencl/inhom_dirichlet.o : bc/bcknd/device/opencl/inhom_dirichle
 bc/bcknd/device/opencl/dong_outflow.o : bc/bcknd/device/opencl/dong_outflow.c bc/bcknd/device/opencl/dong_outflow_kernel.cl.h
 fluid/bcknd/device/opencl/fluid_abbdf.o : fluid/bcknd/device/opencl/fluid_abbdf.c fluid/bcknd/device/opencl/abbdf_kernel.cl.h
 fluid/bcknd/device/opencl/pnpn_res.o : fluid/bcknd/device/opencl/pnpn_res.c fluid/bcknd/device/opencl/pnpn_res_kernel.cl.h
+sem/bcknd/device/opencl/coef.o : sem/bcknd/device/opencl/coef.c sem/bcknd/device/opencl/coef_kernel.cl.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -221,7 +221,8 @@ libneko_a_SOURCES += \
 	bc/bcknd/device/hip/inhom_dirichlet.hip\
 	bc/bcknd/device/hip/dong_outflow.hip\
 	fluid/bcknd/device/hip/fluid_abbdf.hip\
-	fluid/bcknd/device/hip/pnpn_res.hip
+	fluid/bcknd/device/hip/pnpn_res.hip\
+	sem/bcknd/device/hip/coef.hip
 endif
 
 if ENABLE_CUDA

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -334,6 +334,7 @@ EXTRA_DIST = \
 	fluid/bcknd/device/cuda/makebdf_kernel.h\
 	fluid/bcknd/device/cuda/prs_res_kernel.h\
 	fluid/bcknd/device/cuda/vel_res_update_kernel.h\
+	sem/bcknd/device/cuda/coef_kernel.h\
 	bc/bcknd/device/hip/dirichlet_kernel.h\
 	bc/bcknd/device/hip/inflow_kernel.h\
 	bc/bcknd/device/hip/no_slip_wall_kernel.h\
@@ -362,6 +363,7 @@ EXTRA_DIST = \
 	krylov/bcknd/device/hip/pipecg_kernel.h\
 	krylov/bcknd/device/cuda/gmres_kernel.h\
 	krylov/bcknd/device/hip/gmres_kernel.h\
+	sem/bcknd/device/hip/coef_kernel.h\
 	bc/bcknd/device/opencl/dirichlet_kernel.cl\
 	bc/bcknd/device/opencl/inflow_kernel.cl\
 	bc/bcknd/device/opencl/no_slip_wall_kernel.cl\
@@ -384,6 +386,7 @@ EXTRA_DIST = \
 	fluid/bcknd/device/opencl/pnpn_res_kernel.cl\
 	gs/bcknd/device/opencl/gs_kernels.cl\
 	krylov/bcknd/device/opencl/jacobi_kernel.cl\
+	sem/bcknd/device/opencl/coef_kernel.cl\
 	device/opencl/jit.h\
 	device/opencl/prgm_lib.h\
 	device/opencl/check.h\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,6 +24,8 @@ neko_fortran_SOURCES = \
 	sem/space.f90\
 	sem/dofmap.f90\
 	sem/coef.f90\
+	sem/interpolation.f90\
+	sem/bcknd/device/device_coef.F90\
 	gs/gs_bcknd.f90\
 	gs/bcknd/cpu/gs_cpu.f90\
 	gs/bcknd/sx/gs_sx.f90\
@@ -161,7 +163,6 @@ neko_fortran_SOURCES = \
 	common/projection.f90\
 	comm/parmetis.F90\
 	comm/redist.f90\
-	sem/interpolation.f90\
 	krylov/pc_hsmg.f90\
 	common/signal.f90\
 	common/jobctrl.f90\
@@ -249,7 +250,8 @@ libneko_a_SOURCES += \
 	bc/bcknd/device/cuda/inhom_dirichlet.cu\
 	bc/bcknd/device/cuda/dong_outflow.cu\
 	fluid/bcknd/device/cuda/fluid_abbdf.cu\
-	fluid/bcknd/device/cuda/pnpn_res.cu
+	fluid/bcknd/device/cuda/pnpn_res.cu\
+	sem/bcknd/device/cuda/coef.cu
 endif
 
 if ENABLE_OPENCL

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -280,7 +280,8 @@ libneko_a_SOURCES += \
 	bc/bcknd/device/opencl/inhom_dirichlet.c\
 	bc/bcknd/device/opencl/dong_outflow.c\
 	fluid/bcknd/device/opencl/fluid_abbdf.c\
-	fluid/bcknd/device/opencl/pnpn_res.c
+	fluid/bcknd/device/opencl/pnpn_res.c\
+	sem/bcknd/device/opencl/coef.c
 
 %.cl.h: %.cl
 	bash ./scripts/cltostring.sh $<
@@ -298,7 +299,8 @@ CLEANFILES += math/bcknd/device/opencl/*.cl.h\
 	      gs/bcknd/device/opencl/*.cl.h\
 	      bc/bcknd/device/opencl/*.cl.h\
 	      krylov/bcknd/device/opencl/*.cl.h\
-	      fluid/bcknd/device/opencl/*.cl.h
+	      fluid/bcknd/device/opencl/*.cl.h\
+              sem/bcknd/device/opencl/*.cl.h
 endif
 
 if ENABLE_MAKEDEPF90

--- a/src/device/opencl/prgm_lib.F90
+++ b/src/device/opencl/prgm_lib.F90
@@ -73,6 +73,9 @@ module opencl_prgm_lib
   !> Device dong kernels
   type(c_ptr), bind(c) :: dong_program = C_NULL_PTR
 
+  !> Device coef kernels
+  type(c_ptr), bind(c) :: coef_program = C_NULL_PTR
+
 contains
 
   subroutine opencl_prgm_lib_release
@@ -229,6 +232,13 @@ contains
           call neko_error('Failed to release program')
        end if
        dong_program = C_NULL_PTR
+    end if
+
+    if (c_associated(coef_program)) then
+       if(clReleaseProgram(coef_program) .ne. CL_SUCCESS) then
+          call neko_error('Failed to release program')
+       end if
+       coef_program = C_NULL_PTR
     end if
     
   end subroutine opencl_prgm_lib_release

--- a/src/device/opencl/prgm_lib.h
+++ b/src/device/opencl/prgm_lib.h
@@ -71,5 +71,8 @@ extern void *schwarz_program;
 /** Device dong kernels */
 extern void *dong_program;
 
+/** Device coef kernels */
+extern void *coef_program;
+
 
 #endif

--- a/src/math/bcknd/device/cuda/math_kernel.h
+++ b/src/math/bcknd/device/cuda/math_kernel.h
@@ -215,9 +215,10 @@ __global__ void invcol1_kernel(T * __restrict__ a,
 
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const int str = blockDim.x * gridDim.x;
+  const T one = 1.0;
 
   for (int i = idx; i < n; i += str) {
-    a[i] = 1 / a[i];
+    a[i] = one / a[i];
   }
 }
 

--- a/src/math/bcknd/device/hip/math_kernel.h
+++ b/src/math/bcknd/device/hip/math_kernel.h
@@ -215,9 +215,10 @@ __global__ void invcol1_kernel(T * __restrict__ a,
 
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const int str = blockDim.x * gridDim.x;
+  const T one = 1.0;
 
   for (int i = idx; i < n; i += str) {
-    a[i] = 1 / a[i];
+    a[i] = one / a[i];
   }
 }
 

--- a/src/sem/bcknd/device/cuda/coef.cu
+++ b/src/sem/bcknd/device/cuda/coef.cu
@@ -1,0 +1,93 @@
+/*
+ Copyright (c) 2022, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stdio.h>
+#include "coef_kernel.h"
+#include <device/device_config.h>
+#include <device/cuda/check.h>
+
+extern "C" {
+  
+  /** 
+   * Fortran wrapper for generating geometric factors
+   */
+  void cuda_coef_generate_geo(void *G11, void *G12, void *G13, 
+                              void *G22, void *G23, void *G33, 
+                              void *drdx, void *drdy, void *drdz,
+                              void *dsdx, void *dsdy, void *dsdz, 
+                              void *dtdx, void *dtdy, void *dtdz, 
+                              void *jacinv, void *w3, int *nel, 
+                              int *lx, int *gdim) {
+    
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks((*nel), 1, 1);
+
+#define CASE(LX)                                                                \
+    case LX:                                                                    \
+      coef_generate_geo_kernel<real, LX, 1024>                                  \
+        <<<nblcks, nthrds>>>((real *) G11, (real *) G12, (real *) G13,          \
+                             (real *) G22, (real *) G23, (real *) G33,          \
+                             (real *) drdx, (real *) drdy, (real *) drdz,       \
+                             (real *) dsdx, (real *) dsdy, (real *) dsdz,       \
+                             (real *) dtdx, (real *) dtdy, (real *) dtdz,       \
+                             (real *) jacinv, (real *) w3, *gdim);              \
+      CUDA_CHECK(cudaGetLastError());                                           \
+      break
+    
+    switch(*lx) {
+      CASE(2);
+      CASE(3);
+      CASE(4);
+      CASE(5);
+      CASE(6);
+      CASE(7);
+      CASE(8);
+      CASE(9);
+      CASE(10);
+      CASE(11);
+      CASE(12);
+      CASE(13);
+      CASE(14);
+    default:
+      {
+        fprintf(stderr, __FILE__ ": size not supported: %d\n", *lx);
+        exit(1);
+      }
+    }
+  }
+}
+
+
+
+

--- a/src/sem/bcknd/device/cuda/coef.cu
+++ b/src/sem/bcknd/device/cuda/coef.cu
@@ -53,7 +53,7 @@ extern "C" {
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks((*nel), 1, 1);
 
-#define CASE(LX)                                                                \
+#define GEO_CASE(LX)                                                            \
     case LX:                                                                    \
       coef_generate_geo_kernel<real, LX, 1024>                                  \
         <<<nblcks, nthrds>>>((real *) G11, (real *) G12, (real *) G13,          \
@@ -66,25 +66,90 @@ extern "C" {
       break
     
     switch(*lx) {
-      CASE(2);
-      CASE(3);
-      CASE(4);
-      CASE(5);
-      CASE(6);
-      CASE(7);
-      CASE(8);
-      CASE(9);
-      CASE(10);
-      CASE(11);
-      CASE(12);
-      CASE(13);
-      CASE(14);
+      GEO_CASE(2);
+      GEO_CASE(3);
+      GEO_CASE(4);
+      GEO_CASE(5);
+      GEO_CASE(6);
+      GEO_CASE(7);
+      GEO_CASE(8);
+      GEO_CASE(9);
+      GEO_CASE(10);
+      GEO_CASE(11);
+      GEO_CASE(12);
+      GEO_CASE(13);
+      GEO_CASE(14);
     default:
       {
         fprintf(stderr, __FILE__ ": size not supported: %d\n", *lx);
         exit(1);
       }
     }
+  }
+
+  /** 
+   * Fortran wrapper for generating geometric factors
+   */
+  void cuda_coef_generate_dxyzdrst(void *drdx, void *drdy, void *drdz, 
+				   void *dsdx, void *dsdy, void *dsdz, 
+				   void *dtdx, void *dtdy, void *dtdz, 
+				   void *dxdr, void *dydr, void *dzdr, 
+				   void *dxds, void *dyds, void *dzds, 
+				   void *dxdt, void *dydt, void *dzdt,
+				   void *dx, void *dy, void *dz, 
+				   void *x, void *y, void *z,
+				   void *jacinv, void *jac,
+				   int *lx, int *nel)  {
+
+    const int n = (*nel) * (*lx) * (*lx) * (*lx);
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks_dxyz((*nel), 1, 1);
+    const dim3 nblcks_drst((n + 1024 - 1)/ 1024, 1, 1);
+
+#define DXYZDRST_CASE(LX)					               \
+    case LX:								       \
+      coef_generate_dxyz_kernel<real, LX, 1024>                                \
+	<<<nblcks_dxyz, nthrds>>>((real *) dxdr, (real *) dydr, (real *) dzdr, \
+				  (real *) dxds, (real *) dyds, (real *) dzds, \
+				  (real *) dxdt, (real *) dydt, (real *) dzdt, \
+				  (real *) dx, (real *) dy, (real *) dz,       \
+				  (real *) x, (real *) y, (real *) z);	       \
+      CUDA_CHECK(cudaGetLastError());					       \
+      break
+
+    switch(*lx) {
+      DXYZDRST_CASE(2);
+      DXYZDRST_CASE(3);
+      DXYZDRST_CASE(4);
+      DXYZDRST_CASE(5);
+      DXYZDRST_CASE(6);
+      DXYZDRST_CASE(7);
+      DXYZDRST_CASE(8);
+      DXYZDRST_CASE(9);
+      DXYZDRST_CASE(10);
+      DXYZDRST_CASE(11);
+      DXYZDRST_CASE(12);
+      DXYZDRST_CASE(13);
+      DXYZDRST_CASE(14);
+      DXYZDRST_CASE(15);
+      DXYZDRST_CASE(16);
+    default:
+      {
+        fprintf(stderr, __FILE__ ": size not supported: %d\n", *lx);
+        exit(1);
+      }
+    }
+
+    coef_generate_drst_kernel<real>
+      <<<nblcks_drst, nthrds>>>((real *) jac, (real *) jacinv, 
+                                (real *) drdx, (real *) drdy, (real *) drdz,
+                                (real *) dsdx, (real *) dsdy, (real *) dsdz,
+                                (real *) dtdx, (real *) dtdy, (real *) dtdz,
+                                (real *) dxdr, (real *) dydr, (real *) dzdr, 
+                                (real *) dxds, (real *) dyds, (real *) dzds, 
+                                (real *) dxdt, (real *) dydt, (real *) dzdt, n);
+    CUDA_CHECK(cudaGetLastError());
+
   }
 }
 

--- a/src/sem/bcknd/device/cuda/coef_kernel.h
+++ b/src/sem/bcknd/device/cuda/coef_kernel.h
@@ -1,0 +1,104 @@
+/*
+ Copyright (c) 2022, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/**
+ * Device kernel for coef geometry
+ */
+template< typename T, const int LX, const int CHUNKS >
+__global__ void coef_generate_geo_kernel(T * __restrict__ G11,
+					 T * __restrict__ G12, 
+					 T * __restrict__ G13,
+					 T * __restrict__ G22,
+					 T * __restrict__ G23, 
+					 T * __restrict__ G33,
+					 const T * __restrict__ drdx, 
+					 const T * __restrict__ drdy, 
+					 const T * __restrict__ drdz,
+					 const T * __restrict__ dsdx, 
+					 const T * __restrict__ dsdy, 
+					 const T * __restrict__ dsdz, 
+					 const T * __restrict__ dtdx,
+					 const T * __restrict__ dtdy, 
+					 const T * __restrict__ dtdz,
+					 const T * __restrict__ jacinv, 
+					 const T * __restrict__ w3,
+					 const int gdim) {
+
+  int i,j,k;
+  
+  const int e = blockIdx.x;
+  const int iii = threadIdx.x;
+  const int nchunks = (LX * LX * LX - 1) / CHUNKS + 1;
+
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  __shared__ T shw3[LX * LX * LX];
+
+  if (iii < (LX * LX * LX)) {
+    shw3[iii] = w3[iii];
+  }
+
+  j = iii;
+  while( j < (LX * LX * LX)) {
+    const int i = j + e * LX * LX * LX;
+    G11[i] = (drdx[i]*drdx[i] + drdy[i]*drdy[i] + drdz[i]*drdz[i]) * jacinv[i];
+    G22[i] = (dsdx[i]*dsdx[i] + dsdy[i]*dsdy[i] + dsdz[i]*dsdz[i]) * jacinv[i];
+    G33[i] = (dtdx[i]*dtdx[i] + dtdy[i]*dtdy[i] + dtdz[i]*dtdz[i]) * jacinv[i];
+
+    G12[i] = (drdx[i]*dsdx[i] + drdy[i]*dsdy[i] + drdz[i]*dsdz[i]) * jacinv[i];
+    G13[i] = (drdx[i]*dtdx[i] + drdy[i]*dtdy[i] + drdz[i]*dtdz[i]) * jacinv[i];
+    G23[i] = (dsdx[i]*dtdx[i] + dsdy[i]*dtdy[i] + dsdz[i]*dtdz[i]) * jacinv[i];
+    j = j + CHUNKS;
+  }
+
+  __syncthreads();
+
+  for (int n = 0; n < nchunks; n++) {
+    const int ijk = iii + n * CHUNKS;
+    const int jk = ijk / LX;
+    i = ijk - jk * LX;
+    k = jk / LX;
+    j = jk - k * LX;
+    if ( i < LX && j < LX && k < LX) {
+      G11[ijk + e * LX * LX * LX] *= shw3[ijk];
+      G12[ijk + e * LX * LX * LX] *= shw3[ijk];
+      G13[ijk + e * LX * LX * LX] *= shw3[ijk];
+      G22[ijk + e * LX * LX * LX] *= shw3[ijk];
+      G23[ijk + e * LX * LX * LX] *= shw3[ijk];
+      G33[ijk + e * LX * LX * LX] *= shw3[ijk];
+    }
+  }
+}
+

--- a/src/sem/bcknd/device/cuda/coef_kernel.h
+++ b/src/sem/bcknd/device/cuda/coef_kernel.h
@@ -257,6 +257,7 @@ __global__ void coef_generate_drst_kernel(T * __restrict__ jac,
 				
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const int str = blockDim.x * gridDim.x;
+  const T one = 1.0;
 
   for (int i = idx; i < n; i += str) {
     jac[i] = (dxdr[i] * dyds[i] * dzdt[i])
@@ -265,7 +266,7 @@ __global__ void coef_generate_drst_kernel(T * __restrict__ jac,
            - (dxdr[i] * dydt[i] * dzds[i])
            - (dxds[i] * dydr[i] * dzdt[i])
            - (dxdt[i] * dyds[i] * dzdr[i]);
-    jacinv[i] = 1.0 / jac[i];    
+    jacinv[i] = one / jac[i];    
 
     drdx[i] = dyds[i]*dzdt[i] - dydt[i]*dzds[i];
     drdy[i] = dxdt[i]*dzds[i] - dxds[i]*dzdt[i];

--- a/src/sem/bcknd/device/cuda/coef_kernel.h
+++ b/src/sem/bcknd/device/cuda/coef_kernel.h
@@ -61,9 +61,6 @@ __global__ void coef_generate_geo_kernel(T * __restrict__ G11,
   const int iii = threadIdx.x;
   const int nchunks = (LX * LX * LX - 1) / CHUNKS + 1;
 
-  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
-  const int str = blockDim.x * gridDim.x;
-
   __shared__ T shw3[LX * LX * LX];
 
   if (iii < (LX * LX * LX)) {
@@ -102,3 +99,184 @@ __global__ void coef_generate_geo_kernel(T * __restrict__ G11,
   }
 }
 
+/**
+ * Device kernel for coef dxyz
+ */
+template< typename T, const int LX, const int CHUNKS >
+__global__ void coef_generate_dxyz_kernel(T * __restrict__ dxdr, 
+					  T * __restrict__ dydr, 
+					  T * __restrict__ dzdr, 
+					  T * __restrict__ dxds, 
+					  T * __restrict__ dyds, 
+					  T * __restrict__ dzds, 
+					  T * __restrict__ dxdt, 
+					  T * __restrict__ dydt, 
+					  T * __restrict__ dzdt,
+					  const T * __restrict__ dx, 
+					  const T * __restrict__ dy, 
+					  const T * __restrict__ dz, 
+					  const T * __restrict__ x, 
+					  const T * __restrict__ y, 
+					  const T * __restrict__ z) {
+
+  int i,j,k;
+  
+  const int e = blockIdx.x;
+  const int iii = threadIdx.x;
+  const int nchunks = (LX * LX * LX - 1) / CHUNKS + 1;
+
+  __shared__ T shdx[LX * LX];
+  __shared__ T shdy[LX * LX];
+  __shared__ T shdz[LX * LX];
+
+  __shared__ T shu[LX * LX * LX];
+
+  if (iii < (LX * LX)) {
+    shdx[iii] = dx[iii];
+    shdy[iii] = dy[iii];
+    shdz[iii] = dz[iii];
+  }
+
+  j = iii;
+  while(j < (LX * LX * LX)) {
+    shu[iii] = x[j + e * LX * LX * LX];
+    j = j + CHUNKS;
+  }
+
+  __syncthreads();
+   
+  for (int n = 0; n < nchunks; n++) {
+    const int ijk = iii + n * CHUNKS;
+    const int jk = ijk / LX;
+    i = ijk - jk * LX;
+    k = jk / LX;
+    j = jk - k * LX;
+    if ( i < LX && j < LX && k < LX) {
+      T rtmp = 0.0;
+      T stmp = 0.0;
+      T ttmp = 0.0;
+      for (int l = 0; l < LX; l++) {		
+	rtmp += shdx[i + l * LX] * shu[l + j * LX + k * LX * LX];	
+	stmp += shdy[j + l * LX] * shu[i + l * LX + k * LX * LX];
+	ttmp += shdz[k + l * LX] * shu[i + j * LX + l * LX * LX];	
+      } 
+      dxdr[ijk + e * LX * LX * LX] = rtmp;
+      dxds[ijk + e * LX * LX * LX] = stmp;
+      dxdt[ijk + e * LX * LX * LX] = ttmp;
+    }
+  }
+
+  __syncthreads();
+
+  j = iii;
+  while(j < (LX * LX * LX)) {
+    shu[iii] = y[j + e * LX * LX * LX];
+    j = j + CHUNKS;
+  }
+
+  __syncthreads();
+   
+  for (int n = 0; n < nchunks; n++) {
+    const int ijk = iii + n * CHUNKS;
+    const int jk = ijk / LX;
+    i = ijk - jk * LX;
+    k = jk / LX;
+    j = jk - k * LX;
+    if ( i < LX && j < LX && k < LX) {
+      T rtmp = 0.0;
+      T stmp = 0.0;
+      T ttmp = 0.0;
+      for (int l = 0; l < LX; l++) {		
+	rtmp += shdx[i + l * LX] * shu[l + j * LX + k * LX * LX];	
+	stmp += shdy[j + l * LX] * shu[i + l * LX + k * LX * LX];
+	ttmp += shdz[k + l * LX] * shu[i + j * LX + l * LX * LX];	
+      } 
+      dydr[ijk + e * LX * LX * LX] = rtmp;
+      dyds[ijk + e * LX * LX * LX] = stmp;
+      dydt[ijk + e * LX * LX * LX] = ttmp;
+    }
+  }
+
+  __syncthreads();
+
+  j = iii;
+  while(j < (LX * LX * LX)) {
+    shu[iii] = z[j + e * LX * LX * LX];
+    j = j + CHUNKS;
+  }
+
+  __syncthreads();
+   
+  for (int n = 0; n < nchunks; n++) {
+    const int ijk = iii + n * CHUNKS;
+    const int jk = ijk / LX;
+    i = ijk - jk * LX;
+    k = jk / LX;
+    j = jk - k * LX;
+    if ( i < LX && j < LX && k < LX) {
+      T rtmp = 0.0;
+      T stmp = 0.0;
+      T ttmp = 0.0;
+      for (int l = 0; l < LX; l++) {		
+	rtmp += shdx[i + l * LX] * shu[l + j * LX + k * LX * LX];	
+	stmp += shdy[j + l * LX] * shu[i + l * LX + k * LX * LX];
+	ttmp += shdz[k + l * LX] * shu[i + j * LX + l * LX * LX];	
+      } 
+      dzdr[ijk + e * LX * LX * LX] = rtmp;
+      dzds[ijk + e * LX * LX * LX] = stmp;
+      dzdt[ijk + e * LX * LX * LX] = ttmp;
+    }
+  }
+}
+
+/**
+ * Device kernel for coef drst
+ */
+template< typename T >
+__global__ void coef_generate_drst_kernel(T * __restrict__ jac,
+					  T * __restrict__ jacinv,
+					  T * __restrict__ drdx,
+					  T * __restrict__ drdy,
+					  T * __restrict__ drdz,
+					  T * __restrict__ dsdx,
+					  T * __restrict__ dsdy,
+					  T * __restrict__ dsdz,
+					  T * __restrict__ dtdx,
+					  T * __restrict__ dtdy,
+					  T * __restrict__ dtdz,
+					  const T * __restrict__ dxdr, 
+					  const T * __restrict__ dydr, 
+					  const T * __restrict__ dzdr, 
+					  const T * __restrict__ dxds, 
+					  const T * __restrict__ dyds, 
+					  const T * __restrict__ dzds, 
+					  const T * __restrict__ dxdt, 
+					  const T * __restrict__ dydt, 
+					  const T * __restrict__ dzdt,
+					  const int n) {
+				
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  for (int i = idx; i < n; i += str) {
+    jac[i] = (dxdr[i] * dyds[i] * dzdt[i])
+           + (dxdt[i] * dydr[i] * dzds[i])
+           + (dxds[i] * dydt[i] * dzdr[i])
+           - (dxdr[i] * dydt[i] * dzds[i])
+           - (dxds[i] * dydr[i] * dzdt[i])
+           - (dxdt[i] * dyds[i] * dzdr[i]);
+    jacinv[i] = 1.0 / jac[i];    
+
+    drdx[i] = dyds[i]*dzdt[i] - dydt[i]*dzds[i];
+    drdy[i] = dxdt[i]*dzds[i] - dxds[i]*dzdt[i];
+    drdz[i] = dxds[i]*dydt[i] - dxdt[i]*dyds[i];
+    dsdx[i] = dydt[i]*dzdr[i] - dydr[i]*dzdt[i];
+    dsdy[i] = dxdr[i]*dzdt[i] - dxdt[i]*dzdr[i];
+    dsdz[i] = dxdt[i]*dydr[i] - dxdr[i]*dydt[i];
+    dtdx[i] = dydr[i]*dzds[i] - dyds[i]*dzdr[i];
+    dtdy[i] = dxds[i]*dzdr[i] - dxdr[i]*dzds[i];
+    dtdz[i] = dxdr[i]*dyds[i] - dxds[i]*dydr[i];
+
+  }
+
+}

--- a/src/sem/bcknd/device/device_coef.F90
+++ b/src/sem/bcknd/device/device_coef.F90
@@ -37,6 +37,20 @@ module device_coef
   implicit none
 
 #ifdef HAVE_HIP
+    interface
+     subroutine hip_coef_generate_geo(G11, G12, G13, G22, G23, G33, &
+          drdx, drdy, drdz, dsdx, dsdy, dsdz, dtdx, dtdy, dtdz, &
+          jacinv, w3, nel, lx, gdim) &
+          bind(c, name='hip_coef_generate_geo')
+       use, intrinsic :: iso_c_binding
+       type(c_ptr), value :: G11, G12, G13, G22, G23, G33
+       type(c_ptr), value :: drdx, drdy, drdz
+       type(c_ptr), value :: dsdx, dsdy, dsdz 
+       type(c_ptr), value :: dtdx, dtdy, dtdz
+       type(c_ptr), value :: jacinv, w3
+       integer(c_int) :: nel, gdim, lx
+     end subroutine hip_coef_generate_geo
+  end interface
 #elif HAVE_CUDA
   interface
      subroutine cuda_coef_generate_geo(G11, G12, G13, G22, G23, G33, &
@@ -68,6 +82,9 @@ contains
     integer :: nel, gdim, lx
 
 #ifdef HAVE_HIP
+    call hip_coef_generate_geo(G11_d, G12_d, G13_d, G22_d, G23_d, &
+         G33_d, drdx_d, drdy_d, drdz_d, dsdx_d, dsdy_d, dsdz_d, &
+         dtdx_d, dtdy_d, dtdz_d, jacinv_d, w3_d, nel, lx, gdim)
 #elif HAVE_CUDA
     call cuda_coef_generate_geo(G11_d, G12_d, G13_d, G22_d, G23_d, &
          G33_d, drdx_d, drdy_d, drdz_d, dsdx_d, dsdy_d, dsdz_d, &

--- a/src/sem/bcknd/device/device_coef.F90
+++ b/src/sem/bcknd/device/device_coef.F90
@@ -43,6 +43,7 @@ module device_coef
           jacinv, w3, nel, lx, gdim) &
           bind(c, name='hip_coef_generate_geo')
        use, intrinsic :: iso_c_binding
+       implicit none
        type(c_ptr), value :: G11, G12, G13, G22, G23, G33
        type(c_ptr), value :: drdx, drdy, drdz
        type(c_ptr), value :: dsdx, dsdy, dsdz 
@@ -51,6 +52,25 @@ module device_coef
        integer(c_int) :: nel, gdim, lx
      end subroutine hip_coef_generate_geo
   end interface
+
+  interface
+     subroutine hip_coef_generate_dxyzdrst(drdx, drdy, drdz, dsdx, dsdy, &
+          dsdz, dtdx, dtdy, dtdz, dxdr, dydr, dzdr, dxds, dyds, dzds, dxdt, &
+          dydt, dzdt, dx, dy, dz, x, y, z, jacinv, jac, lx, nel) &
+          bind(c, name='hip_coef_generate_dxyzdrst')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr), value :: drdx, drdy, drdz
+       type(c_ptr), value :: dsdx, dsdy, dsdz
+       type(c_ptr), value :: dtdx, dtdy, dtdz
+       type(c_ptr), value :: dxdr, dydr, dzdr
+       type(c_ptr), value :: dxds, dyds, dzds
+       type(c_ptr), value :: dxdt, dydt, dzdt
+       type(c_ptr), value :: dx, dy, dz, x, y, z
+       type(c_ptr), value :: jacinv, jac
+       integer(c_int) :: lx, nel
+     end subroutine hip_coef_generate_dxyzdrst
+  end interface
 #elif HAVE_CUDA
   interface
      subroutine cuda_coef_generate_geo(G11, G12, G13, G22, G23, G33, &
@@ -58,6 +78,7 @@ module device_coef
           jacinv, w3, nel, lx, gdim) &
           bind(c, name='cuda_coef_generate_geo')
        use, intrinsic :: iso_c_binding
+       implicit none
        type(c_ptr), value :: G11, G12, G13, G22, G23, G33
        type(c_ptr), value :: drdx, drdy, drdz
        type(c_ptr), value :: dsdx, dsdy, dsdz 
@@ -73,6 +94,7 @@ module device_coef
           dydt, dzdt, dx, dy, dz, x, y, z, jacinv, jac, lx, nel) &
           bind(c, name='cuda_coef_generate_dxyzdrst')
        use, intrinsic :: iso_c_binding
+       implicit none
        type(c_ptr), value :: drdx, drdy, drdz
        type(c_ptr), value :: dsdx, dsdy, dsdz
        type(c_ptr), value :: dtdx, dtdy, dtdz
@@ -81,7 +103,7 @@ module device_coef
        type(c_ptr), value :: dxdt, dydt, dzdt
        type(c_ptr), value :: dx, dy, dz, x, y, z
        type(c_ptr), value :: jacinv, jac
-       integer(c_int) :: lx, nelf
+       integer(c_int) :: lx, nel
      end subroutine cuda_coef_generate_dxyzdrst
   end interface
 #elif HAVE_OPENCL
@@ -91,6 +113,7 @@ module device_coef
           jacinv, w3, nel, lx, gdim) &
           bind(c, name='opencl_coef_generate_geo')
        use, intrinsic :: iso_c_binding
+       implicit none
        type(c_ptr), value :: G11, G12, G13, G22, G23, G33
        type(c_ptr), value :: drdx, drdy, drdz
        type(c_ptr), value :: dsdx, dsdy, dsdz 
@@ -106,6 +129,7 @@ module device_coef
           dydt, dzdt, dx, dy, dz, x, y, z, jacinv, jac, lx, nel) &
           bind(c, name='opencl_coef_generate_dxyzdrst')
        use, intrinsic :: iso_c_binding
+       implicit none
        type(c_ptr), value :: drdx, drdy, drdz
        type(c_ptr), value :: dsdx, dsdy, dsdz
        type(c_ptr), value :: dtdx, dtdy, dtdz
@@ -114,7 +138,7 @@ module device_coef
        type(c_ptr), value :: dxdt, dydt, dzdt
        type(c_ptr), value :: dx, dy, dz, x, y, z
        type(c_ptr), value :: jacinv, jac
-       integer(c_int) :: lx, nelf
+       integer(c_int) :: lx, nel
      end subroutine opencl_coef_generate_dxyzdrst
   end interface
 #endif
@@ -164,6 +188,10 @@ contains
     integer :: lx, nel
 
 #ifdef HAVE_HIP
+    call hip_coef_generate_dxyzdrst(drdx_d, drdy_d, drdz_d, dsdx_d, &
+         dsdy_d, dsdz_d, dtdx_d, dtdy_d, dtdz_d, dxdr_d, dydr_d, &
+         dzdr_d, dxds_d, dyds_d, dzds_d, dxdt_d, dydt_d, dzdt_d, &
+         dx_d, dy_d, dz_d, x_d, y_d, z_d, jacinv_d, jac_d, lx, nel)
 #elif HAVE_CUDA
     call cuda_coef_generate_dxyzdrst(drdx_d, drdy_d, drdz_d, dsdx_d, &
          dsdy_d, dsdz_d, dtdx_d, dtdy_d, dtdz_d, dxdr_d, dydr_d, &

--- a/src/sem/bcknd/device/device_coef.F90
+++ b/src/sem/bcknd/device/device_coef.F90
@@ -66,6 +66,24 @@ module device_coef
        integer(c_int) :: nel, gdim, lx
      end subroutine cuda_coef_generate_geo
   end interface
+
+  interface
+     subroutine cuda_coef_generate_dxyzdrst(drdx, drdy, drdz, dsdx, dsdy, &
+          dsdz, dtdx, dtdy, dtdz, dxdr, dydr, dzdr, dxds, dyds, dzds, dxdt, &
+          dydt, dzdt, dx, dy, dz, x, y, z, jacinv, jac, lx, nel) &
+          bind(c, name='cuda_coef_generate_dxyzdrst')
+       use, intrinsic :: iso_c_binding
+       type(c_ptr), value :: drdx, drdy, drdz
+       type(c_ptr), value :: dsdx, dsdy, dsdz
+       type(c_ptr), value :: dtdx, dtdy, dtdz
+       type(c_ptr), value :: dxdr, dydr, dzdr
+       type(c_ptr), value :: dxds, dyds, dzds
+       type(c_ptr), value :: dxdt, dydt, dzdt
+       type(c_ptr), value :: dx, dy, dz, x, y, z
+       type(c_ptr), value :: jacinv, jac
+       integer(c_int) :: lx, nelf
+     end subroutine cuda_coef_generate_dxyzdrst
+  end interface
 #elif HAVE_OPENCL
   interface
      subroutine opencl_coef_generate_geo(G11, G12, G13, G22, G23, G33, &
@@ -112,5 +130,31 @@ contains
 #endif
 
   end subroutine device_coef_generate_geo
+
+  subroutine device_coef_generate_dxydrst(drdx_d, drdy_d, drdz_d, dsdx_d, dsdy_d,&
+       dsdz_d, dtdx_d, dtdy_d, dtdz_d, dxdr_d, dydr_d, dzdr_d, dxds_d, &
+       dyds_d, dzds_d, dxdt_d, dydt_d, dzdt_d, dx_d, dy_d, dz_d, &
+       x_d, y_d, z_d, jacinv_d, jac_d, lx, nel)
+    type(c_ptr) :: drdx_d, drdy_d, drdz_d
+    type(c_ptr) :: dsdx_d, dsdy_d, dsdz_d
+    type(c_ptr) :: dtdx_d, dtdy_d, dtdz_d
+    type(c_ptr) :: dxdr_d, dydr_d, dzdr_d
+    type(c_ptr) :: dxds_d, dyds_d, dzds_d
+    type(c_ptr) :: dxdt_d, dydt_d, dzdt_d
+    type(c_ptr) :: dx_d, dy_d, dz_d, x_d, y_d, z_d
+    type(c_ptr) :: jacinv_d, jac_d
+    integer :: lx, nel
+
+#ifdef HAVE_HIP
+#elif HAVE_CUDA
+    call cuda_coef_generate_dxyzdrst(drdx_d, drdy_d, drdz_d, dsdx_d, &
+         dsdy_d, dsdz_d, dtdx_d, dtdy_d, dtdz_d, dxdr_d, dydr_d, &
+         dzdr_d, dxds_d, dyds_d, dzds_d, dxdt_d, dydt_d, dzdt_d, &
+         dx_d, dy_d, dz_d, x_d, y_d, z_d, jacinv_d, jac_d, lx, nel)
+#elif HAVE_OPENCL
+#else
+    call neko_error('No device backend configured')
+#endif
+  end subroutine device_coef_generate_dxydrst
 
 end module device_coef

--- a/src/sem/bcknd/device/device_coef.F90
+++ b/src/sem/bcknd/device/device_coef.F90
@@ -99,6 +99,24 @@ module device_coef
        integer(c_int) :: nel, gdim, lx
      end subroutine opencl_coef_generate_geo
   end interface
+
+  interface
+     subroutine opencl_coef_generate_dxyzdrst(drdx, drdy, drdz, dsdx, dsdy, &
+          dsdz, dtdx, dtdy, dtdz, dxdr, dydr, dzdr, dxds, dyds, dzds, dxdt, &
+          dydt, dzdt, dx, dy, dz, x, y, z, jacinv, jac, lx, nel) &
+          bind(c, name='opencl_coef_generate_dxyzdrst')
+       use, intrinsic :: iso_c_binding
+       type(c_ptr), value :: drdx, drdy, drdz
+       type(c_ptr), value :: dsdx, dsdy, dsdz
+       type(c_ptr), value :: dtdx, dtdy, dtdz
+       type(c_ptr), value :: dxdr, dydr, dzdr
+       type(c_ptr), value :: dxds, dyds, dzds
+       type(c_ptr), value :: dxdt, dydt, dzdt
+       type(c_ptr), value :: dx, dy, dz, x, y, z
+       type(c_ptr), value :: jacinv, jac
+       integer(c_int) :: lx, nelf
+     end subroutine opencl_coef_generate_dxyzdrst
+  end interface
 #endif
 
 contains
@@ -152,6 +170,10 @@ contains
          dzdr_d, dxds_d, dyds_d, dzds_d, dxdt_d, dydt_d, dzdt_d, &
          dx_d, dy_d, dz_d, x_d, y_d, z_d, jacinv_d, jac_d, lx, nel)
 #elif HAVE_OPENCL
+    call opencl_coef_generate_dxyzdrst(drdx_d, drdy_d, drdz_d, dsdx_d, &
+         dsdy_d, dsdz_d, dtdx_d, dtdy_d, dtdz_d, dxdr_d, dydr_d, &
+         dzdr_d, dxds_d, dyds_d, dzds_d, dxdt_d, dydt_d, dzdt_d, &
+         dx_d, dy_d, dz_d, x_d, y_d, z_d, jacinv_d, jac_d, lx, nel)
 #else
     call neko_error('No device backend configured')
 #endif

--- a/src/sem/bcknd/device/device_coef.F90
+++ b/src/sem/bcknd/device/device_coef.F90
@@ -67,6 +67,20 @@ module device_coef
      end subroutine cuda_coef_generate_geo
   end interface
 #elif HAVE_OPENCL
+  interface
+     subroutine opencl_coef_generate_geo(G11, G12, G13, G22, G23, G33, &
+          drdx, drdy, drdz, dsdx, dsdy, dsdz, dtdx, dtdy, dtdz, &
+          jacinv, w3, nel, lx, gdim) &
+          bind(c, name='opencl_coef_generate_geo')
+       use, intrinsic :: iso_c_binding
+       type(c_ptr), value :: G11, G12, G13, G22, G23, G33
+       type(c_ptr), value :: drdx, drdy, drdz
+       type(c_ptr), value :: dsdx, dsdy, dsdz 
+       type(c_ptr), value :: dtdx, dtdy, dtdz
+       type(c_ptr), value :: jacinv, w3
+       integer(c_int) :: nel, gdim, lx
+     end subroutine opencl_coef_generate_geo
+  end interface
 #endif
 
 contains
@@ -90,6 +104,9 @@ contains
          G33_d, drdx_d, drdy_d, drdz_d, dsdx_d, dsdy_d, dsdz_d, &
          dtdx_d, dtdy_d, dtdz_d, jacinv_d, w3_d, nel, lx, gdim)
 #elif HAVE_OPENCL
+    call opencl_coef_generate_geo(G11_d, G12_d, G13_d, G22_d, G23_d, &
+         G33_d, drdx_d, drdy_d, drdz_d, dsdx_d, dsdy_d, dsdz_d, &
+         dtdx_d, dtdy_d, dtdz_d, jacinv_d, w3_d, nel, lx, gdim)
 #else
     call neko_error('No device backend configured')
 #endif

--- a/src/sem/bcknd/device/device_coef.F90
+++ b/src/sem/bcknd/device/device_coef.F90
@@ -1,0 +1,82 @@
+! Copyright (c) 2022, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+module device_coef
+  use num_types
+  use utils
+  use, intrinsic :: iso_c_binding
+  implicit none
+
+#ifdef HAVE_HIP
+#elif HAVE_CUDA
+  interface
+     subroutine cuda_coef_generate_geo(G11, G12, G13, G22, G23, G33, &
+          drdx, drdy, drdz, dsdx, dsdy, dsdz, dtdx, dtdy, dtdz, &
+          jacinv, w3, nel, lx, gdim) &
+          bind(c, name='cuda_coef_generate_geo')
+       use, intrinsic :: iso_c_binding
+       type(c_ptr), value :: G11, G12, G13, G22, G23, G33
+       type(c_ptr), value :: drdx, drdy, drdz
+       type(c_ptr), value :: dsdx, dsdy, dsdz 
+       type(c_ptr), value :: dtdx, dtdy, dtdz
+       type(c_ptr), value :: jacinv, w3
+       integer(c_int) :: nel, gdim, lx
+     end subroutine cuda_coef_generate_geo
+  end interface
+#elif HAVE_OPENCL
+#endif
+
+contains
+
+  subroutine device_coef_generate_geo(G11_d, G12_d, G13_d, G22_d, &
+       G23_d, G33_d, drdx_d, drdy_d, drdz_d, dsdx_d, dsdy_d, &
+       dsdz_d, dtdx_d, dtdy_d, dtdz_d, jacinv_d, w3_d, nel, lx, gdim)
+    type(c_ptr) :: G11_d, G12_d, G13_d, G22_d, G23_d, G33_d
+    type(c_ptr) :: drdx_d, drdy_d, drdz_d
+    type(c_ptr) :: dsdx_d, dsdy_d, dsdz_d
+    type(c_ptr) :: dtdx_d, dtdy_d, dtdz_d
+    type(c_ptr) :: jacinv_d, w3_d
+    integer :: nel, gdim, lx
+
+#ifdef HAVE_HIP
+#elif HAVE_CUDA
+    call cuda_coef_generate_geo(G11_d, G12_d, G13_d, G22_d, G23_d, &
+         G33_d, drdx_d, drdy_d, drdz_d, dsdx_d, dsdy_d, dsdz_d, &
+         dtdx_d, dtdy_d, dtdz_d, jacinv_d, w3_d, nel, lx, gdim)
+#elif HAVE_OPENCL
+#else
+    call neko_error('No device backend configured')
+#endif
+
+  end subroutine device_coef_generate_geo
+
+end module device_coef

--- a/src/sem/bcknd/device/hip/coef.hip
+++ b/src/sem/bcknd/device/hip/coef.hip
@@ -1,0 +1,92 @@
+/*
+ Copyright (c) 2022, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stdio.h>
+#include <hip/hip_runtime.h>
+#include <device/device_config.h>
+#include <device/hip/check.h>
+#include "coef_kernel.h"
+
+extern "C" {
+  
+  /** 
+   * Fortran wrapper for generating geometric factors
+   */
+  void hip_coef_generate_geo(void *G11, void *G12, void *G13, 
+                             void *G22, void *G23, void *G33, 
+                             void *drdx, void *drdy, void *drdz,
+                             void *dsdx, void *dsdy, void *dsdz, 
+                             void *dtdx, void *dtdy, void *dtdz, 
+                             void *jacinv, void *w3, int *nel, 
+                             int *lx, int *gdim) {
+    
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks((*nel), 1, 1);
+
+#define CASE(LX)                                                                \
+    case LX:                                                                    \
+      hipLaunchKernelGGL(                                                       \
+               HIP_KERNEL_NAME(coef_generate_geo_kernel<real, LX, 1024>),       \
+               nblcks, nthrds, 0, 0,                                            \
+               (real *) G11, (real *) G12, (real *) G13,                        \
+               (real *) G22, (real *) G23, (real *) G33,                        \
+               (real *) drdx, (real *) drdy, (real *) drdz,                     \
+               (real *) dsdx, (real *) dsdy, (real *) dsdz,                     \
+               (real *) dtdx, (real *) dtdy, (real *) dtdz,                     \
+               (real *) jacinv, (real *) w3, *gdim);                            \
+      HIP_CHECK(hipGetLastError());                                             \
+      break
+    
+    switch(*lx) {
+      CASE(2);
+      CASE(3);
+      CASE(4);
+      CASE(5);
+      CASE(6);
+      CASE(7);
+      CASE(8);
+      CASE(9);
+      CASE(10);
+      CASE(11);
+      CASE(12);
+      CASE(13);
+      CASE(14);
+    default:
+      {
+        fprintf(stderr, __FILE__ ": size not supported: %d\n", *lx);
+        exit(1);
+      }
+    }
+  }
+}

--- a/src/sem/bcknd/device/hip/coef.hip
+++ b/src/sem/bcknd/device/hip/coef.hip
@@ -54,7 +54,7 @@ extern "C" {
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks((*nel), 1, 1);
 
-#define CASE(LX)                                                                \
+#define GEO_CASE(LX)                                                            \
     case LX:                                                                    \
       hipLaunchKernelGGL(                                                       \
                HIP_KERNEL_NAME(coef_generate_geo_kernel<real, LX, 1024>),       \
@@ -69,24 +69,92 @@ extern "C" {
       break
     
     switch(*lx) {
-      CASE(2);
-      CASE(3);
-      CASE(4);
-      CASE(5);
-      CASE(6);
-      CASE(7);
-      CASE(8);
-      CASE(9);
-      CASE(10);
-      CASE(11);
-      CASE(12);
-      CASE(13);
-      CASE(14);
+      GEO_CASE(2);
+      GEO_CASE(3);
+      GEO_CASE(4);
+      GEO_CASE(5);
+      GEO_CASE(6);
+      GEO_CASE(7);
+      GEO_CASE(8);
+      GEO_CASE(9);
+      GEO_CASE(10);
+      GEO_CASE(11);
+      GEO_CASE(12);
+      GEO_CASE(13);
+      GEO_CASE(14);
     default:
       {
         fprintf(stderr, __FILE__ ": size not supported: %d\n", *lx);
         exit(1);
       }
     }
+  }
+
+  /** 
+   * Fortran wrapper for generating geometric factors
+   */
+  void hip_coef_generate_dxyzdrst(void *drdx, void *drdy, void *drdz, 
+				  void *dsdx, void *dsdy, void *dsdz, 
+				  void *dtdx, void *dtdy, void *dtdz, 
+				  void *dxdr, void *dydr, void *dzdr, 
+				  void *dxds, void *dyds, void *dzds, 
+				  void *dxdt, void *dydt, void *dzdt,
+				  void *dx, void *dy, void *dz, 
+				  void *x, void *y, void *z,
+				  void *jacinv, void *jac,
+				  int *lx, int *nel)  {
+    
+    const int n = (*nel) * (*lx) * (*lx) * (*lx);
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks_dxyz((*nel), 1, 1);
+    const dim3 nblcks_drst((n + 1024 - 1)/ 1024, 1, 1);
+
+#define DXYZDRST_CASE(LX)					               \
+    case LX:								       \
+      hipLaunchKernelGGL(						       \
+               HIP_KERNEL_NAME(coef_generate_dxyz_kernel<real, LX, 1024>),     \
+	       nblcks_dxyz, nthrds, 0, 0,				       \
+  	       (real *) dxdr, (real *) dydr, (real *) dzdr,		       \
+	       (real *) dxds, (real *) dyds, (real *) dzds,		       \
+	       (real *) dxdt, (real *) dydt, (real *) dzdt,		       \
+	       (real *) dx, (real *) dy, (real *) dz,			       \
+	       (real *) x, (real *) y, (real *) z);			       \
+      HIP_CHECK(hipGetLastError());					       \
+      break
+
+    switch(*lx) {
+      DXYZDRST_CASE(2);
+      DXYZDRST_CASE(3);
+      DXYZDRST_CASE(4);
+      DXYZDRST_CASE(5);
+      DXYZDRST_CASE(6);
+      DXYZDRST_CASE(7);
+      DXYZDRST_CASE(8);
+      DXYZDRST_CASE(9);
+      DXYZDRST_CASE(10);
+      DXYZDRST_CASE(11);
+      DXYZDRST_CASE(12);
+      DXYZDRST_CASE(13);
+      DXYZDRST_CASE(14);
+      DXYZDRST_CASE(15);
+      DXYZDRST_CASE(16);
+    default:
+      {
+        fprintf(stderr, __FILE__ ": size not supported: %d\n", *lx);
+        exit(1);
+      }
+    }
+    
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(coef_generate_drst_kernel<real>),
+		       nblcks_drst, nthrds, 0, 0,
+		       (real *) jac, (real *) jacinv, 
+		       (real *) drdx, (real *) drdy, (real *) drdz,
+		       (real *) dsdx, (real *) dsdy, (real *) dsdz,
+		       (real *) dtdx, (real *) dtdy, (real *) dtdz,
+		       (real *) dxdr, (real *) dydr, (real *) dzdr, 
+		       (real *) dxds, (real *) dyds, (real *) dzds, 
+		       (real *) dxdt, (real *) dydt, (real *) dzdt, n);
+    HIP_CHECK(hipGetLastError());
+
   }
 }

--- a/src/sem/bcknd/device/hip/coef_kernel.h
+++ b/src/sem/bcknd/device/hip/coef_kernel.h
@@ -1,0 +1,103 @@
+/*
+ Copyright (c) 2022, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/**
+ * Device kernel for coef geometry
+ */
+template< typename T, const int LX, const int CHUNKS >
+__global__ void coef_generate_geo_kernel(T * __restrict__ G11,
+                                         T * __restrict__ G12, 
+                                         T * __restrict__ G13,
+                                         T * __restrict__ G22,
+                                         T * __restrict__ G23, 
+                                         T * __restrict__ G33,
+                                         const T * __restrict__ drdx, 
+                                         const T * __restrict__ drdy, 
+                                         const T * __restrict__ drdz,
+                                         const T * __restrict__ dsdx, 
+                                         const T * __restrict__ dsdy, 
+                                         const T * __restrict__ dsdz, 
+                                         const T * __restrict__ dtdx,
+                                         const T * __restrict__ dtdy, 
+                                         const T * __restrict__ dtdz,
+                                         const T * __restrict__ jacinv, 
+                                         const T * __restrict__ w3,
+                                         const int gdim) {
+
+  int i,j,k;
+  
+  const int e = blockIdx.x;
+  const int iii = threadIdx.x;
+  const int nchunks = (LX * LX * LX - 1) / CHUNKS + 1;
+
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  __shared__ T shw3[LX * LX * LX];
+
+  if (iii < (LX * LX * LX)) {
+    shw3[iii] = w3[iii];
+  }
+
+  j = iii;
+  while( j < (LX * LX * LX)) {
+    const int i = j + e * LX * LX * LX;
+    G11[i] = (drdx[i]*drdx[i] + drdy[i]*drdy[i] + drdz[i]*drdz[i]) * jacinv[i];
+    G22[i] = (dsdx[i]*dsdx[i] + dsdy[i]*dsdy[i] + dsdz[i]*dsdz[i]) * jacinv[i];
+    G33[i] = (dtdx[i]*dtdx[i] + dtdy[i]*dtdy[i] + dtdz[i]*dtdz[i]) * jacinv[i];
+
+    G12[i] = (drdx[i]*dsdx[i] + drdy[i]*dsdy[i] + drdz[i]*dsdz[i]) * jacinv[i];
+    G13[i] = (drdx[i]*dtdx[i] + drdy[i]*dtdy[i] + drdz[i]*dtdz[i]) * jacinv[i];
+    G23[i] = (dsdx[i]*dtdx[i] + dsdy[i]*dtdy[i] + dsdz[i]*dtdz[i]) * jacinv[i];
+    j = j + CHUNKS;
+  }
+
+  __syncthreads();
+
+  for (int n = 0; n < nchunks; n++) {
+    const int ijk = iii + n * CHUNKS;
+    const int jk = ijk / LX;
+    i = ijk - jk * LX;
+    k = jk / LX;
+    j = jk - k * LX;
+    if ( i < LX && j < LX && k < LX) {
+      G11[ijk + e * LX * LX * LX] *= shw3[ijk];
+      G12[ijk + e * LX * LX * LX] *= shw3[ijk];
+      G13[ijk + e * LX * LX * LX] *= shw3[ijk];
+      G22[ijk + e * LX * LX * LX] *= shw3[ijk];
+      G23[ijk + e * LX * LX * LX] *= shw3[ijk];
+      G33[ijk + e * LX * LX * LX] *= shw3[ijk];
+    }
+  }
+}

--- a/src/sem/bcknd/device/opencl/coef.c
+++ b/src/sem/bcknd/device/opencl/coef.c
@@ -1,0 +1,120 @@
+/*
+ Copyright (c) 2022, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+#ifdef __APPLE__
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
+
+#include <stdio.h>
+#include <math.h>
+#include <device/device_config.h>
+#include <device/opencl/jit.h>
+#include <device/opencl/prgm_lib.h>
+#include <device/opencl/check.h>
+
+#include "coef_kernel.cl.h"
+
+/** 
+ * Fortran wrapper for generating geometric factors
+ */
+void opencl_coef_generate_geo(void *G11, void *G12, void *G13, 
+                              void *G22, void *G23, void *G33, 
+                              void *drdx, void *drdy, void *drdz,
+                              void *dsdx, void *dsdy, void *dsdz, 
+                              void *dtdx, void *dtdy, void *dtdz, 
+                              void *jacinv, void *w3, int *nel, 
+                              int *lx, int *gdim) {
+
+  cl_int err;
+  int i;
+  if (coef_program == NULL)
+    opencl_kernel_jit(coef_kernel, (cl_program *) &coef_program);
+  
+  const size_t global_item_size = 256 * (*nel);
+  const size_t local_item_size = 256;
+
+  CL_CHECK(err);
+
+#define STR(X) #X
+#define CASE(LX)                                                                \
+  case LX:                                                                      \
+    {                                                                           \
+      cl_kernel kernel = clCreateKernel(coef_program,                           \
+                                   STR(coef_generate_geo_kernel_lx##LX), &err); \
+      CL_CHECK(err);                                                            \
+                                                                                \
+      CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &G11));       \
+      CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &G12));       \
+      CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &G13));       \
+      CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &G22));       \
+      CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), (void *) &G23));       \
+      CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_mem), (void *) &G33));       \
+      CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_mem), (void *) &drdx));      \
+      CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_mem), (void *) &drdy));      \
+      CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_mem), (void *) &drdz));      \
+      CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_mem), (void *) &dsdx));      \
+      CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_mem), (void *) &dsdy));     \
+      CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_mem), (void *) &dsdz));     \
+      CL_CHECK(clSetKernelArg(kernel, 12, sizeof(cl_mem), (void *) &dtdx));     \
+      CL_CHECK(clSetKernelArg(kernel, 13, sizeof(cl_mem), (void *) &dtdy));     \
+      CL_CHECK(clSetKernelArg(kernel, 14, sizeof(cl_mem), (void *) &dtdz));     \
+      CL_CHECK(clSetKernelArg(kernel, 15, sizeof(cl_mem), (void *) &jacinv));   \
+      CL_CHECK(clSetKernelArg(kernel, 16, sizeof(cl_mem), (void *) &w3));       \
+      CL_CHECK(clSetKernelArg(kernel, 17, sizeof(int), gdim));                  \
+                                                                                \
+      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,         \
+                                      kernel, 1, NULL, &global_item_size,       \
+                                      &local_item_size, 0, NULL, NULL));        \
+    }                                                                           \
+    break
+    
+  switch(*lx) {
+    CASE(2);
+    CASE(3);
+    CASE(4);
+    CASE(5);
+    CASE(6);
+    CASE(7);
+    CASE(8);
+    CASE(9);
+    CASE(10);
+    CASE(11);
+    CASE(12);
+    CASE(13);
+    CASE(14);
+  }
+}

--- a/src/sem/bcknd/device/opencl/coef_kernel.cl
+++ b/src/sem/bcknd/device/opencl/coef_kernel.cl
@@ -286,6 +286,7 @@ __kernel void coef_generate_drst_kernel(__global real * __restrict__ jac,
                                 
   const int idx = get_global_id(0);
   const int str = get_local_size(0) * get_num_groups(0);
+  const real one = 1.0;
 
   for (int i = idx; i < n; i += str) {
     jac[i] = (dxdr[i] * dyds[i] * dzdt[i])
@@ -294,7 +295,7 @@ __kernel void coef_generate_drst_kernel(__global real * __restrict__ jac,
            - (dxdr[i] * dydt[i] * dzds[i])
            - (dxds[i] * dydr[i] * dzdt[i])
            - (dxdt[i] * dyds[i] * dzdr[i]);
-    jacinv[i] = 1.0 / jac[i];    
+    jacinv[i] = one / jac[i];    
 
     drdx[i] = dyds[i]*dzdt[i] - dydt[i]*dzds[i];
     drdy[i] = dxdt[i]*dzds[i] - dxds[i]*dzdt[i];

--- a/src/sem/bcknd/device/opencl/coef_kernel.cl
+++ b/src/sem/bcknd/device/opencl/coef_kernel.cl
@@ -1,0 +1,115 @@
+/*
+ Copyright (c) 2022, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/**
+ * Device kernel for coef geometry
+ */
+#define DEFINE_GENERATE_GEO_KERNEL(LX, CHUNKS)                                 \
+__kernel                                                                       \
+void coef_generate_geo_kernel(__global real * __restrict__ G11,                \
+                              __global real * __restrict__ G12,                \
+                              __global real * __restrict__ G13,                \
+                              __global real * __restrict__ G22,                \
+                              __global real * __restrict__ G23,                \
+                              __global real * __restrict__ G33,                \
+                              __global const real * __restrict__ drdx,         \
+                              __global const real * __restrict__ drdy,         \
+                              __global const real * __restrict__ drdz,         \
+                              __global const real * __restrict__ dsdx,         \
+                              __global const real * __restrict__ dsdy,         \
+                              __global const real * __restrict__ dsdz,         \
+                              __global const real * __restrict__ dtdx,         \
+                              __global const real * __restrict__ dtdy,         \
+                              __global const real * __restrict__ dtdz,         \
+                              __global const real * __restrict__ jacinv,       \
+                              __global const real * __restrict__ w3,           \
+                              const int gdim) {                                \
+                                                                               \
+  int i,j,k;                                                                   \
+                                                                               \
+  const int e = get_group_id(0);                                               \
+  const int iii = get_local_id(0);                                             \
+  const int nchunks = (LX * LX * LX - 1) / CHUNKS + 1;                         \
+                                                                               \
+  __local real shw3[LX * LX * LX];                                             \
+                                                                               \
+  if (iii < (LX * LX * LX)) {                                                  \
+    shw3[iii] = w3[iii];                                                       \
+  }                                                                            \
+                                                                               \
+  j = iii;                                                                     \
+  while( j < (LX * LX * LX)) {                                                 \
+    const int i = j + e * LX * LX * LX;                                        \
+    G11[i] = (drdx[i]*drdx[i] + drdy[i]*drdy[i] + drdz[i]*drdz[i]) * jacinv[i];\
+    G22[i] = (dsdx[i]*dsdx[i] + dsdy[i]*dsdy[i] + dsdz[i]*dsdz[i]) * jacinv[i];\
+    G33[i] = (dtdx[i]*dtdx[i] + dtdy[i]*dtdy[i] + dtdz[i]*dtdz[i]) * jacinv[i];\
+                                                                               \
+    G12[i] = (drdx[i]*dsdx[i] + drdy[i]*dsdy[i] + drdz[i]*dsdz[i]) * jacinv[i];\
+    G13[i] = (drdx[i]*dtdx[i] + drdy[i]*dtdy[i] + drdz[i]*dtdz[i]) * jacinv[i];\
+    G23[i] = (dsdx[i]*dtdx[i] + dsdy[i]*dtdy[i] + dsdz[i]*dtdz[i]) * jacinv[i];\
+    j = j + CHUNKS;                                                            \
+  }                                                                            \
+                                                                               \
+  barrier(CLK_LOCAL_MEM_FENCE);                                                \
+                                                                               \
+  for (int n = 0; n < nchunks; n++) {                                          \
+    const int ijk = iii + n * CHUNKS;                                          \
+    const int jk = ijk / LX;                                                   \
+    i = ijk - jk * LX;                                                         \
+    k = jk / LX;                                                               \
+    j = jk - k * LX;                                                           \
+    if ( i < LX && j < LX && k < LX) {                                         \
+      G11[ijk + e * LX * LX * LX] *= shw3[ijk];                                \
+      G12[ijk + e * LX * LX * LX] *= shw3[ijk];                                \
+      G13[ijk + e * LX * LX * LX] *= shw3[ijk];                                \
+      G22[ijk + e * LX * LX * LX] *= shw3[ijk];                                \
+      G23[ijk + e * LX * LX * LX] *= shw3[ijk];                                \
+      G33[ijk + e * LX * LX * LX] *= shw3[ijk];                                \
+    }                                                                          \
+  }                                                                            \
+}
+
+#define DEFINE_GENERATE_GEO_KERNEL(2, 256)
+#define DEFINE_GENERATE_GEO_KERNEL(3, 256)
+#define DEFINE_GENERATE_GEO_KERNEL(4, 256)
+#define DEFINE_GENERATE_GEO_KERNEL(5, 256)
+#define DEFINE_GENERATE_GEO_KERNEL(6, 256)
+#define DEFINE_GENERATE_GEO_KERNEL(7, 256)
+#define DEFINE_GENERATE_GEO_KERNEL(8, 256)
+#define DEFINE_GENERATE_GEO_KERNEL(9, 256)
+#define DEFINE_GENERATE_GEO_KERNEL(10, 256)
+#define DEFINE_GENERATE_GEO_KERNEL(11, 256)
+#define DEFINE_GENERATE_GEO_KERNEL(12, 256)
+#define DEFINE_GENERATE_GEO_KERNEL(13, 256)
+#define DEFINE_GENERATE_GEO_KERNEL(14, 256)

--- a/src/sem/coef.f90
+++ b/src/sem/coef.f90
@@ -39,6 +39,7 @@ module coefs
   use math
   use mesh
   use device
+  use device_coef
   use mxm_wrapper
   use, intrinsic :: iso_c_binding
   implicit none
@@ -658,9 +659,7 @@ contains
     lxy=c%Xh%lx*c%Xh%ly
     lyz=c%Xh%ly*c%Xh%lz
        
-    associate(G11 => c%G11, G12 => c%G12, G13 => c%G13, &
-         G22 => c%G22, G23 => c%G23, G33 => c%G33, &
-         drdx => c%drdx, drdy => c%drdy, drdz => c%drdz, &
+    associate(drdx => c%drdx, drdy => c%drdy, drdz => c%drdz, &
          dsdx => c%dsdx, dsdy => c%dsdy, dsdz => c%dsdz, &
          dtdx => c%dtdx, dtdy => c%dtdy, dtdz => c%dtdz, &
          dxdr => c%dxdr, dydr => c%dydr, dzdr => c%dzdr, &
@@ -672,88 +671,94 @@ contains
          dyt => c%Xh%dyt, dzt => c%Xh%dzt, &
          jacinv => c%jacinv, jac => c%jac, n_dofs => c%dof%n_dofs)
 
-      do e = 1, c%msh%nelv
-         call mxm(dx, lx, x(1,1,1,e), lx, dxdr(1,1,1,e), lyz)
-         call mxm(dx, lx, y(1,1,1,e), lx, dydr(1,1,1,e), lyz)
-         call mxm(dx, lx, z(1,1,1,e), lx, dzdr(1,1,1,e), lyz)
-         
-         do i = 1, lz
-            call mxm(x(1,1,i,e), lx, dyt, ly, dxds(1,1,i,e), ly)
-            call mxm(y(1,1,i,e), lx, dyt, ly, dyds(1,1,i,e), ly)
-            call mxm(z(1,1,i,e), lx, dyt, ly, dzds(1,1,i,e), ly)
-         end do
-       
-         ! We actually take 2d into account, wow, need to do that for the rest.
-         if(c%msh%gdim .eq. 3) then
-            call mxm(x(1,1,1,e), lxy, dzt, lz, dxdt(1,1,1,e), lz)
-            call mxm(y(1,1,1,e), lxy, dzt, lz, dydt(1,1,1,e), lz)
-            call mxm(z(1,1,1,e), lxy, dzt, lz, dzdt(1,1,1,e), lz)
-         else
-            call rzero(dxdt(1,1,1,e), lxy)
-            call rzero(dydt(1,1,1,e), lxy)
-            call rone(dzdt(1,1,1,e), lxy)
-         end if
-      end do
-      
-      if (c%msh%gdim .eq. 2) then
-         call rzero   (jac, n_dofs)
-         call addcol3 (jac, dxdr, dyds, n_dofs)
-         call subcol3 (jac, dxds, dydr, n_dofs)
-         call copy    (drdx, dyds, n_dofs)
-         call copy    (drdy, dxds, n_dofs)
-         call chsign  (drdy, n_dofs)
-         call copy    (dsdx, dydr, n_dofs)
-         call chsign  (dsdx, n_dofs)
-         call copy    (dsdy, dxdr, n_dofs)
-         call rzero   (drdz, n_dofs)
-         call rzero   (dsdz, n_dofs)
-         call rone    (dtdz, n_dofs)
-      else
-         call rzero   (jac, n_dofs)
-         call addcol4 (jac, dxdr, dyds, dzdt, n_dofs)
-         call addcol4 (jac, dxdt, dydr, dzds, n_dofs)
-         call addcol4 (jac, dxds, dydt, dzdr, n_dofs)
-         call subcol4 (jac, dxdr, dydt, dzds, n_dofs)
-         call subcol4 (jac, dxds, dydr, dzdt, n_dofs)
-         call subcol4 (jac, dxdt, dyds, dzdr, n_dofs)
-         call ascol5  (drdx, dyds, dzdt, dydt, dzds, n_dofs)
-         call ascol5  (drdy, dxdt, dzds, dxds, dzdt, n_dofs)
-         call ascol5  (drdz, dxds, dydt, dxdt, dyds, n_dofs)
-         call ascol5  (dsdx, dydt, dzdr, dydr, dzdt, n_dofs)
-         call ascol5  (dsdy, dxdr, dzdt, dxdt, dzdr, n_dofs)
-         call ascol5  (dsdz, dxdt, dydr, dxdr, dydt, n_dofs)
-         call ascol5  (dtdx, dydr, dzds, dyds, dzdr, n_dofs)
-         call ascol5  (dtdy, dxds, dzdr, dxdr, dzds, n_dofs)
-         call ascol5  (dtdz, dxdr, dyds, dxds, dydr, n_dofs)
-      end if
-      
-      call invers2(jacinv, jac, n_dofs)
-
-      !>  @todo cleanup once we have device math in place
       if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
           (NEKO_BCKND_OPENCL .eq. 1)) then 
-         call device_memcpy(dxdr, c%dxdr_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(dydr, c%dydr_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(dzdr, c%dzdr_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(dxds, c%dxds_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(dyds, c%dyds_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(dzds, c%dzds_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(dxdt, c%dxdt_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(dydt, c%dydt_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(dzdt, c%dzdt_d, n_dofs, HOST_TO_DEVICE)       
-         call device_memcpy(drdx, c%drdx_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(drdy, c%drdy_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(drdz, c%drdz_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(dsdx, c%dsdx_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(dsdy, c%dsdy_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(dsdz, c%dsdz_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(dtdx, c%dtdx_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(dtdy, c%dtdy_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(dtdz, c%dtdz_d, n_dofs, HOST_TO_DEVICE)       
-         call device_memcpy(jac, c%jac_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(jacinv, c%jacinv_d, n_dofs, HOST_TO_DEVICE)
+
+         call device_coef_generate_dxydrst(c%drdx_d, c%drdy_d, c%drdz_d, &
+              c%dsdx_d, c%dsdy_d, c%dsdz_d, c%dtdx_d, c%dtdy_d, c%dtdz_d, &
+              c%dxdr_d, c%dydr_d, c%dzdr_d, c%dxds_d, c%dyds_d, c%dzds_d, &
+              c%dxdt_d, c%dydt_d, c%dzdt_d, c%Xh%dx_d, c%Xh%dy_d, c%Xh%dz_d, &
+              c%dof%x_d, c%dof%y_d, c%dof%z_d, c%jacinv_d, c%jac_d, &
+              c%Xh%lx, c%msh%nelv)
+
+         call device_memcpy(dxdr, c%dxdr_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(dydr, c%dydr_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(dzdr, c%dzdr_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(dxds, c%dxds_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(dyds, c%dyds_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(dzds, c%dzds_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(dxdt, c%dxdt_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(dydt, c%dydt_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(dzdt, c%dzdt_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(drdx, c%drdx_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(drdy, c%drdy_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(drdz, c%drdz_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(dsdx, c%dsdx_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(dsdy, c%dsdy_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(dsdz, c%dsdz_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(dtdx, c%dtdx_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(dtdy, c%dtdy_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(jac, c%jac_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(jacinv, c%jacinv_d, n_dofs, DEVICE_TO_HOST)
+
+      else
+         do e = 1, c%msh%nelv
+            call mxm(dx, lx, x(1,1,1,e), lx, dxdr(1,1,1,e), lyz)
+            call mxm(dx, lx, y(1,1,1,e), lx, dydr(1,1,1,e), lyz)
+            call mxm(dx, lx, z(1,1,1,e), lx, dzdr(1,1,1,e), lyz)
+            
+            do i = 1, lz
+               call mxm(x(1,1,i,e), lx, dyt, ly, dxds(1,1,i,e), ly)
+               call mxm(y(1,1,i,e), lx, dyt, ly, dyds(1,1,i,e), ly)
+               call mxm(z(1,1,i,e), lx, dyt, ly, dzds(1,1,i,e), ly)
+            end do
+       
+            ! We actually take 2d into account, wow, need to do that for the rest.
+            if(c%msh%gdim .eq. 3) then
+               call mxm(x(1,1,1,e), lxy, dzt, lz, dxdt(1,1,1,e), lz)
+               call mxm(y(1,1,1,e), lxy, dzt, lz, dydt(1,1,1,e), lz)
+               call mxm(z(1,1,1,e), lxy, dzt, lz, dzdt(1,1,1,e), lz)
+            else
+               call rzero(dxdt(1,1,1,e), lxy)
+               call rzero(dydt(1,1,1,e), lxy)
+               call rone(dzdt(1,1,1,e), lxy)
+            end if
+         end do
+
+         if (c%msh%gdim .eq. 2) then
+            call rzero   (jac, n_dofs)
+            call addcol3 (jac, dxdr, dyds, n_dofs)
+            call subcol3 (jac, dxds, dydr, n_dofs)
+            call copy    (drdx, dyds, n_dofs)
+            call copy    (drdy, dxds, n_dofs)
+            call chsign  (drdy, n_dofs)
+            call copy    (dsdx, dydr, n_dofs)
+            call chsign  (dsdx, n_dofs)
+            call copy    (dsdy, dxdr, n_dofs)
+            call rzero   (drdz, n_dofs)
+            call rzero   (dsdz, n_dofs)
+            call rone    (dtdz, n_dofs)
+         else
+            call rzero   (jac, n_dofs)
+            call addcol4 (jac, dxdr, dyds, dzdt, n_dofs)
+            call addcol4 (jac, dxdt, dydr, dzds, n_dofs)
+            call addcol4 (jac, dxds, dydt, dzdr, n_dofs)
+            call subcol4 (jac, dxdr, dydt, dzds, n_dofs)
+            call subcol4 (jac, dxds, dydr, dzdt, n_dofs)
+            call subcol4 (jac, dxdt, dyds, dzdr, n_dofs)
+            call ascol5  (drdx, dyds, dzdt, dydt, dzds, n_dofs)
+            call ascol5  (drdy, dxdt, dzds, dxds, dzdt, n_dofs)
+            call ascol5  (drdz, dxds, dydt, dxdt, dyds, n_dofs)
+            call ascol5  (dsdx, dydt, dzdr, dydr, dzdt, n_dofs)
+            call ascol5  (dsdy, dxdr, dzdt, dxdt, dzdr, n_dofs)
+            call ascol5  (dsdz, dxdt, dydr, dxdr, dydt, n_dofs)
+            call ascol5  (dtdx, dydr, dzds, dyds, dzdr, n_dofs)
+            call ascol5  (dtdy, dxds, dzdr, dxdr, dzds, n_dofs)
+            call ascol5  (dtdz, dxdr, dyds, dxds, dydr, n_dofs)
+         end if
+         
+         call invers2(jacinv, jac, n_dofs)
       end if
-      
     end associate
     
   end subroutine coef_generate_dxyzdrst
@@ -772,52 +777,61 @@ contains
          dsdx => c%dsdx, dsdy => c%dsdy, dsdz => c%dsdz, &
          dtdx => c%dtdx, dtdy => c%dtdy, dtdz => c%dtdz, &
          jacinv => c%jacinv, n_dofs => c%dof%n_dofs, w3 => c%Xh%w3)
-    
-      if(c%msh%gdim .eq. 2) then
-         call vdot2(G11, drdx, drdy, drdx, drdy, n_dofs)
-         call vdot2(G22, dsdx, dsdy, dsdx, dsdy, n_dofs)
-         call vdot2(G12, drdx, drdy, dsdx, dsdy, n_dofs)
-         call  col2(G11, jacinv, n_dofs)
-         call  col2(G22, jacinv, n_dofs)
-         call  col2(G12, jacinv, n_dofs)
-         call rzero(G33, n_dofs)
-         call rzero(G13, n_dofs)
-         call rzero(G23, n_dofs)
-      else
-         call vdot3(G11, drdx, drdy, drdz, drdx, drdy, drdz, n_dofs)
-         call vdot3(G22, dsdx, dsdy, dsdz, dsdx, dsdy, dsdz, n_dofs)
-         call vdot3(G33, dtdx, dtdy, dtdz, dtdx, dtdy, dtdz, n_dofs)
-         call vdot3(G12, drdx, drdy, drdz, dsdx, dsdy, dsdz, n_dofs)
-         call vdot3(G13, drdx, drdy, drdz, dtdx, dtdy, dtdz, n_dofs)
-         call vdot3(G23, dsdx, dsdy, dsdz, dtdx, dtdy, dtdz, n_dofs)
-         
-         call col2(G11, jacinv, n_dofs)
-         call col2(G22, jacinv, n_dofs)
-         call col2(G33, jacinv, n_dofs)
-         call col2(G12, jacinv, n_dofs)
-         call col2(G13, jacinv, n_dofs)
-         call col2(G23, jacinv, n_dofs)
-      end if
-      do e = 1, c%msh%nelv
-         call col2(G11(1,1,1,e), w3, lxyz)
-         call col2(G22(1,1,1,e), w3, lxyz)
-         call col2(G12(1,1,1,e), w3, lxyz)
-         if (c%msh%gdim .eq. 3) then
-            call col2(G33(1,1,1,e), w3, lxyz)
-            call col2(G13(1,1,1,e), w3, lxyz)
-            call col2(G23(1,1,1,e), w3, lxyz)
-         end if
-      end do
 
-      !>  @todo cleanup once we have device math in place
       if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-          (NEKO_BCKND_OPENCL .eq. 1)) then 
-         call device_memcpy(G11, c%G11_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(G22, c%G22_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(G33, c%G33_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(G12, c%G12_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(G13, c%G13_d, n_dofs, HOST_TO_DEVICE)
-         call device_memcpy(G23, c%G23_d, n_dofs, HOST_TO_DEVICE)
+           (NEKO_BCKND_OPENCL .eq. 1)) then 
+
+         call device_coef_generate_geo(c%G11_d, c%G12_d, c%G13_d, &
+                                       c%G22_d, c%G23_d, c%G33_d, &
+                                       c%drdx_d, c%drdy_d, c%drdz_d, &
+                                       c%dsdx_d, c%dsdy_d, c%dsdz_d, &
+                                       c%dtdx_d, c%dtdy_d, c%dtdz_d, &
+                                       c%jacinv_d, c%Xh%w3_d, c%msh%nelv, &
+                                       c%Xh%lx, c%msh%gdim)
+
+         call device_memcpy(G11, c%G11_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(G22, c%G22_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(G33, c%G33_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(G12, c%G12_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(G13, c%G13_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(G23, c%G23_d, n_dofs, DEVICE_TO_HOST)
+
+      else    
+         if(c%msh%gdim .eq. 2) then
+            call vdot2(G11, drdx, drdy, drdx, drdy, n_dofs)
+            call vdot2(G22, dsdx, dsdy, dsdx, dsdy, n_dofs)
+            call vdot2(G12, drdx, drdy, dsdx, dsdy, n_dofs)
+            call  col2(G11, jacinv, n_dofs)
+            call  col2(G22, jacinv, n_dofs)
+            call  col2(G12, jacinv, n_dofs)
+            call rzero(G33, n_dofs)
+            call rzero(G13, n_dofs)
+            call rzero(G23, n_dofs)
+         else
+            call vdot3(G11, drdx, drdy, drdz, drdx, drdy, drdz, n_dofs)
+            call vdot3(G22, dsdx, dsdy, dsdz, dsdx, dsdy, dsdz, n_dofs)
+            call vdot3(G33, dtdx, dtdy, dtdz, dtdx, dtdy, dtdz, n_dofs)
+            call vdot3(G12, drdx, drdy, drdz, dsdx, dsdy, dsdz, n_dofs)
+            call vdot3(G13, drdx, drdy, drdz, dtdx, dtdy, dtdz, n_dofs)
+            call vdot3(G23, dsdx, dsdy, dsdz, dtdx, dtdy, dtdz, n_dofs)
+         
+            call col2(G11, jacinv, n_dofs)
+            call col2(G22, jacinv, n_dofs)
+            call col2(G33, jacinv, n_dofs)
+            call col2(G12, jacinv, n_dofs)
+            call col2(G13, jacinv, n_dofs)
+            call col2(G23, jacinv, n_dofs)
+         end if
+         do e = 1, c%msh%nelv
+            call col2(G11(1,1,1,e), w3, lxyz)
+            call col2(G22(1,1,1,e), w3, lxyz)
+            call col2(G12(1,1,1,e), w3, lxyz)
+            if (c%msh%gdim .eq. 3) then
+               call col2(G33(1,1,1,e), w3, lxyz)
+               call col2(G13(1,1,1,e), w3, lxyz)
+               call col2(G23(1,1,1,e), w3, lxyz)
+            end if
+         end do
       end if
       
     end associate

--- a/src/sem/coef.f90
+++ b/src/sem/coef.f90
@@ -698,6 +698,7 @@ contains
          call device_memcpy(dsdz, c%dsdz_d, n_dofs, DEVICE_TO_HOST)
          call device_memcpy(dtdx, c%dtdx_d, n_dofs, DEVICE_TO_HOST)
          call device_memcpy(dtdy, c%dtdy_d, n_dofs, DEVICE_TO_HOST)
+         call device_memcpy(dtdz, c%dtdz_d, n_dofs, DEVICE_TO_HOST)
          call device_memcpy(jac, c%jac_d, n_dofs, DEVICE_TO_HOST)
          call device_memcpy(jacinv, c%jacinv_d, n_dofs, DEVICE_TO_HOST)
 


### PR DESCRIPTION
- CUDA kernels for computing geometric factors on device
- Add HIP kernel for geometric factors
- Add OpenCL kernel for geometric factors
- Map dof coords. to device
- Add CUDA kernel for dxyzdrst computation
- add missing copy
- Add missing kernels in DIST target
- Fix and add missing OpenCL kernels for device coef
- Fix ambigous use of '1.0'
- Update HIP kernels for coef
- Fix horrible bugs...
