### PR TITLE
Add external style to Doxygen

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,7 +13,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup env.
       run: |
-        sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev autoconf automake autotools-dev libopenblas-dev make git m4 python3 doxygen fonts-freefont-ttf graphviz
+        sudo apt-get update && sudo apt-get install -y git openmpi-bin libopenmpi-dev autoconf automake autotools-dev libopenblas-dev make git m4 python3 doxygen fonts-freefont-ttf graphviz
+        git clone https://github.com/ExtremeFLOW/doxygen-awesome-css doc/doxygen-awesome-css
     - name: Doxygen
       run: |
         ./regen.sh

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1085,7 +1085,7 @@ HTML_STYLESHEET        =
 # list). For an example see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_STYLESHEET  = doxygen-awesome-css/doxygen-awesome.css
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note


### PR DESCRIPTION
This adds an external css theme to the Doxygen, taken from https://github.com/ExtremeFLOW/doxygen-awesome-css doc/doxygen-awesome-css 
The theme is cloned to `docs` on the fly in `documentaion.yml`.
