### PR TITLE
Padded version of ax_helm_kernel on CUDA to fix Bank Conflicts

### DIFF
--- a/src/math/bcknd/device/cuda/ax_helm.cu
+++ b/src/math/bcknd/device/cuda/ax_helm.cu
@@ -59,6 +59,16 @@ extern "C" {
       CUDA_CHECK(cudaGetLastError());                                           \
       break
 
+#define CASE_PADDED(LX)                                                         \
+    case LX:                                                                    \
+      ax_helm_kernel_padded<real, LX>                                           \
+      <<<nblcks, nthrds>>>((real *) w, (real *) u,                              \
+                           (real *) dx, (real *) dy, (real *) dz, (real *) h1,  \
+                           (real *) g11, (real *) g22, (real *) g33,            \
+                           (real *) g12, (real *) g13, (real *) g23);           \
+      CUDA_CHECK(cudaGetLastError());                                           \
+      break
+
     switch(*lx) {
       CASE(2);
       CASE(3);
@@ -66,7 +76,7 @@ extern "C" {
       CASE(5);
       CASE(6);
       CASE(7);
-      CASE(8);
+      CASE_PADDED(8);
       CASE(9);
       CASE(10);
       CASE(11);

--- a/src/math/bcknd/device/cuda/ax_helm_kernel.h
+++ b/src/math/bcknd/device/cuda/ax_helm_kernel.h
@@ -133,3 +133,107 @@ __global__ void ax_helm_kernel(T * __restrict__ w,
     w[ij + k*LX*LX + ele] = rw[k]; 
   }
 }
+
+/**
+ * Device kernel for axhelm with padding in shared memory to 
+ * remove bank conflicts when LX is a power of 2
+ */
+
+template< typename T, const int LX >
+__global__ void ax_helm_kernel_padded(T * __restrict__ w,
+              			      const T * __restrict__ u,
+			              const T * __restrict__ dx,
+			              const T * __restrict__ dy,
+			              const T * __restrict__ dz,
+ 			              const T * __restrict__ h1,
+			              const T * __restrict__ g11,
+			              const T * __restrict__ g22,
+			              const T * __restrict__ g33,
+			              const T * __restrict__ g12,
+			              const T * __restrict__ g13,
+			              const T * __restrict__ g23) {
+
+  __shared__ T shdx[LX * (LX+1)];
+  __shared__ T shdy[LX * (LX+1)]; 
+  __shared__ T shdz[LX * (LX+1)];
+    
+  __shared__ T shu[LX * (LX+1)];
+  __shared__ T shur[LX * LX];  // only accessed using fastest dimension
+  __shared__ T shus[LX * (LX+1)];
+
+  T ru[LX];
+  T rw[LX];
+  T rut;
+
+  const int e = blockIdx.x;
+  const int j = threadIdx.y;
+  const int i = threadIdx.x;
+  const int ij = i + j*LX;
+  const int ij_p = i + j*(LX+1);
+  const int ele = e*LX*LX*LX;
+
+  shdx[ij_p] = dx[ij];
+  shdy[ij_p] = dy[ij];
+  shdz[ij_p] = dz[ij];
+  
+#pragma unroll
+  for(int k = 0; k < LX; ++k){
+    ru[k] = u[ij + k*LX*LX + ele];
+    rw[k] = 0.0;
+  }
+
+
+  __syncthreads();
+#pragma unroll
+  for (int k = 0; k < LX; ++k){
+    const int ijk = ij + k*LX*LX; 
+    const T G00 = g11[ijk+ele];
+    const T G11 = g22[ijk+ele];
+    const T G22 = g33[ijk+ele]; 
+    const T G01 = g12[ijk+ele];
+    const T G02 = g13[ijk+ele];
+    const T G12 = g23[ijk+ele];
+    const T H1  = h1[ijk+ele];
+    T ttmp = 0.0;
+    shu[ij_p] = ru[k];
+    for (int l = 0; l < LX; l++){
+      ttmp += shdz[k+l*(LX+1)] * ru[l];
+    }
+    __syncthreads();
+    
+    T rtmp = 0.0;
+    T stmp = 0.0;
+#pragma unroll
+    for (int l = 0; l < LX; l++){
+      rtmp += shdx[i+l*(LX+1)] * shu[l+j*(LX+1)];
+      stmp += shdy[j+l*(LX+1)] * shu[i+l*(LX+1)];
+    }
+    shur[ij] = H1
+	     * (G00 * rtmp
+		+ G01 * stmp
+		+ G02 * ttmp);
+    shus[ij_p] = H1
+	     * (G01 * rtmp
+		+ G11 * stmp
+		+ G12 * ttmp);
+    rut      = H1
+	     * (G02 * rtmp
+		+ G12 * stmp 
+		+ G22 * ttmp);
+
+    __syncthreads();
+
+    T wijke = 0.0;
+#pragma unroll
+    for (int l = 0; l < LX; l++){
+      wijke += shur[l+j*LX] * shdx[l+i*(LX+1)];
+      rw[l] += rut * shdz[k+l*(LX+1)];
+      wijke += shus[i+l*(LX+1)] * shdy[l + j*(LX+1)];
+    }
+    rw[k] += wijke;
+  }
+#pragma unroll
+  for (int k = 0; k < LX; ++k){
+    w[ij + k*LX*LX + ele] = rw[k]; 
+  }
+}


### PR DESCRIPTION
For lx=8 we have bank conflicts in ax_helm_kernel, which was hurting performance. Padding the shared memory arrays where needed fixes that and improves performance.