### PR TITLE
Pass down parameters in user_check

### DIFF
--- a/bench/tgv32/tgv.f90
+++ b/bench/tgv32/tgv.f90
@@ -62,10 +62,11 @@ contains
     uvw(3)   = zero
   end function tgv_ic
 
-  subroutine usr_calc_quantities( t, dt, tstep,u, v, w, p, coef)
-    real(kind=rp), intent(in) :: t, dt
+  subroutine usr_calc_quantities( t, tstep, u, v, w, p, coef, params)
+    real(kind=rp), intent(in) :: t
     integer, intent(in) :: tstep
     type(coef_t), intent(inout) :: coef
+    type(param_t), intent(inout) :: params
     type(field_t), intent(inout) :: u
     type(field_t), intent(inout) :: v
     type(field_t), intent(inout) :: w

--- a/examples/lid/lid.f90
+++ b/examples/lid/lid.f90
@@ -69,7 +69,6 @@ module user
     type(coef_t), intent(inout) :: coef
     type(param_t), intent(inout) :: params
 
-    real(kind=rp) dt
     integer tstep
 
     ! initialize work arrays for postprocessing
@@ -80,17 +79,17 @@ module user
     call field_init(w2, u%dof, 'work1')
 
     ! call usercheck also for tstep=0
-    dt = params%dt
     tstep = 0
-    call user_calc_quantities(t, dt, tstep, u, v, w, p, coef)
+    call user_calc_quantities(t, tstep, u, v, w, p, coef, params)
 
   end subroutine user_initialize
 
   ! User-defined routine called at the end of every time step
-  subroutine user_calc_quantities(t, dt, tstep,u, v, w, p, coef)
-    real(kind=rp), intent(in) :: t, dt
+  subroutine user_calc_quantities(t, tstep, u, v, w, p, coef, params)
+    real(kind=rp), intent(in) :: t
     integer, intent(in) :: tstep
     type(coef_t), intent(inout) :: coef
+    type(param_t), intent(inout) :: params
     type(field_t), intent(inout) :: u
     type(field_t), intent(inout) :: v
     type(field_t), intent(inout) :: w

--- a/examples/lid/lid2d.f90
+++ b/examples/lid/lid2d.f90
@@ -69,7 +69,6 @@ module user
     type(coef_t), intent(inout) :: coef
     type(param_t), intent(inout) :: params
 
-    real(kind=rp) dt
     integer tstep
 
     ! initialize work arrays for postprocessing
@@ -80,17 +79,17 @@ module user
     call field_init(w2, u%dof, 'work1')
 
     ! call usercheck also for tstep=0
-    dt = params%dt
     tstep = 0
-    call user_calc_quantities(t, dt, tstep, u, v, w, p, coef)
+    call user_calc_quantities(t, tstep, u, v, w, p, coef, params)
 
   end subroutine user_initialize
 
   ! User-defined routine called at the end of every time step
-  subroutine user_calc_quantities(t, dt, tstep,u, v, w, p, coef)
-    real(kind=rp), intent(in) :: t, dt
+  subroutine user_calc_quantities(t, tstep, u, v, w, p, coef, params)
+    real(kind=rp), intent(in) :: t
     integer, intent(in) :: tstep
     type(coef_t), intent(inout) :: coef
+    type(param_t), intent(inout) :: params
     type(field_t), intent(inout) :: u
     type(field_t), intent(inout) :: v
     type(field_t), intent(inout) :: w

--- a/examples/tgv/tgv.f90
+++ b/examples/tgv/tgv.f90
@@ -92,17 +92,17 @@ contains
     call field_init(w2, u%dof, 'work1')
 
     ! call usercheck also for tstep=0
-    dt = params%dt
     tstep = 0
-    call user_calc_quantities(t, dt, tstep, u, v, w, p, coef)
+    call user_calc_quantities(t, tstep, u, v, w, p, coef, params)
 
   end subroutine user_initialize
  
   ! User-defined routine called at the end of every time step
-  subroutine user_calc_quantities(t, dt, tstep,u, v, w, p, coef)
-    real(kind=rp), intent(in) :: t, dt
+  subroutine user_calc_quantities(t, tstep, u, v, w, p, coef, params)
+    real(kind=rp), intent(in) :: t
     integer, intent(in) :: tstep
     type(coef_t), intent(inout) :: coef
+    type(param_t), intent(inout) :: params
     type(field_t), intent(inout) :: u
     type(field_t), intent(inout) :: v
     type(field_t), intent(inout) :: w

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -55,7 +55,7 @@ module user_intf
 
   !> Abstract interface for initilialization of modules
   abstract interface
-     subroutine user_initialize_modules(t, u, v, w, p, c_Xh, params)
+     subroutine user_initialize_modules(t, u, v, w, p, coef, params)
        import field_t
        import param_t
        import coef_t
@@ -65,7 +65,7 @@ module user_intf
        type(field_t), intent(inout) :: v
        type(field_t), intent(inout) :: w
        type(field_t), intent(inout) :: p
-       type(coef_t), intent(inout) :: c_Xh
+       type(coef_t), intent(inout) :: coef
        type(param_t), intent(inout) :: params
      end subroutine user_initialize_modules
   end interface
@@ -186,13 +186,13 @@ contains
     type(field_t), intent(inout) :: p
   end subroutine dummy_user_check
 
-  subroutine dummy_user_init_no_modules(t, u, v, w, p, c_Xh, params)
+  subroutine dummy_user_init_no_modules(t, u, v, w, p, coef, params)
     real(kind=rp) :: t
     type(field_t), intent(inout) :: u
     type(field_t), intent(inout) :: v
     type(field_t), intent(inout) :: w
     type(field_t), intent(inout) :: p
-    type(coef_t), intent(inout) :: c_Xh
+    type(coef_t), intent(inout) :: coef
     type(param_t), intent(inout) :: params
   end subroutine dummy_user_init_no_modules
 

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -81,17 +81,19 @@ module user_intf
 
   !> Abstract interface for user defined check functions
   abstract interface
-     subroutine usercheck(t, dt, tstep, u, v, w, p, coef)
+     subroutine usercheck(t, tstep, u, v, w, p, coef, param)
        import field_t
        import coef_t
+       import param_t
        import rp
-       real(kind=rp), intent(in) :: t, dt
+       real(kind=rp), intent(in) :: t
        integer, intent(in) :: tstep
-       type(coef_t), intent(inout) :: coef
        type(field_t), intent(inout) :: u
        type(field_t), intent(inout) :: v
        type(field_t), intent(inout) :: w
        type(field_t), intent(inout) :: p
+       type(coef_t), intent(inout) :: coef
+       type(param_t), intent(inout) :: param
      end subroutine usercheck
   end interface
 
@@ -176,14 +178,15 @@ contains
   end subroutine dummy_user_mesh_setup
   
   !> Dummy user check
-  subroutine dummy_user_check(t, dt, tstep, u, v, w, p, coef)
-    real(kind=rp), intent(in) :: t, dt
+  subroutine dummy_user_check(t, tstep, u, v, w, p, coef, params)
+    real(kind=rp), intent(in) :: t    
     integer, intent(in) :: tstep
-    type(coef_t), intent(inout) :: coef
     type(field_t), intent(inout) :: u
     type(field_t), intent(inout) :: v
     type(field_t), intent(inout) :: w
     type(field_t), intent(inout) :: p
+    type(coef_t), intent(inout) :: coef
+    type(param_t), intent(inout) :: params
   end subroutine dummy_user_check
 
   subroutine dummy_user_init_no_modules(t, u, v, w, p, coef, params)

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -99,8 +99,8 @@ contains
        call neko_log%section('Postprocessing')       
        call C%q%eval(t, C%params%dt)
        call C%s%sample(t)
-       call C%usr%usr_chk(t, C%params%dt, tstep,&
-            C%fluid%u, C%fluid%v, C%fluid%w, C%fluid%p, C%fluid%c_Xh)
+       call C%usr%usr_chk(t, tstep,&
+            C%fluid%u, C%fluid%v, C%fluid%w, C%fluid%p, C%fluid%c_Xh, C%params)
        call neko_log%end_section()
        
        call neko_log%end()


### PR DESCRIPTION
Pass down parameters to `user_check` to allow access to e.g. the Reynolds number, fixes #640

Note: This breaks all existing examples using `user_check`. All provided examples have been updated.


