### PR TITLE
Use warp shuffle in CFL calculation to reduce data transfer

### DIFF
--- a/src/math/bcknd/device/hip/cfl_kernel.h
+++ b/src/math/bcknd/device/hip/cfl_kernel.h
@@ -32,6 +32,52 @@
  POSSIBILITY OF SUCH DAMAGE.
 */
 
+
+/**
+ * Warp shuffle reduction
+ */
+template< typename T>
+__inline__ __device__ T cfl_reduce_warp(T val) {
+  val = fmax(val, __shfl_down(val, 32));
+  val = fmax(val, __shfl_down(val, 16));
+  val = fmax(val, __shfl_down(val, 8));
+  val = fmax(val, __shfl_down(val, 4));
+  val = fmax(val, __shfl_down(val, 2));
+  val = fmax(val, __shfl_down(val, 1));
+  return val;
+}
+
+/**
+ * CFL reduction kernel
+ */
+template< typename T >
+__global__ void cfl_reduce_kernel(T * bufred, const int n) {
+                
+  T cfl = 0;
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+  for (int i = idx; i<n ; i += str) 
+  {
+    cfl = fmax(cfl, bufred[i]);
+  }
+
+  __shared__ T shared[64];
+  unsigned int lane = threadIdx.x % warpSize;
+  unsigned int wid = threadIdx.x / warpSize;
+
+  cfl = cfl_reduce_warp<T>(cfl);
+  if (lane == 0)
+    shared[wid] = cfl;
+  __syncthreads();
+
+  cfl = (threadIdx.x < blockDim.x / warpSize) ? shared[lane] : 0;
+  if (wid == 0)
+    cfl = cfl_reduce_warp<T>(cfl);
+
+  if (threadIdx.x == 0)
+    bufred[blockIdx.x] = cfl;
+}
+
 /**
  * Device kernel for CFL
  */
@@ -61,7 +107,9 @@ __global__ void cfl_kernel(const T dt,
   const int e = blockIdx.x;
   const int iii = threadIdx.x;
   const int nchunks = (LX * LX * LX - 1) / CHUNKS + 1;
-
+  const unsigned int lane = threadIdx.x % warpSize;
+  const unsigned int wid = threadIdx.x / warpSize;
+  
   __shared__ T shu[LX * LX * LX];
   __shared__ T shv[LX * LX * LX];
   __shared__ T shw[LX * LX * LX];
@@ -72,7 +120,7 @@ __global__ void cfl_kernel(const T dt,
 
   __shared__ T shjacinv[LX * LX * LX];
 
-  __shared__ T shcfl[1024];
+  __shared__ T shared[64];
 
   if (iii < LX) {
     shdr_inv[iii] = dr_inv[iii];
@@ -91,8 +139,6 @@ __global__ void cfl_kernel(const T dt,
     j = j + CHUNKS;
   }
   
-  shcfl[iii] = 0.0;
-
   __syncthreads();
 
   T cfl_tmp = 0.0;
@@ -120,19 +166,17 @@ __global__ void cfl_kernel(const T dt,
 
     }
   }
-  shcfl[iii] = cfl_tmp;
-  
-  i = blockDim.x >> 1;
-  while (i != 0) {
-    if (iii < i) {
-      shcfl[iii] = fmax(shcfl[iii], shcfl[iii + i]);
-    }
-    __syncthreads();
-    i = i>>1;
-  }
 
-  if (threadIdx.x == 0) {
-    cfl_h[blockIdx.x] = shcfl[0];
-  }
+  cfl_tmp = cfl_reduce_warp<T>(cfl_tmp);
+  if (lane == 0)
+    shared[wid] = cfl_tmp;
+  __syncthreads();
+  
+  cfl_tmp = (threadIdx.x < blockDim.x / warpSize) ? shared[lane] : 0;
+  if (wid == 0)
+    cfl_tmp = cfl_reduce_warp<T>(cfl_tmp);
+
+  if (threadIdx.x == 0)
+    cfl_h[blockIdx.x] = cfl_tmp;  
 }
 

--- a/src/math/bcknd/device/hip/opr_cfl.hip
+++ b/src/math/bcknd/device/hip/opr_cfl.hip
@@ -40,6 +40,11 @@
 
 extern "C" {
 
+  /**
+   * @todo Make sure that this gets deleted at some point...
+   */
+  real *cfl_d = NULL;
+  
   /** 
    * Fortran wrapper for device hip CFL
    */
@@ -52,10 +57,10 @@ extern "C" {
     
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks((*nel), 1, 1);
-    real * cfl = (real *) malloc((*nel) * sizeof(real));
-    real * cfl_d ;
-
-    HIP_CHECK(hipMalloc(&cfl_d, (*nel) * sizeof(real)));
+  
+    if (cfl_d == NULL) {
+      HIP_CHECK(hipMalloc(&cfl_d, (*nel) * sizeof(real)));
+    }
 
 #define CASE(LX)                                                                \
     case LX:                                                                    \
@@ -86,17 +91,19 @@ extern "C" {
         exit(1);
       }
     }
-    HIP_CHECK(hipMemcpy(cfl, cfl_d, (*nel) * sizeof(real),
+
+
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(cfl_reduce_kernel<real>),
+                       1, 1024, 0, 0,
+                       cfl_d, (*nel));
+    HIP_CHECK(hipGetLastError());
+
+    real cfl = 0.0;
+    HIP_CHECK(hipMemcpy(&cfl, cfl_d, sizeof(real),
 			hipMemcpyDeviceToHost));
     
-    real cfl_max = 0.0;
-    for (int i = 0; i < (*nel); i++) {
-      cfl_max = fmax(cfl_max, cfl[i]);
-    }
 
-    free(cfl);
-    HIP_CHECK(hipFree(cfl_d));
 
-    return cfl_max;
+    return cfl;
   } 
 }


### PR DESCRIPTION
This avoids copying large arrays for over to the host for a final reduction (`fmax`)