### PR TITLE
Fix/pin memory in glsc3

### DIFF
--- a/src/math/bcknd/device/cuda/math.cu
+++ b/src/math/bcknd/device/cuda/math.cu
@@ -396,10 +396,10 @@ extern "C" {
     if((*j)*nb>red_s){
       red_s = (*j)*nb;
       if (bufred != NULL) {
-	free(bufred);
+	CUDA_CHECK(cudaFreeHost(bufred));
 	CUDA_CHECK(cudaFree(bufred_d));
       }
-      bufred = (real *) malloc((*j)*nb * sizeof(real));
+      CUDA_CHECK(cudaMallocHost(&bufred,(*j)*nb*sizeof(real)));
       CUDA_CHECK(cudaMalloc(&bufred_d, (*j)*nb*sizeof(real)));
     }
     

--- a/src/math/bcknd/device/hip/math.hip
+++ b/src/math/bcknd/device/hip/math.hip
@@ -392,7 +392,7 @@ extern "C" {
         HIP_CHECK(hipHostFree(bufred));
         HIP_CHECK(hipFree(bufred_d));
       }      
-      HIP_CHECK(hipHostMalloc(&bufred,(*j)*nb*sizeof(real),hipHostMallocDefault);
+      HIP_CHECK(hipHostMalloc(&bufred,(*j)*nb*sizeof(real),hipHostMallocDefault));
       HIP_CHECK(hipMalloc(&bufred_d, (*j)*nb*sizeof(real)));
     }
     hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_many_kernel<real>), nblcks, nthrds,

--- a/src/math/bcknd/device/hip/math.hip
+++ b/src/math/bcknd/device/hip/math.hip
@@ -389,10 +389,10 @@ extern "C" {
     if((*j)*nb>red_s){
       red_s = (*j)*nb;
       if (bufred != NULL) {
-        free(bufred);
+        HIP_CHECK(hipHostFree(bufred));
         HIP_CHECK(hipFree(bufred_d));
       }      
-      bufred = (real *) malloc((*j)*nb * sizeof(real));
+      HIP_CHECK(hipHostMalloc(&bufred,(*j)*nb*sizeof(real),hipHostMallocDefault);
       HIP_CHECK(hipMalloc(&bufred_d, (*j)*nb*sizeof(real)));
     }
     hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_many_kernel<real>), nblcks, nthrds,

--- a/src/math/bcknd/device/opencl/math.c
+++ b/src/math/bcknd/device/opencl/math.c
@@ -674,10 +674,12 @@ void opencl_glsc3_many(real *h, void * w, void *v, void *mult, int *j, int *n){
   if((*j)*nb > red_s) {
     red_s = (*j)*nb;
     if (bufred != NULL) {
-      free(bufred);    
+      CL_CHECK(clReleaseMemObject(bufred));
       CL_CHECK(clReleaseMemObject(bufred_d));
     }
-    bufred = (real *) malloc((*j)*nb * sizeof(real));
+    bufred = clCreateBuffer(glb_ctx, CL_MEM_ALLOC_HOST_PTR,
+		    (*j) * nb * sizeof(real), NULL, &err);
+    CL_CHECK(err);
     bufred_d = clCreateBuffer(glb_ctx, CL_MEM_READ_WRITE,
                               (*j) * nb * sizeof(real), NULL, &err);
     CL_CHECK(err);


### PR DESCRIPTION
Update to pin the memory used for the Device to Host transfer in cuda/hip_glsc3_many to improve performance of transfer