### PR TITLE
Add support for non-uniform distributions of elements

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -9,7 +9,7 @@ common/log.o : common/log.f90 config/num_types.o comm/comm.o
 comm/comm.o : comm/comm.F90 
 mesh/curve.o : mesh/curve.f90 mesh/hex.o mesh/point.o common/structs.o common/utils.o adt/stack.o 
 comm/mpi_types.o : comm/mpi_types.f90 common/parameters.o io/format/stl.o io/format/nmsh.o io/format/re2.o comm/comm.o 
-common/datadist.o : common/datadist.f90 
+common/datadist.o : common/datadist.f90 common/log.o
 common/distdata.o : common/distdata.f90 adt/uset.o adt/tuple.o adt/stack.o 
 common/utils.o : common/utils.f90 
 math/mxm_wrapper.o : math/mxm_wrapper.F90 common/utils.o config/num_types.o 


### PR DESCRIPTION
Adds an environment variable `rank_weight` that can be set in order to weight the distribution of elements across ranks.