### PR TITLE
Add ROCm/HIP builds to CI

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -80,7 +80,6 @@ jobs:
           wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
           echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
           sudo apt-get update && sudo apt-get install -y rocm-dev
-          source /etc/profile.d/rocm.sh
           ./regen.sh 
           ./configure FC=${FC} FCFLAGS="-O2 -pedantic -std=f2008 -fPIC"  --enable-real=${RP} --with-hip=/opt/rocm/hip
           make -j$(nproc)
@@ -119,7 +118,7 @@ jobs:
           mkdir releng
           tar xf neko-*.tar.gz -C releng
           cd releng/neko-*
-          ./configure FC=${FC} --enable-real=${RP} --with-cuda=/opt/rocm/hip
+          ./configure FC=${FC} FCFLAGS="-fPIC" --enable-real=${RP} --with-cuda=/opt/rocm/hip
           make -j $(nproc)
       - name: Dist (OpenCL backend)
         if: matrix.backend == 'opencl'

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -81,7 +81,7 @@ jobs:
           echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
           sudo apt-get update && sudo apt-get install -y rocm-dev
           ./regen.sh 
-          ./configure FC=${FC} FCFLAGS="-O2 -pedantic -std=f2008 -fPIC"  --enable-real=${RP} --with-hip=/opt/rocm/hip
+          ./configure FC=${FC} FCFLAGS="-O2 -pedantic -std=f2008 -fPIE"  --enable-real=${RP} --with-hip=/opt/rocm/hip
           make -j$(nproc)
       - name: Build (OpenCL backend)
         if: matrix.backend == 'opencl'
@@ -118,7 +118,7 @@ jobs:
           mkdir releng
           tar xf neko-*.tar.gz -C releng
           cd releng/neko-*
-          ./configure FC=${FC} FCFLAGS="-fPIC" --enable-real=${RP} --with-cuda=/opt/rocm/hip
+          ./configure FC=${FC} FCFLAGS="-fPIE" --enable-real=${RP} --with-cuda=/opt/rocm/hip
           make -j $(nproc)
       - name: Dist (OpenCL backend)
         if: matrix.backend == 'opencl'

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -81,7 +81,7 @@ jobs:
           echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
           sudo apt-get update && sudo apt-get install -y rocm-dev
           ./regen.sh 
-          ./configure FC=${FC} FCFLAGS="-O2 -pedantic -std=f2008 -fPIE"  --enable-real=${RP} --with-hip=/opt/rocm/hip
+          ./configure FC=${FC} FCFLAGS="-O2 -pedantic -std=f2008" HIP_HIPCC_FLAGS="-O2 -fPIE" --enable-real=${RP} --with-hip=/opt/rocm/hip
           make -j$(nproc)
       - name: Build (OpenCL backend)
         if: matrix.backend == 'opencl'
@@ -118,7 +118,7 @@ jobs:
           mkdir releng
           tar xf neko-*.tar.gz -C releng
           cd releng/neko-*
-          ./configure FC=${FC} FCFLAGS="-fPIE" --enable-real=${RP} --with-cuda=/opt/rocm/hip
+          ./configure FC=${FC} FCFLAGS="-fPIE" --enable-real=${RP} HIP_HIPCC_FLAGS="-O2 -fPIE" --with-hip=/opt/rocm/hip
           make -j $(nproc)
       - name: Dist (OpenCL backend)
         if: matrix.backend == 'opencl'

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -28,7 +28,7 @@ jobs:
           backend: cuda
         include:
         - os: ubuntu-20.04
-          setup-env: sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev autoconf automake autotools-dev libopenblas-dev make git m4 python3  cmake-curses-gui nvidia-cuda-toolkit
+          setup-env: sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev autoconf automake autotools-dev libopenblas-dev make git m4 python3  cmake-curses-gui
         - os: macos-latest
           setup-env: brew update && brew install openmpi && brew install automake
     env:
@@ -68,6 +68,7 @@ jobs:
       - name: Build (CUDA backend)        
         if: matrix.backend == 'cuda'
         run: |
+          sudo apt-get install -y nvidia-cuda-toolkit
           ./regen.sh 
           ./configure FC=${FC} FCFLAGS="-O2 -pedantic -std=f2008"  --enable-real=${RP} --with-cuda=/usr
           make -j$(nproc)

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -111,6 +111,15 @@ jobs:
           cd releng/neko-*
           ./configure FC=${FC} --enable-real=${RP} --with-cuda=/usr
           make -j $(nproc)
+      - name: Dist (HIP backend)
+        if: matrix.backend == 'hip'
+        run: |
+          make dist
+          mkdir releng
+          tar xf neko-*.tar.gz -C releng
+          cd releng/neko-*
+          ./configure FC=${FC} --enable-real=${RP} --with-cuda=/opt/rocm/hip
+          make -j $(nproc)
       - name: Dist (OpenCL backend)
         if: matrix.backend == 'opencl'
         run: |

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -80,8 +80,9 @@ jobs:
           wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
           echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
           sudo apt-get update && sudo apt-get install -y rocm-dev
+          source /etc/profile.d/rocm.sh
           ./regen.sh 
-          ./configure FC=${FC} FCFLAGS="-O2 -pedantic -std=f2008"  --enable-real=${RP} --with-hip=/opt/rocm/hip
+          ./configure FC=${FC} FCFLAGS="-O2 -pedantic -std=f2008 -fPIC"  --enable-real=${RP} --with-hip=/opt/rocm/hip
           make -j$(nproc)
       - name: Build (OpenCL backend)
         if: matrix.backend == 'opencl'

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-latest]
         compiler: [gfortran-10, gfortran-11]
-        backend: [cpu, cuda, opencl]
+        backend: [cpu, cuda, hip, opencl]
         precision: [sp, dp]
         exclude:
         - os: ubuntu-20.04
@@ -26,6 +26,8 @@ jobs:
           compiler: gfortran-10
         - os: macos-latest
           backend: cuda
+        - os: macos-latest
+          backend: hip
         include:
         - os: ubuntu-20.04
           setup-env: sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev autoconf automake autotools-dev libopenblas-dev make git m4 python3  cmake-curses-gui
@@ -71,6 +73,15 @@ jobs:
           sudo apt-get install -y nvidia-cuda-toolkit
           ./regen.sh 
           ./configure FC=${FC} FCFLAGS="-O2 -pedantic -std=f2008"  --enable-real=${RP} --with-cuda=/usr
+          make -j$(nproc)
+      - name: Build (HIP backend)        
+        if: matrix.backend == 'HIP'
+        run: |
+          wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
+          echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
+          sudo apt-get update && sudo apt-get install -y rocm-dev
+          ./regen.sh 
+          ./configure FC=${FC} FCFLAGS="-O2 -pedantic -std=f2008"  --enable-real=${RP} --with-hip=/opt/rocm/hip
           make -j$(nproc)
       - name: Build (OpenCL backend)
         if: matrix.backend == 'opencl'

--- a/src/math/bcknd/device/device_math.F90
+++ b/src/math/bcknd/device/device_math.F90
@@ -278,8 +278,8 @@ module device_math
        import c_rp
        implicit none
        type(c_ptr), value :: w_d, v_d_d, mult_d
-       real(c_rp) :: h(j)
        integer(c_int) :: j, n
+       real(c_rp) :: h(j)
      end subroutine hip_glsc3_many
   end interface
 


### PR DESCRIPTION
This adds ROCm/HIP build stages to the develop CI. Note, given the lack of accelerator hardware in the runners, unit tests are not executed.
