### PR TITLE
Change CUDA glsc3 to use shuffle warp reduce

### DIFF
--- a/src/math/bcknd/device/cuda/math.cu
+++ b/src/math/bcknd/device/cuda/math.cu
@@ -368,16 +368,12 @@ extern "C" {
     glsc3_kernel<real><<<nblcks, nthrds>>>((real *) a, (real *) b,
                                            (real *) c, bufred_d, *n);
     CUDA_CHECK(cudaGetLastError());
+    reduce_kernel<<<1, 1024>>> (bufred_d, nb);
+    CUDA_CHECK(cudaGetLastError());
 
-    CUDA_CHECK(cudaMemcpy(bufred, bufred_d, nb * sizeof(real),
+    CUDA_CHECK(cudaMemcpy(bufred, bufred_d, sizeof(real),
                           cudaMemcpyDeviceToHost));
-
-    real res = 0.0;
-    for (int i = 0; i < nb; i++) {
-      res += bufred[i];
-    }
-
-    return res;
+    return bufred[0];
   }
   
   /**

--- a/src/math/bcknd/device/cuda/math_kernel.h
+++ b/src/math/bcknd/device/cuda/math_kernel.h
@@ -32,7 +32,6 @@
  POSSIBILITY OF SUCH DAMAGE.
 */
 
-
 /**
  * Device kernel for cmult
  */

--- a/src/math/bcknd/device/cuda/math_kernel.h
+++ b/src/math/bcknd/device/cuda/math_kernel.h
@@ -32,6 +32,8 @@
  POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include <cub/cub.cuh>
+
 /**
  * Device kernel for cmult
  */
@@ -359,8 +361,52 @@ __global__ void addcol4_kernel(T * __restrict__ a,
 }
 
 /**
+ * Warp shuffle reduction
+ */
+template< typename T>
+__inline__ __device__ T reduce_warp(T val) {
+  val += __shfl_down_sync(0xffffffff, val, 16);
+  val += __shfl_down_sync(0xffffffff, val, 8);
+  val += __shfl_down_sync(0xffffffff, val, 4);
+  val += __shfl_down_sync(0xffffffff, val, 2);
+  val += __shfl_down_sync(0xffffffff, val, 1);
+  return val;
+}
+
+/**
+ * Vector reduction kernel
+ */
+template< typename T >
+__global__ void reduce_kernel(T * bufred, const int n) {
+                
+  T sum = 0;
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+  for (int i = idx; i<n ; i += str) 
+  {
+    sum += bufred[i];
+  }
+
+  __shared__ T shared[32];
+  unsigned int lane = threadIdx.x % warpSize;
+  unsigned int wid = threadIdx.x / warpSize;
+
+  sum = reduce_warp<T>(sum);
+  if (lane == 0)
+    shared[wid] = sum;
+  __syncthreads();
+
+  sum = (threadIdx.x < blockDim.x / warpSize) ? shared[lane] : 0;
+  if (wid == 0)
+    sum = reduce_warp<T>(sum);
+
+  if (threadIdx.x == 0)
+    bufred[blockIdx.x] = sum;
+}
+
+
+/**
  * Reduction kernel for glsc3
- *
  */
 
 template< typename T >
@@ -408,27 +454,26 @@ __global__ void glsc3_kernel(const T * a,
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const int str = blockDim.x * gridDim.x;
 
-  __shared__ T buf[1024];
-  T tmp = 0.0;
-
+  const unsigned int lane = threadIdx.x % warpSize;
+  const unsigned int wid = threadIdx.x / warpSize;
+  
+  __shared__ T shared[32];  
+  T sum = 0.0;
   for (int i = idx; i < n; i+= str) {
-    tmp += a[i] * b[i] * c[i];
+    sum += a[i] * b[i] * c[i];
   }
-  buf[threadIdx.x] = tmp;
+
+  sum = reduce_warp<T>(sum);
+  if (lane == 0)
+    shared[wid] = sum;
   __syncthreads();
 
-  int i = blockDim.x>>1;
-  while (i != 0) {
-    if (threadIdx.x < i) {
-      buf[threadIdx.x] += buf[threadIdx.x + i];
-    }
-    __syncthreads();
-    i = i>>1;
-  }
- 
-  if (threadIdx.x == 0) {
-    buf_h[blockIdx.x] = buf[0];
-  }
+  sum = (threadIdx.x < blockDim.x / warpSize) ? shared[lane] : 0;
+  if (wid == 0)
+    sum = reduce_warp<T>(sum);
+
+  if (threadIdx.x == 0)
+    buf_h[blockIdx.x] = sum;
 }
 
 /**

--- a/src/math/bcknd/device/cuda/math_kernel.h
+++ b/src/math/bcknd/device/cuda/math_kernel.h
@@ -32,7 +32,6 @@
  POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <cub/cub.cuh>
 
 /**
  * Device kernel for cmult


### PR DESCRIPTION
Use a shuffle warp reduction for `glsc3` routines. Reduces runtime with ~15% (and shared memory load by 99%)
**Note requires CUDA > 8**