### PR TITLE
Feature/glsc3 optimisation

### DIFF
--- a/src/math/bcknd/device/cuda/math.cu
+++ b/src/math/bcknd/device/cuda/math.cu
@@ -393,14 +393,14 @@ extern "C" {
     const dim3 nthrds(nt, pow2, 1);
     const dim3 nblcks(((*n)+nt - 1)/nt, 1, 1);
     const int nb = ((*n) + nt - 1)/nt;
-    if((*j)>red_s){
-      red_s = (*j);
+    if((*j)*nb>red_s){
+      red_s = (*j)*nb;
       if (bufred != NULL) {
 	CUDA_CHECK(cudaFreeHost(bufred));
 	CUDA_CHECK(cudaFree(bufred_d));
       }
-      CUDA_CHECK(cudaMallocHost(&bufred,(*j)*sizeof(real)));
-      CUDA_CHECK(cudaMalloc(&bufred_d, (*j)*sizeof(real)));
+      CUDA_CHECK(cudaMallocHost(&bufred,(*j)*nb*sizeof(real)));
+      CUDA_CHECK(cudaMalloc(&bufred_d, (*j)*nb*sizeof(real)));
     }
     
     glsc3_many_kernel<real><<<nblcks, nthrds>>>((const real *) w,

--- a/src/math/bcknd/device/cuda/math.cu
+++ b/src/math/bcknd/device/cuda/math.cu
@@ -408,17 +408,11 @@ extern "C" {
                                                 (const real *)mult,
                                                 bufred_d, *j, *n);
     CUDA_CHECK(cudaGetLastError());
-    CUDA_CHECK(cudaMemcpy(bufred, bufred_d, (*j)*nb * sizeof(real),
+    glsc3_reduce_kernel<<<(*j),1024>>> (bufred_d, nb, *j);
+    CUDA_CHECK(cudaGetLastError());
+
+    CUDA_CHECK(cudaMemcpy(h, bufred_d, (*j) * sizeof(real),
                           cudaMemcpyDeviceToHost));
-    for (int k = 0; k < (*j); k++) {
-      h[k] = 0.0;
-    }
-    
-    for (int i = 0; i < nb; i++) {
-      for (int k = 0; k < (*j); k++) {
-        h[k] += bufred[i*(*j)+k];
-      }
-    }
   }
 
   /**

--- a/src/math/bcknd/device/cuda/math.cu
+++ b/src/math/bcknd/device/cuda/math.cu
@@ -393,14 +393,14 @@ extern "C" {
     const dim3 nthrds(nt, pow2, 1);
     const dim3 nblcks(((*n)+nt - 1)/nt, 1, 1);
     const int nb = ((*n) + nt - 1)/nt;
-    if((*j)*nb>red_s){
-      red_s = (*j)*nb;
+    if((*j)>red_s){
+      red_s = (*j);
       if (bufred != NULL) {
 	CUDA_CHECK(cudaFreeHost(bufred));
 	CUDA_CHECK(cudaFree(bufred_d));
       }
-      CUDA_CHECK(cudaMallocHost(&bufred,(*j)*nb*sizeof(real)));
-      CUDA_CHECK(cudaMalloc(&bufred_d, (*j)*nb*sizeof(real)));
+      CUDA_CHECK(cudaMallocHost(&bufred,(*j)*sizeof(real)));
+      CUDA_CHECK(cudaMalloc(&bufred_d, (*j)*sizeof(real)));
     }
     
     glsc3_many_kernel<real><<<nblcks, nthrds>>>((const real *) w,

--- a/src/math/bcknd/device/cuda/math_kernel.h
+++ b/src/math/bcknd/device/cuda/math_kernel.h
@@ -357,6 +357,7 @@ __global__ void addcol4_kernel(T * __restrict__ a,
   }  
  
 }
+
 /**
  * Reduction kernel for glsc3
  *

--- a/src/math/bcknd/device/cuda/math_kernel.h
+++ b/src/math/bcknd/device/cuda/math_kernel.h
@@ -357,6 +357,42 @@ __global__ void addcol4_kernel(T * __restrict__ a,
   }  
  
 }
+/**
+ * Reduction kernel for glsc3
+ *
+ */
+
+template< typename T >
+__global__ void glsc3_reduce_kernel( T * bufred,
+                                    const int n,
+                                    const int j
+                                   ) {
+   __shared__ T buf[1024] ;
+   const int idx = threadIdx.x;
+   const int y= blockIdx.x;
+   const int step = blockDim.x;
+
+   buf[idx]=0;
+   for (int i=idx ; i<n ; i+=step)
+   {
+     buf[idx] += bufred[i*j + y];
+   }
+   __syncthreads();
+
+   int i = 512;
+   while (i != 0)
+   {
+     if(threadIdx.x < i && (threadIdx.x + i) < n )
+     {
+        buf[threadIdx.x] += buf[threadIdx.x + i] ;
+     }
+     i = i>>1;
+     __syncthreads();
+   }
+
+   bufred[y] = buf[0];
+}
+
 
 /**
  * Device kernel for glsc3

--- a/src/math/bcknd/device/hip/math.hip
+++ b/src/math/bcknd/device/hip/math.hip
@@ -385,33 +385,30 @@ extern "C" {
     const int nt = 1024/pow2;   
     const dim3 nthrds(nt, pow2, 1);
     const dim3 nblcks(((*n)+nt - 1)/nt, 1, 1);
+    const dim3 nthrds_red(1024,1,1);
+    const dim3 nblcks_red( (*j),1,1);
     const int nb = ((*n) + nt - 1)/nt;
-    if((*j)*nb>red_s){
-      red_s = (*j)*nb;
+    if((*j)>red_s){
+      red_s = (*j);
       if (bufred != NULL) {
         HIP_CHECK(hipHostFree(bufred));
         HIP_CHECK(hipFree(bufred_d));
       }      
-      HIP_CHECK(hipHostMalloc(&bufred,(*j)*nb*sizeof(real),hipHostMallocDefault));
-      HIP_CHECK(hipMalloc(&bufred_d, (*j)*nb*sizeof(real)));
+      HIP_CHECK(hipHostMalloc(&bufred,(*j)*sizeof(real),hipHostMallocDefault));
+      HIP_CHECK(hipMalloc(&bufred_d, (*j)*sizeof(real)));
     }
     hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_many_kernel<real>), nblcks, nthrds,
                        0, 0, (const real *) w, (const real **) v,
                        (const real *)mult, bufred_d, *j, *n);
     HIP_CHECK(hipGetLastError());
     
-    HIP_CHECK(hipMemcpy(bufred, bufred_d, (*j)*nb * sizeof(real),
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_reduce_kernel<real>), nblcks_red, nthrds_red,
+                       0, 0, bufred_d, nb, *j);
+    HIP_CHECK(hipGetLastError());
+
+
+    HIP_CHECK(hipMemcpy(h, bufred_d, (*j)* sizeof(real),
                         hipMemcpyDeviceToHost));
-    
-    for (int k = 0; k < (*j); k++) {
-      h[k] = 0.0;
-    }
-    
-    for (int i = 0; i < nb; i++) {
-      for (int k = 0; k < (*j); k++) {
-        h[k] += bufred[i*(*j)+k];
-      }
-    }
   }
 
   /**

--- a/src/math/bcknd/device/hip/math.hip
+++ b/src/math/bcknd/device/hip/math.hip
@@ -388,14 +388,14 @@ extern "C" {
     const dim3 nthrds_red(1024,1,1);
     const dim3 nblcks_red( (*j),1,1);
     const int nb = ((*n) + nt - 1)/nt;
-    if((*j)>red_s){
-      red_s = (*j);
+    if((*j)*nb>red_s){
+      red_s = (*j)*nb;
       if (bufred != NULL) {
         HIP_CHECK(hipHostFree(bufred));
         HIP_CHECK(hipFree(bufred_d));
       }      
-      HIP_CHECK(hipHostMalloc(&bufred,(*j)*sizeof(real),hipHostMallocDefault));
-      HIP_CHECK(hipMalloc(&bufred_d, (*j)*sizeof(real)));
+      HIP_CHECK(hipHostMalloc(&bufred,(*j)*nb*sizeof(real),hipHostMallocDefault));
+      HIP_CHECK(hipMalloc(&bufred_d, (*j)*nb*sizeof(real)));
     }
     hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_many_kernel<real>), nblcks, nthrds,
                        0, 0, (const real *) w, (const real **) v,


### PR DESCRIPTION
Replace the memcpy and cpu reduction with a GPU reduction then much smaller memcpy in glsc3_many

Comes out significantly ahead on CUDA generally. Looks to be better on HIP as well, Did not touch the OpenCL