### PR TITLE
Fix (re)size of gmres reduction buffers

### DIFF
--- a/src/krylov/bcknd/device/cuda/gmres_aux.cu
+++ b/src/krylov/bcknd/device/cuda/gmres_aux.cu
@@ -38,19 +38,30 @@
 #include <device/cuda/check.h>
 
 extern "C" {
-
+  
+  /**
+   * @todo Make sure that this gets deleted at some point...
+   */
   real * gmres_bf1 = NULL;
   real * gmres_bfd1 = NULL;
-  
+  int gmres_bf_len = 0;
+
   real cuda_gmres_part2(void *w, void *v, void *h, void * mult, int *j, int *n) {
         
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     const int nb = ((*n) + 1024 - 1)/ 1024;
     
+    if (gmres_bf1 != NULL && gmres_bf_len < nb) {
+      free(gmres_bf1);
+      CUDA_CHECK(cudaFree(gmres_bfd1));
+      gmres_bf1 = NULL;
+    }
+
     if (gmres_bf1 == NULL){
       gmres_bf1 = (real *) malloc(nb * sizeof(real));
       CUDA_CHECK(cudaMalloc(&gmres_bfd1, nb*sizeof(real)));
+      gmres_bf_len = nb;
     }
      
     gmres_part2_kernel<real><<<nblcks, nthrds>>>((real *) w, (real **) v,

--- a/src/krylov/bcknd/device/hip/gmres_aux.hip
+++ b/src/krylov/bcknd/device/hip/gmres_aux.hip
@@ -39,18 +39,30 @@
 #include <device/hip/check.h>
 
 extern "C" {
+
+  /**
+   * @todo Make sure that this gets deleted at some point...
+   */
   real * gmres_bf1 = NULL;
   real * gmres_bfd1 = NULL;
-  
+  int gmres_bf_len = 0;  
+
   real hip_gmres_part2(void *w, void *v, void *h, void * mult, int *j, int *n) {
 	
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     const int nb = ((*n) + 1024 - 1)/ 1024;
     
+    if (gmres_bf1 != NULL && gmres_bf_len < nb) {
+      free(gmres_bf1);
+      HIP_CHECK(hipFree(gmres_bfd1));
+      gmres_bf1 = NULL;
+    }
+
     if (gmres_bf1 == NULL){
       gmres_bf1 = (real *) malloc(nb * sizeof(real));
       HIP_CHECK(hipMalloc(&gmres_bfd1, nb*sizeof(real)));
+      gmres_bf_len = nb;
     }
      
     hipLaunchKernelGGL(HIP_KERNEL_NAME(gmres_part2_kernel<real>),


### PR DESCRIPTION
Device reduction buffers aren't resized appropriately if a GMRES solver is used with different `lx` in the same session, e.g. via `pyNeko` or at different multigrid levels.