### PR TITLE
Scalar checkpoint

### DIFF
--- a/src/case.f90
+++ b/src/case.f90
@@ -187,6 +187,7 @@ contains
     if (scalar) then
        allocate(C%scalar)
        call C%scalar%init(C%msh, C%fluid%c_Xh, C%fluid%gs_Xh, C%params)
+       call C%fluid%chkp%add_scalar(C%scalar%s)
     end if
     !
     ! Setup user defined conditions    

--- a/src/common/checkpoint.f90
+++ b/src/common/checkpoint.f90
@@ -54,12 +54,15 @@ module checkpoint
      type(field_series_t), pointer :: vlag => null()
      type(field_series_t), pointer :: wlag => null()
 
+     type(field_t), pointer :: s => null()
+
      real(kind=dp) :: t         !< Restart time (valid after load)
    contains
      procedure, pass(this) :: init => chkp_init
      procedure, pass(this) :: sync_host => chkp_sync_host
      procedure, pass(this) :: sync_device => chkp_sync_device
      procedure, pass(this) :: add_lag => chkp_add_lag
+     procedure, pass(this) :: add_scalar => chkp_add_scalar
      procedure, pass(this) :: restart_time => chkp_restart_time
      final :: chkp_free
   end type chkp_t
@@ -142,6 +145,10 @@ contains
             call device_memcpy(wlag%lf(2)%x, wlag%lf(2)%x_d, &
                                w%dof%size(), DEVICE_TO_HOST)
          end if
+         if (associated(this%s)) then
+            call device_memcpy(this%s%x, this%s%x_d, &
+                               this%s%dof%size(), DEVICE_TO_HOST)
+         end if
        end associate
     end if
          
@@ -179,6 +186,10 @@ contains
             call device_memcpy(wlag%lf(2)%x, wlag%lf(2)%x_d, &
                                w%dof%size(), HOST_TO_DEVICE)
          end if
+         if (associated(this%s)) then
+            call device_memcpy(this%s%x, this%s%x_d, &
+                               this%s%dof%size(), HOST_TO_DEVICE)
+         end if
        end associate
     end if
          
@@ -196,6 +207,16 @@ contains
     this%wlag => wlag
     
   end subroutine chkp_add_lag
+
+  !> Add lagged velocity terms
+  subroutine chkp_add_scalar(this, s)
+    class(chkp_t), intent(inout) :: this    
+    type(field_t), target :: s
+
+    this%s => s
+    
+  end subroutine chkp_add_scalar
+
 
   !> Return restart time from a loaded checkpoint
   pure function chkp_restart_time(this) result(rtime)

--- a/src/common/checkpoint.f90
+++ b/src/common/checkpoint.f90
@@ -208,7 +208,7 @@ contains
     
   end subroutine chkp_add_lag
 
-  !> Add lagged velocity terms
+  !> Add scalars
   subroutine chkp_add_scalar(this, s)
     class(chkp_t), intent(inout) :: this    
     type(field_t), target :: s

--- a/src/io/chkp_file.f90
+++ b/src/io/chkp_file.f90
@@ -125,8 +125,6 @@ contains
        call neko_error('Invalid data')
     end select
 
-    print *, ' exists'
-
     
     suffix_pos = filename_suffix_pos(this%fname)
     write(id_str, '(i5.5)') this%counter

--- a/src/io/chkp_file.f90
+++ b/src/io/chkp_file.f90
@@ -67,8 +67,8 @@ contains
     real(kind=dp) :: time
     character(len=5) :: id_str
     character(len=1024) :: fname
-    integer :: ierr, suffix_pos, have_lag
-    type(field_t), pointer :: u, v, w, p
+    integer :: ierr, suffix_pos, optional_fields
+    type(field_t), pointer :: u, v, w, p, s
     type(field_series_t), pointer :: ulag => null()
     type(field_series_t), pointer :: vlag => null()
     type(field_series_t), pointer :: wlag => null()
@@ -77,7 +77,7 @@ contains
     type(MPI_File) :: fh
     integer (kind=MPI_OFFSET_KIND) :: mpi_offset, byte_offset
     integer(kind=i8) :: n_glb_dofs, dof_offset
-    logical write_lag
+    logical :: write_lag, write_scalar
     integer :: i
 
     if (present(t)) then
@@ -101,22 +101,31 @@ contains
        w => data%w
        p => data%p
        msh => u%msh
+       
+       optional_fields = 0
 
        if (associated(data%ulag)) then       
           ulag => data%ulag
           vlag => data%vlag
           wlag => data%wlag
           write_lag = .true.
-          have_lag = 1
+          optional_fields = optional_fields + 1
        else
           write_lag = .false.
-          have_lag = 0
        end if
-       
+ 
+       if (associated(data%s)) then       
+          s => data%s
+          write_scalar = .true.
+          optional_fields = optional_fields + 2
+       else
+          write_scalar = .false.
+       end if      
     class default
        call neko_error('Invalid data')
     end select
 
+    print *, ' exists'
 
     
     suffix_pos = filename_suffix_pos(this%fname)
@@ -132,7 +141,7 @@ contains
     call MPI_File_write_all(fh, msh%glb_nelv, 1, MPI_INTEGER, status, ierr)
     call MPI_File_write_all(fh, msh%gdim, 1, MPI_INTEGER, status, ierr)
     call MPI_File_write_all(fh, u%Xh%lx, 1, MPI_INTEGER, status, ierr)
-    call MPI_File_write_all(fh, have_lag, 1, MPI_INTEGER, status, ierr)
+    call MPI_File_write_all(fh, optional_fields, 1, MPI_INTEGER, status, ierr)
     call MPI_File_write_all(fh, time, 1, MPI_DOUBLE_PRECISION, status, ierr)
     
     
@@ -211,7 +220,15 @@ contains
        end do
               
     end if
-    
+
+    if (write_scalar) then 
+       byte_offset = mpi_offset + &
+            dof_offset * int(MPI_REAL_PREC_SIZE, i8)
+       call MPI_File_write_at_all(fh, byte_offset, s%x, p%dof%size(), &
+            MPI_REAL_PRECISION, status, ierr)
+       mpi_offset = mpi_offset + n_glb_dofs * int(MPI_REAL_PREC_SIZE, i8)
+    end if
+   
     call MPI_File_close(fh, ierr)
 
     this%counter = this%counter + 1
@@ -226,7 +243,7 @@ contains
     character(len=5) :: id_str
     character(len=1024) :: fname
     integer :: ierr, suffix_pos
-    type(field_t), pointer :: u, v, w, p
+    type(field_t), pointer :: u, v, w, p, s
     type(field_series_t), pointer :: ulag => null()
     type(field_series_t), pointer :: vlag => null()
     type(field_series_t), pointer :: wlag => null()
@@ -235,8 +252,8 @@ contains
     type(MPI_File) :: fh
     integer (kind=MPI_OFFSET_KIND) :: mpi_offset, byte_offset
     integer(kind=i8) :: n_glb_dofs, dof_offset
-    integer :: glb_nelv, gdim, lx, have_lag, nel
-    logical read_lag
+    integer :: glb_nelv, gdim, lx, have_lag, have_scalar, nel, optional_fields
+    logical :: read_lag, read_scalar
     integer :: i
     
     select type(data)
@@ -264,6 +281,13 @@ contains
           read_lag = .false.
        end if
 
+       if (associated(data%s)) then       
+          s => data%s
+          read_scalar = .true.
+       else
+          read_scalar = .false.
+       end if
+
        chkp => data
        
     class default
@@ -277,12 +301,16 @@ contains
     call MPI_File_read_all(fh, glb_nelv, 1, MPI_INTEGER, status, ierr)
     call MPI_File_read_all(fh, gdim, 1, MPI_INTEGER, status, ierr)
     call MPI_File_read_all(fh, lx, 1, MPI_INTEGER, status, ierr)
-    call MPI_File_read_all(fh, have_lag, 1, MPI_INTEGER, status, ierr)
+    call MPI_File_read_all(fh, optional_fields, 1, MPI_INTEGER, status, ierr)
     call MPI_File_read_all(fh, chkp%t, 1, MPI_DOUBLE_PRECISION, status, ierr)
+
+    have_lag = mod(optional_fields,2)/1
+    have_scalar = mod(optional_fields,4)/2
 
     if ( ( glb_nelv .ne. msh%glb_nelv ) .or. &
          ( gdim .ne. msh%gdim) .or. &
-         ( (have_lag .eq. 1) .and. (.not. read_lag) ) ) then
+         ( (have_lag .eq. 0) .and. (read_lag) ) .or. &
+        ( (have_scalar .eq. 0) .and. (read_scalar) ) ) then
        call neko_error('Checkpoint does not match case')
     end if
     nel = msh%nelv
@@ -347,7 +375,13 @@ contains
           call this%read_field(fh, byte_offset, wlag%lf(i)%x, nel)
           mpi_offset = mpi_offset + n_glb_dofs * int(MPI_REAL_PREC_SIZE, i8)
        end do
-       
+    end if
+
+    if (read_scalar) then 
+       byte_offset = mpi_offset + &
+            dof_offset * int(MPI_REAL_PREC_SIZE, i8)
+       call this%read_field(fh, byte_offset, s%x, nel)
+       mpi_offset = mpi_offset + n_glb_dofs * int(MPI_REAL_PREC_SIZE, i8)
     end if
     
     call MPI_File_close(fh, ierr)      

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -188,6 +188,9 @@ contains
        call col2(fld%wlag%lf(i)%x,fld%c_Xh%mult,fld%u%dof%size())
     end do
     end select
+    if (allocated(C%scalar)) then
+        call col2(C%scalar%s%x,C%scalar%c_Xh%mult, C%scalar%s%dof%size()) 
+    end if
 
     call C%fluid%chkp%sync_device()
     call gs_op(C%fluid%gs_Xh,C%fluid%u,GS_OP_ADD)
@@ -203,6 +206,9 @@ contains
     end do
     end select
  
+    if (allocated(C%scalar)) then
+       call gs_op(C%scalar%gs_Xh,C%scalar%s,GS_OP_ADD)
+    end if
     t = C%fluid%chkp%restart_time()
     call neko_log%section('Restarting from checkpoint')
     write(log_buf,'(A,A)') 'File :   ', &


### PR DESCRIPTION
Adds a scalar as an optional field in a checkpoint. Maybe we should consider moving chkp up from fluid into case. In some sense we save a case rather than only the fluid fields. 

There is still a risk that one sets incorrect ics for scalars as we do not ensure that there are no jumps between elements, but before addressing that we maybe should consider how we would like to handle user defined ics and bcs for multiple fields.