### PR TITLE
Reduce memory traffic in abbdf CUDA kernels 

### DIFF
--- a/src/fluid/bcknd/device/cuda/fluid_abbdf.cu
+++ b/src/fluid/bcknd/device/cuda/fluid_abbdf.cu
@@ -74,8 +74,7 @@ extern "C" {
       CUDA_CHECK(cudaGetLastError());
   }
   
-  void fluid_makebdf_cuda(void *tb1, void *tb2, void *tb3,
-                          void *ulag1, void *ulag2, void *vlag1,
+  void fluid_makebdf_cuda(void *ulag1, void *ulag2, void *vlag1,
                           void *vlag2, void *wlag1, void *wlag2, 
                           void *bfx, void *bfy, void *bfz,
                           void *u, void *v, void *w, void *B, 
@@ -86,8 +85,7 @@ extern "C" {
     const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
 
     makebdf_kernel<real>
-      <<<nblcks, nthrds>>>((real *) tb1, (real *) tb2, (real *) tb3,
-                           (real *) ulag1, (real *) ulag2, (real *) vlag1,
+      <<<nblcks, nthrds>>>((real *) ulag1, (real *) ulag2, (real *) vlag1,
                            (real *) vlag2, (real *) wlag1, (real *) wlag2, 
                            (real *) bfx, (real *) bfy, (real *) bfz,
                            (real *) u, (real *) v, (real *) w, (real *) B, 

--- a/src/fluid/bcknd/device/cuda/fluid_abbdf.cu
+++ b/src/fluid/bcknd/device/cuda/fluid_abbdf.cu
@@ -58,8 +58,7 @@ extern "C" {
     CUDA_CHECK(cudaGetLastError());
   }
 
-  void fluid_makeabf_cuda(void *ta1, void *ta2, void *ta3,
-                          void *abx1, void *aby1, void *abz1, 
+  void fluid_makeabf_cuda(void *abx1, void *aby1, void *abz1, 
                           void *abx2, void *aby2, void *abz2,
                           void *bfx, void *bfy, void *bfz,
                           real *rho, real *ab1, real *ab2, real *ab3, int *n) {
@@ -68,16 +67,14 @@ extern "C" {
     const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
     
     makeabf_kernel<real>
-      <<<nblcks, nthrds>>>((real *) ta1, (real *) ta2, (real *) ta3,
-                           (real *) abx1, (real *) aby1, (real *) abz1, 
+      <<<nblcks, nthrds>>>((real *) abx1, (real *) aby1, (real *) abz1, 
                            (real *) abx2, (real *) aby2, (real *) abz2,
                            (real *) bfx, (real *) bfy, (real *) bfz,
                            *rho, *ab1, *ab2, *ab3, *n);      
       CUDA_CHECK(cudaGetLastError());
   }
   
-  void fluid_makebdf_cuda(void *ta1, void *ta2, void *ta3,
-                          void *tb1, void *tb2, void *tb3,
+  void fluid_makebdf_cuda(void *tb1, void *tb2, void *tb3,
                           void *ulag1, void *ulag2, void *vlag1,
                           void *vlag2, void *wlag1, void *wlag2, 
                           void *bfx, void *bfy, void *bfz,
@@ -89,8 +86,7 @@ extern "C" {
     const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
 
     makebdf_kernel<real>
-      <<<nblcks, nthrds>>>((real *) ta1, (real *) ta2, (real *) ta3,
-                           (real *) tb1, (real *) tb2, (real *) tb3,
+      <<<nblcks, nthrds>>>((real *) tb1, (real *) tb2, (real *) tb3,
                            (real *) ulag1, (real *) ulag2, (real *) vlag1,
                            (real *) vlag2, (real *) wlag1, (real *) wlag2, 
                            (real *) bfx, (real *) bfy, (real *) bfz,

--- a/src/fluid/bcknd/device/cuda/makeabf_kernel.h
+++ b/src/fluid/bcknd/device/cuda/makeabf_kernel.h
@@ -33,10 +33,7 @@
 */
 
 template< typename T >
-__global__ void makeabf_kernel(T * __restrict__ ta1,
-                               T * __restrict__ ta2,
-                               T * __restrict__ ta3,
-                               T * __restrict__ abx1,
+__global__ void makeabf_kernel(T * __restrict__ abx1,
                                T * __restrict__ aby1,
                                T * __restrict__ abz1,
                                T * __restrict__ abx2,
@@ -55,24 +52,20 @@ __global__ void makeabf_kernel(T * __restrict__ ta1,
   const int str = blockDim.x * gridDim.x;
 
   for (int i = idx; i < n; i += str) {
-    ta1[i] = ab2 * abx1[i] + ab3 * abx2[i];
-    ta2[i] = ab2 * aby1[i] + ab3 * aby2[i];
-    ta3[i] = ab2 * abz1[i] + ab3 * abz2[i];
-  }
+    T ta1_val = ab2 * abx1[i] + ab3 * abx2[i];
+    T ta2_val = ab2 * aby1[i] + ab3 * aby2[i];
+    T ta3_val = ab2 * abz1[i] + ab3 * abz2[i];
 
-  for (int i = idx; i < n; i += str) {
     abx2[i] = abx1[i];
     aby2[i] = aby1[i];
     abz2[i] = abz1[i];
     abx1[i] = bfx[i];
     aby1[i] = bfy[i];
     abz1[i] = bfz[i];
-  }
-  
-  for (int i = idx; i < n; i += str) {
-    bfx[i] = (ab1 * bfx[i] + ta1[i]) * rho;
-    bfy[i] = (ab1 * bfy[i] + ta2[i]) * rho;
-    bfz[i] = (ab1 * bfz[i] + ta3[i]) * rho;
+
+    bfx[i] = (ab1 * bfx[i] + ta1_val) * rho;
+    bfy[i] = (ab1 * bfy[i] + ta2_val) * rho;
+    bfz[i] = (ab1 * bfz[i] + ta3_val) * rho;
   } 
   
 }

--- a/src/fluid/bcknd/device/cuda/makebdf_kernel.h
+++ b/src/fluid/bcknd/device/cuda/makebdf_kernel.h
@@ -33,10 +33,7 @@
 */
 
 template< typename T >
-__global__ void makebdf_kernel(T * __restrict__ ta1,
-                               T * __restrict__ ta2,
-                               T * __restrict__ ta3,
-                               T * __restrict__ tb1,
+__global__ void makebdf_kernel(T * __restrict__ tb1,
                                T * __restrict__ tb2,
                                T * __restrict__ tb3,
                                const T * __restrict__ ulag1,
@@ -68,33 +65,24 @@ __global__ void makebdf_kernel(T * __restrict__ ta1,
     tb2[i] = v[i] * B[i] * bd2;
     tb3[i] = w[i] * B[i] * bd2;
 
-    ta1[i] = ulag1[i] * B[i] * bd3;
-    ta2[i] = vlag1[i] * B[i] * bd3;
-    ta3[i] = wlag1[i] * B[i] * bd3;
+    T ta1_val = ulag1[i] * B[i] * bd3;
+    T ta2_val = vlag1[i] * B[i] * bd3;
+    T ta3_val = wlag1[i] * B[i] * bd3;
 
-    tb1[i] += ta1[i];
-    tb2[i] += ta2[i];
-    tb3[i] += ta3[i];
-  }
+    tb1[i] += ta1_val;
+    tb2[i] += ta2_val;
+    tb3[i] += ta3_val;
 
-  if (nbd == 3) {
-    for (int i = idx; i < n; i += str) {
-      ta1[i] = ulag2[i] * B[i] * bd4;
-      ta2[i] = vlag2[i] * B[i] * bd4;
-      ta3[i] = wlag2[i] * B[i] * bd4;
-      
-      tb1[i] += ta1[i];
-      tb2[i] += ta2[i];
-      tb3[i] += ta3[i];
+    if (nbd == 3) {
+      tb1[i] += ulag2[i] * B[i] * bd4;
+      tb2[i] += vlag2[i] * B[i] * bd4;
+      tb3[i] += wlag2[i] * B[i] * bd4;
     }
-  }
-
-  for (int i = idx; i < n; i += str) {
+    
     bfx[i] = bfx[i] + tb1[i] * (rho / dt);
     bfy[i] = bfy[i] + tb2[i] * (rho / dt);
     bfz[i] = bfz[i] + tb3[i] * (rho / dt);
   }
-
-
+  
 }
 

--- a/src/fluid/bcknd/device/cuda/makebdf_kernel.h
+++ b/src/fluid/bcknd/device/cuda/makebdf_kernel.h
@@ -33,10 +33,7 @@
 */
 
 template< typename T >
-__global__ void makebdf_kernel(T * __restrict__ tb1,
-                               T * __restrict__ tb2,
-                               T * __restrict__ tb3,
-                               const T * __restrict__ ulag1,
+__global__ void makebdf_kernel(const T * __restrict__ ulag1,
                                const T * __restrict__ ulag2,
                                const T * __restrict__ vlag1,
                                const T * __restrict__ vlag2,
@@ -61,27 +58,27 @@ __global__ void makebdf_kernel(T * __restrict__ tb1,
   const int str = blockDim.x * gridDim.x;
 
   for (int i = idx; i < n; i += str) {
-    tb1[i] = u[i] * B[i] * bd2;
-    tb2[i] = v[i] * B[i] * bd2;
-    tb3[i] = w[i] * B[i] * bd2;
+    T tb1_val = u[i] * B[i] * bd2;
+    T tb2_val = v[i] * B[i] * bd2;
+    T tb3_val = w[i] * B[i] * bd2;
 
     T ta1_val = ulag1[i] * B[i] * bd3;
     T ta2_val = vlag1[i] * B[i] * bd3;
     T ta3_val = wlag1[i] * B[i] * bd3;
 
-    tb1[i] += ta1_val;
-    tb2[i] += ta2_val;
-    tb3[i] += ta3_val;
+    tb1_val += ta1_val;
+    tb2_val += ta2_val;
+    tb3_val += ta3_val;
 
     if (nbd == 3) {
-      tb1[i] += ulag2[i] * B[i] * bd4;
-      tb2[i] += vlag2[i] * B[i] * bd4;
-      tb3[i] += wlag2[i] * B[i] * bd4;
+      tb1_val += ulag2[i] * B[i] * bd4;
+      tb2_val += vlag2[i] * B[i] * bd4;
+      tb3_val += wlag2[i] * B[i] * bd4;
     }
     
-    bfx[i] = bfx[i] + tb1[i] * (rho / dt);
-    bfy[i] = bfy[i] + tb2[i] * (rho / dt);
-    bfz[i] = bfz[i] + tb3[i] * (rho / dt);
+    bfx[i] = bfx[i] + tb1_val * (rho / dt);
+    bfy[i] = bfy[i] + tb2_val * (rho / dt);
+    bfz[i] = bfz[i] + tb3_val * (rho / dt);
   }
   
 }

--- a/src/fluid/bcknd/device/fluid_abbdf_device.F90
+++ b/src/fluid/bcknd/device/fluid_abbdf_device.F90
@@ -112,27 +112,29 @@ module fluid_abbdf_device
   end interface
 
   interface
-     subroutine fluid_makeabf_cuda(ta1_d, ta2_d, ta3_d, abx1_d, aby1_d, abz1_d, &
-          abx2_d, aby2_d, abz2_d, bfx_d, bfy_d, bfz_d, rho, ab1, ab2, ab3, n) &
+     subroutine fluid_makeabf_cuda(abx1_d, aby1_d, abz1_d, &
+                                   abx2_d, aby2_d, abz2_d, &
+                                   bfx_d, bfy_d, bfz_d, &
+                                   rho, ab1, ab2, ab3, n) &
           bind(c, name='fluid_makeabf_cuda')
        use, intrinsic :: iso_c_binding
        import c_rp
-       type(c_ptr), value :: ta1_d, ta2_d, ta3_D, abx1_d, aby1_d, abz1_d 
-       type(c_ptr), value :: abx2_d, aby2_d, abz2_d, bfx_d, bfy_d, bfz_d
+       type(c_ptr), value :: abx1_d, aby1_d, abz1_d 
+       type(c_ptr), value :: abx2_d, aby2_d, abz2_d
+       type(c_ptr), value :: bfx_d, bfy_d, bfz_d
        real(c_rp) :: rho, ab1, ab2, ab3
        integer(c_int) :: n
      end subroutine fluid_makeabf_cuda
   end interface
 
   interface
-     subroutine fluid_makebdf_cuda(ta1_d, ta2_d, ta3_d, tb1_d, tb2_d, tb3_d, &
-                       ulag1_d, ulag2_d, vlag1_d, vlag2_d, wlag1_d, wlag2_d, &
-                       bfx_d, bfy_d, bfz_d, u_d, v_d, w_d, B_d, &
-                       rho, dt, bd2, bd3, bd4, nbd, n) &
-                       bind(c, name='fluid_makebdf_cuda')
+     subroutine fluid_makebdf_cuda(tb1_d, tb2_d, tb3_d, ulag1_d, ulag2_d, &
+                                   vlag1_d, vlag2_d, wlag1_d, wlag2_d, &
+                                   bfx_d, bfy_d, bfz_d, u_d, v_d, w_d, B_d, &
+                                   rho, dt, bd2, bd3, bd4, nbd, n) &
+                                   bind(c, name='fluid_makebdf_cuda')
        use, intrinsic :: iso_c_binding
        import c_rp
-       type(c_ptr), value :: ta1_d, ta2_d, ta3_d
        type(c_ptr), value :: tb1_d, tb2_d, tb3_d
        type(c_ptr), value :: ulag1_d, ulag2_d, vlag1_d
        type(c_ptr), value :: vlag2_d, wlag1_d, wlag2_d
@@ -234,9 +236,10 @@ contains
          abx1%x_d, aby1%x_d, abz1%x_d, abx2%x_d, aby2%x_d, abz2%x_d, &
          bfx_d, bfy_d, bfz_d, rho, ab(1), ab(2), ab(3), n)
 #elif HAVE_CUDA
-    call fluid_makeabf_cuda(ta1%x_d, ta2%x_d, ta3%x_d, &
-         abx1%x_d, aby1%x_d, abz1%x_d, abx2%x_d, aby2%x_d, abz2%x_d, &
-         bfx_d, bfy_d, bfz_d, rho, ab(1), ab(2), ab(3), n)
+    call fluid_makeabf_cuda(abx1%x_d, aby1%x_d, abz1%x_d, &
+                            abx2%x_d, aby2%x_d, abz2%x_d, &
+                            bfx_d, bfy_d, bfz_d, rho, &
+                            ab(1), ab(2), ab(3), n)
 #elif HAVE_OPENCL
     call fluid_makeabf_opencl(ta1%x_d, ta2%x_d, ta3%x_d, &
          abx1%x_d, aby1%x_d, abz1%x_d, abx2%x_d, aby2%x_d, abz2%x_d, &
@@ -270,11 +273,12 @@ contains
          bfx_d, bfy_d, bfz_d, u%x_d, v%x_d, w%x_d, B_d, &
          rho, dt, bd(2), bd(3), bd(4), nbd, n)
 #elif HAVE_CUDA
-    call fluid_makebdf_cuda(ta1%x_d, ta2%x_d, ta3%x_d, &
-         tb1%x_d, tb2%x_d, tb3%x_d, ulag%lf(1)%x_d, ulag%lf(2)%x_d, &
-         vlag%lf(1)%x_d, vlag%lf(2)%x_d, wlag%lf(1)%x_d, wlag%lf(2)%x_d, &
-         bfx_d, bfy_d, bfz_d, u%x_d, v%x_d, w%x_d, B_d, &
-         rho, dt, bd(2), bd(3), bd(4), nbd, n)
+    call fluid_makebdf_cuda(tb1%x_d, tb2%x_d, tb3%x_d, &
+                            ulag%lf(1)%x_d, ulag%lf(2)%x_d, &
+                            vlag%lf(1)%x_d, vlag%lf(2)%x_d, &
+                            wlag%lf(1)%x_d, wlag%lf(2)%x_d, &
+                            bfx_d, bfy_d, bfz_d, u%x_d, v%x_d, w%x_d,&
+                            B_d, rho, dt, bd(2), bd(3), bd(4), nbd, n)
 #elif HAVE_OPENCL
     call fluid_makebdf_opencl(ta1%x_d, ta2%x_d, ta3%x_d, &
          tb1%x_d, tb2%x_d, tb3%x_d, ulag%lf(1)%x_d, ulag%lf(2)%x_d, &

--- a/src/fluid/bcknd/device/fluid_abbdf_device.F90
+++ b/src/fluid/bcknd/device/fluid_abbdf_device.F90
@@ -128,14 +128,12 @@ module fluid_abbdf_device
   end interface
 
   interface
-     subroutine fluid_makebdf_cuda(tb1_d, tb2_d, tb3_d, ulag1_d, ulag2_d, &
-                                   vlag1_d, vlag2_d, wlag1_d, wlag2_d, &
-                                   bfx_d, bfy_d, bfz_d, u_d, v_d, w_d, B_d, &
-                                   rho, dt, bd2, bd3, bd4, nbd, n) &
+     subroutine fluid_makebdf_cuda(ulag1_d, ulag2_d, vlag1_d, vlag2_d, &
+          wlag1_d, wlag2_d, bfx_d, bfy_d, bfz_d, u_d, v_d, w_d, B_d, &
+          rho, dt, bd2, bd3, bd4, nbd, n) &
                                    bind(c, name='fluid_makebdf_cuda')
        use, intrinsic :: iso_c_binding
        import c_rp
-       type(c_ptr), value :: tb1_d, tb2_d, tb3_d
        type(c_ptr), value :: ulag1_d, ulag2_d, vlag1_d
        type(c_ptr), value :: vlag2_d, wlag1_d, wlag2_d
        type(c_ptr), value :: bfx_d, bfy_d, bfz_d, u_d, v_d, w_d, B_d
@@ -273,8 +271,7 @@ contains
          bfx_d, bfy_d, bfz_d, u%x_d, v%x_d, w%x_d, B_d, &
          rho, dt, bd(2), bd(3), bd(4), nbd, n)
 #elif HAVE_CUDA
-    call fluid_makebdf_cuda(tb1%x_d, tb2%x_d, tb3%x_d, &
-                            ulag%lf(1)%x_d, ulag%lf(2)%x_d, &
+    call fluid_makebdf_cuda(ulag%lf(1)%x_d, ulag%lf(2)%x_d, &
                             vlag%lf(1)%x_d, vlag%lf(2)%x_d, &
                             wlag%lf(1)%x_d, wlag%lf(2)%x_d, &
                             bfx_d, bfy_d, bfz_d, u%x_d, v%x_d, w%x_d,&


### PR DESCRIPTION
Remove redundant arrays in abbdf kernels, reducing memory traffic by ~70% and kernel runtime by ~30%