### PR TITLE
Consistent spelling in exposed intf, usr -> user

### DIFF
--- a/bench/tgv32/tgv.f90
+++ b/bench/tgv32/tgv.f90
@@ -5,9 +5,9 @@ contains
   ! Register user defined functions (see user_intf.f90)
   subroutine user_setup(u)
     type(user_t), intent(inout) :: u
-    u%fluid_usr_ic => user_ic
-    u%usr_msh_setup => user_mesh_scale
-    u%usr_chk => usr_calc_quantities
+    u%fluid_user_ic => user_ic
+    u%user_mesh_setup => user_mesh_scale
+    u%user_check => usr_calc_quantities
   end subroutine user_setup
 
   ! Normalize mesh

--- a/examples/cyl_boundary_layer/cyl_bl.f90
+++ b/examples/cyl_boundary_layer/cyl_bl.f90
@@ -23,10 +23,10 @@ contains
   ! Register user defined functions (see user_intf.f90)
   subroutine user_setup(u)
     type(user_t), intent(inout) :: u
-    u%fluid_usr_ic => user_ic
-    u%fluid_usr_if => user_inflow_eval
-    !u%usr_chk => user_do_stuff
-    u%usr_msh_setup => cylinder_deform
+    u%fluid_user_ic => user_ic
+    u%fluid_user_if => user_inflow_eval
+    !u%user_check => user_do_stuff
+    u%user_mesh_setup => cylinder_deform
   end subroutine user_setup
  
   subroutine cylinder_deform(msh)

--- a/examples/lid/lid.f90
+++ b/examples/lid/lid.f90
@@ -15,9 +15,9 @@ module user
   ! Register user-defined functions (see user_intf.f90)
   subroutine user_setup(user)
     type(user_t), intent(inout) :: user
-    user%fluid_usr_ic => user_ic
-    user%fluid_usr_if => user_bc
-    user%usr_chk => user_calc_quantities
+    user%fluid_user_ic => user_ic
+    user%fluid_user_if => user_bc
+    user%user_check => user_calc_quantities
     user%user_init_modules => user_initialize
   end subroutine user_setup
 

--- a/examples/rayleigh-benard/rayleigh.f90
+++ b/examples/rayleigh-benard/rayleigh.f90
@@ -11,8 +11,8 @@ contains
   subroutine user_setup(u)
     type(user_t), intent(inout) :: u
     u%user_init_modules => set_Pr
-    u%fluid_usr_ic => set_ic
-    u%fluid_usr_f_vector => forcing
+    u%fluid_user_ic => set_ic
+    u%fluid_user_f_vector => forcing
   end subroutine user_setup
 
   !> Dummy user initial condition

--- a/examples/tgv/tgv.f90
+++ b/examples/tgv/tgv.f90
@@ -16,9 +16,9 @@ contains
   ! Register user-defined functions (see user_intf.f90)
   subroutine user_setup(user)
     type(user_t), intent(inout) :: user
-    user%fluid_usr_ic => user_ic
-    user%usr_msh_setup => user_mesh_scale
-    user%usr_chk => user_calc_quantities
+    user%fluid_user_ic => user_ic
+    user%user_mesh_setup => user_mesh_scale
+    user%user_check => user_calc_quantities
     user%user_init_modules => user_initialize
   end subroutine user_setup
 

--- a/examples/turbpipe/pipe.f90
+++ b/examples/turbpipe/pipe.f90
@@ -5,8 +5,8 @@ contains
   ! Register user defined functions (see user_intf.f90)
   subroutine user_setup(u)
     type(user_t), intent(inout) :: u
-    u%fluid_usr_ic => user_ic
-    u%fluid_usr_f_vector => forcing
+    u%fluid_user_ic => user_ic
+    u%fluid_user_f_vector => forcing
   end subroutine user_setup
   ! User defined initial condition
   subroutine user_ic(u, v, w, p, params)

--- a/reframe/src/tgv.f90
+++ b/reframe/src/tgv.f90
@@ -5,9 +5,9 @@ contains
   ! Register user defined functions (see user_intf.f90)
   subroutine user_setup(u)
     type(user_t), intent(inout) :: u
-    u%fluid_usr_ic => user_ic
-    u%usr_msh_setup => user_mesh_scale
-    u%usr_chk => usr_calc_quantities
+    u%fluid_user_ic => user_ic
+    u%user_mesh_setup => user_mesh_scale
+    u%user_check => usr_calc_quantities
   end subroutine user_setup
 
   ! Normalize mesh

--- a/src/case.f90
+++ b/src/case.f90
@@ -163,7 +163,7 @@ contains
     ! Setup user defined functions
     !
     call C%usr%init()
-    call C%usr%usr_msh_setup(C%msh)
+    call C%usr%user_mesh_setup(C%msh)
     
     !
     ! Setup fluid scheme
@@ -182,16 +182,17 @@ contains
     ! Setup user defined conditions    
     !
     if (trim(C%params%fluid_inflow) .eq. 'user') then
-       call C%fluid%set_usr_inflow(C%usr%fluid_usr_if)
+       call C%fluid%set_usr_inflow(C%usr%fluid_user_if)
     end if
     
     !
     ! Setup source term
     ! 
     if (trim(source_term) .eq. 'user') then
-       call C%fluid%set_source(trim(source_term), usr_f=C%usr%fluid_usr_f)
+       call C%fluid%set_source(trim(source_term), usr_f=C%usr%fluid_user_f)
     else if (trim(source_term) .eq. 'user_vector') then
-       call C%fluid%set_source(trim(source_term), usr_f_vec=C%usr%fluid_usr_f_vector)
+       call C%fluid%set_source(trim(source_term), &
+            usr_f_vec=C%usr%fluid_user_f_vector)
     else
        call C%fluid%set_source(trim(source_term))
     end if
@@ -211,7 +212,7 @@ contains
                C%fluid%c_Xh, C%fluid%gs_Xh, initial_condition, C%params)
        else
           call set_flow_ic(C%fluid%u, C%fluid%v, C%fluid%w, C%fluid%p, &
-               C%fluid%c_Xh, C%fluid%gs_Xh, C%usr%fluid_usr_ic, C%params)
+               C%fluid%c_Xh, C%fluid%gs_Xh, C%usr%fluid_user_ic, C%params)
        end if
     end if
 

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -98,13 +98,13 @@ module user_intf
   end interface
 
   type :: user_t
-     procedure(useric), nopass, pointer :: fluid_usr_ic => null()
+     procedure(useric), nopass, pointer :: fluid_user_ic => null()
      procedure(user_initialize_modules), nopass, pointer :: user_init_modules => null()
-     procedure(usermsh), nopass, pointer :: usr_msh_setup => null()
-     procedure(usercheck), nopass, pointer :: usr_chk => null()
-     procedure(source_term_pw), nopass, pointer :: fluid_usr_f => null()
-     procedure(source_term), nopass, pointer :: fluid_usr_f_vector => null()
-     procedure(usr_inflow_eval), nopass, pointer :: fluid_usr_if => null()
+     procedure(usermsh), nopass, pointer :: user_mesh_setup => null()
+     procedure(usercheck), nopass, pointer :: user_check => null()
+     procedure(source_term_pw), nopass, pointer :: fluid_user_f => null()
+     procedure(source_term), nopass, pointer :: fluid_user_f_vector => null()
+     procedure(usr_inflow_eval), nopass, pointer :: fluid_user_if => null()
    contains
      procedure, pass(u) :: init => user_intf_init
   end type user_t
@@ -114,23 +114,23 @@ contains
   subroutine user_intf_init(u)
     class(user_t), intent(inout) :: u
 
-    if (.not. associated(u%fluid_usr_ic)) then
-       u%fluid_usr_ic => dummy_user_ic
+    if (.not. associated(u%fluid_user_ic)) then
+       u%fluid_user_ic => dummy_user_ic
     end if
 
-    if (.not. associated(u%fluid_usr_f)) then
-       u%fluid_usr_f => dummy_user_f
+    if (.not. associated(u%fluid_user_f)) then
+       u%fluid_user_f => dummy_user_f
     end if
-    if (.not. associated(u%fluid_usr_f_vector)) then
-       u%fluid_usr_f_vector => dummy_user_f_vector
-    end if
-
-    if (.not. associated(u%usr_msh_setup)) then
-       u%usr_msh_setup => dummy_user_mesh_setup
+    if (.not. associated(u%fluid_user_f_vector)) then
+       u%fluid_user_f_vector => dummy_user_f_vector
     end if
 
-    if (.not. associated(u%usr_chk)) then
-       u%usr_chk => dummy_user_check
+    if (.not. associated(u%user_mesh_setup)) then
+       u%user_mesh_setup => dummy_user_mesh_setup
+    end if
+
+    if (.not. associated(u%user_check)) then
+       u%user_check => dummy_user_check
     end if
     if (.not. associated(u%user_init_modules)) then
        u%user_init_modules => dummy_user_init_no_modules

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -117,7 +117,7 @@ contains
        call neko_log%section('Postprocessing')       
        call C%q%eval(t, C%params%dt)
        call C%s%sample(t)
-       call C%usr%usr_chk(t, tstep,&
+       call C%usr%user_check(t, tstep,&
             C%fluid%u, C%fluid%v, C%fluid%w, C%fluid%p, C%fluid%c_Xh, C%params)
        call neko_log%end_section()
        


### PR DESCRIPTION
Make naming consistent in exposed user interface, expanding abbreviations e.g. change usr -> user. fixes #632
**Note:** This is a breaking change, and affect most provided examples 
