### PR TITLE
Runtime selection of Sync. / Async. gs pack/unpack w. device MPI

### DIFF
--- a/src/device/cuda_intf.F90
+++ b/src/device/cuda_intf.F90
@@ -124,6 +124,16 @@ module cuda_intf
   end interface
 
   interface
+     integer (c_int) function cudaStreamCreateWithFlags(stream, flags) &
+          bind(c, name='cudaStreamCreate')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr) :: stream
+       integer(c_int), value :: flags
+     end function cudaStreamCreateWithFlags
+  end interface
+
+  interface
      integer (c_int) function cudaStreamDestroy(steam) &
           bind(c, name='cudaStreamDestroy')
        use, intrinsic :: iso_c_binding

--- a/src/device/cuda_intf.F90
+++ b/src/device/cuda_intf.F90
@@ -125,7 +125,7 @@ module cuda_intf
 
   interface
      integer (c_int) function cudaStreamCreateWithFlags(stream, flags) &
-          bind(c, name='cudaStreamCreate')
+          bind(c, name='cudaStreamCreateWithFlags')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr) :: stream

--- a/src/device/device.F90
+++ b/src/device/device.F90
@@ -944,7 +944,7 @@ contains
     integer, optional :: flags
 #ifdef HAVE_HIP
     if (present(flags)) then
-       if (hipStreamCreateWithFlags(stream, flags) .ne. cudaSuccess) then
+       if (hipStreamCreateWithFlags(stream, flags) .ne. hipSuccess) then
           call neko_error('Error during stream create (w. flags)')
        end if
     else

--- a/src/device/device.F90
+++ b/src/device/device.F90
@@ -939,15 +939,28 @@ contains
   end subroutine device_sync_stream
 
   !> Create a device stream/command queue
-  subroutine device_stream_create(stream)
+  subroutine device_stream_create(stream, flags)
     type(c_ptr), intent(inout) :: stream
+    integer, optional :: flags
 #ifdef HAVE_HIP
-    if (hipStreamCreate(stream) .ne. hipSuccess) then
-       call neko_error('Error during stream create')
+    if (present(flags)) then
+       if (hipStreamCreateWithFlags(stream, flags) .ne. cudaSuccess) then
+          call neko_error('Error during stream create (w. flags)')
+       end if
+    else
+       if (hipStreamCreate(stream) .ne. hipSuccess) then
+          call neko_error('Error during stream create')
+       end if
     end if
 #elif HAVE_CUDA
-    if (cudaStreamCreate(stream) .ne. cudaSuccess) then
-       call neko_error('Error during stream create')
+    if (present(flags)) then
+       if (cudaStreamCreateWithFlags(stream, flags) .ne. cudaSuccess) then
+          call neko_error('Error during stream create (w. flags)')
+       end if
+    else
+       if (cudaStreamCreate(stream) .ne. cudaSuccess) then
+          call neko_error('Error during stream create')
+       end if
     end if
 #elif HAVE_OPENCL
     call neko_error('Not implemented yet')

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -145,12 +145,12 @@ module hip_intf
 
   interface
      integer (c_int) function hipStreamCreateWithFlags(stream, flags) &
-          bind(c, name='hipStreamCreate')
+          bind(c, name='hipStreamCreateWithFlags')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr) :: stream
        integer(c_int), value :: flags
-     end function hipStreamCreate
+     end function hipStreamCreateWithFlags
   end interface
 
   interface

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -144,6 +144,16 @@ module hip_intf
   end interface
 
   interface
+     integer (c_int) function hipStreamCreateWithFlags(stream, flags) &
+          bind(c, name='hipStreamCreate')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr) :: stream
+       integer(c_int), value :: flags
+     end function hipStreamCreate
+  end interface
+
+  interface
      integer (c_int) function hipStreamDestroy(steam) &
           bind(c, name='hipStreamDestroy')
        use, intrinsic :: iso_c_binding

--- a/src/gs/bcknd/device/cuda/gs.cu
+++ b/src/gs/bcknd/device/cuda/gs.cu
@@ -117,9 +117,17 @@ extern "C" {
     const int nthrds = 1024;
     const int nblcks = (n + nthrds - 1) / nthrds;
 
-    gs_pack_kernel<real>
-      <<<nblcks, nthrds, 0, stream>>>((real *) u_d, (real *) buf_d + offset,
-                           (int *) dof_d + offset, n);
+    if (stream == NULL) {
+      gs_pack_kernel<real>
+        <<<nblcks, nthrds>>>((real *) u_d, (real *) buf_d + offset,
+                             (int *) dof_d + offset, n);
+    }
+    else {
+      gs_pack_kernel<real>
+        <<<nblcks, nthrds, 0, stream>>>((real *) u_d, (real *) buf_d + offset,
+                                        (int *) dof_d + offset, n);
+    }
+      
     CUDA_CHECK(cudaGetLastError());
   }
 
@@ -134,9 +142,15 @@ extern "C" {
 
     switch (op) {
     case GS_OP_ADD:
-      gs_unpack_add_kernel<real>
-        <<<nblcks, nthrds, 0, stream>>>(u_d, buf_d + offset,
-                                        dof_d + offset, n);
+      if (stream == NULL) {
+        gs_unpack_add_kernel<real>
+          <<<nblcks, nthrds>>>(u_d, buf_d + offset, dof_d + offset, n);
+      }
+      else {
+        gs_unpack_add_kernel<real>
+          <<<nblcks, nthrds, 0, stream>>>(u_d, buf_d + offset,
+                                          dof_d + offset, n);
+      }
       break;
     default:
       printf("%s: unknown gs op %d\n", __FILE__, op);

--- a/src/gs/bcknd/device/cuda/gs.cu
+++ b/src/gs/bcknd/device/cuda/gs.cu
@@ -126,7 +126,7 @@ extern "C" {
    * Unpack receive buffer on device
    */
   void cuda_gs_unpack(real *u_d, int op, real *buf_d, int *dof_d,
-		      int offset, int n) {
+		      int offset, int n, cudaStream_t stream) {
 
     const int nthrds = 1024;
     const int nblcks = (n + nthrds - 1) / nthrds;
@@ -134,8 +134,8 @@ extern "C" {
     switch (op) {
     case GS_OP_ADD:
       gs_unpack_add_kernel<real>
-	<<<nblcks, nthrds>>>(u_d + offset, buf_d + offset,
-			     dof_d + offset, n);
+	<<<nblcks, nthrds, 0, stream>>>(u_d + offset, buf_d + offset,
+                                        dof_d + offset, n);
       break;
     default:
       printf("%s: unknown gs op %d\n", __FILE__, op);

--- a/src/gs/bcknd/device/cuda/gs.cu
+++ b/src/gs/bcknd/device/cuda/gs.cu
@@ -134,7 +134,7 @@ extern "C" {
     switch (op) {
     case GS_OP_ADD:
       gs_unpack_add_kernel<real>
-	<<<nblcks, nthrds, 0, stream>>>(u_d + offset, buf_d + offset,
+	<<<nblcks, nthrds, 0, stream>>>(u_d, buf_d + offset,
                                         dof_d + offset, n);
       break;
     default:

--- a/src/gs/bcknd/device/cuda/gs.cu
+++ b/src/gs/bcknd/device/cuda/gs.cu
@@ -49,8 +49,8 @@ extern "C" {
    * Fortran wrapper for device gather kernels
    */
   void cuda_gather_kernel(void *v, int *m, int *o, void *dg,
-			  void *u, int *n, void *gd, int *nb,
-			  void *b, void *bo, int *op) {
+                          void *u, int *n, void *gd, int *nb,
+                          void *b, void *bo, int *op) {
 
     if ((*m) == 0) return;
     
@@ -60,30 +60,30 @@ extern "C" {
     switch (*op) {
     case GS_OP_ADD:
       gather_kernel_add<real>
-	<<<nblcks, nthrds>>>((real *) v, *m, *o, (int *) dg,
-			     (real *) u, *n, (int *) gd,
-			     *nb, (int *) b, (int *) bo);
+        <<<nblcks, nthrds>>>((real *) v, *m, *o, (int *) dg,
+                             (real *) u, *n, (int *) gd,
+                             *nb, (int *) b, (int *) bo);
       CUDA_CHECK(cudaGetLastError());
       break;
     case GS_OP_MUL:
       gather_kernel_mul<real>
-	<<<nblcks, nthrds>>>((real *) v, *m, *o, (int *) dg,
-			     (real *) u, *n, (int *) gd,
-			     *nb, (int *) b, (int *) bo);
+        <<<nblcks, nthrds>>>((real *) v, *m, *o, (int *) dg,
+                             (real *) u, *n, (int *) gd,
+                             *nb, (int *) b, (int *) bo);
       CUDA_CHECK(cudaGetLastError());
       break;
     case GS_OP_MIN:
       gather_kernel_min<real>
-	<<<nblcks, nthrds>>>((real *) v, *m, *o, (int *) dg,
-			     (real *) u, *n, (int *) gd,
-			     *nb, (int *) b, (int *) bo);
+        <<<nblcks, nthrds>>>((real *) v, *m, *o, (int *) dg,
+                             (real *) u, *n, (int *) gd,
+                             *nb, (int *) b, (int *) bo);
       CUDA_CHECK(cudaGetLastError());
       break;
     case GS_OP_MAX:
       gather_kernel_max<real>
-	<<<nblcks, nthrds>>>((real *) v, *m, *o, (int *) dg,
-			     (real *) u, *n, (int *) gd,
-			     *nb, (int *) b, (int *) bo);
+        <<<nblcks, nthrds>>>((real *) v, *m, *o, (int *) dg,
+                             (real *) u, *n, (int *) gd,
+                             *nb, (int *) b, (int *) bo);
       CUDA_CHECK(cudaGetLastError());
       break;
     }
@@ -93,32 +93,33 @@ extern "C" {
    * Fortran wrapper for device scatter kernel
    */
   void cuda_scatter_kernel(void *v, int *m, void *dg,
-			   void *u, int *n, void *gd,
-			   int *nb, void *b, void *bo) {
+                           void *u, int *n, void *gd,
+                           int *nb, void *b, void *bo) {
 
     if ((*m) == 0) return;
-	
+        
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*m)+1024 - 1)/ 1024, 1, 1);
 
     scatter_kernel<real>
       <<<nblcks, nthrds>>>((real *) v, *m, (int *) dg,
-			   (real *) u, *n, (int *) gd,
-			   *nb, (int *) b, (int *) bo);
+                           (real *) u, *n, (int *) gd,
+                           *nb, (int *) b, (int *) bo);
     CUDA_CHECK(cudaGetLastError());
   }
 
   /**
    * Pack send buffer on device
    */
-  void cuda_gs_pack(void *u_d, void *buf_d, void *dof_d, int n) {
+  void cuda_gs_pack(void *u_d, void *buf_d, void *dof_d,
+                    int offset, int n, cudaStream_t stream) {
 
     const int nthrds = 1024;
     const int nblcks = (n + nthrds - 1) / nthrds;
 
     gs_pack_kernel<real>
-      <<<nblcks, nthrds>>>((real *) u_d, (real *) buf_d,
-			   (int *) dof_d, n);
+      <<<nblcks, nthrds, 0, stream>>>((real *) u_d, (real *) buf_d + offset,
+                           (int *) dof_d + offset, n);
     CUDA_CHECK(cudaGetLastError());
   }
 
@@ -126,7 +127,7 @@ extern "C" {
    * Unpack receive buffer on device
    */
   void cuda_gs_unpack(real *u_d, int op, real *buf_d, int *dof_d,
-		      int offset, int n, cudaStream_t stream) {
+                      int offset, int n, cudaStream_t stream) {
 
     const int nthrds = 1024;
     const int nblcks = (n + nthrds - 1) / nthrds;
@@ -134,7 +135,7 @@ extern "C" {
     switch (op) {
     case GS_OP_ADD:
       gs_unpack_add_kernel<real>
-	<<<nblcks, nthrds, 0, stream>>>(u_d, buf_d + offset,
+        <<<nblcks, nthrds, 0, stream>>>(u_d, buf_d + offset,
                                         dof_d + offset, n);
       break;
     default:

--- a/src/gs/bcknd/device/gs_device_mpi.F90
+++ b/src/gs/bcknd/device/gs_device_mpi.F90
@@ -315,6 +315,9 @@ contains
 
     u_d = device_get_ptr(u)
 
+    ! Sync device since all streams are non-blocking
+    call device_sync()
+    
     do i = 1, size(this%send_pe)
 #ifdef HAVE_HIP
        call hip_gs_pack(u_d, &
@@ -393,8 +396,10 @@ contains
     
     call device_mpi_waitall(size(this%send_pe), this%send_buf%reqs)
 
-    ! Syncing here seems to prevent some race condition
-    call device_sync()
+    ! Sync non-blocking streams
+    do done_req = 1, size(this%recv_pe)
+       call device_sync(this%stream(done_req))
+    end do
 
   end subroutine gs_device_mpi_nbwait
 

--- a/src/gs/bcknd/device/gs_device_mpi.F90
+++ b/src/gs/bcknd/device/gs_device_mpi.F90
@@ -314,26 +314,27 @@ contains
 
     u_d = device_get_ptr(u)
 
-#ifdef HAVE_HIP
-    call hip_gs_pack(u_d, &
-                     this%send_buf%buf_d, &
-                     this%send_buf%dof_d, &
-                     this%send_buf%offset(i), &
-                     this%send_buf%ndofs(i), &
-                     this%stream(i))
-#elif HAVE_CUDA
     do i = 1, size(this%send_pe)
+#ifdef HAVE_HIP
+       call hip_gs_pack(u_d, &
+                        this%send_buf%buf_d, &
+                        this%send_buf%dof_d, &
+                        this%send_buf%offset(i), &
+                        this%send_buf%ndofs(i), &
+                        this%stream(i))
+#elif HAVE_CUDA
        call cuda_gs_pack(u_d, &
                          this%send_buf%buf_d, &
                          this%send_buf%dof_d, &
                          this%send_buf%offset(i), &
                          this%send_buf%ndofs(i), &
                          this%stream(i))
-    end do
 #else
-    call neko_error('gs_device_mpi: no backend')
+       call neko_error('gs_device_mpi: no backend')
 #endif
+    end do
 
+   
     ! Consider adding a poll loop here once we have device_query in place
     do i = 1, size(this%send_pe)
        call device_sync(this%stream(i))

--- a/src/gs/bcknd/device/gs_device_mpi.F90
+++ b/src/gs/bcknd/device/gs_device_mpi.F90
@@ -69,6 +69,7 @@ module gs_device_mpi
      procedure, pass(this) :: nbwait => gs_device_mpi_nbwait
   end type gs_device_mpi_t
 
+#ifdef HAVE_HIP
   interface
     subroutine hip_gs_pack(u_d, buf_d, dof_d, n) &
           bind(c, name='hip_gs_pack')
@@ -80,16 +81,6 @@ module gs_device_mpi
   end interface
 
   interface
-    subroutine cuda_gs_pack(u_d, buf_d, dof_d, n) &
-          bind(c, name='cuda_gs_pack')
-       use, intrinsic :: iso_c_binding
-       implicit none
-       integer(c_int), value :: n
-       type(c_ptr), value :: u_d, buf_d, dof_d
-     end subroutine cuda_gs_pack
-  end interface
-
-  interface
     subroutine hip_gs_unpack(u_d, op, buf_d, dof_d, offset, n, stream) &
           bind(c, name='hip_gs_unpack')
        use, intrinsic :: iso_c_binding
@@ -97,6 +88,16 @@ module gs_device_mpi
        integer(c_int), value :: op, offset, n
        type(c_ptr), value :: u_d, buf_d, dof_d, stream
      end subroutine hip_gs_unpack
+  end interface
+#elif HAVE_CUDA  
+  interface
+    subroutine cuda_gs_pack(u_d, buf_d, dof_d, n) &
+          bind(c, name='cuda_gs_pack')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int), value :: n
+       type(c_ptr), value :: u_d, buf_d, dof_d
+     end subroutine cuda_gs_pack
   end interface
 
   interface
@@ -108,7 +109,8 @@ module gs_device_mpi
        type(c_ptr), value :: u_d, buf_d, dof_d, stream
      end subroutine cuda_gs_unpack
   end interface
-
+#endif
+  
   interface
     subroutine device_mpi_init_reqs(n, reqs) &
           bind(c, name='device_mpi_init_reqs')

--- a/src/gs/bcknd/device/gs_device_mpi.F90
+++ b/src/gs/bcknd/device/gs_device_mpi.F90
@@ -277,9 +277,10 @@ contains
     call this%send_buf%init(this%send_pe, this%send_dof, .false.)
     call this%recv_buf%init(this%recv_pe, this%recv_dof, .true.)
 
+    ! Create a set of non-blocking streams
     allocate(this%stream(size(this%recv_pe)))
     do i = 1, size(this%recv_pe)
-       call device_stream_create(this%stream(i))
+       call device_stream_create(this%stream(i), 1)
     end do
     
   end subroutine gs_device_mpi_init

--- a/src/gs/bcknd/device/gs_device_mpi.F90
+++ b/src/gs/bcknd/device/gs_device_mpi.F90
@@ -366,14 +366,14 @@ contains
        call hip_gs_unpack(u_d, op, &
                           this%recv_buf%buf_d, &
                           this%recv_buf%dof_d, &
-                          rp*this%recv_buf%offset(done_req), &
+                          this%recv_buf%offset(done_req), &
                           this%recv_buf%ndofs(done_req), &
                           this%recv_strm(done_req))
 #elif HAVE_CUDA    
        call cuda_gs_unpack(u_d, op, &
                            this%recv_buf%buf_d, &
                            this%recv_buf%dof_d, &
-                           rp*this%recv_buf%offset(done_req), &
+                           this%recv_buf%offset(done_req), &
                            this%recv_buf%ndofs(done_req), &
                            this%recv_strm(done_req))
 #else

--- a/src/gs/bcknd/device/hip/gs.hip
+++ b/src/gs/bcknd/device/hip/gs.hip
@@ -133,7 +133,7 @@ extern "C" {
    * Unpack receive buffer on device
    */
   void hip_gs_unpack(real *u_d, int op, real *buf_d, int *dof_d,
-		     int offset, int n) {
+		     int offset, int n, hipStream_t stream) {
 
     const int nthrds = 1024;
     const int nblcks = (n + nthrds - 1) / nthrds;
@@ -141,7 +141,7 @@ extern "C" {
     switch (op) {
     case GS_OP_ADD:
       hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_unpack_add_kernel<real>),
-			 nblcks, nthrds, 0, 0,
+			 nblcks, nthrds, 0, stream,
 			 u_d + offset, buf_d + offset,
 			 dof_d + offset, n);
       break;

--- a/src/gs/bcknd/device/hip/gs.hip
+++ b/src/gs/bcknd/device/hip/gs.hip
@@ -50,8 +50,8 @@ extern "C" {
    * Fortran wrapper for device gather kernels
    */
   void hip_gather_kernel(void *v, int *m, int *o, void *dg,
-			 void *u, int *n, void *gd, int *nb,
-			 void *b, void *bo, int *op) {
+                         void *u, int *n, void *gd, int *nb,
+                         void *b, void *bo, int *op) {
 
     if ((*m) == 0) return;
     
@@ -61,34 +61,34 @@ extern "C" {
     switch (*op) {
     case GS_OP_ADD:
       hipLaunchKernelGGL(HIP_KERNEL_NAME(gather_kernel_add<real>),
-			 nblcks, nthrds, 0, 0,
-			 (real *) v, *m, *o, (int *) dg,
-			 (real *) u, *n, (int *) gd,
-			 *nb, (int *) b, (int *) bo);
+                         nblcks, nthrds, 0, 0,
+                         (real *) v, *m, *o, (int *) dg,
+                         (real *) u, *n, (int *) gd,
+                         *nb, (int *) b, (int *) bo);
       HIP_CHECK(hipGetLastError());
       break;
     case GS_OP_MUL:
       hipLaunchKernelGGL(HIP_KERNEL_NAME(gather_kernel_mul<real>),
-			 nblcks, nthrds, 0, 0,
-			 (real *) v, *m, *o, (int *) dg,
-			 (real *) u, *n, (int *) gd,
-			 *nb, (int *) b, (int *) bo);
+                         nblcks, nthrds, 0, 0,
+                         (real *) v, *m, *o, (int *) dg,
+                         (real *) u, *n, (int *) gd,
+                         *nb, (int *) b, (int *) bo);
       HIP_CHECK(hipGetLastError());
       break;
     case GS_OP_MIN:
       hipLaunchKernelGGL(HIP_KERNEL_NAME(gather_kernel_min<real>),
-			 nblcks, nthrds, 0, 0,
-			 (real *) v, *m, *o, (int *) dg,
-			 (real *) u, *n, (int *) gd,
-			 *nb, (int *) b, (int *) bo);
+                         nblcks, nthrds, 0, 0,
+                         (real *) v, *m, *o, (int *) dg,
+                         (real *) u, *n, (int *) gd,
+                         *nb, (int *) b, (int *) bo);
       HIP_CHECK(hipGetLastError());
       break;
     case GS_OP_MAX:
       hipLaunchKernelGGL(HIP_KERNEL_NAME(gather_kernel_max<real>),
-			 nblcks, nthrds, 0, 0,
-			 (real *) v, *m, *o, (int *) dg,
-			 (real *) u, *n, (int *) gd,
-			 *nb, (int *) b, (int *) bo);
+                         nblcks, nthrds, 0, 0,
+                         (real *) v, *m, *o, (int *) dg,
+                         (real *) u, *n, (int *) gd,
+                         *nb, (int *) b, (int *) bo);
       HIP_CHECK(hipGetLastError());
       break;
     }
@@ -98,34 +98,35 @@ extern "C" {
    * Fortran wrapper for device scatter kernel
    */
   void hip_scatter_kernel(void *v, int *m, void *dg,
-			  void *u, int *n, void *gd,
-			  int *nb, void *b, void *bo) {
+                          void *u, int *n, void *gd,
+                          int *nb, void *b, void *bo) {
 
     if ((*m) == 0) return;
-	
+        
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*m)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(scatter_kernel<real>),
-		       nblcks, nthrds, 0, 0,
-		       (real *) v, *m, (int *) dg,
-		       (real *) u, *n, (int *) gd,
-		       *nb, (int *) b, (int *) bo);
+                       nblcks, nthrds, 0, 0,
+                       (real *) v, *m, (int *) dg,
+                       (real *) u, *n, (int *) gd,
+                       *nb, (int *) b, (int *) bo);
     HIP_CHECK(hipGetLastError());
   }
 
   /**
    * Pack send buffer on device
    */
-  void hip_gs_pack(void *u_d, void *buf_d, void *dof_d, int n) {
+  void hip_gs_pack(void *u_d, void *buf_d, void *dof_d,
+                   int offset, int n, hipStream_t stream) {
 
     const int nthrds = 1024;
     const int nblcks = (n + nthrds - 1) / nthrds;
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_pack_kernel<real>),
-		       nblcks, nthrds, 0, 0,
-		       (real *) u_d, (real *) buf_d,
-		       (int *) dof_d, n);
+                       nblcks, nthrds, 0, stream,
+                       (real *) u_d, (real *) buf_d,
+                       (int *) dof_d, n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -133,7 +134,7 @@ extern "C" {
    * Unpack receive buffer on device
    */
   void hip_gs_unpack(real *u_d, int op, real *buf_d, int *dof_d,
-		     int offset, int n, hipStream_t stream) {
+                     int offset, int n, hipStream_t stream) {
 
     const int nthrds = 1024;
     const int nblcks = (n + nthrds - 1) / nthrds;
@@ -141,9 +142,9 @@ extern "C" {
     switch (op) {
     case GS_OP_ADD:
       hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_unpack_add_kernel<real>),
-			 nblcks, nthrds, 0, stream,
-			 u_d, buf_d + offset,
-			 dof_d + offset, n);
+                         nblcks, nthrds, 0, stream,
+                         u_d, buf_d + offset,
+                         dof_d + offset, n);
       break;
     default:
       printf("%s: unknown gs op %d\n", __FILE__, op);

--- a/src/gs/bcknd/device/hip/gs.hip
+++ b/src/gs/bcknd/device/hip/gs.hip
@@ -123,10 +123,18 @@ extern "C" {
     const int nthrds = 1024;
     const int nblcks = (n + nthrds - 1) / nthrds;
 
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_pack_kernel<real>),
-                       nblcks, nthrds, 0, stream,
-                       (real *) u_d, (real *) buf_d,
-                       (int *) dof_d, n);
+    if (stream == NULL) {
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_pack_kernel<real>),
+                         nblcks, nthrds, 0, 0,
+                         (real *) u_d, (real *) buf_d,
+                         (int *) dof_d, n);
+    }
+    else {
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_pack_kernel<real>),
+                         nblcks, nthrds, 0, stream,
+                         (real *) u_d, (real *) buf_d,
+                         (int *) dof_d, n);
+    }
     HIP_CHECK(hipGetLastError());
   }
 
@@ -141,10 +149,19 @@ extern "C" {
 
     switch (op) {
     case GS_OP_ADD:
-      hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_unpack_add_kernel<real>),
-                         nblcks, nthrds, 0, stream,
-                         u_d, buf_d + offset,
-                         dof_d + offset, n);
+      if (stream == NULL) {
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_unpack_add_kernel<real>),
+                           nblcks, nthrds, 0, 0,
+                           u_d, buf_d + offset,
+                           dof_d + offset, n);
+      }
+      else {
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_unpack_add_kernel<real>),
+                           nblcks, nthrds, 0, stream,
+                           u_d, buf_d + offset,
+                           dof_d + offset, n);
+
+      }
       break;
     default:
       printf("%s: unknown gs op %d\n", __FILE__, op);

--- a/src/gs/bcknd/device/hip/gs.hip
+++ b/src/gs/bcknd/device/hip/gs.hip
@@ -142,7 +142,7 @@ extern "C" {
     case GS_OP_ADD:
       hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_unpack_add_kernel<real>),
 			 nblcks, nthrds, 0, stream,
-			 u_d + offset, buf_d + offset,
+			 u_d, buf_d + offset,
 			 dof_d + offset, n);
       break;
     default:

--- a/src/gs/bcknd/device/hip/gs_kernels.h
+++ b/src/gs/bcknd/device/hip/gs_kernels.h
@@ -38,15 +38,15 @@
  */
 template< typename T >
 __global__ void gather_kernel_add(T * __restrict__ v,
-				  const int m,
-				  const int o,
-				  const int * __restrict__ dg,
-				  const T * __restrict__ u,
-				  const int n,
-				  const int * __restrict__ gd,
-				  const int nb,
-				  const int * __restrict__ b,
-				  const int * __restrict__ bo) {
+                                  const int m,
+                                  const int o,
+                                  const int * __restrict__ dg,
+                                  const T * __restrict__ u,
+                                  const int n,
+                                  const int * __restrict__ gd,
+                                  const int nb,
+                                  const int * __restrict__ b,
+                                  const int * __restrict__ bo) {
 
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const int str = blockDim.x * gridDim.x;
@@ -69,8 +69,8 @@ __global__ void gather_kernel_add(T * __restrict__ v,
   else {
     if ((idx%2 == 0)) {
       for (int i = ((o - 1) + idx); i < m ; i += str) {
-	T tmp = u[gd[i] - 1] + u[gd[i+1] - 1];
-	v[dg[i] - 1] = tmp;
+        T tmp = u[gd[i] - 1] + u[gd[i+1] - 1];
+        v[dg[i] - 1] = tmp;
       }
     }
   }
@@ -83,15 +83,15 @@ __global__ void gather_kernel_add(T * __restrict__ v,
  */
 template< typename T >
 __global__ void gather_kernel_mul(T * __restrict__ v,
-				  const int m,
-				  const int o,
-				  const int * __restrict__ dg,
-				  const T * __restrict__ u,
-				  const int n,
-				  const int * __restrict__ gd,
-				  const int nb,
-				  const int * __restrict__ b,
-				  const int * __restrict__ bo) { 
+                                  const int m,
+                                  const int o,
+                                  const int * __restrict__ dg,
+                                  const T * __restrict__ u,
+                                  const int n,
+                                  const int * __restrict__ gd,
+                                  const int nb,
+                                  const int * __restrict__ b,
+                                  const int * __restrict__ bo) { 
 
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const int str = blockDim.x * gridDim.x;
@@ -114,8 +114,8 @@ __global__ void gather_kernel_mul(T * __restrict__ v,
   else {
     if ((idx%2 == 0)) {
       for (int i = ((o - 1) + idx); i < m ; i += str) {
-	T tmp = u[gd[i] - 1] * u[gd[i+1] - 1];
-	v[dg[i] - 1] = tmp;
+        T tmp = u[gd[i] - 1] * u[gd[i+1] - 1];
+        v[dg[i] - 1] = tmp;
       }
     }
   }
@@ -128,15 +128,15 @@ __global__ void gather_kernel_mul(T * __restrict__ v,
  */
 template< typename T >
 __global__ void gather_kernel_min(T * __restrict__ v,
-				  const int m,
-				  const int o,
-				  const int * __restrict__ dg,
-				  const T * __restrict__ u,
-				  const int n,
-				  const int * __restrict__ gd,
-				  const int nb,
-				  const int * __restrict__ b,
-				  const int * __restrict__ bo) { 
+                                  const int m,
+                                  const int o,
+                                  const int * __restrict__ dg,
+                                  const T * __restrict__ u,
+                                  const int n,
+                                  const int * __restrict__ gd,
+                                  const int nb,
+                                  const int * __restrict__ b,
+                                  const int * __restrict__ bo) { 
 
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const int str = blockDim.x * gridDim.x;
@@ -159,8 +159,8 @@ __global__ void gather_kernel_min(T * __restrict__ v,
   else {
     if ((idx%2 == 0)) {
       for (int i = ((o - 1) + idx); i < m ; i += str) {
-	T tmp = min(u[gd[i] - 1], u[gd[i+1] - 1]);
-	v[dg[i] - 1] = tmp;
+        T tmp = min(u[gd[i] - 1], u[gd[i+1] - 1]);
+        v[dg[i] - 1] = tmp;
       }
     }
   }
@@ -173,15 +173,15 @@ __global__ void gather_kernel_min(T * __restrict__ v,
  */
 template< typename T >
 __global__ void gather_kernel_max(T * __restrict__ v,
-				  const int m,
-				  const int o,
-				  const int * __restrict__ dg,
-				  const T * __restrict__ u,
-				  const int n,
-				  const int * __restrict__ gd,
-				  const int nb,
-				  const int * __restrict__ b,
-				  const int * __restrict__ bo) { 
+                                  const int m,
+                                  const int o,
+                                  const int * __restrict__ dg,
+                                  const T * __restrict__ u,
+                                  const int n,
+                                  const int * __restrict__ gd,
+                                  const int nb,
+                                  const int * __restrict__ b,
+                                  const int * __restrict__ bo) { 
 
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const int str = blockDim.x * gridDim.x;
@@ -204,8 +204,8 @@ __global__ void gather_kernel_max(T * __restrict__ v,
   else {
     if ((idx%2 == 0)) {
       for (int i = ((o - 1) + idx); i < m ; i += str) {
-	T tmp = max(u[gd[i] - 1], u[gd[i+1] - 1]);
-	v[dg[i] - 1] = tmp;
+        T tmp = max(u[gd[i] - 1], u[gd[i+1] - 1]);
+        v[dg[i] - 1] = tmp;
       }
     }
   }
@@ -218,14 +218,14 @@ __global__ void gather_kernel_max(T * __restrict__ v,
  */
 template< typename T >
 __global__ void scatter_kernel(T * __restrict__ v,
-			       const int m,
-			       const int * __restrict__ dg,
-			       T * __restrict__ u,
-			       const int n,
-			       const int * __restrict__ gd,
-			       const int nb,
-			       const int *__restrict__ b,
-			       const int *__restrict__ bo) {
+                               const int m,
+                               const int * __restrict__ dg,
+                               T * __restrict__ u,
+                               const int n,
+                               const int * __restrict__ gd,
+                               const int nb,
+                               const int *__restrict__ b,
+                               const int *__restrict__ bo) {
   
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const int str = blockDim.x * gridDim.x;
@@ -249,9 +249,9 @@ __global__ void scatter_kernel(T * __restrict__ v,
 
 template< typename T >
 __global__ void gs_pack_kernel(const T * __restrict__ u,
-			       T * __restrict__ buf,
-			       const int32_t * __restrict__ dof,
-			       const int n) {
+                               T * __restrict__ buf,
+                               const int32_t * __restrict__ dof,
+                               const int n) {
 
   const int j = threadIdx.x + blockDim.x * blockIdx.x;
 
@@ -264,9 +264,9 @@ __global__ void gs_pack_kernel(const T * __restrict__ u,
 
 template< typename T >
 __global__ void gs_unpack_add_kernel(T * __restrict__ u,
-				     const T * __restrict__ buf,
-				     const int32_t * __restrict__ dof,
-				     const int n) {
+                                     const T * __restrict__ buf,
+                                     const int32_t * __restrict__ dof,
+                                     const int n) {
 
   const int j = threadIdx.x + blockDim.x * blockIdx.x;
 

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -188,10 +188,10 @@ contains
           do i = 1, size(strtgy)          
              c%nb_strtgy = strtgy(i)
              strtgy_time(i) = MPI_Wtime()
-             do j = 1, 500
+             do j = 1, 1000
                 call gs_op_vector(gs, tmp, dofmap%n_dofs, GS_OP_ADD)
              end do
-             strtgy_time(i) = (MPI_Wtime() - strtgy_time(i)) / real(500, rp)
+             strtgy_time(i) = (MPI_Wtime() - strtgy_time(i)) / 1000d0
           end do
 
           c%nb_strtgy = strtgy(minloc(strtgy_time, 1))

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -184,6 +184,7 @@ contains
           allocate(tmp(dofmap%n_dofs))
           call device_map(tmp, tmp_d, dofmap%n_dofs)
           tmp = 1.0_rp
+          call device_memcpy(tmp, tmp_d, dofmap%n_dofs, HOST_TO_DEVICE)
 
           do i = 1, size(strtgy)          
              c%nb_strtgy = strtgy(i)

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -88,8 +88,13 @@ contains
     character(len=LOG_SIZE) :: log_buf
     character(len=20) :: bcknd_str
     integer, optional :: bcknd
-    integer :: ierr, bcknd_, glb_nshared, glb_nlocal
+    integer :: i, j, ierr, bcknd_, glb_nshared, glb_nlocal
     logical :: use_device_mpi
+    real(kind=rp), allocatable :: tmp(:)
+    type(c_ptr) :: tmp_d
+    integer :: strtgy(4) = (/ int(B'00'), int(B'01'), int(B'10'), int(B'11') /)
+    integer :: avg_strtgy
+    real(kind=dp) :: strtgy_time(4)
 
     call gs_free(gs)
 
@@ -163,7 +168,7 @@ contains
     write(log_buf, '(A)') 'Backend      : ' // trim(bcknd_str)
     call neko_log%message(log_buf)
     
-    call neko_log%end_section()
+
 
     call gs%bcknd%init(gs%nlocal, gs%nshared, gs%nlocal_blks, gs%nshared_blks)
 
@@ -172,8 +177,41 @@ contains
        type is (gs_device_t)
           b%shared_on_host = .false.
        end select
+
+       ! Select fastest device MPI strategy at runtime
+       select type(c => gs%comm)
+       type is (gs_device_mpi_t)
+          allocate(tmp(dofmap%n_dofs))
+          call device_map(tmp, tmp_d, dofmap%n_dofs)
+          tmp = 1.0_rp
+
+          do i = 1, size(strtgy)          
+             c%nb_strtgy = strtgy(i)
+             strtgy_time(i) = MPI_Wtime()
+             do j = 1, 500
+                call gs_op_vector(gs, tmp, dofmap%n_dofs, GS_OP_ADD)
+             end do
+             strtgy_time(i) = (MPI_Wtime() - strtgy_time(i)) / real(500, rp)
+          end do
+
+          c%nb_strtgy = strtgy(minloc(strtgy_time, 1))
+
+          avg_strtgy = minloc(strtgy_time, 1)
+          call MPI_Allreduce(MPI_IN_PLACE, avg_strtgy, 1, &
+                             MPI_INTEGER, MPI_SUM, NEKO_COMM)
+          avg_strtgy = avg_strtgy / pe_size
+          
+          write(log_buf, '(AB0.2)') 'Avg. strtgy  :         0x', &
+               strtgy(avg_strtgy)
+          call neko_log%message(log_buf)
+
+          call device_free(tmp_d)
+          deallocate(tmp)
+       end select
     end if
-  
+
+    call neko_log%end_section()
+    
   end subroutine gs_init
 
   !> Deallocate a gather-scatter kernel

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -201,7 +201,7 @@ contains
                              MPI_INTEGER, MPI_SUM, NEKO_COMM)
           avg_strtgy = avg_strtgy / pe_size
           
-          write(log_buf, '(AB0.2)') 'Avg. strtgy  :         0x', &
+          write(log_buf, '(A,B0.2)') 'Avg. strtgy  :         0x', &
                strtgy(avg_strtgy)
           call neko_log%message(log_buf)
 

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -202,8 +202,8 @@ contains
                              MPI_INTEGER, MPI_SUM, NEKO_COMM)
           avg_strtgy = avg_strtgy / pe_size
           
-          write(log_buf, '(A,B0.2)') 'Avg. strtgy  :         0x', &
-               strtgy(avg_strtgy)
+          write(log_buf, '(A,B0.2,A)') 'Avg. strtgy  :         [', &
+               strtgy(avg_strtgy),']'
           call neko_log%message(log_buf)
 
           call device_free(tmp_d)


### PR DESCRIPTION
**Rework device aware MPI gs alg.**

**Send:**
Either, issue one asynchronous gather-scatter pack kernel per, to be sent, message, instead of packing all buffers at once. or issue a global device sync, sync on each packing stream, followed by issuing the non-blocking send (old way).

**Recv:**
Either, issue one asynchronous gather-scatter unpack kernels per received MPI message in gs, or wait for all messages to arrive. 

The strategy is selected at runtime, and can be different for each `gs_t`, and for each device in a `gs_t`
