### PR TITLE
Dont assume local .ne. shared during gs operations

### DIFF
--- a/src/gs/bcknd/cpu/gs_cpu.f90
+++ b/src/gs/bcknd/cpu/gs_cpu.f90
@@ -64,7 +64,7 @@ contains
   end subroutine gs_cpu_free
 
   !> Gather kernel
-  subroutine gs_gather_cpu(this, v, m, o, dg, u, n, gd, nb, b, op)
+  subroutine gs_gather_cpu(this, v, m, o, dg, u, n, gd, nb, b, op, shrd)
     integer, intent(inout) :: m
     integer, intent(inout) :: n
     integer, intent(inout) :: nb
@@ -75,7 +75,8 @@ contains
     integer, dimension(m), intent(inout) :: gd
     integer, dimension(nb), intent(inout) :: b
     integer, intent(inout) :: o
-    integer :: op
+    integer, intent(inout) :: op
+    logical, intent(in) :: shrd
     
     select case(op)
     case (GS_OP_ADD)
@@ -247,7 +248,7 @@ contains
   end subroutine gs_gather_kernel_max
 
   !> Scatter kernel  @todo Make the kernel abstract
-  subroutine gs_scatter_cpu(this, v, m, dg, u, n, gd, nb, b)
+  subroutine gs_scatter_cpu(this, v, m, dg, u, n, gd, nb, b, shrd)
     integer, intent(in) :: m
     integer, intent(in) :: n
     integer, intent(in) :: nb
@@ -257,6 +258,7 @@ contains
     real(kind=rp), dimension(n), intent(inout) :: u
     integer, dimension(m), intent(inout) :: gd
     integer, dimension(nb), intent(inout) :: b
+    logical, intent(in) :: shrd
         
     call gs_scatter_kernel(v, m, dg, u, n, gd, nb, b)
 

--- a/src/gs/bcknd/device/gs_device.F90
+++ b/src/gs/bcknd/device/gs_device.F90
@@ -204,7 +204,7 @@ contains
   end subroutine gs_device_free
 
   !> Gather kernel
-  subroutine gs_gather_device(this, v, m, o, dg, u, n, gd, nb, b, op)
+  subroutine gs_gather_device(this, v, m, o, dg, u, n, gd, nb, b, op, shrd)
     integer, intent(inout) :: m
     integer, intent(inout) :: n
     integer, intent(inout) :: nb
@@ -215,12 +215,14 @@ contains
     integer, dimension(m), intent(inout) :: gd
     integer, dimension(nb), intent(inout) :: b
     integer, intent(inout) :: o
-    integer :: op, i
+    integer, intent(inout) :: op
+    logical, intent(in) :: shrd
+    integer :: i
     type(c_ptr) :: u_d
 
     u_d = device_get_ptr(u)
         
-    if (this%nlocal .eq. m) then       
+    if (.not. shrd) then
        associate(v_d=>this%local_gs_d, dg_d=>this%local_dof_gs_d, &
             gd_d=>this%local_gs_dof_d, b_d=>this%local_blk_len_d, &
             bo=>this%local_blk_off, bo_d=>this%local_blk_off_d)
@@ -267,7 +269,7 @@ contains
 #endif
          
        end associate
-    else if (this%nshared .eq. m) then
+    else if (shrd) then
        associate(v_d=>this%shared_gs_d, dg_d=>this%shared_dof_gs_d, &
             gd_d=>this%shared_gs_dof_d, b_d=>this%shared_blk_len_d, &
             bo=>this%shared_blk_off, bo_d=>this%shared_blk_off_d)
@@ -326,7 +328,7 @@ contains
   end subroutine gs_gather_device
  
   !> Scatter kernel
-  subroutine gs_scatter_device(this, v, m, dg, u, n, gd, nb, b)
+  subroutine gs_scatter_device(this, v, m, dg, u, n, gd, nb, b, shrd)
     integer, intent(in) :: m
     integer, intent(in) :: n
     integer, intent(in) :: nb
@@ -336,11 +338,12 @@ contains
     real(kind=rp), dimension(n), intent(inout) :: u
     integer, dimension(m), intent(inout) :: gd
     integer, dimension(nb), intent(inout) :: b
+    logical, intent(in) :: shrd
     type(c_ptr) :: u_d
 
     u_d = device_get_ptr(u)
 
-    if (this%nlocal .eq. m) then
+    if (.not. shrd) then
        associate(v_d=>this%local_gs_d, dg_d=>this%local_dof_gs_d, &
             gd_d=>this%local_gs_dof_d, b_d=>this%local_blk_len_d, &
             bo_d=>this%local_blk_off_d)
@@ -354,7 +357,7 @@ contains
          call neko_error('No device backend configured')
 #endif
        end associate
-    else if (this%nshared .eq. m) then
+    else if (shrd) then
        associate(v_d=>this%shared_gs_d, dg_d=>this%shared_dof_gs_d, &
             gd_d=>this%shared_gs_dof_d, b_d=>this%shared_blk_len_d, &
             bo_d=>this%shared_blk_off_d)

--- a/src/gs/bcknd/sx/gs_sx.f90
+++ b/src/gs/bcknd/sx/gs_sx.f90
@@ -89,7 +89,7 @@ contains
   end subroutine gs_sx_free
 
   !> Gather kernel
-  subroutine gs_gather_sx(this, v, m, o, dg, u, n, gd, nb, b, op)
+  subroutine gs_gather_sx(this, v, m, o, dg, u, n, gd, nb, b, op, shrd)
     integer, intent(inout) :: m
     integer, intent(inout) :: n
     integer, intent(inout) :: nb
@@ -100,9 +100,10 @@ contains
     integer, dimension(m), intent(inout) :: gd
     integer, dimension(nb), intent(inout) :: b
     integer, intent(inout) :: o
-    integer :: op
+    integer, intent(inout) :: op
+    logical, intent(in) :: shrd
 
-    if (this%nlocal .eq. m) then
+    if (.not. shrd) then
        associate(w=>this%local_wrk)
          select case(op)
          case (GS_OP_ADD)
@@ -115,7 +116,7 @@ contains
             call gs_gather_kernel_max(v, m, o, dg, u, n, gd, nb, b, w)
          end select
        end associate
-    else if (this%nshared .eq. m) then
+    else if (shrd) then
        associate(w=>this%shared_wrk)
          select case(op)
          case (GS_OP_ADD)
@@ -282,7 +283,7 @@ contains
   end subroutine gs_gather_kernel_max
 
   !> Scatter kernel  @todo Make the kernel abstract
-  subroutine gs_scatter_sx(this, v, m, dg, u, n, gd, nb, b)
+  subroutine gs_scatter_sx(this, v, m, dg, u, n, gd, nb, b, shrd)
     integer, intent(in) :: m
     integer, intent(in) :: n
     integer, intent(in) :: nb
@@ -292,10 +293,11 @@ contains
     real(kind=rp), dimension(n), intent(inout) :: u
     integer, dimension(m), intent(inout) :: gd
     integer, dimension(nb), intent(inout) :: b
+    logical, intent(in) :: shrd
         
-    if (this%nlocal .eq. m) then
+    if (.not. shrd) then
        call gs_scatter_kernel(v, m, dg, u, n, gd, nb, b, this%local_wrk)
-    else if (this%nshared .eq. m) then
+    else if (shrd) then
        call gs_scatter_kernel(v, m, dg, u, n, gd, nb, b, this%shared_wrk)
     end if
 

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -1120,7 +1120,7 @@ contains
        call gs%comm%nbrecv()
 
        call gs%bcknd%gather(gs%shared_gs, l, so, gs%shared_dof_gs, u, n, &
-            gs%shared_gs_dof, gs%nshared_blks, gs%shared_blk_len, op)
+            gs%shared_gs_dof, gs%nshared_blks, gs%shared_blk_len, op, .true.)
 
        call gs%comm%nbsend(gs%shared_gs, l)
        
@@ -1129,9 +1129,9 @@ contains
     ! Gather-scatter local dofs
 
     call gs%bcknd%gather(gs%local_gs, m, lo, gs%local_dof_gs, u, n, &
-         gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, op)
+         gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, op, .false.)
     call gs%bcknd%scatter(gs%local_gs, m, gs%local_dof_gs, u, n, &
-         gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len)
+         gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, .false.)
 
     ! Scatter shared dofs
     if (pe_size .gt. 1) then
@@ -1139,7 +1139,7 @@ contains
        call gs%comm%nbwait(gs%shared_gs, l, op)
 
        call gs%bcknd%scatter(gs%shared_gs, l, gs%shared_dof_gs, u, n, &
-            gs%shared_gs_dof, gs%nshared_blks, gs%shared_blk_len)
+            gs%shared_gs_dof, gs%nshared_blks, gs%shared_blk_len, .true.)
     end if
 
   end subroutine gs_op_vector

--- a/src/gs/gs_bcknd.f90
+++ b/src/gs/gs_bcknd.f90
@@ -70,7 +70,7 @@ module gs_bcknd
   !> Abstract interface for the Gather kernel
   !! \f$ v(dg(i)) = op(v(dg(i)), u(gd(i)) \f$
   abstract interface
-     subroutine gs_gather(this, v, m, o, dg, u, n, gd, nb, b, op)
+     subroutine gs_gather(this, v, m, o, dg, u, n, gd, nb, b, op, shrd)
        import gs_bcknd_t       
        import rp
        integer, intent(inout) :: m
@@ -83,15 +83,15 @@ module gs_bcknd
        integer, dimension(m), intent(inout) :: gd
        integer, dimension(nb), intent(inout) :: b
        integer, intent(inout) :: o
-       integer :: op
-    
+       integer, intent(inout) :: op
+       logical, intent(in) :: shrd    
      end subroutine gs_gather
   end interface
   
   !> Abstract interface for the Scatter kernel
   !! \f$ u(gd(i) = v(dg(i)) \f$
   abstract interface
-     subroutine gs_scatter(this, v, m, dg, u, n, gd, nb, b)
+     subroutine gs_scatter(this, v, m, dg, u, n, gd, nb, b, shrd)
        import gs_bcknd_t       
        import rp
        integer, intent(in) :: m
@@ -103,8 +103,7 @@ module gs_bcknd
        real(kind=rp), dimension(n), intent(inout) :: u
        integer, dimension(m), intent(inout) :: gd
        integer, dimension(nb), intent(inout) :: b
-       integer :: i, j, k, blk_len
-       real(kind=rp) :: tmp       
+       logical, intent(in) :: shrd
      end subroutine gs_scatter
   end interface
 


### PR DESCRIPTION
Don't assume nshared or nlocal can be used to test if a gs operation is "shared" or "local". Closes #506
