### PR TITLE
Ensure accel target is loaded on Cray platforms for device MPI

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -166,6 +166,12 @@ if (test "x${have_cuda}" = xyes ||
     test "x${have_hip}" = xyes  ||
     test "x${have_opencl}" = xyes); then
    if test "x${enable_device_mpi}" = xyes; then
+
+      # Check that necessary acceleator modules are loaded
+      if (test "x${is_cray}" = xyes || test "x${is_hpe_cray}" = xyes); then    
+      	 AX_CRAY_ACCEL
+      fi
+
       AC_SUBST(device_mpi, .true.)
       
       # Make sure we have support for atomicAdd

--- a/m4/ax_cray.m4
+++ b/m4/ax_cray.m4
@@ -168,3 +168,22 @@ AC_DEFUN([AX_CRAY_CUDATOOLKIT],[
 	fi
 	AC_SUBST(cuda_bcknd)
 ])
+
+AC_DEFUN([AX_CRAY_ACCEL], [
+	AC_MSG_CHECKING([Cray Accelerator Target])
+	if test "${CRAY_ACCEL_TARGET}"; then
+	   if test "x${CRAY_ACCEL_TARGET}" = "xhost"; then
+	      AC_MSG_RESULT([no])
+	      AC_MSG_ERROR([Invalid accelerator target (host)])
+	      have_cray_accel="no"	      
+	   else
+              AC_MSG_RESULT([yes])
+	      have_cray_accel="yes"
+	   fi
+	else
+	   AC_MSG_RESULT([no])
+	   AC_MSG_ERROR([Cray Accelerator Target not found])
+	   have_cray_accel="no"
+	fi
+	AC_SUBST(have_cray_accel)
+])


### PR DESCRIPTION
Ensure that `craype-accel-XYZ` is loaded when device MPI is requested. However, an error is thrown if the accelerator is target is `host` i.e `craype-accel-host`
