### PR TITLE
Port EuroHack22 optimisations to HIP/OpenCL kernels

### DIFF
--- a/src/fluid/bcknd/device/fluid_abbdf_device.F90
+++ b/src/fluid/bcknd/device/fluid_abbdf_device.F90
@@ -68,28 +68,27 @@ module fluid_abbdf_device
   end interface
 
   interface
-     subroutine fluid_makeabf_hip(ta1_d, ta2_d, ta3_d, abx1_d, aby1_d, abz1_d, &
-          abx2_d, aby2_d, abz2_d, bfx_d, bfy_d, bfz_d, rho, ab1, ab2, ab3, n) &
+     subroutine fluid_makeabf_hip(abx1_d, aby1_d, abz1_d, &
+                                  abx2_d, aby2_d, abz2_d, &
+                                  bfx_d, bfy_d, bfz_d, &
+                                  rho, ab1, ab2, ab3, n) &
           bind(c, name='fluid_makeabf_hip')
        use, intrinsic :: iso_c_binding
        import c_rp
-       type(c_ptr), value :: ta1_d, ta2_d, ta3_D, abx1_d, aby1_d, abz1_d 
-       type(c_ptr), value :: abx2_d, aby2_d, abz2_d, bfx_d, bfy_d, bfz_d
+       type(c_ptr), value :: abx1_d, aby1_d, abz1_d 
+       type(c_ptr), value :: abx2_d, aby2_d, abz2_d
+       type(c_ptr), value :: bfx_d, bfy_d, bfz_d
        real(c_rp) :: rho, ab1, ab2, ab3
        integer(c_int) :: n
      end subroutine fluid_makeabf_hip
   end interface
 
   interface
-     subroutine fluid_makebdf_hip(ta1_d, ta2_d, ta3_d, tb1_d, tb2_d, tb3_d, &
-                       ulag1_d, ulag2_d, vlag1_d, vlag2_d, wlag1_d, wlag2_d, &
-                       bfx_d, bfy_d, bfz_d, u_d, v_d, w_d, B_d, &
-                       rho, dt, bd2, bd3, bd4, nbd, n) &
-                       bind(c, name='fluid_makebdf_hip')
+     subroutine fluid_makebdf_hip(ulag1_d, ulag2_d, vlag1_d, vlag2_d, &
+          wlag1_d, wlag2_d, bfx_d, bfy_d, bfz_d, u_d, v_d, w_d, B_d, &
+          rho, dt, bd2, bd3, bd4, nbd, n) bind(c, name='fluid_makebdf_hip')
        use, intrinsic :: iso_c_binding
        import c_rp
-       type(c_ptr), value :: ta1_d, ta2_d, ta3_d
-       type(c_ptr), value :: tb1_d, tb2_d, tb3_d
        type(c_ptr), value :: ulag1_d, ulag2_d, vlag1_d
        type(c_ptr), value :: vlag2_d, wlag1_d, wlag2_d
        type(c_ptr), value :: bfx_d, bfy_d, bfz_d, u_d, v_d, w_d, B_d
@@ -130,8 +129,7 @@ module fluid_abbdf_device
   interface
      subroutine fluid_makebdf_cuda(ulag1_d, ulag2_d, vlag1_d, vlag2_d, &
           wlag1_d, wlag2_d, bfx_d, bfy_d, bfz_d, u_d, v_d, w_d, B_d, &
-          rho, dt, bd2, bd3, bd4, nbd, n) &
-                                   bind(c, name='fluid_makebdf_cuda')
+          rho, dt, bd2, bd3, bd4, nbd, n) bind(c, name='fluid_makebdf_cuda')
        use, intrinsic :: iso_c_binding
        import c_rp
        type(c_ptr), value :: ulag1_d, ulag2_d, vlag1_d
@@ -230,9 +228,10 @@ contains
     bfz_d = device_get_ptr(bfz)
 
 #ifdef HAVE_HIP
-    call fluid_makeabf_hip(ta1%x_d, ta2%x_d, ta3%x_d, &
-         abx1%x_d, aby1%x_d, abz1%x_d, abx2%x_d, aby2%x_d, abz2%x_d, &
-         bfx_d, bfy_d, bfz_d, rho, ab(1), ab(2), ab(3), n)
+    call fluid_makeabf_hip(abx1%x_d, aby1%x_d, abz1%x_d, &
+                           abx2%x_d, aby2%x_d, abz2%x_d, &
+                           bfx_d, bfy_d, bfz_d, &
+                           rho, ab(1), ab(2), ab(3), n)
 #elif HAVE_CUDA
     call fluid_makeabf_cuda(abx1%x_d, aby1%x_d, abz1%x_d, &
                             abx2%x_d, aby2%x_d, abz2%x_d, &
@@ -265,11 +264,11 @@ contains
     B_d = device_get_ptr(B)
     
 #ifdef HAVE_HIP
-    call fluid_makebdf_hip(ta1%x_d, ta2%x_d, ta3%x_d, &
-         tb1%x_d, tb2%x_d, tb3%x_d, ulag%lf(1)%x_d, ulag%lf(2)%x_d, &
-         vlag%lf(1)%x_d, vlag%lf(2)%x_d, wlag%lf(1)%x_d, wlag%lf(2)%x_d, &
-         bfx_d, bfy_d, bfz_d, u%x_d, v%x_d, w%x_d, B_d, &
-         rho, dt, bd(2), bd(3), bd(4), nbd, n)
+    call fluid_makebdf_hip(ulag%lf(1)%x_d, ulag%lf(2)%x_d, &
+                           vlag%lf(1)%x_d, vlag%lf(2)%x_d, &
+                           wlag%lf(1)%x_d, wlag%lf(2)%x_d, &
+                           bfx_d, bfy_d, bfz_d, u%x_d, v%x_d, w%x_d, &
+                           B_d, rho, dt, bd(2), bd(3), bd(4), nbd, n)
 #elif HAVE_CUDA
     call fluid_makebdf_cuda(ulag%lf(1)%x_d, ulag%lf(2)%x_d, &
                             vlag%lf(1)%x_d, vlag%lf(2)%x_d, &

--- a/src/fluid/bcknd/device/fluid_abbdf_device.F90
+++ b/src/fluid/bcknd/device/fluid_abbdf_device.F90
@@ -72,7 +72,7 @@ module fluid_abbdf_device
                                   abx2_d, aby2_d, abz2_d, &
                                   bfx_d, bfy_d, bfz_d, &
                                   rho, ab1, ab2, ab3, n) &
-          bind(c, name='fluid_makeabf_hip')
+                                  bind(c, name='fluid_makeabf_hip')
        use, intrinsic :: iso_c_binding
        import c_rp
        type(c_ptr), value :: abx1_d, aby1_d, abz1_d 
@@ -115,7 +115,7 @@ module fluid_abbdf_device
                                    abx2_d, aby2_d, abz2_d, &
                                    bfx_d, bfy_d, bfz_d, &
                                    rho, ab1, ab2, ab3, n) &
-          bind(c, name='fluid_makeabf_cuda')
+                                   bind(c, name='fluid_makeabf_cuda')
        use, intrinsic :: iso_c_binding
        import c_rp
        type(c_ptr), value :: abx1_d, aby1_d, abz1_d 
@@ -154,28 +154,27 @@ module fluid_abbdf_device
   end interface
 
   interface
-     subroutine fluid_makeabf_opencl(ta1_d, ta2_d, ta3_d, abx1_d, aby1_d, abz1_d, &
-          abx2_d, aby2_d, abz2_d, bfx_d, bfy_d, bfz_d, rho, ab1, ab2, ab3, n) &
-          bind(c, name='fluid_makeabf_opencl')
+     subroutine fluid_makeabf_opencl(abx1_d, aby1_d, abz1_d, &
+                                     abx2_d, aby2_d, abz2_d, &
+                                     bfx_d, bfy_d, bfz_d, &
+                                     rho, ab1, ab2, ab3, n) &
+                                     bind(c, name='fluid_makeabf_opencl')
        use, intrinsic :: iso_c_binding
        import c_rp
-       type(c_ptr), value :: ta1_d, ta2_d, ta3_D, abx1_d, aby1_d, abz1_d 
-       type(c_ptr), value :: abx2_d, aby2_d, abz2_d, bfx_d, bfy_d, bfz_d
+       type(c_ptr), value :: abx1_d, aby1_d, abz1_d 
+       type(c_ptr), value :: abx2_d, aby2_d, abz2_d
+       type(c_ptr), value :: bfx_d, bfy_d, bfz_d
        real(c_rp) :: rho, ab1, ab2, ab3
        integer(c_int) :: n
      end subroutine fluid_makeabf_opencl
   end interface
 
   interface
-     subroutine fluid_makebdf_opencl(ta1_d, ta2_d, ta3_d, tb1_d, tb2_d, tb3_d, &
-                       ulag1_d, ulag2_d, vlag1_d, vlag2_d, wlag1_d, wlag2_d, &
-                       bfx_d, bfy_d, bfz_d, u_d, v_d, w_d, B_d, &
-                       rho, dt, bd2, bd3, bd4, nbd, n) &
-                       bind(c, name='fluid_makebdf_opencl')
+     subroutine fluid_makebdf_opencl(ulag1_d, ulag2_d, vlag1_d, vlag2_d, &
+          wlag1_d, wlag2_d, bfx_d, bfy_d, bfz_d, u_d, v_d, w_d, B_d, &
+          rho, dt, bd2, bd3, bd4, nbd, n) bind(c, name='fluid_makebdf_opencl')
        use, intrinsic :: iso_c_binding
        import c_rp
-       type(c_ptr), value :: ta1_d, ta2_d, ta3_d
-       type(c_ptr), value :: tb1_d, tb2_d, tb3_d
        type(c_ptr), value :: ulag1_d, ulag2_d, vlag1_d
        type(c_ptr), value :: vlag2_d, wlag1_d, wlag2_d
        type(c_ptr), value :: bfx_d, bfy_d, bfz_d, u_d, v_d, w_d, B_d
@@ -238,9 +237,10 @@ contains
                             bfx_d, bfy_d, bfz_d, rho, &
                             ab(1), ab(2), ab(3), n)
 #elif HAVE_OPENCL
-    call fluid_makeabf_opencl(ta1%x_d, ta2%x_d, ta3%x_d, &
-         abx1%x_d, aby1%x_d, abz1%x_d, abx2%x_d, aby2%x_d, abz2%x_d, &
-         bfx_d, bfy_d, bfz_d, rho, ab(1), ab(2), ab(3), n)
+    call fluid_makeabf_opencl(abx1%x_d, aby1%x_d, abz1%x_d, &
+                              abx2%x_d, aby2%x_d, abz2%x_d, &
+                              bfx_d, bfy_d, bfz_d, rho, &
+                              ab(1), ab(2), ab(3), n)
 #endif
     
   end subroutine fluid_makeabf_device
@@ -273,14 +273,14 @@ contains
     call fluid_makebdf_cuda(ulag%lf(1)%x_d, ulag%lf(2)%x_d, &
                             vlag%lf(1)%x_d, vlag%lf(2)%x_d, &
                             wlag%lf(1)%x_d, wlag%lf(2)%x_d, &
-                            bfx_d, bfy_d, bfz_d, u%x_d, v%x_d, w%x_d,&
+                            bfx_d, bfy_d, bfz_d, u%x_d, v%x_d, w%x_d, &
                             B_d, rho, dt, bd(2), bd(3), bd(4), nbd, n)
 #elif HAVE_OPENCL
-    call fluid_makebdf_opencl(ta1%x_d, ta2%x_d, ta3%x_d, &
-         tb1%x_d, tb2%x_d, tb3%x_d, ulag%lf(1)%x_d, ulag%lf(2)%x_d, &
-         vlag%lf(1)%x_d, vlag%lf(2)%x_d, wlag%lf(1)%x_d, wlag%lf(2)%x_d, &
-         bfx_d, bfy_d, bfz_d, u%x_d, v%x_d, w%x_d, B_d, &
-         rho, dt, bd(2), bd(3), bd(4), nbd, n)
+    call fluid_makebdf_opencl(ulag%lf(1)%x_d, ulag%lf(2)%x_d, &
+                              vlag%lf(1)%x_d, vlag%lf(2)%x_d, &
+                              wlag%lf(1)%x_d, wlag%lf(2)%x_d, &
+                              bfx_d, bfy_d, bfz_d, u%x_d, v%x_d, w%x_d, &
+                              B_d, rho, dt, bd(2), bd(3), bd(4), nbd, n)
 #endif
 
   end subroutine fluid_makebdf_device

--- a/src/fluid/bcknd/device/hip/fluid_abbdf.hip
+++ b/src/fluid/bcknd/device/hip/fluid_abbdf.hip
@@ -61,8 +61,7 @@ extern "C" {
     HIP_CHECK(hipGetLastError());
   }
 
-  void fluid_makeabf_hip(void *ta1, void *ta2, void *ta3,
-                         void *abx1, void *aby1, void *abz1, 
+  void fluid_makeabf_hip(void *abx1, void *aby1, void *abz1, 
                          void *abx2, void *aby2, void *abz2,
                          void *bfx, void *bfy, void *bfz,
                          real *rho, real *ab1, real *ab2, real *ab3, int *n) {
@@ -72,7 +71,6 @@ extern "C" {
     
     hipLaunchKernelGGL(HIP_KERNEL_NAME( makeabf_kernel<real> ),
                        nblcks, nthrds, 0, 0,
-                       (real *) ta1, (real *) ta2, (real *) ta3,
                        (real *) abx1, (real *) aby1, (real *) abz1, 
                        (real *) abx2, (real *) aby2, (real *) abz2,
                        (real *) bfx, (real *) bfy, (real *) bfz,
@@ -80,9 +78,7 @@ extern "C" {
     HIP_CHECK(hipGetLastError());
   }
   
-  void fluid_makebdf_hip(void *ta1, void *ta2, void *ta3,
-                         void *tb1, void *tb2, void *tb3,
-                         void *ulag1, void *ulag2, void *vlag1,
+  void fluid_makebdf_hip(void *ulag1, void *ulag2, void *vlag1,
                          void *vlag2, void *wlag1, void *wlag2, 
                          void *bfx, void *bfy, void *bfz,
                          void *u, void *v, void *w, void *B, 
@@ -94,8 +90,6 @@ extern "C" {
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME( makebdf_kernel<real> ),
                        nblcks, nthrds, 0, 0,
-                       (real *) ta1, (real *) ta2, (real *) ta3,
-                       (real *) tb1, (real *) tb2, (real *) tb3,
                        (real *) ulag1, (real *) ulag2, (real *) vlag1,
                        (real *) vlag2, (real *) wlag1, (real *) wlag2, 
                        (real *) bfx, (real *) bfy, (real *) bfz,

--- a/src/fluid/bcknd/device/hip/makeabf_kernel.h
+++ b/src/fluid/bcknd/device/hip/makeabf_kernel.h
@@ -33,10 +33,7 @@
 */
 
 template< typename T >
-__global__ void makeabf_kernel(T * __restrict__ ta1,
-                               T * __restrict__ ta2,
-                               T * __restrict__ ta3,
-                               T * __restrict__ abx1,
+__global__ void makeabf_kernel(T * __restrict__ abx1,
                                T * __restrict__ aby1,
                                T * __restrict__ abz1,
                                T * __restrict__ abx2,
@@ -55,25 +52,21 @@ __global__ void makeabf_kernel(T * __restrict__ ta1,
   const int str = blockDim.x * gridDim.x;
 
   for (int i = idx; i < n; i += str) {
-    ta1[i] = ab2 * abx1[i] + ab3 * abx2[i];
-    ta2[i] = ab2 * aby1[i] + ab3 * aby2[i];
-    ta3[i] = ab2 * abz1[i] + ab3 * abz2[i];
-  }
+    T ta1_val = ab2 * abx1[i] + ab3 * abx2[i];
+    T ta2_val = ab2 * aby1[i] + ab3 * aby2[i];
+    T ta3_val = ab2 * abz1[i] + ab3 * abz2[i];
 
-  for (int i = idx; i < n; i += str) {
     abx2[i] = abx1[i];
     aby2[i] = aby1[i];
     abz2[i] = abz1[i];
     abx1[i] = bfx[i];
     aby1[i] = bfy[i];
     abz1[i] = bfz[i];
+
+    bfx[i] = (ab1 * bfx[i] + ta1_val) * rho;
+    bfy[i] = (ab1 * bfy[i] + ta2_val) * rho;
+    bfz[i] = (ab1 * bfz[i] + ta3_val) * rho;
   }
-  
-  for (int i = idx; i < n; i += str) {
-    bfx[i] = (ab1 * bfx[i] + ta1[i]) * rho;
-    bfy[i] = (ab1 * bfy[i] + ta2[i]) * rho;
-    bfz[i] = (ab1 * bfz[i] + ta3[i]) * rho;
-  } 
   
 }
 

--- a/src/fluid/bcknd/device/hip/makebdf_kernel.h
+++ b/src/fluid/bcknd/device/hip/makebdf_kernel.h
@@ -33,13 +33,7 @@
 */
 
 template< typename T >
-__global__ void makebdf_kernel(T * __restrict__ ta1,
-                               T * __restrict__ ta2,
-                               T * __restrict__ ta3,
-                               T * __restrict__ tb1,
-                               T * __restrict__ tb2,
-                               T * __restrict__ tb3,
-                               const T * __restrict__ ulag1,
+__global__ void makebdf_kernel(const T * __restrict__ ulag1,
                                const T * __restrict__ ulag2,
                                const T * __restrict__ vlag1,
                                const T * __restrict__ vlag2,
@@ -64,37 +58,28 @@ __global__ void makebdf_kernel(T * __restrict__ ta1,
   const int str = blockDim.x * gridDim.x;
 
   for (int i = idx; i < n; i += str) {
-    tb1[i] = u[i] * B[i] * bd2;
-    tb2[i] = v[i] * B[i] * bd2;
-    tb3[i] = w[i] * B[i] * bd2;
+    T tb1_val = u[i] * B[i] * bd2;
+    T tb2_val = v[i] * B[i] * bd2;
+    T tb3_val = w[i] * B[i] * bd2;
 
-    ta1[i] = ulag1[i] * B[i] * bd3;
-    ta2[i] = vlag1[i] * B[i] * bd3;
-    ta3[i] = wlag1[i] * B[i] * bd3;
+    T ta1_val = ulag1[i] * B[i] * bd3;
+    T ta2_val = vlag1[i] * B[i] * bd3;
+    T ta3_val = wlag1[i] * B[i] * bd3;
 
-    tb1[i] += ta1[i];
-    tb2[i] += ta2[i];
-    tb3[i] += ta3[i];
-  }
+    tb1_val += ta1_val;
+    tb2_val += ta2_val;
+    tb3_val += ta3_val;
 
-  if (nbd == 3) {
-    for (int i = idx; i < n; i += str) {
-      ta1[i] = ulag2[i] * B[i] * bd4;
-      ta2[i] = vlag2[i] * B[i] * bd4;
-      ta3[i] = wlag2[i] * B[i] * bd4;
-      
-      tb1[i] += ta1[i];
-      tb2[i] += ta2[i];
-      tb3[i] += ta3[i];
+    if (nbd == 3) {
+      tb1_val += ulag2[i] * B[i] * bd4;
+      tb2_val += vlag2[i] * B[i] * bd4;
+      tb3_val += wlag2[i] * B[i] * bd4;
     }
+    
+    bfx[i] = bfx[i] + tb1_val * (rho / dt);
+    bfy[i] = bfy[i] + tb2_val * (rho / dt);
+    bfz[i] = bfz[i] + tb3_val * (rho / dt);
   }
-
-  for (int i = idx; i < n; i += str) {
-    bfx[i] = bfx[i] + tb1[i] * (rho / dt);
-    bfy[i] = bfy[i] + tb2[i] * (rho / dt);
-    bfz[i] = bfz[i] + tb3[i] * (rho / dt);
-  }
-
 
 }
 

--- a/src/fluid/bcknd/device/opencl/abbdf_kernel.cl
+++ b/src/fluid/bcknd/device/opencl/abbdf_kernel.cl
@@ -69,10 +69,7 @@ __kernel void sumab_kernel(__global real * __restrict__ u,
   
 }
 
-__kernel void makeabf_kernel(__global real * __restrict__ ta1,
-                             __global real * __restrict__ ta2,
-                             __global real * __restrict__ ta3,
-                             __global real * __restrict__ abx1,
+__kernel void makeabf_kernel(__global real * __restrict__ abx1,
                              __global real * __restrict__ aby1,
                              __global real * __restrict__ abz1,
                              __global real * __restrict__ abx2,
@@ -91,35 +88,25 @@ __kernel void makeabf_kernel(__global real * __restrict__ ta1,
   const int str = get_global_size(0);
 
   for (int i = idx; i < n; i += str) {
-    ta1[i] = ab2 * abx1[i] + ab3 * abx2[i];
-    ta2[i] = ab2 * aby1[i] + ab3 * aby2[i];
-    ta3[i] = ab2 * abz1[i] + ab3 * abz2[i];
-  }
+    real ta1_val = ab2 * abx1[i] + ab3 * abx2[i];
+    real ta2_val = ab2 * aby1[i] + ab3 * aby2[i];
+    real ta3_val = ab2 * abz1[i] + ab3 * abz2[i];
 
-  for (int i = idx; i < n; i += str) {
     abx2[i] = abx1[i];
     aby2[i] = aby1[i];
     abz2[i] = abz1[i];
     abx1[i] = bfx[i];
     aby1[i] = bfy[i];
     abz1[i] = bfz[i];
+
+    bfx[i] = (ab1 * bfx[i] + ta1_val) * rho;
+    bfy[i] = (ab1 * bfy[i] + ta2_val) * rho;
+    bfz[i] = (ab1 * bfz[i] + ta3_val) * rho;
   }
-  
-  for (int i = idx; i < n; i += str) {
-    bfx[i] = (ab1 * bfx[i] + ta1[i]) * rho;
-    bfy[i] = (ab1 * bfy[i] + ta2[i]) * rho;
-    bfz[i] = (ab1 * bfz[i] + ta3[i]) * rho;
-  } 
-  
+    
 }
 
-__kernel void makebdf_kernel(__global real * __restrict__ ta1,
-                             __global real * __restrict__ ta2,
-                             __global real * __restrict__ ta3,
-                             __global real * __restrict__ tb1,
-                             __global real * __restrict__ tb2,
-                             __global real * __restrict__ tb3,
-                             __global const real * __restrict__ ulag1,
+__kernel void makebdf_kernel(__global const real * __restrict__ ulag1,
                              __global const real * __restrict__ ulag2,
                              __global const real * __restrict__ vlag1,
                              __global const real * __restrict__ vlag2,
@@ -144,37 +131,29 @@ __kernel void makebdf_kernel(__global real * __restrict__ ta1,
   const int str = get_global_size(0);
 
   for (int i = idx; i < n; i += str) {
-    tb1[i] = u[i] * B[i] * bd2;
-    tb2[i] = v[i] * B[i] * bd2;
-    tb3[i] = w[i] * B[i] * bd2;
+    real tb1_val = u[i] * B[i] * bd2;
+    real tb2_val = v[i] * B[i] * bd2;
+    real tb3_val = w[i] * B[i] * bd2;
 
-    ta1[i] = ulag1[i] * B[i] * bd3;
-    ta2[i] = vlag1[i] * B[i] * bd3;
-    ta3[i] = wlag1[i] * B[i] * bd3;
+    real ta1_val = ulag1[i] * B[i] * bd3;
+    real ta2_val = vlag1[i] * B[i] * bd3;
+    real ta3_val = wlag1[i] * B[i] * bd3;
 
-    tb1[i] += ta1[i];
-    tb2[i] += ta2[i];
-    tb3[i] += ta3[i];
-  }
+    tb1_val += ta1_val;
+    tb2_val += ta2_val;
+    tb3_val += ta3_val;
 
-  if (nbd == 3) {
-    for (int i = idx; i < n; i += str) {
-      ta1[i] = ulag2[i] * B[i] * bd4;
-      ta2[i] = vlag2[i] * B[i] * bd4;
-      ta3[i] = wlag2[i] * B[i] * bd4;
-      
-      tb1[i] += ta1[i];
-      tb2[i] += ta2[i];
-      tb3[i] += ta3[i];
+    if (nbd == 3) {
+      tb1_val += ulag2[i] * B[i] * bd4;
+      tb2_val += vlag2[i] * B[i] * bd4;
+      tb3_val += wlag2[i] * B[i] * bd4;
     }
+    
+    bfx[i] = bfx[i] + tb1_val * (rho / dt);
+    bfy[i] = bfy[i] + tb2_val * (rho / dt);
+    bfz[i] = bfz[i] + tb3_val * (rho / dt);
   }
-
-  for (int i = idx; i < n; i += str) {
-    bfx[i] = bfx[i] + tb1[i] * (rho / dt);
-    bfy[i] = bfy[i] + tb2[i] * (rho / dt);
-    bfz[i] = bfz[i] + tb3[i] * (rho / dt);
-  }
-
+  
 }
 
 

--- a/src/fluid/bcknd/device/opencl/fluid_abbdf.c
+++ b/src/fluid/bcknd/device/opencl/fluid_abbdf.c
@@ -86,8 +86,7 @@ void fluid_sumab_opencl(void *u, void *v, void *w,
                                   0, NULL, NULL));  
 }
 
-void fluid_makeabf_opencl(void *ta1, void *ta2, void *ta3,
-                          void *abx1, void *aby1, void *abz1, 
+void fluid_makeabf_opencl(void *abx1, void *aby1, void *abz1, 
                           void *abx2, void *aby2, void *abz2,
                           void *bfx, void *bfy, void *bfz,
                           real *rho, real *ab1, real *ab2, real *ab3, int *n) {
@@ -99,23 +98,20 @@ void fluid_makeabf_opencl(void *ta1, void *ta2, void *ta3,
   cl_kernel kernel = clCreateKernel(abbdf_program, "makeabf_kernel", &err);
   CL_CHECK(err);
 
-  CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &ta1));
-  CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &ta2));
-  CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &ta3));
-  CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &abx1));
-  CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), (void *) &aby1));
-  CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_mem), (void *) &abz1));
-  CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_mem), (void *) &abx2));
-  CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_mem), (void *) &aby2));
-  CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_mem), (void *) &abz2));
-  CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_mem), (void *) &bfx));
-  CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_mem), (void *) &bfy));
-  CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_mem), (void *) &bfz));
-  CL_CHECK(clSetKernelArg(kernel, 12, sizeof(real), rho));
-  CL_CHECK(clSetKernelArg(kernel, 13, sizeof(real), ab1));
-  CL_CHECK(clSetKernelArg(kernel, 14, sizeof(real), ab2));
-  CL_CHECK(clSetKernelArg(kernel, 15, sizeof(real), ab3));
-  CL_CHECK(clSetKernelArg(kernel, 16, sizeof(int), n));
+  CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &abx1));
+  CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &aby1));
+  CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &abz1));
+  CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &abx2));
+  CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), (void *) &aby2));
+  CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_mem), (void *) &abz2));
+  CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_mem), (void *) &bfx));
+  CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_mem), (void *) &bfy));
+  CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_mem), (void *) &bfz));
+  CL_CHECK(clSetKernelArg(kernel, 9, sizeof(real), rho));
+  CL_CHECK(clSetKernelArg(kernel, 10, sizeof(real), ab1));
+  CL_CHECK(clSetKernelArg(kernel, 11, sizeof(real), ab2));
+  CL_CHECK(clSetKernelArg(kernel, 12, sizeof(real), ab3));
+  CL_CHECK(clSetKernelArg(kernel, 13, sizeof(int), n));
   
   const int nb = ((*n) + 256 - 1) / 256;
   const size_t global_item_size = 256 * nb;
@@ -127,9 +123,7 @@ void fluid_makeabf_opencl(void *ta1, void *ta2, void *ta3,
   
 }
 
-void fluid_makebdf_opencl(void *ta1, void *ta2, void *ta3,
-                          void *tb1, void *tb2, void *tb3,
-                          void *ulag1, void *ulag2, void *vlag1,
+void fluid_makebdf_opencl(void *ulag1, void *ulag2, void *vlag1,
                           void *vlag2, void *wlag1, void *wlag2, 
                           void *bfx, void *bfy, void *bfz,
                           void *u, void *v, void *w, void *B, 
@@ -143,32 +137,26 @@ void fluid_makebdf_opencl(void *ta1, void *ta2, void *ta3,
   cl_kernel kernel = clCreateKernel(abbdf_program, "makebdf_kernel", &err);
   CL_CHECK(err);
 
-  CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &ta1));
-  CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &ta2));
-  CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &ta3));
-  CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &tb1));
-  CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), (void *) &tb2));
-  CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_mem), (void *) &tb3));
-  CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_mem), (void *) &ulag1));
-  CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_mem), (void *) &ulag2));
-  CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_mem), (void *) &vlag1));
-  CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_mem), (void *) &vlag2));
-  CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_mem), (void *) &wlag1));
-  CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_mem), (void *) &wlag2));
-  CL_CHECK(clSetKernelArg(kernel, 12, sizeof(cl_mem), (void *) &bfx));
-  CL_CHECK(clSetKernelArg(kernel, 13, sizeof(cl_mem), (void *) &bfy));
-  CL_CHECK(clSetKernelArg(kernel, 14, sizeof(cl_mem), (void *) &bfz));
-  CL_CHECK(clSetKernelArg(kernel, 15, sizeof(cl_mem), (void *) &u));
-  CL_CHECK(clSetKernelArg(kernel, 16, sizeof(cl_mem), (void *) &v));
-  CL_CHECK(clSetKernelArg(kernel, 17, sizeof(cl_mem), (void *) &w));
-  CL_CHECK(clSetKernelArg(kernel, 18, sizeof(cl_mem), (void *) &B));
-  CL_CHECK(clSetKernelArg(kernel, 19, sizeof(real), rho));
-  CL_CHECK(clSetKernelArg(kernel, 20, sizeof(real), dt));
-  CL_CHECK(clSetKernelArg(kernel, 21, sizeof(real), bd2));
-  CL_CHECK(clSetKernelArg(kernel, 22, sizeof(real), bd3));
-  CL_CHECK(clSetKernelArg(kernel, 23, sizeof(real), bd4));
-  CL_CHECK(clSetKernelArg(kernel, 24, sizeof(int), nbd));
-  CL_CHECK(clSetKernelArg(kernel, 25, sizeof(int), n));
+  CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &ulag1));
+  CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &ulag2));
+  CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &vlag1));
+  CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &vlag2));
+  CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), (void *) &wlag1));
+  CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_mem), (void *) &wlag2));
+  CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_mem), (void *) &bfx));
+  CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_mem), (void *) &bfy));
+  CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_mem), (void *) &bfz));
+  CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_mem), (void *) &u));
+  CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_mem), (void *) &v));
+  CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_mem), (void *) &w));
+  CL_CHECK(clSetKernelArg(kernel, 12, sizeof(cl_mem), (void *) &B));
+  CL_CHECK(clSetKernelArg(kernel, 13, sizeof(real), rho));
+  CL_CHECK(clSetKernelArg(kernel, 14, sizeof(real), dt));
+  CL_CHECK(clSetKernelArg(kernel, 15, sizeof(real), bd2));
+  CL_CHECK(clSetKernelArg(kernel, 16, sizeof(real), bd3));
+  CL_CHECK(clSetKernelArg(kernel, 17, sizeof(real), bd4));
+  CL_CHECK(clSetKernelArg(kernel, 18, sizeof(int), nbd));
+  CL_CHECK(clSetKernelArg(kernel, 19, sizeof(int), n));
   
   const int nb = ((*n) + 256 - 1) / 256;
   const size_t global_item_size = 256 * nb;


### PR DESCRIPTION
- Reduce memory trafic in abf and bdf kernels (HIP), based on the CUDA opt from EuroHack22
- Reduce memory trafic in OpenCL kernels
