### PR TITLE
Fix build for compilers who does not provied REAL128

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ AC_LANG(Fortran)
 AC_PROG_FC(,90)
 AX_COARRAY
 AX_DTYPE_IO
+AX_REAL128
 
 # Test for a working MPI compiler
 AX_MPI([have_mpi=yes], [have_mpi=no])
@@ -160,6 +161,15 @@ elif test "x$enable_real" = xqp; then
 else
    AC_MSG_ERROR([Invalid working precision])
 fi
+
+if test "x$have_real128" = xyes; then
+   AC_SUBST(NEKO_REAL128_TYPE, "REAL128")
+else
+   AC_SUBST(NEKO_REAL128_TYPE, "selected_real_kind(1)")
+   if test "x$enable_real" = xqp; then
+      AC_MSG_ERROR([REAL128 not supported])
+   fi
+fi                          
 
 AC_SUBST(blk_size, ${blk_size})
 

--- a/m4/ax_real128.m4
+++ b/m4/ax_real128.m4
@@ -1,0 +1,37 @@
+#
+# ----------------------------------------------------------------------------
+# "THE BEER-WARE LICENSE" (Revision 42):
+# <leifniclas.jansson@riken.jp> wrote this file. As long as you retain
+# this notice you can do whatever you want with this stuff. If we meet
+# some day, and you think this stuff is worth it, you can buy me a
+# beer in return Niclas Jansson
+# ----------------------------------------------------------------------------
+#
+AC_DEFUN([AX_REAL128], [
+
+AC_REQUIRE([AC_PROG_FC])
+AC_LANG_PUSH([Fortran])
+
+AC_MSG_CHECKING([for REAL128 support])
+AC_COMPILE_IFELSE([
+       module tt
+       integer, parameter :: qp = REAL128
+       end module tt
+
+       program conftest
+       use tt       
+       real(kind=qp) :: test
+       end program conftest
+],
+[have_real128=yes], [have_real128=no])
+
+AC_LANG_POP([Fortran])
+
+if test "x$have_real128" = "xyes"; then
+    AC_MSG_RESULT([yes])
+    AC_DEFINE([HAVE_REAL128], [1], [REAL128 support])
+else
+    AC_MSG_RESULT([no])
+fi
+
+])

--- a/src/config/num_types.f90.in
+++ b/src/config/num_types.f90.in
@@ -6,7 +6,7 @@ module num_types
   integer, parameter :: i8 = INT64
   integer, parameter :: sp = REAL32
   integer, parameter :: dp = REAL64
-  integer, parameter :: qp = REAL128
+  integer, parameter :: qp = @NEKO_REAL128_TYPE@
   !> Global precision used in computations
   integer, parameter :: rp = @NEKO_REAL_TYPE@
   integer, parameter :: c_rp = @NEKO_C_REAL_TYPE@


### PR DESCRIPTION
Fix build for compilers who doesn't implement the entire Fortran 2008 standard. This relates to most LLVM/Flang based compilers e.g. `nvfortran`,`aocc-flang`

Note: the fix will set quad precision type to `select_real_kind(1)` to allow the build. However, if the user request a quad precision build of Neko `--enable-real=qp` a hard error will be thrown during configure

