### PR TITLE
Avoid linking against Fortran libraries when testing for nvcc/hipcc

### DIFF
--- a/m4/ax_cuda.m4
+++ b/m4/ax_cuda.m4
@@ -34,8 +34,10 @@ AC_DEFUN([AX_CUDA],[
                 AS_IF([test "$CUDA_CFLAGS"],[],[CUDA_CFLAGS="-O3"])
 		
 		_CC=$CC
+		_LIBS=$LIBS
 		AC_LANG_PUSH([C])
 		CC=$NVCC
+		LIBS=""
 
 		AC_CHECK_LIB(cudart, cudaFree,
 		             [have_cuda=yes;CUDA_LIBS="-lcudart"],[have_cuda=no])
@@ -43,7 +45,7 @@ AC_DEFUN([AX_CUDA],[
 		if test x"${have_cuda}" = xyes; then		   
                    cuda_bcknd="1"
 		   AC_DEFINE(HAVE_CUDA,1,[Define if you have CUDA.])
-		   LIBS="$CUDA_LIBS $LIBS"
+		   LIBS="$CUDA_LIBS $_LIBS"
 		else
 		   AC_MSG_ERROR([CUDA not found])
 		fi

--- a/m4/ax_hip.m4
+++ b/m4/ax_hip.m4
@@ -32,8 +32,10 @@ AC_DEFUN([AX_HIP],[
                 AS_IF([test "$HIP_HIPCC_FLAGS"],[],[HIP_HIPCC_FLAGS="-O3"])
 
 		_CC=$CC
+		_LIBS=$LIBS
 		AC_LANG_PUSH([C])
 		CC=$HIPCC
+		LIBS=""
 
 		AC_CHECK_LIB(amdhip64, hipFree,
 		             [have_hip=yes;HIP_LIBS="-lamdhip64"],[have_hip=no])
@@ -41,7 +43,7 @@ AC_DEFUN([AX_HIP],[
 		if test x"${have_hip}" = xyes; then		   
                    hip_bcknd="1"
 		   AC_DEFINE(HAVE_HIP,1,[Define if you have HIP.])
-		   LIBS="$HIP_LIBS $LIBS"
+		   LIBS="$HIP_LIBS $_LIBS"
 		else
 		   AC_MSG_ERROR([HIP not found])
 		fi


### PR DESCRIPTION
Only link against relevant libraries when testing for nvcc/hip.

Relating to (some of) the problems in issue #569

