### PR TITLE
Consitent symmetric vertex notation

### DIFF
--- a/src/io/nmsh_file.f90
+++ b/src/io/nmsh_file.f90
@@ -434,6 +434,8 @@ contains
     integer :: nmsh_quad_size, nmsh_hex_size, nmsh_zone_size, nmsh_curve_size
     integer :: nzones, ncurves 
     class(element_t), pointer :: ep
+    integer(i4),  dimension(8), parameter :: vcyc_to_sym = (/1, 2, 4, 3, 5, &
+         & 6, 8, 7/) ! cyclic to symmetric vertex mapping
 
     select type(data)
     type is (mesh_t)
@@ -469,8 +471,8 @@ contains
           ep => msh%elements(i)%e
           nmsh_quad(i)%el_idx = ep%id()
           do j = 1, 4
-             nmsh_quad(i)%v(j)%v_idx = ep%pts(j)%p%id()
-             nmsh_quad(i)%v(j)%v_xyz = ep%pts(j)%p%x
+             nmsh_quad(i)%v(j)%v_idx = ep%pts(vcyc_to_sym(j))%p%id()
+             nmsh_quad(i)%v(j)%v_xyz = ep%pts(vcyc_to_sym(j))%p%x
           end do
        end do
        mpi_offset = 2 * MPI_INTEGER_SIZE + element_offset * nmsh_quad_size
@@ -484,8 +486,8 @@ contains
           ep => msh%elements(i)%e
           nmsh_hex(i)%el_idx = ep%id()
           do j = 1, 8
-             nmsh_hex(i)%v(j)%v_idx = ep%pts(j)%p%id()
-             nmsh_hex(i)%v(j)%v_xyz = ep%pts(j)%p%x
+             nmsh_hex(i)%v(j)%v_idx = ep%pts(vcyc_to_sym(j))%p%id()
+             nmsh_hex(i)%v(j)%v_xyz = ep%pts(vcyc_to_sym(j))%p%x
           end do
        end do
        mpi_offset = 2 * MPI_INTEGER_SIZE + element_offset * nmsh_hex_size

--- a/src/io/nmsh_file.f90
+++ b/src/io/nmsh_file.f90
@@ -119,7 +119,8 @@ contains
           do j = 1, 4
              p(j) = point_t(nmsh_quad(i)%v(j)%v_xyz, nmsh_quad(i)%v(j)%v_idx)
           end do
-          call mesh_add_element(msh, i, p(1), p(2), p(3), p(4))
+          ! swap vertices to keep symmetric vertex numbering in neko
+          call mesh_add_element(msh, i, p(1), p(2), p(4), p(3))
        end do
        deallocate(nmsh_quad)
        mpi_el_offset = 2 * MPI_INTEGER_SIZE + dist%num_global() * nmsh_quad_size
@@ -132,8 +133,9 @@ contains
           do j = 1, 8
              p(j) = point_t(nmsh_hex(i)%v(j)%v_xyz, nmsh_hex(i)%v(j)%v_idx)
           end do
+          ! swap vertices to keep symmetric vertex numbering in neko
           call mesh_add_element(msh, i, &
-               p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8))
+               p(1), p(2), p(4), p(3), p(5), p(6), p(8), p(7))
        end do
        deallocate(nmsh_hex)
        mpi_el_offset = 2 * MPI_INTEGER_SIZE + dist%num_global() * nmsh_hex_size
@@ -289,8 +291,9 @@ contains
           id = nmsh_quad(i)%v(j)%v_idx+msh%glb_nelv*8
           p(j+4) = point_t(coord, id)
        end do
+       ! swap vertices to keep symmetric vertex numbering in neko
        call mesh_add_element(msh, i, &
-            p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8))
+            p(1), p(2), p(4), p(3), p(5), p(6), p(8), p(7))
     end do
     deallocate(nmsh_quad)
     mpi_el_offset = 2 * MPI_INTEGER_SIZE + dist%num_global() * nmsh_quad_size

--- a/src/io/re2_file.f90
+++ b/src/io/re2_file.f90
@@ -325,8 +325,8 @@ contains
                 call re2_file_add_point(htp, p(j), pt_idx)
              end do
              if(mod(i,nelv/10) .eq. 0) write(*,*) i, 'elements read'
-             
-             call mesh_add_element(msh, i, p(1), p(2), p(3), p(4))
+             ! swap vertices to keep symmetric vertex numbering in neko
+             call mesh_add_element(msh, i, p(1), p(2), p(4), p(3))
           end do
           deallocate(re2v1_data_xy)
        else
@@ -340,8 +340,8 @@ contains
                 call re2_file_add_point(htp, p(j), pt_idx)
              end do
              if(mod(i,nelv/10) .eq. 0) write(*,*) i, 'elements read'
-             
-             call mesh_add_element(msh, i, p(1), p(2), p(3), p(4))
+             ! swap vertices to keep symmetric vertex numbering in neko
+             call mesh_add_element(msh, i, p(1), p(2), p(4), p(3))
           end do
           deallocate(re2v2_data_xy)
        end if
@@ -359,8 +359,9 @@ contains
                 call re2_file_add_point(htp, p(j), pt_idx)
              end do
              if(mod(i,nelv/10) .eq. 0) write(*,*) i, 'elements read'
+             ! swap vertices to keep symmetric vertex numbering in neko
              call mesh_add_element(msh, i, &
-                  p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8))          
+                  p(1), p(2), p(4), p(3), p(5), p(6), p(8), p(7))          
           end do
           deallocate(re2v1_data_xyz)
        else
@@ -376,8 +377,9 @@ contains
              end do
              
              if(mod(i,nelv/10) .eq. 0) write(*,*) i, 'elements read'
+             ! swap vertices to keep symmetric vertex numbering in neko
              call mesh_add_element(msh, i, &
-                  p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8))          
+                  p(1), p(2), p(4), p(3), p(5), p(6), p(8), p(7))          
           end do
           deallocate(re2v2_data_xyz)
        end if

--- a/src/io/rea_file.f90
+++ b/src/io/rea_file.f90
@@ -188,7 +188,8 @@ contains
                    p(j) = point_t(real(xc(j),dp), real(yc(j),dp),real(0d0,dp))
                    call rea_file_add_point(htp, p(j), pt_idx)
                 end do
-                call mesh_add_element(msh, el_idx, p(1), p(2), p(3), p(4))
+                ! swap vertices to keep symmetric vertex numbering in neko
+                call mesh_add_element(msh, el_idx, p(1), p(2), p(4), p(3))
              end if
           else if (ndim .eq. 3) then
              read(9, *) (xc(j),j=1,4)
@@ -202,8 +203,9 @@ contains
                    p(j) = point_t(real(xc(j),dp), real(yc(j),dp), real(zc(j),dp))
                    call rea_file_add_point(htp, p(j), pt_idx)
                 end do
+                ! swap vertices to keep symmetric vertex numbering in neko
                 call mesh_add_element(msh, el_idx, &
-                     p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8))
+                     p(1), p(2), p(4), p(3), p(5), p(6), p(8), p(7))
              end if
           end if
           if (i .ge. start_el .and. i .le. end_el) then

--- a/src/io/vtk_file.f90
+++ b/src/io/vtk_file.f90
@@ -214,14 +214,14 @@ contains
 
        point_data(id(1)) = real(fld%x(1,1,1,i),dp)
        point_data(id(2)) = real(fld%x(lx,1,1,i),dp)
-       point_data(id(4)) = real(fld%x(1,ly,1,i),dp)
-       point_data(id(3)) = real(fld%x(lx,ly,1,i),dp)       
+       point_data(id(3)) = real(fld%x(1,ly,1,i),dp)
+       point_data(id(4)) = real(fld%x(lx,ly,1,i),dp)       
 
        if (fld%msh%gdim .eq. 3) then
           point_data(id(5)) = real(fld%x(1,1,lz,i),dp)
           point_data(id(6)) = real(fld%x(lx,1,lz,i),dp)
-          point_data(id(8)) = real(fld%x(1,ly,lz,i),dp)
-          point_data(id(7)) = real(fld%x(lx,ly,lz,i),dp)    
+          point_data(id(7)) = real(fld%x(1,ly,lz,i),dp)
+          point_data(id(8)) = real(fld%x(lx,ly,lz,i),dp)    
        end if
 
     end do

--- a/src/mesh/hex.f90
+++ b/src/mesh/hex.f90
@@ -51,10 +51,10 @@ module hex
   !! @verbatim
   !! Node numbering (NEKTON preprocessor notation)
   !!
-  !!          4+-----+3    ^ s                 
+  !!          3+-----+4    ^ s                 
   !!          /     /|     |                   
   !!         /     / |     |                   
-  !!       8+-----+7 +2    +----> r            
+  !!       7+-----+8 +2    +----> r            
   !!        |     | /     /                    
   !!        |     |/     /                     
   !!       5+-----+6    t
@@ -90,12 +90,12 @@ module hex
   !!
   !! @endverbatim
   !! @note Local node numbering (points)
-  integer, parameter, dimension(4, 6) :: face_nodes = reshape((/1,5,8,4,&
-                                                                2,6,7,3,&
+  integer, parameter, dimension(4, 6) :: face_nodes = reshape((/1,5,7,3,&
+                                                                2,6,8,4,&
                                                                 1,2,6,5,&
-                                                                4,3,7,8,&
-                                                                1,2,3,4,&
-                                                                5,6,7,8/),&
+                                                                3,4,8,7,&
+                                                                1,2,4,3,&
+                                                                5,6,8,7/),&
                                                                 (/4,6/))
   
   !> Edge node ids
@@ -117,17 +117,17 @@ module hex
   !!
   !! @endverbatim
   integer, parameter, dimension(2, 12) :: edge_nodes = reshape((/1,2,&
-                                                                4,3,&
+                                                                3,4,&
                                                                 5,6,&
-                                                                8,7,&
-                                                                1,4,&
-                                                                2,3,&
-                                                                5,8,&
-                                                                6,7,&
+                                                                7,8,&
+                                                                1,3,&
+                                                                2,4,&
+                                                                5,7,&
+                                                                6,8,&
                                                                 1,5,&
                                                                 2,6,&
-                                                                4,8,&
-                                                                3,7/),&
+                                                                3,7,&
+                                                                4,8/),&
                                                                 (/2,12/))
   
 contains
@@ -244,10 +244,10 @@ contains
     p8 => this%p(8)
 
     do i = 1, NEKO_HEX_GDIM
-       d1 = d1 + (p7%x(i) - p1%x(i))**2
-       d2 = d2 + (p8%x(i) - p2%x(i))**2
-       d3 = d3 + (p5%x(i) - p3%x(i))**2
-       d4 = d4 + (p6%x(i) - p4%x(i))**2
+       d1 = d1 + (p8%x(i) - p1%x(i))**2
+       d2 = d2 + (p7%x(i) - p2%x(i))**2
+       d3 = d3 + (p5%x(i) - p4%x(i))**2
+       d4 = d4 + (p6%x(i) - p3%x(i))**2
     end do
 
     res = sqrt(max(max(d1, d2), max(d3, d4)))

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -379,21 +379,21 @@ contains
        if (m%gdim .eq. 2) then
           m%dfrmd_el(e) = .false.
           u = m%elements(e)%e%pts(2)%p%x - m%elements(e)%e%pts(1)%p%x
-          v = m%elements(e)%e%pts(4)%p%x - m%elements(e)%e%pts(1)%p%x
+          v = m%elements(e)%e%pts(3)%p%x - m%elements(e)%e%pts(1)%p%x
           temp = u(1)*v(1) + u(2)*v(2)
           if(.not. abscmp(temp, 0d0)) m%dfrmd_el(e) = .true.
        else
           m%dfrmd_el(e) = .false.
           u = m%elements(e)%e%pts(2)%p%x - m%elements(e)%e%pts(1)%p%x
-          v = m%elements(e)%e%pts(4)%p%x - m%elements(e)%e%pts(1)%p%x
+          v = m%elements(e)%e%pts(3)%p%x - m%elements(e)%e%pts(1)%p%x
           w = m%elements(e)%e%pts(5)%p%x - m%elements(e)%e%pts(1)%p%x
           temp = u(1)*v(1) + u(2)*v(2) + u(3)*v(3)
           if(.not. abscmp(temp, 0d0)) m%dfrmd_el(e) = .true.
           temp = u(1)*w(1) + u(2)*w(2) + u(3)*w(3)
           if(.not. abscmp(temp, 0d0)) m%dfrmd_el(e) = .true.
-          u = m%elements(e)%e%pts(8)%p%x - m%elements(e)%e%pts(7)%p%x
-          v = m%elements(e)%e%pts(6)%p%x - m%elements(e)%e%pts(7)%p%x
-          w = m%elements(e)%e%pts(3)%p%x - m%elements(e)%e%pts(7)%p%x
+          u = m%elements(e)%e%pts(7)%p%x - m%elements(e)%e%pts(8)%p%x
+          v = m%elements(e)%e%pts(6)%p%x - m%elements(e)%e%pts(8)%p%x
+          w = m%elements(e)%e%pts(4)%p%x - m%elements(e)%e%pts(8)%p%x
           temp = u(1)*v(1) + u(2)*v(2) + u(3)*v(3)
           if(.not. abscmp(temp, 0d0)) m%dfrmd_el(e) = .true.
           temp = u(1)*w(1) + u(2)*w(2) + u(3)*w(3)
@@ -1543,17 +1543,17 @@ contains
     integer :: pe
     integer :: org_ids(4), pids(4)
     type(point_t), pointer :: pi
-    integer, dimension(4, 6) :: face_nodes = reshape((/1,5,8,4,&
-                                                       2,6,7,3,&
+    integer, dimension(4, 6) :: face_nodes = reshape((/1,5,7,3,&
+                                                       2,6,8,4,&
                                                        1,2,6,5,&
-                                                       4,3,7,8,&
-                                                       1,2,3,4,&
-                                                       5,6,7,8/),&
+                                                       3,4,8,7,&
+                                                       1,2,4,3,&
+                                                       5,6,8,7/),&
                                                        (/4,6/))
-    integer, dimension(2, 4) :: edge_nodes = reshape((/1,4,&
-                                                                2,3,&
+    integer, dimension(2, 4) :: edge_nodes = reshape((/1,3,&
+                                                                2,4,&
                                                                 1,2,&
-                                                                4,3 /),&
+                                                                3,4 /),&
                                                                 (/2,4/))
  
     do i = 1, m%periodic%size
@@ -1596,17 +1596,17 @@ contains
     integer :: i, j, id, p_local_idx
     type(tuple4_i4_t) :: ft
     type(tuple_i4_t) :: et
-    integer, dimension(4, 6) :: face_nodes = reshape((/1,5,8,4,&
-                                                       2,6,7,3,&
+    integer, dimension(4, 6) :: face_nodes = reshape((/1,5,7,3,&
+                                                       2,6,8,4,&
                                                        1,2,6,5,&
-                                                       4,3,7,8,&
-                                                       1,2,3,4,&
-                                                       5,6,7,8/),&
+                                                       3,4,8,7,&
+                                                       1,2,4,3,&
+                                                       5,6,8,7/),&
                                                        (/4,6/))
-    integer, dimension(2, 4) :: edge_nodes = reshape((/1,4,&
-                                                                2,3,&
+    integer, dimension(2, 4) :: edge_nodes = reshape((/1,3,&
+                                                                2,4,&
                                                                 1,2,&
-                                                                4,3 /),&
+                                                                3,4 /),&
                                                                 (/2,4/))
   
     select type(ele => m%elements(e)%e)
@@ -1700,12 +1700,12 @@ contains
     integer :: i, id, p_local_idx
     type(tuple4_i4_t) :: ft
     type(tuple_i4_t) :: et
-    integer, dimension(4, 6) :: face_nodes = reshape((/1,5,8,4,&
-                                                       2,6,7,3,&
+    integer, dimension(4, 6) :: face_nodes = reshape((/1,5,7,3,&
+                                                       2,6,8,4,&
                                                        1,2,6,5,&
-                                                       4,3,7,8,&
-                                                       1,2,3,4,&
-                                                       5,6,7,8/),&
+                                                       3,4,8,7,&
+                                                       1,2,4,3,&
+                                                       5,6,8,7/),&
                                                        (/4,6/))
   
     select type(ele => m%elements(e)%e)

--- a/src/mesh/quad.f90
+++ b/src/mesh/quad.f90
@@ -49,7 +49,7 @@ module quad
   !! @verbatim
   !! Node numbering (NEKTON preprocessor notation)
   !!
-  !!      4+-----+3    ^ s                 
+  !!      3+-----+4    ^ s                 
   !!       |     |     |                   
   !!       |     |     |                   
   !!      1+-----+2    +----> r            
@@ -78,10 +78,10 @@ module quad
   !!       +------+      +-----> r            
   !!          3
   !! @endverbatim
-  integer, parameter, dimension(2, 4) :: edge_nodes = reshape((/1,4,&
-                                                                2,3,&
+  integer, parameter, dimension(2, 4) :: edge_nodes = reshape((/1,3,&
+                                                                2,4,&
                                                                 1,2,&
-                                                                4,3 /),&
+                                                                3,4 /),&
                                                                 (/2,4/))
   
 contains

--- a/src/sem/dofmap.f90
+++ b/src/sem/dofmap.f90
@@ -209,9 +209,9 @@ contains
           this%dof(Xh%lx, 1, 1, i) = &
                int(msh%elements(i)%e%pts(2)%p%id(), i8)
           this%dof(1, Xh%ly, 1, i) = &
-               int(msh%elements(i)%e%pts(4)%p%id(), i8)
-          this%dof(Xh%lx, Xh%ly, 1, i) = &
                int(msh%elements(i)%e%pts(3)%p%id(), i8)
+          this%dof(Xh%lx, Xh%ly, 1, i) = &
+               int(msh%elements(i)%e%pts(4)%p%id(), i8)
 
           this%shared_dof(1, 1, 1, i) = &
                mesh_is_shared(msh, msh%elements(i)%e%pts(1)%p)
@@ -220,10 +220,10 @@ contains
                mesh_is_shared(msh, msh%elements(i)%e%pts(2)%p)
 
           this%shared_dof(1, Xh%ly, 1, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(4)%p)
+               mesh_is_shared(msh, msh%elements(i)%e%pts(3)%p)
           
           this%shared_dof(Xh%lx, Xh%ly, 1, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(3)%p)
+               mesh_is_shared(msh, msh%elements(i)%e%pts(4)%p)
        end do
     else    
        do i = 1, msh%nelv
@@ -232,18 +232,18 @@ contains
           this%dof(Xh%lx, 1, 1, i) = &
                int(msh%elements(i)%e%pts(2)%p%id(), i8)
           this%dof(1, Xh%ly, 1, i) = &
-               int(msh%elements(i)%e%pts(4)%p%id(), i8)
-          this%dof(Xh%lx, Xh%ly, 1, i) = &
                int(msh%elements(i)%e%pts(3)%p%id(), i8)
+          this%dof(Xh%lx, Xh%ly, 1, i) = &
+               int(msh%elements(i)%e%pts(4)%p%id(), i8)
 
           this%dof(1, 1, Xh%lz, i) = &
                int(msh%elements(i)%e%pts(5)%p%id(), i8)
           this%dof(Xh%lx, 1, Xh%lz, i) = &
                int(msh%elements(i)%e%pts(6)%p%id(), i8)
           this%dof(1, Xh%ly, Xh%lz, i) = &
-               int(msh%elements(i)%e%pts(8)%p%id(), i8)
-          this%dof(Xh%lx, Xh%ly, Xh%lz, i) = &
                int(msh%elements(i)%e%pts(7)%p%id(), i8)
+          this%dof(Xh%lx, Xh%ly, Xh%lz, i) = &
+               int(msh%elements(i)%e%pts(8)%p%id(), i8)
 
           this%shared_dof(1, 1, 1, i) = &
                mesh_is_shared(msh, msh%elements(i)%e%pts(1)%p)
@@ -252,10 +252,10 @@ contains
                mesh_is_shared(msh, msh%elements(i)%e%pts(2)%p)
 
           this%shared_dof(1, Xh%ly, 1, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(4)%p)
+               mesh_is_shared(msh, msh%elements(i)%e%pts(3)%p)
           
           this%shared_dof(Xh%lx, Xh%ly, 1, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(3)%p)
+               mesh_is_shared(msh, msh%elements(i)%e%pts(4)%p)
 
           this%shared_dof(1, 1, Xh%lz, i) = &
                mesh_is_shared(msh, msh%elements(i)%e%pts(5)%p)
@@ -264,10 +264,10 @@ contains
                mesh_is_shared(msh, msh%elements(i)%e%pts(6)%p)
 
           this%shared_dof(1, Xh%ly, Xh%lz, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(8)%p)
+               mesh_is_shared(msh, msh%elements(i)%e%pts(7)%p)
           
           this%shared_dof(Xh%lx, Xh%ly, Xh%lz, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(7)%p)
+               mesh_is_shared(msh, msh%elements(i)%e%pts(8)%p)
        end do
     end if
   end subroutine dofmap_number_points
@@ -782,14 +782,14 @@ contains
     do j = 1, msh%gdim
        xyzb(1,1,1,j) = element%pts(1)%p%x(j)
        xyzb(2,1,1,j) = element%pts(2)%p%x(j)
-       xyzb(1,2,1,j) = element%pts(4)%p%x(j)
-       xyzb(2,2,1,j) = element%pts(3)%p%x(j)
+       xyzb(1,2,1,j) = element%pts(3)%p%x(j)
+       xyzb(2,2,1,j) = element%pts(4)%p%x(j)
 
        if (msh%gdim .gt. 2) then
           xyzb(1,1,2,j) = element%pts(5)%p%x(j)
           xyzb(2,1,2,j) = element%pts(6)%p%x(j)
-          xyzb(1,2,2,j) = element%pts(8)%p%x(j)
-          xyzb(2,2,2,j) = element%pts(7)%p%x(j)
+          xyzb(1,2,2,j) = element%pts(7)%p%x(j)
+          xyzb(2,2,2,j) = element%pts(8)%p%x(j)
        end if
     end do
     if (msh%gdim .eq. 3) then

--- a/src/sem/dofmap.f90
+++ b/src/sem/dofmap.f90
@@ -196,80 +196,23 @@ contains
   !> Assign numbers to each dofs on points
   subroutine dofmap_number_points(this)
     type(dofmap_t), target :: this
-    integer :: i
+    integer :: il, jl, ix, iy, iz
     type(mesh_t), pointer :: msh
     type(space_t), pointer :: Xh
 
     msh => this%msh
     Xh => this%Xh
-    if (msh%gdim .eq. 2) then
-       do i = 1, msh%nelv
-          this%dof(1, 1, 1, i) = &
-               int(msh%elements(i)%e%pts(1)%p%id(), i8)
-          this%dof(Xh%lx, 1, 1, i) = &
-               int(msh%elements(i)%e%pts(2)%p%id(), i8)
-          this%dof(1, Xh%ly, 1, i) = &
-               int(msh%elements(i)%e%pts(3)%p%id(), i8)
-          this%dof(Xh%lx, Xh%ly, 1, i) = &
-               int(msh%elements(i)%e%pts(4)%p%id(), i8)
-
-          this%shared_dof(1, 1, 1, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(1)%p)
-          
-          this%shared_dof(Xh%lx, 1, 1, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(2)%p)
-
-          this%shared_dof(1, Xh%ly, 1, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(3)%p)
-          
-          this%shared_dof(Xh%lx, Xh%ly, 1, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(4)%p)
+    do il = 1, msh%nelv
+       do jl = 1, msh%npts
+          ix = mod(jl -1 ,2)
+          iy = mod(jl -1 ,4)/2
+          iz = (jl - 1)/4
+          this%dof(ix*(Xh%lx - 1) + 1, iy*(Xh%ly - 1) + 1, iz*(Xh%lz - 1) + 1, il) = &
+               & int(msh%elements(il)%e%pts(jl)%p%id(), i8)
+          this%shared_dof(ix*(Xh%lx - 1) + 1, iy*(Xh%ly - 1) + 1, iz*(Xh%lz - 1) + 1, il) = &
+               & mesh_is_shared(msh, msh%elements(il)%e%pts(jl)%p)
        end do
-    else    
-       do i = 1, msh%nelv
-          this%dof(1, 1, 1, i) = &
-               int(msh%elements(i)%e%pts(1)%p%id(), i8)
-          this%dof(Xh%lx, 1, 1, i) = &
-               int(msh%elements(i)%e%pts(2)%p%id(), i8)
-          this%dof(1, Xh%ly, 1, i) = &
-               int(msh%elements(i)%e%pts(3)%p%id(), i8)
-          this%dof(Xh%lx, Xh%ly, 1, i) = &
-               int(msh%elements(i)%e%pts(4)%p%id(), i8)
-
-          this%dof(1, 1, Xh%lz, i) = &
-               int(msh%elements(i)%e%pts(5)%p%id(), i8)
-          this%dof(Xh%lx, 1, Xh%lz, i) = &
-               int(msh%elements(i)%e%pts(6)%p%id(), i8)
-          this%dof(1, Xh%ly, Xh%lz, i) = &
-               int(msh%elements(i)%e%pts(7)%p%id(), i8)
-          this%dof(Xh%lx, Xh%ly, Xh%lz, i) = &
-               int(msh%elements(i)%e%pts(8)%p%id(), i8)
-
-          this%shared_dof(1, 1, 1, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(1)%p)
-          
-          this%shared_dof(Xh%lx, 1, 1, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(2)%p)
-
-          this%shared_dof(1, Xh%ly, 1, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(3)%p)
-          
-          this%shared_dof(Xh%lx, Xh%ly, 1, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(4)%p)
-
-          this%shared_dof(1, 1, Xh%lz, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(5)%p)
-          
-          this%shared_dof(Xh%lx, 1, Xh%lz, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(6)%p)
-
-          this%shared_dof(1, Xh%ly, Xh%lz, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(7)%p)
-          
-          this%shared_dof(Xh%lx, Xh%ly, Xh%lz, i) = &
-               mesh_is_shared(msh, msh%elements(i)%e%pts(8)%p)
-       end do
-    end if
+    end do
   end subroutine dofmap_number_points
 
   !> Assing numbers to dofs on edges


### PR DESCRIPTION
The assumption is to keep backward compatibility and do not rewrite file format and converters used at pre-proessing step. Only neko internals are changed and the points are swapped at the file reading step. Periodic bc, dof numberring and grid generation are corrected as well.
Stuff left to change/test:
- mesh file writers (e.g. nmsh_file_write) have to swap points
- curved faces/edges are not tested yet
- vtk file writers
- krylov/pc_hsmg.f90 should be checked as it operates on elements