### PR TITLE
Fix invalid offset in HIP async. GS pack

### DIFF
--- a/src/gs/bcknd/device/hip/gs.hip
+++ b/src/gs/bcknd/device/hip/gs.hip
@@ -126,14 +126,14 @@ extern "C" {
     if (stream == NULL) {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_pack_kernel<real>),
                          nblcks, nthrds, 0, 0,
-                         (real *) u_d, (real *) buf_d,
-                         (int *) dof_d, n);
+                         (real *) u_d, (real *) buf_d + offset,
+                         (int *) dof_d + offset, n);
     }
     else {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_pack_kernel<real>),
                          nblcks, nthrds, 0, stream,
-                         (real *) u_d, (real *) buf_d,
-                         (int *) dof_d, n);
+                         (real *) u_d, (real *) buf_d + offset,
+                         (int *) dof_d + offset, n);
     }
     HIP_CHECK(hipGetLastError());
   }


### PR DESCRIPTION
This fixes the divergence observed on LUMI-G, when an asynchronous gather-scatter strategy was picked.