### PR TITLE
Add option to select HIP flags via configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -188,6 +188,7 @@ AM_CONDITIONAL([ENABLE_OPENCL], [test "x${have_opencl}" = xyes])
 # Set device dependent flags
 AC_SUBST(CUDA_ARCH)
 AC_SUBST(CUDA_CFLAGS)
+AC_SUBST(HIP_HIPCC_FLAGS)
 
 AC_CONFIG_FILES([Makefile\
 		 src/Makefile\

--- a/hip.mk
+++ b/hip.mk
@@ -1,2 +1,0 @@
-.hip.o:
-	$(HIPCC) -I@top_builddir@/src -I@top_srcdir@/src -O3 -o $@ -c $<

--- a/m4/ax_hip.m4
+++ b/m4/ax_hip.m4
@@ -26,8 +26,10 @@ AC_DEFUN([AX_HIP],[
 		   LDFLAGS="$HIP_LDFLAGS $LDFLAGS"
 		   export CPPFLAGS
 		   export LDFLAGS
-		   AC_PATH_PROG(HIPCC, hipcc, "no")
+		   AS_IF([test "$HIPCC"],[],[AC_PATH_PROG(HIPCC, hipcc, "no")])
 		fi
+
+                AS_IF([test "$HIP_HIPCC_FLAGS"],[],[HIP_HIPCC_FLAGS="-O3"])
 
 		_CC=$CC
 		AC_LANG_PUSH([C])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,3 @@
-include $(top_srcdir)/hip.mk
 
 lib_LIBRARIES = libneko.a
 neko_fortran_SOURCES = \
@@ -399,5 +398,10 @@ include	.depends
 # Device deps. (manually updated)
 include .depends_device
 
+# CUDA Build rules
 .cu.o:
 	$(NVCC) @CUDA_ARCH@ @CUDA_CFLAGS@ -I@top_builddir@/src -I@top_srcdir@/src -o $@ -c $<
+
+# HIP Build rules
+.hip.o:
+	$(HIPCC) @HIP_HIPCC_FLAGS@ -I@top_builddir@/src -I@top_srcdir@/src -o $@ -c $<


### PR DESCRIPTION
Add the possibility to define `HIP_HIPCC_FLAGS` for `HIPCC` during configure by issuing

`./configure HIP_HIPCC_FLAGS=....`

