### PR TITLE
updated glsc3 routines to pin the malloc in all glsc3 routines

### DIFF
--- a/src/math/bcknd/device/cuda/math.cu
+++ b/src/math/bcknd/device/cuda/math.cu
@@ -358,10 +358,10 @@ extern "C" {
     if ( nb > red_s){
       red_s = nb;
       if (bufred != NULL) {
-        free(bufred);
+        CUDA_CHECK(cudaFreeHost(bufred));
         CUDA_CHECK(cudaFree(bufred_d));        
       }
-      bufred = (real *) malloc(nb * sizeof(real));      
+      CUDA_CHECK(cudaMallocHost(&bufred,nb*sizeof(real)));
       CUDA_CHECK(cudaMalloc(&bufred_d, nb*sizeof(real)));
     }
      
@@ -435,10 +435,10 @@ extern "C" {
     if ( nb > red_s){
       red_s = nb;
       if (bufred != NULL) {
-        free(bufred);
+        CUDA_CHECK(cudaFreeHost(bufred));
         CUDA_CHECK(cudaFree(bufred_d));        
       }
-      bufred = (real *) malloc(nb * sizeof(real));      
+      CUDA_CHECK(cudaMallocHost(&bufred,nb*sizeof(real)));
       CUDA_CHECK(cudaMalloc(&bufred_d, nb*sizeof(real)));
     }
          
@@ -469,10 +469,10 @@ extern "C" {
     if ( nb > red_s){
       red_s = nb;
       if (bufred != NULL) {
-        free(bufred);
+        CUDA_CHECK(cudaFreeHost(bufred));
         CUDA_CHECK(cudaFree(bufred_d));        
       }
-      bufred = (real *) malloc(nb * sizeof(real));      
+      CUDA_CHECK(cudaMallocHost(&bufred,nb*sizeof(real)));
       CUDA_CHECK(cudaMalloc(&bufred_d, nb*sizeof(real)));
     }
      

--- a/src/math/bcknd/device/hip/math.hip
+++ b/src/math/bcknd/device/hip/math.hip
@@ -349,10 +349,10 @@ extern "C" {
     if ( nb > red_s){
       red_s = nb;
       if (bufred != NULL) {
-        free(bufred);
+        HIP_CHECK(hipHostFree(bufred));
         HIP_CHECK(hipFree(bufred_d));        
       }
-      bufred = (real *) malloc(nb * sizeof(real));      
+      HIP_CHECK(hipHostMalloc(&bufred,nb*sizeof(real),hipHostMallocDefault));
       HIP_CHECK(hipMalloc(&bufred_d, nb*sizeof(real)));
     }
      
@@ -445,10 +445,10 @@ extern "C" {
     if ( nb > red_s){
       red_s = nb;
       if (bufred != NULL) {
-        free(bufred);
+        HIP_CHECK(hipHostFree(bufred));
         HIP_CHECK(hipFree(bufred_d));        
       }
-      bufred = (real *) malloc(nb * sizeof(real));      
+      HIP_CHECK(hipHostMalloc(&bufred,nb*sizeof(real),hipHostMallocDefault));
       HIP_CHECK(hipMalloc(&bufred_d, nb*sizeof(real)));
     }
      
@@ -481,10 +481,10 @@ extern "C" {
     if ( nb > red_s){
       red_s = nb;
       if (bufred != NULL) {
-        free(bufred);
+        HIP_CHECK(hipHostFree(bufred));
         HIP_CHECK(hipFree(bufred_d));        
       }
-      bufred = (real *) malloc(nb * sizeof(real));      
+      HIP_CHECK(hipHostMalloc(&bufred,nb*sizeof(real),hipHostMallocDefault));
       HIP_CHECK(hipMalloc(&bufred_d, nb*sizeof(real)));
     }
      

--- a/src/math/bcknd/device/opencl/math.c
+++ b/src/math/bcknd/device/opencl/math.c
@@ -615,10 +615,12 @@ real opencl_glsc3(void *a, void *b, void *c, int *n) {
   if ( nb > red_s){
     red_s = nb;
     if (bufred != NULL) {
-      free(bufred);
+      CL_CHECK(clReleaseMemObject(bufred));
       CL_CHECK(clReleaseMemObject(bufred_d));
     }
-    bufred = (real *) malloc(nb * sizeof(real));
+    bufred = clCreateBuffer(glb_ctx, CL_MEM_ALLOC_HOST_PTR,
+                            nb * sizeof(real), NULL, &err);
+    CL_CHECK(err);
     bufred_d = clCreateBuffer(glb_ctx, CL_MEM_READ_WRITE,
                               nb * sizeof(real), NULL, &err);
     CL_CHECK(err);
@@ -678,7 +680,7 @@ void opencl_glsc3_many(real *h, void * w, void *v, void *mult, int *j, int *n){
       CL_CHECK(clReleaseMemObject(bufred_d));
     }
     bufred = clCreateBuffer(glb_ctx, CL_MEM_ALLOC_HOST_PTR,
-		    (*j) * nb * sizeof(real), NULL, &err);
+		            (*j) * nb * sizeof(real), NULL, &err);
     CL_CHECK(err);
     bufred_d = clCreateBuffer(glb_ctx, CL_MEM_READ_WRITE,
                               (*j) * nb * sizeof(real), NULL, &err);


### PR DESCRIPTION
Changed all malloc and free of bufred in the glsc3 routines to use pinned memory.  Avoiding race condition that could result in host memory being created with MallocHost and freed with free, and making sure we are always using pinned memory for the transfers.