### PR TITLE
Add NEKO_BCKND_DEVICE config flag

### DIFF
--- a/bench/tgv32/tgv.f90
+++ b/bench/tgv32/tgv.f90
@@ -88,8 +88,7 @@ contains
 
     call curl(omg1, omg2, omg3, u, v, w, w1, w2, coef)
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) &
-      .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_memcpy(u%x, u%x_d, n, DEVICE_TO_HOST)
        call device_memcpy(v%x, v%x_d, n, DEVICE_TO_HOST)
        call device_memcpy(w%x, w%x_d, n, DEVICE_TO_HOST)

--- a/configure.ac
+++ b/configure.ac
@@ -246,6 +246,15 @@ AC_SUBST(CUDA_ARCH)
 AC_SUBST(CUDA_CFLAGS)
 AC_SUBST(HIP_HIPCC_FLAGS)
 
+# Set device backend if requested (and found)
+if (test "x${have_cuda}" = xyes ||
+    test "x${have_hip}" = xyes  ||
+    test "x${have_opencl}" = xyes); then
+    AC_SUBST(device_bcknd, "1")
+else
+    AC_SUBST(device_bcknd, "0")
+fi
+
 AC_CONFIG_FILES([Makefile\
 		 src/Makefile\
 		 tests/Makefile\

--- a/examples/turbpipe/pipe.f90
+++ b/examples/turbpipe/pipe.f90
@@ -82,8 +82,7 @@ contains
     Re_B = 5300_rp 
     w = 2d0 * (2d0*Re_tau/Re_B)**2
 
-    if ((NEKO_BCKND_CUDA .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
-       .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_rzero(f%u_d,f%dm%size())
        call device_rzero(f%v_d,f%dm%size())
        call device_rzero(f%w_d,f%dm%size())

--- a/reframe/src/tgv.f90
+++ b/reframe/src/tgv.f90
@@ -88,8 +88,7 @@ contains
 
     call curl(omg1, omg2, omg3, u, v, w, w1, w2, coef)
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) &
-      .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_memcpy(u%x, u%x_d, n, DEVICE_TO_HOST)
        call device_memcpy(v%x, v%x_d, n, DEVICE_TO_HOST)
        call device_memcpy(w%x, w%x_d, n, DEVICE_TO_HOST)

--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -331,8 +331,7 @@ contains
     this%msk(0) = msk_c
     this%facet(0) = msk_c
     
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then 
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        n = facet_size * this%marked_facet%size() + 1
        call device_map(this%msk, this%msk_d, n)
        call device_map(this%facet, this%facet_d, n)
@@ -412,8 +411,7 @@ contains
     type(c_ptr) :: x_d
     integer :: i
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then 
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        x_d = device_get_ptr(x)
        do i = 1, bclst%n
           call bclst%bc(i)%bcp%apply_scalar_dev(x_d)
@@ -438,8 +436,7 @@ contains
     type(c_ptr) :: z_d
     integer :: i
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then 
+    if (NEKO_BCKND_HIP .eq. 1) then
        x_d = device_get_ptr(x)
        y_d = device_get_ptr(y)
        z_d = device_get_ptr(z)

--- a/src/common/checkpoint.f90
+++ b/src/common/checkpoint.f90
@@ -114,8 +114,7 @@ contains
   subroutine chkp_sync_host(this)
     class(chkp_t), intent(inout) :: this
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        associate(u=>this%u, v=>this%v, w=>this%w, &
             ulag=>this%ulag, vlag=>this%vlag, wlag=>this%wlag)
 
@@ -152,8 +151,7 @@ contains
   subroutine chkp_sync_device(this)
     class(chkp_t), intent(inout) :: this
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        associate(u=>this%u, v=>this%v, w=>this%w, &
             ulag=>this%ulag, vlag=>this%vlag, wlag=>this%wlag)
 

--- a/src/common/ext_bdf_scheme.f90
+++ b/src/common/ext_bdf_scheme.f90
@@ -111,8 +111,7 @@ contains
        call neko_warning('Invalid time order, defaulting to 3')
     end if
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_map(this%ext, this%ext_d, 10)
        call device_map(this%bdf, this%bdf_d, 10)
     end if

--- a/src/common/rhs_maker_fctry.f90
+++ b/src/common/rhs_maker_fctry.f90
@@ -50,8 +50,7 @@ contains
 
     if (NEKO_BCKND_SX .eq. 1) then
        allocate(rhs_maker_sumab_sx_t::sumab)
-    else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &         
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    else if (NEKO_BCKND_DEVICE .eq. 1) then
        allocate(rhs_maker_sumab_device_t::sumab)
     else
        allocate(rhs_maker_sumab_cpu_t::sumab)
@@ -68,8 +67,7 @@ contains
 
     if (NEKO_BCKND_SX .eq. 1) then
        allocate(rhs_maker_ext_sx_t::makeabf)
-    else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    else if (NEKO_BCKND_DEVICE .eq. 1) then
        allocate(rhs_maker_ext_device_t::makeabf)
     else
        allocate(rhs_maker_ext_cpu_t::makeabf)
@@ -86,8 +84,7 @@ contains
 
     if (NEKO_BCKND_SX .eq. 1) then
        allocate(rhs_maker_bdf_sx_t::makebdf)
-    else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    else if (NEKO_BCKND_DEVICE .eq. 1) then
        allocate(rhs_maker_bdf_device_t::makebdf)
     else       
        allocate(rhs_maker_bdf_cpu_t::makebdf)

--- a/src/common/source.f90
+++ b/src/common/source.f90
@@ -95,8 +95,7 @@ contains
     f%v = 0d0
     f%w = 0d0
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then 
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_map(f%u, f%u_d, dm%size())
        call device_map(f%v, f%v_d, dm%size())
        call device_map(f%w, f%w_d, dm%size())
@@ -147,8 +146,7 @@ contains
   subroutine source_set_pw_type(f, f_eval_pw)
     type(source_t), intent(inout) :: f
     procedure(source_term_pw) :: f_eval_pw
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then 
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call neko_error('Pointwise source terms not supported on accelerators')
     end if
     f%eval => source_eval_pw
@@ -159,8 +157,7 @@ contains
   !! @note Maybe this should be cache, avoding zeroing at each time-step
   subroutine source_eval_noforce(f)
     class(source_t) :: f
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_rzero(f%u_d, f%dm%size())
        call device_rzero(f%v_d, f%dm%size())
        call device_rzero(f%w_d, f%dm%size())

--- a/src/common/source_scalar.f90
+++ b/src/common/source_scalar.f90
@@ -85,8 +85,7 @@ contains
 
     f%s = 0d0
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then 
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_map(f%s, f%s_d, dm%size())
     end if
     
@@ -119,8 +118,7 @@ contains
   subroutine source_scalar_set_pw_type(f, f_eval_pw)
     type(source_scalar_t), intent(inout) :: f
     procedure(source_scalar_term_pw) :: f_eval_pw
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then 
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call neko_error('Pointwise source_scalar terms not supported on accelerators')
     end if
     f%eval => source_scalar_eval_pw
@@ -131,8 +129,7 @@ contains
   !! @note Maybe this should be cache, avoding zeroing at each time-step
   subroutine source_scalar_eval_noforce(f)
     class(source_scalar_t) :: f
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_rzero(f%s_d, f%dm%size())
     else
        f%s = 0d0

--- a/src/config/neko_config.f90.in
+++ b/src/config/neko_config.f90.in
@@ -41,6 +41,7 @@ module neko_config
   integer, parameter :: NEKO_BCKND_CUDA = @cuda_bcknd@
   integer, parameter :: NEKO_BCKND_HIP = @hip_bcknd@
   integer, parameter :: NEKO_BCKND_OPENCL = @opencl_bcknd@
+  integer, parameter :: NEKO_BCKND_DEVICE = @device_bcknd@
 
   logical, parameter :: NEKO_DEVICE_MPI = @device_mpi@
 

--- a/src/field/field.f90
+++ b/src/field/field.f90
@@ -137,8 +137,7 @@ contains
        f%name = "Field"
     end if
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        n = lx * ly * lz * nelv           
        call device_map(f%x, f%x_d, n)
     end if
@@ -197,16 +196,14 @@ contains
        
        allocate(f%x(f%Xh%lx, f%Xh%ly, f%Xh%lz, f%msh%nelv))
        
-       if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-            (NEKO_BCKND_OPENCL .eq. 1)) then
+       if (NEKO_BCKND_DEVICE .eq. 1) then
           call device_map(f%x, f%x_d, n)
        end if
        
     end if
 
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_copy(f%x_d, g%x_d, n)
     else
        call copy(f%x, g%x, n)
@@ -221,8 +218,7 @@ contains
     integer :: n, i, j, k, l
 
     n = f%msh%nelv * f%Xh%lx * f%Xh%ly * f%Xh%lz
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_cfill(f%x_d, a, n)
     else
        do i = 1, f%msh%nelv
@@ -247,8 +243,7 @@ contains
     integer :: n
 
     n = f%msh%nelv * f%Xh%lx * f%Xh%ly * f%Xh%lz
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_add2(f%x_d, g%x_d, n)
     else
        call add2(f%x, g%x, n)
@@ -265,8 +260,7 @@ contains
     integer :: n
 
     n = f%msh%nelv * f%Xh%lx * f%Xh%ly * f%Xh%lz
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_cadd(f%x_d, a, n)
     else
        call cadd(f%x, a, n)

--- a/src/field/mean_field.f90
+++ b/src/field/mean_field.f90
@@ -85,8 +85,7 @@ contains
     class(mean_field_t), intent(inout) :: this
     real(kind=rp), intent(in) :: k !< Time since last sample
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_cmult(this%mf%x_d, this%time, size(this%mf%x))
        call device_add2s2(this%mf%x_d, this%f%x_d, k, size(this%mf%x))
        this%time = this%time + k

--- a/src/field/mean_sqr_field.f90
+++ b/src/field/mean_sqr_field.f90
@@ -51,8 +51,7 @@ contains
     class(mean_sqr_field_t), intent(inout) :: this
     real(kind=rp), intent(in) :: k !< Time since last sample
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_cmult(this%mf%x_d, this%time, size(this%mf%x))
        call device_addsqr2s2(this%mf%x_d, this%f%x_d, k, size(this%mf%x))
        this%time = this%time + k

--- a/src/fluid/advection.f90
+++ b/src/fluid/advection.f90
@@ -164,8 +164,7 @@ contains
 
     allocate(this%temp(coef%dof%size()))
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_map(this%temp, this%temp_d, coef%dof%size())
     end if
 
@@ -209,8 +208,7 @@ contains
        allocate(this%vt(n_GL))
     end if
     
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then       
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_map(this%temp, this%temp_d, n_GL)
        call device_map(this%tbf, this%tbf_d, n_GL)
        call device_map(this%tx, this%tx_d, n_GL)
@@ -242,8 +240,7 @@ contains
     n_GL = nel * this%Xh_GL%lxyz
     !This is extremely primitive and unoptimized  on the device //Karp
     associate(c_GL => this%coef_GL)
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        fx_d = device_get_ptr(fx)
        fy_d = device_get_ptr(fy)
        fz_d = device_get_ptr(fz)
@@ -350,8 +347,7 @@ contains
     real(kind=rp), intent(inout), dimension(n) :: fx, fy, fz
     type(c_ptr) :: fx_d, fy_d, fz_d
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        fx_d = device_get_ptr(fx)
        fy_d = device_get_ptr(fy)
        fz_d = device_get_ptr(fz)
@@ -392,8 +388,7 @@ contains
     type(coef_t), intent(inout) :: coef
     type(c_ptr) :: fs_d
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        fs_d = device_get_ptr(fs)
        
        call conv1(this%temp, s%x, vx%x, vy%x, vz%x, Xh, coef)

--- a/src/fluid/flow_ic.f90
+++ b/src/fluid/flow_ic.f90
@@ -102,8 +102,7 @@ contains
     type(coef_t), intent(in) :: coef
     type(gs_t), intent(inout) :: gs
     
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then 
        call device_memcpy(u%x, u%x_d, u%dof%size(), HOST_TO_DEVICE)
        call device_memcpy(v%x, v%x_d, v%dof%size(), HOST_TO_DEVICE)
        call device_memcpy(w%x, w%x_d, w%dof%size(), HOST_TO_DEVICE)
@@ -114,8 +113,7 @@ contains
     call gs_op(gs, v%x, v%dof%size(), GS_OP_ADD) 
     call gs_op(gs, w%x, w%dof%size(), GS_OP_ADD) 
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_col2(u%x_d, coef%mult_d, u%dof%size())
        call device_col2(v%x_d, coef%mult_d, v%dof%size())
        call device_col2(w%x_d, coef%mult_d, w%dof%size())
@@ -138,8 +136,7 @@ contains
     v = uinf(2)
     w = uinf(3)
     n = u%dof%size()
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call cfill(u%x, uinf(1), n)
        call cfill(v%x, uinf(2), n)
        call cfill(w%x, uinf(3), n)

--- a/src/fluid/fluid_fctry.f90
+++ b/src/fluid/fluid_fctry.f90
@@ -51,8 +51,7 @@ contains
     if (trim(fluid_scheme) .eq. 'plan1') then
        allocate(fluid_plan1_t::fluid)
     else if (trim(fluid_scheme) .eq. 'plan4') then
-       if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-            (NEKO_BCKND_OPENCL .eq. 1)) then
+       if (NEKO_BCKND_DEVICE .eq. 1) then
           allocate(device_fluid_plan4_t::fluid)
        else
           allocate(fluid_plan4_t::fluid)

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -382,8 +382,7 @@ contains
      
       call f_Xh%eval()
 
-      if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-           (NEKO_BCKND_OPENCL .eq. 1)) then
+      if (NEKO_BCKND_DEVICE .eq. 1) then
          call device_opcolv(f_Xh%u_d, f_Xh%v_d, f_Xh%w_d, c_Xh%B_d, msh%gdim, n)
       else
          call opcolv(f_Xh%u, f_Xh%v, f_Xh%w, c_Xh%B, msh%gdim, n)
@@ -440,8 +439,7 @@ contains
                                          this%bclst_dp, gs_Xh, n)
       end if
 
-      if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-           (NEKO_BCKND_OPENCL .eq. 1)) then
+      if (NEKO_BCKND_DEVICE .eq. 1) then
          call device_add2(p%x_d, dp%x_d,n)
       else
          call add2(p%x, dp%x,n)
@@ -489,8 +487,7 @@ contains
                                   this%bclst_dw, gs_Xh, n)
       end if
       
-      if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-           (NEKO_BCKND_OPENCL .eq. 1)) then
+      if (NEKO_BCKND_DEVICE .eq. 1) then
          call device_opadd2cm(u%x_d, v%x_d, w%x_d, &
               du%x_d, dv%x_d, dw%x_d, 1.0_rp, n, msh%gdim)
       else

--- a/src/fluid/fluid_volflow.f90
+++ b/src/fluid/fluid_volflow.f90
@@ -165,8 +165,7 @@ contains
       if (this%flow_dir.eq.2) this%domain_length = ylmax - ylmin
       if (this%flow_dir.eq.3) this%domain_length = zlmax - zlmin
 
-      if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-           (NEKO_BCKND_OPENCL .eq. 1)) then
+      if (NEKO_BCKND_DEVICE .eq. 1) then
          call device_cfill(c_Xh%h1_d, 1.0_rp/rho, n)
          call device_rzero(c_Xh%h2_d, n)
       else
@@ -218,8 +217,7 @@ contains
        
       ! add forcing
 
-      if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-           (NEKO_BCKND_OPENCL .eq. 1)) then
+      if (NEKO_BCKND_DEVICE .eq. 1) then
          if (this%flow_dir .eq. 1) then
             call device_add2(u_res%x_d, ta1%x_d, n) 
          else if (this%flow_dir .eq. 2) then
@@ -237,8 +235,7 @@ contains
          end if
       end if
 
-      if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-           (NEKO_BCKND_OPENCL .eq. 1)) then
+      if (NEKO_BCKND_DEVICE .eq. 1) then
          call device_cfill(c_Xh%h1_d, (1.0_rp / Re), n)
          call device_cfill(c_Xh%h2_d, rho * (bd / dt), n)
       else
@@ -264,8 +261,7 @@ contains
        ksp_result = ksp_vel%solve(Ax, w_vol, w_res%x, n, &
             c_Xh, bclst_dw, gs_Xh, niter)
 
-      if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-           (NEKO_BCKND_OPENCL .eq. 1)) then
+      if (NEKO_BCKND_DEVICE .eq. 1) then
          if (this%flow_dir .eq. 1) then
             this%base_flow = &
                  device_glsc2(u_vol%x_d, c_Xh%B_d, n) / this%domain_length
@@ -356,8 +352,7 @@ contains
               Ax, ksp_vel, ksp_prs, pc_prs, pc_vel, niter)
       end if
       
-      if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-           (NEKO_BCKND_OPENCL .eq. 1)) then
+      if (NEKO_BCKND_DEVICE .eq. 1) then
          if (this%flow_dir .eq. 1) then
             current_flow = &
                  device_glsc2(u%x_d, c_Xh%B_d, n) / this%domain_length  ! for X
@@ -386,8 +381,7 @@ contains
       delta_flow = flow_rate - current_flow            
       scale = delta_flow / this%base_flow
       
-      if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-           (NEKO_BCKND_OPENCL .eq. 1)) then
+      if (NEKO_BCKND_DEVICE .eq. 1) then
          call device_add2s2(u%x_d, u_vol%x_d, scale, n)
          call device_add2s2(v%x_d, v_vol%x_d, scale, n)
          call device_add2s2(w%x_d, w_vol%x_d, scale, n)

--- a/src/fluid/pnpn_res_fctry.f90
+++ b/src/fluid/pnpn_res_fctry.f90
@@ -52,8 +52,7 @@ contains
     
     if (NEKO_BCKND_SX .eq. 1) then
        allocate(pnpn_prs_res_sx_t::prs_res)
-    else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    else if (NEKO_BCKND_DEVICE .eq. 1) then
        allocate(pnpn_prs_res_device_t::prs_res)
     else
        allocate(pnpn_prs_res_cpu_t::prs_res)
@@ -70,8 +69,7 @@ contains
 
     if (NEKO_BCKND_SX .eq. 1) then
        allocate(pnpn_vel_res_sx_t::vel_res)
-    else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    else if (NEKO_BCKND_DEVICE .eq. 1) then
        allocate(pnpn_vel_res_device_t::vel_res)
     else
        allocate(pnpn_vel_res_cpu_t::vel_res)

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -149,8 +149,7 @@ contains
     else
        if (NEKO_BCKND_SX .eq. 1) then
           bcknd_ = GS_BCKND_SX
-       else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-            (NEKO_BCKND_OPENCL .eq. 1)) then
+       else if (NEKO_BCKND_DEVICE .eq. 1) then
           bcknd_ = GS_BCKND_DEV
        else
           bcknd_ = GS_BCKND_CPU

--- a/src/io/fluid_output.f90
+++ b/src/io/fluid_output.f90
@@ -78,8 +78,7 @@ contains
     class(fluid_output_t), intent(inout) :: this
     real(kind=rp), intent(in) :: t
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
 
        associate(p => this%fluid%p, u =>this%fluid%u, v => this%fluid%v, &
             w => this%fluid%w, dm_Xh => this%fluid%dm_Xh)

--- a/src/io/scalar_output.f90
+++ b/src/io/scalar_output.f90
@@ -78,8 +78,7 @@ contains
     class(scalar_output_t), intent(inout) :: this
     real(kind=rp), intent(in) :: t
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
 
        associate(s=> this%scalar%s, dm_Xh => this%scalar%dm_Xh)
        

--- a/src/krylov/krylov.f90
+++ b/src/krylov/krylov.f90
@@ -139,8 +139,7 @@ contains
        this%M => M
     else
        if (.not. associated(this%M)) then
-          if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) &
-               .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+          if (NEKO_BCKND_DEVICE .eq. 1) then
              allocate(device_ident_t::this%M_ident)
           else
              allocate(ident_t::this%M_ident)

--- a/src/krylov/krylov_fctry.f90
+++ b/src/krylov/krylov_fctry.f90
@@ -64,8 +64,7 @@ contains
     if (trim(solver) .eq. 'cg') then
        if (NEKO_BCKND_SX .eq. 1) then
           allocate(sx_cg_t::ksp)
-       else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-            (NEKO_BCKND_OPENCL .eq. 1)) then
+       else if (NEKO_BCKND_DEVICE .eq. 1) then
           allocate(cg_device_t::ksp)
        else
           allocate(cg_t::ksp)
@@ -73,8 +72,7 @@ contains
     else if (trim(solver) .eq. 'pipecg') then
        if (NEKO_BCKND_SX .eq. 1) then
           allocate(sx_pipecg_t::ksp)
-       else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-            (NEKO_BCKND_OPENCL .eq. 1)) then
+       else if (NEKO_BCKND_DEVICE .eq. 1) then
           allocate(pipecg_device_t::ksp)
        else
           allocate(pipecg_t::ksp)
@@ -84,8 +82,7 @@ contains
     else if (trim(solver) .eq. 'gmres') then
        if (NEKO_BCKND_SX .eq. 1) then
           allocate(sx_gmres_t::ksp)
-       else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-            (NEKO_BCKND_OPENCL .eq. 1)) then
+       else if (NEKO_BCKND_DEVICE .eq. 1) then
           allocate(gmres_device_t::ksp)
        else
           allocate(gmres_t::ksp)

--- a/src/krylov/pc_hsmg.f90
+++ b/src/krylov/pc_hsmg.f90
@@ -181,8 +181,7 @@ contains
        allocate(sx_jacobi_t::this%pc_crs)
     else if (NEKO_BCKND_XSMM .eq. 1) then
        allocate(jacobi_t::this%pc_crs)
-    else if ((NEKO_BCKND_CUDA .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
-         .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+    else if (NEKO_BCKND_DEVICE .eq. 1) then
        allocate(device_jacobi_t::this%pc_crs)
     else
        allocate(jacobi_t::this%pc_crs)
@@ -240,8 +239,7 @@ contains
                         this%e_crs, this%grids, 1) 
                  
     call hsmg_set_h(this)
-    if ((NEKO_BCKND_CUDA .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
-         .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_map(this%w, this%w_d, n)
        call device_map(this%r, this%r_d, n)
     end if
@@ -265,8 +263,7 @@ contains
     this%grids(1)%coef%ifh2 = .false.
     call copy(this%grids(1)%coef%h1, this%grids(3)%coef%h1, &
          this%grids(1)%dof%size())
-    if ((NEKO_BCKND_CUDA .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
-         .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_copy(this%grids(1)%coef%h1_d, this%grids(3)%coef%h1_d, &
             this%grids(1)%dof%size())
     end if
@@ -352,8 +349,7 @@ contains
     type(c_ptr) :: z_d, r_d
     type(ksp_monitor_t) :: crs_info
      
-    if ((NEKO_BCKND_CUDA .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
-         .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        z_d = device_get_ptr(z)
        r_d = device_get_ptr(r)
        !We should not work with the input 

--- a/src/krylov/precon_fctry.f90
+++ b/src/krylov/precon_fctry.f90
@@ -57,8 +57,7 @@ contains
     if (trim(pctype) .eq. 'jacobi') then
        if (NEKO_BCKND_SX .eq. 1) then
           allocate(sx_jacobi_t::pc)
-       else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-            (NEKO_BCKND_OPENCL .eq. 1)) then
+       else if (NEKO_BCKND_DEVICE .eq. 1) then
           allocate(device_jacobi_t::pc)
        else
           allocate(jacobi_t::pc)
@@ -66,8 +65,7 @@ contains
     else if (pctype(1:4) .eq. 'hsmg') then
        allocate(hsmg_t::pc)
     else if(trim(pctype) .eq. 'ident') then
-       if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-            (NEKO_BCKND_OPENCL .eq. 1)) then
+       if (NEKO_BCKND_DEVICE .eq. 1) then
           allocate(device_ident_t::pc)
        else
           allocate(ident_t::pc)

--- a/src/math/ax_helm_fctry.f90
+++ b/src/math/ax_helm_fctry.f90
@@ -52,8 +52,7 @@ contains
        allocate(ax_helm_sx_t::Ax)
     else if (NEKO_BCKND_XSMM .eq. 1) then
        allocate(ax_helm_xsmm_t::Ax)
-    else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) &
-         .or. (NEKO_BCKND_OPENCL .eq. 1)) then       
+    else if (NEKO_BCKND_DEVICE .eq. 1)then
        allocate(ax_helm_device_t::Ax)
     else
        allocate(ax_helm_t::Ax)

--- a/src/math/fdm.f90
+++ b/src/math/fdm.f90
@@ -127,8 +127,7 @@ contains
     ! MPI messages in GS are deterministic
     call rzero(this%swplen, Xh%lxyz * dm%msh%nelv)
  
-    if ((NEKO_BCKND_CUDA .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
-         .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_map(this%s, this%s_d,nl*nl*2*dm%msh%gdim*dm%msh%nelv) 
        call device_map(this%d, this%d_d,nl**dm%msh%gdim*dm%msh%nelv) 
        call device_map(this%swplen,this%swplen_d, Xh%lxyz*dm%msh%nelv) 
@@ -144,8 +143,7 @@ contains
 
     call fdm_setup_fast(this, ah, bh, nl, n)
 
-    if ((NEKO_BCKND_CUDA .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
-         .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_memcpy(this%s, this%s_d, &
             nl*nl*2*dm%msh%gdim*dm%msh%nelv, HOST_TO_DEVICE) 
        call device_memcpy(this%d, this%d_d, &
@@ -190,7 +188,7 @@ contains
                end do
             end do
          end do
-         if (NEKO_BCKND_CUDA .eq. 1 .or. NEKO_BCKND_HIP .eq. 1) then
+         if (NEKO_BCKND_DEVICE .eq. 1) then
             call device_memcpy(l, this%swplen_d, this%dof%size(), HOST_TO_DEVICE)
             call gs_op(this%gs_h, l, this%dof%size(), GS_OP_ADD)
             call device_memcpy(l, this%swplen_d, this%dof%size(), DEVICE_TO_HOST)
@@ -216,8 +214,7 @@ contains
             end do
          end do
 
-         if ((NEKO_BCKND_CUDA .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
-              .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+         if (NEKO_BCKND_DEVICE .eq. 1) then
             call device_memcpy(l, this%swplen_d, this%dof%size(),HOST_TO_DEVICE)
             call gs_op(this%gs_h, l, this%dof%size(), GS_OP_ADD)
             call device_memcpy(l, this%swplen_d, this%dof%size(),DEVICE_TO_HOST)
@@ -626,8 +623,7 @@ contains
     else if (NEKO_BCKND_XSMM .eq. 1) then
        call fdm_do_fast_xsmm(e, r, this%s, this%d, &
             this%Xh%lx+2, this%msh%gdim, this%msh%nelv)
-    else if ((NEKO_BCKND_CUDA .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
-         .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+    else if (NEKO_BCKND_DEVICE .eq. 1) then
        call fdm_do_fast_device(e, r, this%s, this%d, &
             this%Xh%lx+2, this%msh%gdim, this%msh%nelv)
     else

--- a/src/math/operators.f90
+++ b/src/math/operators.f90
@@ -61,8 +61,7 @@ contains
        call opr_sx_dudxyz(du, u, dr, ds, dt, coef)
     else if (NEKO_BCKND_XSMM .eq. 1) then
        call opr_xsmm_dudxyz(du, u, dr, ds, dt, coef)
-    else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) &
-         .or. (NEKO_BCKND_OPENCL .eq. 1)) then       
+    else if (NEKO_BCKND_DEVICE .eq. 1) then
        call opr_device_dudxyz(du, u, dr, ds, dt, coef)
     else
        call opr_cpu_dudxyz(du, u, dr, ds, dt, coef)
@@ -96,8 +95,7 @@ contains
        call opr_sx_opgrad(ux, uy, uz, u, coef)
     else if (NEKO_BCKND_XSMM .eq. 1) then
        call opr_xsmm_opgrad(ux, uy, uz, u, coef)
-    else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) &
-         .or. (NEKO_BCKND_OPENCL .eq. 1)) then       
+    else if (NEKO_BCKND_DEVICE .eq. 1) then
        call opr_device_opgrad(ux, uy, uz, u, coef)
     else
        call opr_cpu_opgrad(ux, uy, uz, u, coef, eblk_start, eblk_end)
@@ -131,8 +129,7 @@ contains
        call opr_sx_cdtp(dtx, x, dr, ds, dt, coef)
     else if (NEKO_BCKND_XSMM .eq. 1) then
        call opr_xsmm_cdtp(dtx, x, dr, ds, dt, coef)
-    else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) &
-         .or. (NEKO_BCKND_OPENCL .eq. 1)) then       
+    else if (NEKO_BCKND_DEVICE .eq. 1) then
        call opr_device_cdtp(dtx, x, dr, ds, dt, coef)
     else
        call opr_cpu_cdtp(dtx, x, dr, ds, dt, coef)
@@ -168,8 +165,7 @@ contains
          call opr_sx_conv1(du, u, vx, vy, vz, Xh, coef, nelv, gdim)
       else if (NEKO_BCKND_XSMM .eq. 1) then
          call opr_xsmm_conv1(du, u, vx, vy, vz, Xh, coef, nelv, gdim)
-      else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) &
-           .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+      else if (NEKO_BCKND_DEVICE .eq. 1) then
          call opr_device_conv1(du, u, vx, vy, vz, Xh, coef, nelv, gdim)
       else
          call opr_cpu_conv1(du, u, vx, vy, vz, Xh, coef, eblk_start, eblk_end)
@@ -193,8 +189,7 @@ contains
        call opr_sx_curl(w1, w2, w3, u1, u2, u3, work1, work2, c_Xh)
     else if (NEKO_BCKND_XSMM .eq. 1) then
        call opr_xsmm_curl(w1, w2, w3, u1, u2, u3, work1, work2, c_Xh)
-    else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) &
-         .or. (NEKO_BCKND_OPENCL .eq. 1)) then       
+    else if (NEKO_BCKND_DEVICE .eq. 1) then
        call opr_device_curl(w1, w2, w3, u1, u2, u3, work1, work2, c_Xh)
     else
        call opr_cpu_curl(w1, w2, w3, u1, u2, u3, work1, work2, c_Xh)
@@ -213,8 +208,7 @@ contains
 
     if (NEKO_BCKND_SX .eq. 1) then
        cfl = opr_sx_cfl(dt, u, v, w, Xh, coef, nelv, gdim)
-    else if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) &
-         .or. (NEKO_BCKND_OPENCL .eq. 1)) then  
+    else if (NEKO_BCKND_DEVICE .eq. 1) then
        cfl = opr_device_cfl(dt, u, v, w, Xh, coef, nelv, gdim)
     else
        cfl = opr_cpu_cfl(dt, u, v, w, Xh, coef, nelv, gdim)

--- a/src/math/schwarz.f90
+++ b/src/math/schwarz.f90
@@ -119,16 +119,14 @@ contains
     this%bclst => bclst
     this%dm => dm
     this%gs_h => gs_h
-    if ((NEKO_BCKND_CUDA .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
-         .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_map(this%work1, this%work1_d,this%dm_schwarz%size()) 
        call device_map(this%work2, this%work2_d,this%dm_schwarz%size()) 
     end if
 
 
     call schwarz_setup_wt(this)
-    if ((NEKO_BCKND_CUDA .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
-         .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_alloc(this%wt_d,int(this%dm%size()*rp, i8)) 
        call rone(this%work1, this%dm%size())
        call schwarz_wt3d(this%work1, this%wt, Xh%lx, msh%nelv)
@@ -178,8 +176,7 @@ contains
       !   Sum overlap region (border excluded)
       !   Cred to PFF for this, very clever
       call schwarz_extrude(work1, 0, zero, work2, 0, one , enx, eny, enz, msh%nelv)
-      if ((NEKO_BCKND_CUDA .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
-           .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+      if (NEKO_BCKND_DEVICE .eq. 1) then
          call device_memcpy(work2, this%work2_d, ns, HOST_TO_DEVICE)
          call gs_op(this%gs_schwarz, work2, ns, GS_OP_ADD) 
          call device_memcpy(work2, this%work2_d, ns, DEVICE_TO_HOST)
@@ -195,8 +192,7 @@ contains
       call schwarz_toreg3d(work1, work2, Xh%lx, msh%nelv)
       ! endif
       
-      if ((NEKO_BCKND_CUDA .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
-           .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+      if (NEKO_BCKND_DEVICE .eq. 1) then
          call device_memcpy(work1, this%work1_d, n, HOST_TO_DEVICE)
          call gs_op(this%gs_h, work1, n, GS_OP_ADD) 
          call device_memcpy(work1, this%work1_d, n, DEVICE_TO_HOST)
@@ -382,8 +378,7 @@ contains
     enz=this%Xh_schwarz%lz
     if(.not. this%msh%gdim .eq. 3) enz=1
     ns = enx*eny*enz*this%msh%nelv
-    if ((NEKO_BCKND_CUDA .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
-         .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        r_d = device_get_ptr(r)
        e_d = device_get_ptr(e)
        call bc_list_apply_scalar(this%bclst, r, n)

--- a/src/scalar/scalar_pnpn.f90
+++ b/src/scalar/scalar_pnpn.f90
@@ -247,8 +247,7 @@ contains
       ! evaluate the source term and scale with the mass matrix
       call f_Xh%eval()
 
-      if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-           (NEKO_BCKND_OPENCL .eq. 1)) then
+      if (NEKO_BCKND_DEVICE .eq. 1) then
          call device_col2(f_Xh%s_d, c_Xh%B_d, n)
       else
          call col2(f_Xh%s, c_Xh%B, n)
@@ -292,8 +291,7 @@ contains
               this%bclst_ds, gs_Xh, n)
       end if
 
-      if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-           (NEKO_BCKND_OPENCL .eq. 1)) then
+      if (NEKO_BCKND_DEVICE .eq. 1) then
          call device_add2s2(s%x_d, ds%x_d, 1.0_rp, n)
       else
          call add2s2(s%x, ds%x, 1.0_rp, n)

--- a/src/sem/coef.f90
+++ b/src/sem/coef.f90
@@ -261,8 +261,7 @@ contains
     !
     
     n = coef%Xh%lx * coef%Xh%ly * coef%Xh%lz * coef%msh%nelv
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-        (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_map(coef%G11, coef%G11_d, n)
        call device_map(coef%G22, coef%G22_d, n)
        call device_map(coef%G33, coef%G33_d, n)
@@ -321,8 +320,7 @@ contains
     
     ! This is a placeholder, just for now
     ! We can probably find a prettier solution
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_rone(coef%h1_d, n)
        call device_rone(coef%h2_d, n)
        call device_memcpy(coef%h1, coef%h1_d, n, DEVICE_TO_HOST)
@@ -337,8 +335,7 @@ contains
     !
     ! Set up multiplicity
     !
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then 
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_rone(coef%mult_d, n)
     else
        call rone(coef%mult, n)
@@ -346,8 +343,7 @@ contains
        
     call gs_op(gs_h, coef%mult, n, GS_OP_ADD)
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then 
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_invcol1(coef%mult_d, n)
        call device_memcpy(coef%mult, coef%mult_d, n, DEVICE_TO_HOST)
     else    
@@ -670,8 +666,7 @@ contains
          dyt => c%Xh%dyt, dzt => c%Xh%dzt, &
          jacinv => c%jacinv, jac => c%jac)
 
-        if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-           (NEKO_BCKND_OPENCL .eq. 1)) then
+        if (NEKO_BCKND_DEVICE .eq. 1) then
 
          call device_coef_generate_dxydrst(c%drdx_d, c%drdy_d, c%drdz_d, &
               c%dsdx_d, c%dsdy_d, c%dsdz_d, c%dtdx_d, c%dtdy_d, c%dtdz_d, &
@@ -780,8 +775,7 @@ contains
          dtdx => c%dtdx, dtdy => c%dtdy, dtdz => c%dtdz, &
          jacinv => c%jacinv, w3 => c%Xh%w3)
 
-      if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-           (NEKO_BCKND_OPENCL .eq. 1)) then 
+      if (NEKO_BCKND_DEVICE .eq. 1) then
 
          call device_coef_generate_geo(c%G11_d, c%G12_d, c%G13_d, &
                                        c%G22_d, c%G23_d, c%G33_d, &
@@ -859,16 +853,14 @@ contains
     call copy(c%Binv, c%B, ntot)
 
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then 
-      call device_memcpy(c%B, c%B_d, ntot, HOST_TO_DEVICE)
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_memcpy(c%B, c%B_d, ntot, HOST_TO_DEVICE)
        call device_memcpy(c%Binv, c%Binv_d, ntot, HOST_TO_DEVICE)
     end if
     
     call gs_op(c%gs_h, c%Binv, ntot, GS_OP_ADD)
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then 
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_invcol1(c%Binv_d, ntot)
        call device_memcpy(c%Binv, c%Binv_d, ntot, DEVICE_TO_HOST)
     else
@@ -876,8 +868,7 @@ contains
     end if
 
     !>  @todo cleanup once we have device math in place
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        c%volume = device_glsum(c%B_d, ntot)
     else
        c%volume = glsum(c%B, ntot)
@@ -1001,8 +992,7 @@ contains
     deallocate(b)
     deallocate(a)
     !>  @todo cleanup once we have device math in place
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-        (NEKO_BCKND_OPENCL .eq. 1)) then 
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        n = size(coef%area)
        call device_memcpy(coef%area, coef%area_d, n, HOST_TO_DEVICE)
        call device_memcpy(coef%nx, coef%nx_d, n, HOST_TO_DEVICE)

--- a/src/sem/dofmap.f90
+++ b/src/sem/dofmap.f90
@@ -129,8 +129,7 @@ contains
 
     call dofmap_generate_xyz(this)    
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-        (NEKO_BCKND_OPENCL .eq. 1)) then 
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_map(this%x, this%x_d, this%ntot)
        call device_map(this%y, this%y_d, this%ntot)
        call device_map(this%z, this%z_d, this%ntot)

--- a/src/sem/interpolation.f90
+++ b/src/sem/interpolation.f90
@@ -90,8 +90,7 @@ contains
 
     this%Xh => Xh
     this%Yh => Yh
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-         (NEKO_BCKND_OPENCL .eq. 1)) then
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_map(this%Xh_to_Yh, this%Xh_Yh_d, Yh%lx*Xh%lx)
        call device_map(this%Xh_to_YhT, this%Xh_YhT_d, Yh%lx*Xh%lx)
        call device_map(this%Yh_to_Xh, this%Yh_Xh_d, Yh%lx*Xh%lx)

--- a/src/sem/space.f90
+++ b/src/sem/space.f90
@@ -222,8 +222,7 @@ contains
        s%dt_inv = 0d0
     end if
 
-    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
-        (NEKO_BCKND_OPENCL .eq. 1)) then 
+    if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_map(s%dr_inv, s%dr_inv_d, s%lx)
        call device_map(s%ds_inv, s%ds_inv_d, s%lx)
        call device_map(s%dt_inv, s%dt_inv_d, s%lx)


### PR DESCRIPTION
Add a generic NEKO_BCKND_DEVICE flag, which is true whenever any of NEKO_BCKND_CUDA, NEKO_BCKND_HIP or NEKO_BCKND_OPENCL flags are set.

Note that the old flags are still accessible, if specialisation is needed. 
