### PR TITLE
Add option to select CUDA flags via configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -167,6 +167,12 @@ if (test "x${have_cuda}" = xyes ||
     test "x${have_opencl}" = xyes); then
    if test "x${enable_device_mpi}" = xyes; then
       AC_SUBST(device_mpi, .true.)
+      
+      # Make sure we have support for atomicAdd
+      if test "x${have_cuda}" = xyes; then
+      	 AS_IF([test "$CUDA_ARCH"],[],[CUDA_ARCH="-arch sm_60"])
+      fi      
+
    else
       AC_SUBST(device_mpi, .false.)
    fi
@@ -179,7 +185,9 @@ AM_CONDITIONAL([ENABLE_CUDA], [test "x${have_cuda}" = xyes])
 AM_CONDITIONAL([ENABLE_HIP], [test "x${have_hip}" = xyes])
 AM_CONDITIONAL([ENABLE_OPENCL], [test "x${have_opencl}" = xyes])
 
-
+# Set device dependent flags
+AC_SUBST(CUDA_ARCH)
+AC_SUBST(CUDA_CFLAGS)
 
 AC_CONFIG_FILES([Makefile\
 		 src/Makefile\

--- a/cuda.mk
+++ b/cuda.mk
@@ -1,2 +1,0 @@
-.cu.o:
-	$(NVCC) -arch sm_60 -I@top_builddir@/src -I@top_srcdir@/src -O3 -o $@ -c $<

--- a/m4/ax_cuda.m4
+++ b/m4/ax_cuda.m4
@@ -30,7 +30,9 @@ AC_DEFUN([AX_CUDA],[
 		   export LDFLAGS
 		   AC_PATH_PROG(NVCC, nvcc, "no")
 		fi
-
+		
+                AS_IF([test "$CUDA_CFLAGS"],[],[CUDA_CFLAGS="-O3"])
+		
 		_CC=$CC
 		AC_LANG_PUSH([C])
 		CC=$NVCC

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,4 @@
 include $(top_srcdir)/hip.mk
-include $(top_srcdir)/cuda.mk
 
 lib_LIBRARIES = libneko.a
 neko_fortran_SOURCES = \
@@ -399,3 +398,6 @@ include	.depends
 
 # Device deps. (manually updated)
 include .depends_device
+
+.cu.o:
+	$(NVCC) @CUDA_ARCH@ @CUDA_CFLAGS@ -I@top_builddir@/src -I@top_srcdir@/src -o $@ -c $<

--- a/src/gs/bcknd/device/cuda/gs_kernels.h
+++ b/src/gs/bcknd/device/cuda/gs_kernels.h
@@ -276,7 +276,9 @@ __global__ void gs_unpack_add_kernel(T * __restrict__ u,
   const int32_t idx = dof[j];
   const T val = buf[j];
   if (idx < 0) {
+#if __CUDA_ARCH__ >= 600
     atomicAdd(&u[-idx-1], val);
+#endif
   } else {
     u[idx-1] += val;
   }


### PR DESCRIPTION
Add the possibility to define `CUDA_ARCH` and `CUDA_CFLAGS` for `nvcc` during configure by issuing

```shell
./configure CUDA_ARCH=... CUDA_CFLAGS=....
```

This will also reenable builds for older devices without `atomicAdd` but without `--enable-device-mpi` 