### PR TITLE
Add NVIDIA Fortran to the integration tests

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -210,13 +210,12 @@ jobs:
   NVIDIA:
     needs: linting
     runs-on: ${{matrix.os}}
-#    container: nvcr.io/nvidia/nvhpc:22.9-devel-cuda_multi-ubuntu20.04
     strategy:
       fail-fast: true
       matrix:
         os: [ubuntu-20.04]
         compiler: [nvfortran]
-        backend: [cpu]
+        backend: [cpu, cuda]
         precision: [dp]
         include:
         - os: ubuntu-20.04

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -244,8 +244,8 @@ jobs:
           git apply patches/nvhpc_bge.patch
           nvfortran --version
           ./regen.sh
-          ./configure FC=${FC} --enable-real=${RP}
-          make FCFLAGS="-O3" -j$(nproc)
+          ./configure FC=${FC} FCFLAGS="-O3" --enable-real=${RP}
+          make -j$(nproc)
       - name: Build (CUDA backend)
         if: matrix.backend == 'cuda'
         run: |

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -239,30 +239,7 @@ jobs:
           fetch-depth: 1
       - name: Build
         run: |
-          cat >> nvfortran.patch << _ACEOF
-          diff --git a/src/common/signal.f90 b/src/common/signal.f90
-          index 0793c48a0..1419e9378 100644
-          --- a/src/common/signal.f90
-          +++ b/src/common/signal.f90
-          @@ -99,11 +99,11 @@ contains
-          
-               usr12 = sighdl_timeout()
-          
-          -    if (bge(usr12, usr)) then
-          -       raised = .true.
-          -    else
-          -       raised = .false.
-          -    end if
-          +  !  if (bge(usr12, usr)) then
-          +  !     raised = .true.
-          +  !  else
-          +  !     raised = .false.
-          +  !  end if
-          
-             end function signal_usr
-          
-          _ACEOF
-          git apply nvfortran.patch
+          git apply patches/nvhpc_bge.patch
           ./regen.sh
           ./configure FC=${FC} CC=${CC} --enable-real=${RP}
           make FCFLAGS="-O2" -j$(nproc)

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -210,7 +210,7 @@ jobs:
   NVIDIA:
     needs: linting
     runs-on: ${{matrix.os}}
-    container: nvcr.io/nvidia/nvhpc:22.09-devel-cuda_multi-ubuntu20.04
+    container: nvcr.io/nvidia/nvhpc:22.9-devel-cuda_multi-ubuntu20.04
     strategy:
       fail-fast: true
       matrix:
@@ -220,9 +220,9 @@ jobs:
         precision: [sp, dp]
         include:
         - os: ubuntu-20.04
-#          setup-env: sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev autoconf automake autotools-dev libopenblas-dev make git m4 python3  cmake-curses-gui
-
+          setup-env: sudo apt-get update && sudo apt-get install -y autoconf automake autotools-dev make git m4
     env:
+      CC: nvcc
       FC: ${{ matrix.compiler }}
       OMPI_FC: ${{ matrix.compiler }}
       OMPI_ALLOW_RUN_AS_ROOT: 1
@@ -233,7 +233,15 @@ jobs:
     steps:
       - name: Setup env.
         run: ${{ matrix.setup-env }}
-
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Build
+        run: |
+          ./regen.sh
+          ./configure FC=${FC} CC=${CC} --enable-real=${RP}
+          make FCFLAGS="-O2" -j$(nproc)
   ReFrame:
       needs: GNU
       runs-on: ubuntu-20.04

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -222,8 +222,10 @@ jobs:
         - os: ubuntu-20.04
           setup-env: apt-get update && apt-get install -y autoconf automake autotools-dev make git m4
     env:
+      CC: gcc
       FC: ${{ matrix.compiler }}
       OMPI_FC: ${{ matrix.compiler }}
+      OMPI_CC: gcc
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
       OMPI_MCA_btl_vader_single_copy_mechanism: none

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -220,7 +220,7 @@ jobs:
         precision: [sp, dp]
         include:
         - os: ubuntu-20.04
-          setup-env: sudo apt-get update && sudo apt-get install -y autoconf automake autotools-dev make git m4 libopenblas-dev && curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg && echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list && sudo apt-get update -y && sudo apt-get install -y nvhpc-22-11-cuda-multi 
+          setup-env: sudo apt-get update && sudo apt-get install -y autoconf automake autotools-dev make git m4 libopenblas-dev && curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg && echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list && sudo apt-get update -y && sudo apt-get install -y nvhpc-22-11-cuda-multi &&  NVARCH=`uname -s`_`uname -m`; export NVARCH && NVCOMPILERS=/opt/nvidia/hpc_sdk; export NVCOMPILERS && PATH=$NVCOMPILERS/$NVARCH/22.11/compilers/bin:$PATH; export PATH &&  export PATH=$NVCOMPILERS/$NVARCH/22.11/comm_libs/mpi/bin:$PATH && printenv >> $GITHUB_ENV 
     env:
       CC: gcc
       FC: ${{ matrix.compiler }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -249,10 +249,11 @@ jobs:
       - name: Build (CUDA backend)
         if: matrix.backend == 'cuda'
         run: |
+          sudo apt-get install -y nvidia-cuda-toolkit
           git apply patches/nvhpc_bge.patch
           nvfortran --version
           ./regen.sh
-          ./configure FC=${FC} --enable-real=${RP} --with-cuda=${CUDA_HOME}
+          ./configure FC=${FC} --enable-real=${RP} --with-cuda=/usr
           make FCFLAGS="-O3" -j$(nproc)          
   ReFrame:
       needs: GNU

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -239,9 +239,31 @@ jobs:
           fetch-depth: 1
       - name: Build
         run: |
+          cat >> nvfortran.patch << _ACEOF
+          diff --git a/src/common/signal.f90 b/src/common/signal.f90
+          index 0793c48a0..1419e9378 100644
+          --- a/src/common/signal.f90
+          +++ b/src/common/signal.f90
+          @@ -99,11 +99,11 @@ contains
+          
+          usr12 = sighdl_timeout()
+          
+          -    if (bge(usr12, usr)) then
+          -       raised = .true.
+          -    else
+          -       raised = .false.
+          -    end if
+          +  !  if (bge(usr12, usr)) then
+          +  !     raised = .true.
+          +  !  else
+          +  !     raised = .false.
+          +  !  end if
+          _ACEOF
+          git apply nvfortran.patch
           ./regen.sh
           ./configure FC=${FC} CC=${CC} --enable-real=${RP}
           make FCFLAGS="-O2" -j$(nproc)
+          
   ReFrame:
       needs: GNU
       runs-on: ubuntu-20.04

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -220,7 +220,7 @@ jobs:
         precision: [sp, dp]
         include:
         - os: ubuntu-20.04
-          setup-env: sudo apt-get update && sudo apt-get install -y autoconf automake autotools-dev make git m4
+          setup-env: apt-get update && apt-get install -y autoconf automake autotools-dev make git m4
     env:
       CC: nvcc
       FC: ${{ matrix.compiler }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -216,8 +216,8 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         compiler: [nvfortran]
-        backend: [cpu, cuda]
-        precision: [sp, dp]
+        backend: [cpu]
+        precision: [dp]
         include:
         - os: ubuntu-20.04
           setup-env: sudo apt-get update && sudo apt-get install -y autoconf automake autotools-dev make git m4 libopenblas-dev && curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg && echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list && sudo apt-get update -y && sudo apt-get install -y nvhpc-22-11-cuda-multi &&  NVARCH=`uname -s`_`uname -m`; export NVARCH && NVCOMPILERS=/opt/nvidia/hpc_sdk; export NVCOMPILERS && PATH=$NVCOMPILERS/$NVARCH/22.11/compilers/bin:$PATH; export PATH &&  export PATH=$NVCOMPILERS/$NVARCH/22.11/comm_libs/mpi/bin:$PATH && printenv >> $GITHUB_ENV 

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -210,7 +210,7 @@ jobs:
   NVIDIA:
     needs: linting
     runs-on: ${{matrix.os}}
-    container: nvcr.io/nvidia/nvhpc:22.9-devel-cuda_multi-ubuntu20.04
+#    container: nvcr.io/nvidia/nvhpc:22.9-devel-cuda_multi-ubuntu20.04
     strategy:
       fail-fast: true
       matrix:
@@ -220,7 +220,7 @@ jobs:
         precision: [sp, dp]
         include:
         - os: ubuntu-20.04
-          setup-env: apt-get update && apt-get install -y autoconf automake autotools-dev make git m4
+          setup-env: sudo apt-get update && sudo apt-get install -y autoconf automake autotools-dev make git m4 libopenblas-dev && curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg && echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list && sudo apt-get update -y && sudo apt-get install -y nvhpc-22-11-cuda-multi 
     env:
       CC: gcc
       FC: ${{ matrix.compiler }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -206,6 +206,34 @@ jobs:
           ./regen.sh
           ./configure FC=${FC} CC=${CC} MPIFC"=mpiifort -fc=${FC}" --enable-real=${RP} 
           make FCFLAGS="-O2 -stand f08 -warn errors" -j$(nproc)
+  
+  NVIDIA:
+    needs: linting
+    runs-on: ${{matrix.os}}
+    container: nvcr.io/nvidia/nvhpc:22.11-devel-cuda_multi-ubuntu20.04
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-20.04]
+        compiler: [nvfortran]
+        backend: [cpu]
+        precision: [sp, dp]
+        include:
+        - os: ubuntu-20.04
+#          setup-env: sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev autoconf automake autotools-dev libopenblas-dev make git m4 python3  cmake-curses-gui
+
+    env:
+      FC: ${{ matrix.compiler }}
+      OMPI_FC: ${{ matrix.compiler }}
+      OMPI_ALLOW_RUN_AS_ROOT: 1
+      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+      OMPI_MCA_btl_vader_single_copy_mechanism: none
+      RP: ${{ matrix.precision }}
+    name: ${{ matrix.os }} / ${{ matrix.compiler }} / ${{ matrix.backend }} / ${{ matrix.precision }}
+    steps:
+      - name: Setup env.
+        run: ${{ matrix.setup-env }}
+
   ReFrame:
       needs: GNU
       runs-on: ubuntu-20.04

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -210,7 +210,7 @@ jobs:
   NVIDIA:
     needs: linting
     runs-on: ${{matrix.os}}
-    container: nvcr.io/nvidia/nvhpc:22.11-devel-cuda_multi-ubuntu20.04
+    container: nvcr.io/nvidia/nvhpc:22.09-devel-cuda_multi-ubuntu20.04
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -222,7 +222,6 @@ jobs:
         - os: ubuntu-20.04
           setup-env: apt-get update && apt-get install -y autoconf automake autotools-dev make git m4
     env:
-      CC: nvcc
       FC: ${{ matrix.compiler }}
       OMPI_FC: ${{ matrix.compiler }}
       OMPI_ALLOW_RUN_AS_ROOT: 1

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -253,8 +253,8 @@ jobs:
           git apply patches/nvhpc_bge.patch
           nvfortran --version
           ./regen.sh
-          ./configure FC=${FC} --enable-real=${RP} --with-cuda=/usr
-          make FCFLAGS="-O3" -j$(nproc)          
+          ./configure FC=${FC} FCFLAGS="-O3" --enable-real=${RP} --with-cuda=/usr
+          make -j$(nproc)          
   ReFrame:
       needs: GNU
       runs-on: ubuntu-20.04

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -216,7 +216,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         compiler: [nvfortran]
-        backend: [cpu]
+        backend: [cpu, cuda]
         precision: [sp, dp]
         include:
         - os: ubuntu-20.04
@@ -238,13 +238,22 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Build
+      - name: Build (CPU backend)
+        if: matrix.backend == 'cpu'
         run: |
           git apply patches/nvhpc_bge.patch
+          nvfortran --version
           ./regen.sh
-          ./configure FC=${FC} CC=${CC} --enable-real=${RP}
-          make FCFLAGS="-O2" -j$(nproc)
-          
+          ./configure FC=${FC} --enable-real=${RP}
+          make FCFLAGS="-O3" -j$(nproc)
+      - name: Build (CUDA backend)
+        if: matrix.backend == 'cuda'
+        run: |
+          git apply patches/nvhpc_bge.patch
+          nvfortran --version
+          ./regen.sh
+          ./configure FC=${FC} --enable-real=${RP} --with-cuda=${CUDA_HOME}
+          make FCFLAGS="-O3" -j$(nproc)          
   ReFrame:
       needs: GNU
       runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,6 +206,54 @@ jobs:
           ./regen.sh
           ./configure FC=${FC} CC=${CC} MPIFC"=mpiifort -fc=${FC}" --enable-real=${RP} 
           make FCFLAGS="-O2 -stand f08 -warn errors" -j$(nproc)
+  
+  NVIDIA:
+    needs: linting
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-20.04]
+        compiler: [nvfortran]
+        backend: [cpu, cuda]
+        precision: [dp]
+        include:
+        - os: ubuntu-20.04
+          setup-env: sudo apt-get update && sudo apt-get install -y autoconf automake autotools-dev make git m4 libopenblas-dev && curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg && echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list && sudo apt-get update -y && sudo apt-get install -y nvhpc-22-11-cuda-multi &&  NVARCH=`uname -s`_`uname -m`; export NVARCH && NVCOMPILERS=/opt/nvidia/hpc_sdk; export NVCOMPILERS && PATH=$NVCOMPILERS/$NVARCH/22.11/compilers/bin:$PATH; export PATH &&  export PATH=$NVCOMPILERS/$NVARCH/22.11/comm_libs/mpi/bin:$PATH && printenv >> $GITHUB_ENV 
+    env:
+      CC: gcc
+      FC: ${{ matrix.compiler }}
+      OMPI_FC: ${{ matrix.compiler }}
+      OMPI_CC: gcc
+      OMPI_ALLOW_RUN_AS_ROOT: 1
+      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+      OMPI_MCA_btl_vader_single_copy_mechanism: none
+      RP: ${{ matrix.precision }}
+    name: ${{ matrix.os }} / ${{ matrix.compiler }} / ${{ matrix.backend }} / ${{ matrix.precision }}
+    steps:
+      - name: Setup env.
+        run: ${{ matrix.setup-env }}
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Build (CPU backend)
+        if: matrix.backend == 'cpu'
+        run: |
+          git apply patches/nvhpc_bge.patch
+          nvfortran --version
+          ./regen.sh
+          ./configure FC=${FC} FCFLAGS="-O3" --enable-real=${RP}
+          make -j$(nproc)
+      - name: Build (CUDA backend)
+        if: matrix.backend == 'cuda'
+        run: |
+          sudo apt-get install -y nvidia-cuda-toolkit
+          git apply patches/nvhpc_bge.patch
+          nvfortran --version
+          ./regen.sh
+          ./configure FC=${FC} FCFLAGS="-O3" --enable-real=${RP} --with-cuda=/usr
+          make -j$(nproc)          
   ReFrame:
       needs: GNU
       runs-on: ubuntu-20.04

--- a/patches/nvhpc_bge.patch
+++ b/patches/nvhpc_bge.patch
@@ -1,0 +1,21 @@
+diff --git a/src/common/signal.f90 b/src/common/signal.f90
+index 0793c48a0..1419e9378 100644
+--- a/src/common/signal.f90
++++ b/src/common/signal.f90
+@@ -99,11 +99,11 @@ contains
+ 
+     usr12 = sighdl_timeout()
+     
+-    if (bge(usr12, usr)) then
+-       raised = .true.
+-    else
+-       raised = .false.
+-    end if
++  !  if (bge(usr12, usr)) then
++  !     raised = .true.
++  !  else
++  !     raised = .false.
++  !  end if
+     
+   end function signal_usr
+   


### PR DESCRIPTION
This adds the NVIDIA Fortran to the integration tests.

With the latest release of NVHPC toolkit v22.11, the NVIDIA Fortran compiler is now able to compile the REAL64 version of Neko with a minimal set off patches (`patches/nvhpc_bge.patch`) to disable missing F2008 features.

