### PR TITLE
Use Cray provided ROCm on Cray EX platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -159,7 +159,11 @@ AC_SUBST(blk_size, ${blk_size})
 AX_LIBXSMM
 
 # Checks for HIP backend
-AX_HIP
+if test "x${is_hpe_cray}" = xyes; then
+   AX_CRAY_ROCM
+else
+   AX_HIP
+fi
 
 # Checks for CUDA backend
 if test "x${is_cray}" = xyes; then

--- a/m4/ax_cray.m4
+++ b/m4/ax_cray.m4
@@ -170,6 +170,29 @@ AC_DEFUN([AX_CRAY_CUDATOOLKIT],[
 	AC_SUBST(cuda_bcknd)
 ])
 
+AC_DEFUN([AX_CRAY_ROCM],[
+	AC_ARG_WITH([hip],[],
+		    [
+		    ], [with_hip=no])
+	hip_bcknd="0"
+	if test "x${with_hip}" != xno; then
+	  AC_MSG_CHECKING([Cray ROCm Toolkit])
+	  if test "${CRAY_ROCM_VERSION}"; then
+	    AC_MSG_RESULT([yes])
+	    AC_PATH_PROG(HIPCC, hipcc, "no")
+            AS_IF([test "$HIP_HIPCC_FLAGS"],[],[HIP_HIPCC_FLAGS="-O3"])
+	    AC_DEFINE(HAVE_HIP,1,[Define if you have HIP.])
+	    have_hip="yes"
+	    hip_bcknd="1"
+	  else
+	    AC_MSG_RESULT([no])
+            AC_MSG_ERROR([Cray ROCm Toolkit not found])
+	    have_hip="no"
+	  fi
+	fi
+	AC_SUBST(hip_bcknd)
+])
+
 AC_DEFUN([AX_CRAY_ACCEL], [
 	AC_MSG_CHECKING([Cray Accelerator Target])
 	if test "${CRAY_ACCEL_TARGET}"; then


### PR DESCRIPTION
Use the Cray provided ROCm module on Cray EX platforms for HIP enabled builds
