### PR TITLE
Fuse kernels and remove redudant HtoD (DtoH) transfers in proj.

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -167,7 +167,8 @@ math/bcknd/cpu/ax_helm.o : math/bcknd/cpu/ax_helm.f90 math/ax.o
 math/bcknd/sx/ax_helm_sx.o : math/bcknd/sx/ax_helm_sx.f90 config/num_types.o math/ax.o 
 math/bcknd/xsmm/ax_helm_xsmm.o : math/bcknd/xsmm/ax_helm_xsmm.F90 config/num_types.o math/mxm_wrapper.o math/ax.o 
 math/bcknd/device/ax_helm_device.o : math/bcknd/device/ax_helm_device.F90 config/num_types.o math/ax.o math/bcknd/device/device_math.o 
-common/projection.o : common/projection.f90 common/log.o math/bcknd/device/device_math.o device/device.o config/neko_config.o gs/gather_scatter.o comm/comm.o bc/bc.o math/ax.o sem/coef.o math/math.o config/num_types.o 
+common/projection.o : common/projection.f90 common/log.o common/bcknd/device/device_projection.o math/bcknd/device/device_math.o device/device.o config/neko_config.o gs/gather_scatter.o comm/comm.o bc/bc.o math/ax.o sem/coef.o math/math.o config/num_types.o 
+common/bcknd/device/device_projection.o : common/bcknd/device/device_projection.F90 math/bcknd/device/device_math.o device/device.o 
 comm/parmetis.o : comm/parmetis.F90 mesh/mesh.o field/mesh_field.o config/num_types.o common/utils.o mesh/point.o comm/comm.o 
 comm/redist.o : comm/redist.f90 mesh/zone.o io/format/nmsh.o mesh/mesh.o comm/comm.o mesh/curve.o adt/stack.o mesh/point.o adt/htable.o comm/mpi_types.o field/mesh_field.o 
 krylov/pc_hsmg.o : krylov/pc_hsmg.f90 math/bcknd/device/device_math.o device/device.o krylov/bcknd/device/pc_jacobi_device.o krylov/bcknd/sx/pc_jacobi_sx.o krylov/bcknd/cpu/pc_jacobi.o math/tensor.o math/schwarz.o math/fdm.o bc/dirichlet.o bc/bc.o sem/interpolation.o math/fast3d.o gs/gather_scatter.o krylov/krylov_fctry.o math/ax_helm_fctry.o math/ax.o krylov/precon.o common/utils.o math/math.o config/neko_config.o 

--- a/src/.depends_device
+++ b/src/.depends_device
@@ -22,6 +22,7 @@ bc/bcknd/device/hip/facet_normal.o : bc/bcknd/device/hip/facet_normal.hip bc/bck
 bc/bcknd/device/hip/inhom_dirichlet.o : bc/bcknd/device/hip/inhom_dirichlet.hip bc/bcknd/device/hip/inhom_dirichlet_kernel.h
 bc/bcknd/device/hip/dong_outflow.o : bc/bcknd/device/hip/dong_outflow.hip bc/bcknd/device/hip/dong_outflow_kernel.h
 common/bcknd/device/hip/rhs_maker.o : common/bcknd/device/hip/rhs_maker.hip common/bcknd/device/hip/sumab_kernel.h common/bcknd/device/hip/makeext_kernel.h common/bcknd/device/hip/makebdf_kernel.h
+common/bcknd/device/hip/projection.o : common/bcknd/device/hip/projection.hip common/bcknd/device/hip/projection_kernel.h
 fluid/bcknd/device/hip/pnpn_res.o : fluid/bcknd/device/hip/pnpn_res.hip fluid/bcknd/device/hip/vel_res_update_kernel.h fluid/bcknd/device/hip/prs_res_kernel.h 
 scalar/bcknd/device/hip/scalar_residual.o : scalar/bcknd/device/hip/scalar_residual.hip scalar/bcknd/device/hip/scalar_residual_update_kernel.h
 sem/bcknd/device/hip/coef.o : sem/bcknd/device/hip/coef.hip sem/bcknd/device/hip/coef_kernel.h

--- a/src/.depends_device
+++ b/src/.depends_device
@@ -49,6 +49,7 @@ bc/bcknd/device/cuda/facet_normal.o : bc/bcknd/device/cuda/facet_normal.cu bc/bc
 bc/bcknd/device/cuda/inhom_dirichlet.o : bc/bcknd/device/cuda/inhom_dirichlet.cu bc/bcknd/device/cuda/inhom_dirichlet_kernel.h
 bc/bcknd/device/cuda/dong_outflow.o : bc/bcknd/device/cuda/dong_outflow.cu bc/bcknd/device/cuda/dong_outflow_kernel.h
 common/bcknd/device/cuda/rhs_maker.o : common/bcknd/device/cuda/rhs_maker.cu common/bcknd/device/cuda/sumab_kernel.h common/bcknd/device/cuda/makeext_kernel.h common/bcknd/device/cuda/makebdf_kernel.h
+common/bcknd/device/cuda/projection.o : common/bcknd/device/cuda/projection.cu common/bcknd/device/cuda/projection_kernel.h
 fluid/bcknd/device/cuda/pnpn_res.o : fluid/bcknd/device/cuda/pnpn_res.cu fluid/bcknd/device/cuda/vel_res_update_kernel.h fluid/bcknd/device/cuda/prs_res_kernel.h 
 scalar/bcknd/device/cuda/scalar_residual.o : scalar/bcknd/device/cuda/scalar_residual.cu scalar/bcknd/device/cuda/scalar_residual_update_kernel.h
 sem/bcknd/device/cuda/coef.o : sem/bcknd/device/cuda/coef.cu sem/bcknd/device/cuda/coef_kernel.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -171,6 +171,7 @@ neko_fortran_SOURCES = \
 	math/bcknd/xsmm/ax_helm_xsmm.F90\
 	math/bcknd/device/ax_helm_device.F90\
 	common/projection.f90\
+	common/bcknd/device/device_projection.F90\
 	comm/parmetis.F90\
 	comm/redist.f90\
 	krylov/pc_hsmg.f90\
@@ -273,6 +274,7 @@ libneko_a_SOURCES += \
 	bc/bcknd/device/cuda/inhom_dirichlet.cu\
 	bc/bcknd/device/cuda/dong_outflow.cu\
 	common/bcknd/device/cuda/rhs_maker.cu\
+	common/bcknd/device/cuda/projection.cu\
 	fluid/bcknd/device/cuda/pnpn_res.cu\
 	scalar/bcknd/device/cuda/scalar_residual.cu\
 	sem/bcknd/device/cuda/coef.cu
@@ -374,6 +376,7 @@ EXTRA_DIST = \
 	common/bcknd/device/cuda/sumab_kernel.h\
 	common/bcknd/device/cuda/makeext_kernel.h\
 	common/bcknd/device/cuda/makebdf_kernel.h\
+	common/bcknd/device/cuda/projection.h\
 	fluid/bcknd/device/cuda/prs_res_kernel.h\
 	fluid/bcknd/device/cuda/vel_res_update_kernel.h\
 	scalar/bcknd/device/cuda/scalar_residual_update_kernel.h\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -243,6 +243,7 @@ libneko_a_SOURCES += \
 	bc/bcknd/device/hip/inhom_dirichlet.hip\
 	bc/bcknd/device/hip/dong_outflow.hip\
 	common/bcknd/device/hip/rhs_maker.hip\
+	common/bcknd/device/hip/projection.hip\
 	fluid/bcknd/device/hip/pnpn_res.hip\
 	scalar/bcknd/device/hip/scalar_residual.hip\
 	sem/bcknd/device/hip/coef.hip
@@ -403,6 +404,7 @@ EXTRA_DIST = \
 	common/bcknd/device/hip/sumab_kernel.h\
 	common/bcknd/device/hip/makeext_kernel.h\
 	common/bcknd/device/hip/makebdf_kernel.h\
+	common/bcknd/device/hip/projection.h\
 	fluid/bcknd/device/hip/prs_res_kernel.h\
 	fluid/bcknd/device/hip/vel_res_update_kernel.h\
 	scalar/bcknd/device/hip/scalar_residual_update_kernel.h\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -377,7 +377,7 @@ EXTRA_DIST = \
 	common/bcknd/device/cuda/sumab_kernel.h\
 	common/bcknd/device/cuda/makeext_kernel.h\
 	common/bcknd/device/cuda/makebdf_kernel.h\
-	common/bcknd/device/cuda/projection.h\
+	common/bcknd/device/cuda/projection_kernel.h\
 	fluid/bcknd/device/cuda/prs_res_kernel.h\
 	fluid/bcknd/device/cuda/vel_res_update_kernel.h\
 	scalar/bcknd/device/cuda/scalar_residual_update_kernel.h\
@@ -404,7 +404,7 @@ EXTRA_DIST = \
 	common/bcknd/device/hip/sumab_kernel.h\
 	common/bcknd/device/hip/makeext_kernel.h\
 	common/bcknd/device/hip/makebdf_kernel.h\
-	common/bcknd/device/hip/projection.h\
+	common/bcknd/device/hip/projection_kernel.h\
 	fluid/bcknd/device/hip/prs_res_kernel.h\
 	fluid/bcknd/device/hip/vel_res_update_kernel.h\
 	scalar/bcknd/device/hip/scalar_residual_update_kernel.h\

--- a/src/common/bcknd/device/cuda/projection.cu
+++ b/src/common/bcknd/device/cuda/projection.cu
@@ -75,7 +75,7 @@ extern "C" {
                                        (const real *) mult,
                                        proj_bufred_d, *j, *n);
     CUDA_CHECK(cudaGetLastError());
-    glsc3_reduce_kernel<<<(*j),1024>>> (proj_bufred_d, glsc3_nb, *j);
+    glsc3_reduce_kernel<real><<<(*j),1024>>> (proj_bufred_d, glsc3_nb, *j);
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaMemcpy(alpha, proj_bufred_d, (*j) * sizeof(real),
                           cudaMemcpyDeviceToDevice));
@@ -101,7 +101,7 @@ extern "C" {
                                        (const real *) mult,
                                        proj_bufred_d, *j, *n);
     CUDA_CHECK(cudaGetLastError());
-    glsc3_reduce_kernel<<<(*j),1024>>> (proj_bufred_d, glsc3_nb, *j);
+    glsc3_reduce_kernel<real><<<(*j),1024>>> (proj_bufred_d, glsc3_nb, *j);
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaMemcpy(alpha, proj_bufred_d, (*j) * sizeof(real),
                           cudaMemcpyDeviceToDevice));
@@ -110,12 +110,12 @@ extern "C" {
     device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
 
     /* Second vector operation block */
-    project_on_vec_kernel<<<vec_nblcks, vec_nthrds>>>((real *) xbar,
-                                                      (const real **) xx,
-                                                      (real *) b,
-                                                      (const real **) bb,
-                                                      (const real *) alpha,
-                                                      *j, *n);
+    project_on_vec_kernel<real><<<vec_nblcks, vec_nthrds>>>((real *) xbar,
+                                                            (const real **) xx,
+                                                            (real *) b,
+                                                            (const real **) bb,
+                                                            (const real *) alpha,
+                                                            *j, *n);
   }
 
   void cuda_project_ortho(void *alpha, void * b, void *xx, void *bb,
@@ -144,7 +144,7 @@ extern "C" {
                                        (const real *) w,
                                        proj_bufred_d, *j, *n);
     CUDA_CHECK(cudaGetLastError());
-    glsc3_reduce_kernel<<<(*j),1024>>> (proj_bufred_d, glsc3_nb, *j);
+    glsc3_reduce_kernel<real><<<(*j),1024>>> (proj_bufred_d, glsc3_nb, *j);
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaMemcpy(alpha, proj_bufred_d, (*j) * sizeof(real),
                           cudaMemcpyDeviceToDevice));
@@ -173,7 +173,7 @@ extern "C" {
                                        (const real *) w,
                                        proj_bufred_d, *j, *n);
     CUDA_CHECK(cudaGetLastError());
-    glsc3_reduce_kernel<<<(*j),1024>>> (proj_bufred_d, glsc3_nb, *j);
+    glsc3_reduce_kernel<real><<<(*j),1024>>> (proj_bufred_d, glsc3_nb, *j);
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaMemcpy(alpha, proj_bufred_d, (*j) * sizeof(real),
                           cudaMemcpyDeviceToDevice));

--- a/src/common/bcknd/device/cuda/projection.cu
+++ b/src/common/bcknd/device/cuda/projection.cu
@@ -117,5 +117,77 @@ extern "C" {
                                                       (const real *) alpha,
                                                       *j, *n);
   }
+
+  void cuda_project_ortho(void *alpha, void * b, void *xx, void *bb,
+                          void *w, void *xm, int *j, int *n, real *nrm){
+
+    int pow2 = 1;
+    while(pow2 < (*j)){
+      pow2 = 2*pow2;
+    }
+    const int nt = 1024/pow2;   
+    const dim3 glsc3_nthrds(pow2, nt, 1);
+    const dim3 glsc3_nblcks(((*n)+nt - 1)/nt, 1, 1);
+    const int glsc3_nb = ((*n) + nt - 1)/nt;
+    if((*j)*glsc3_nb>proj_red_s){
+      proj_red_s = (*j)*glsc3_nb;
+      if (proj_bufred_d != NULL) {
+	CUDA_CHECK(cudaFree(proj_bufred_d));
+      }
+      CUDA_CHECK(cudaMalloc(&proj_bufred_d, (*j)*glsc3_nb*sizeof(real)));
+    }
+
+    /* First glsc3_many call */
+    glsc3_many_kernel<real>
+      <<<glsc3_nblcks, glsc3_nthrds>>>((const real *) b,
+                                       (const real **) xx,
+                                       (const real *) w,
+                                       proj_bufred_d, *j, *n);
+    CUDA_CHECK(cudaGetLastError());
+    glsc3_reduce_kernel<<<(*j),1024>>> (proj_bufred_d, glsc3_nb, *j);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaMemcpy(alpha, proj_bufred_d, (*j) * sizeof(real),
+                          cudaMemcpyDeviceToDevice));
+
+    cudaDeviceSynchronize();
+    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
+
+    CUDA_CHECK(cudaMemcpy(nrm, (real *) alpha + (*j - 1),
+                          sizeof(real), cudaMemcpyDeviceToHost));
+    (*nrm) = sqrt(*nrm);
+
+
+    const dim3 vec_nthrds(1024, 1, 1);
+    const dim3 vec_nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
+
+    /* First vector operation block */
+    project_ortho_vec_kernel<real>
+      <<<vec_nblcks, vec_nthrds>>>((real *) xm, (const real **) xx,
+                                   (real *) b, (const real **) bb,
+                                   (const real *) alpha, *j, *n);
+
+    /* Second glsc3_many call */
+    glsc3_many_kernel<real>
+      <<<glsc3_nblcks, glsc3_nthrds>>>((const real *) b,
+                                       (const real **) xx,
+                                       (const real *) w,
+                                       proj_bufred_d, *j, *n);
+    CUDA_CHECK(cudaGetLastError());
+    glsc3_reduce_kernel<<<(*j),1024>>> (proj_bufred_d, glsc3_nb, *j);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaMemcpy(alpha, proj_bufred_d, (*j) * sizeof(real),
+                          cudaMemcpyDeviceToDevice));
+
+    cudaDeviceSynchronize();
+    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
+
+    /* Second vector operation block */
+    project_ortho_vec_kernel<real>
+      <<<vec_nblcks, vec_nthrds>>>((real *) xm, (const real **) xx,
+                                   (real *) b, (const real **) bb,
+                                   (const real *) alpha, *j, *n);
+    
+  }
+      
 }
 

--- a/src/common/bcknd/device/cuda/projection.cu
+++ b/src/common/bcknd/device/cuda/projection.cu
@@ -1,0 +1,121 @@
+/*
+ Copyright (c) 2022, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <device/device_config.h>
+#include <device/cuda/check.h>
+
+#include "projection_kernel.h"
+#include <math/bcknd/device/cuda/math_kernel.h>
+
+
+/*
+ * Reduction buffer
+ */
+int proj_red_s = 0;
+real * proj_bufred_d = NULL;
+
+extern "C" {
+
+#include <math/bcknd/device/device_mpi_reduce.h>
+
+  void cuda_project_on(void *alpha, void * b, void *xx, void *bb, void *mult,
+                       void *xbar, int *j, int *n){ 
+    
+    int pow2 = 1;
+    while(pow2 < (*j)){
+      pow2 = 2*pow2;
+    }
+    const int nt = 1024/pow2;   
+    const dim3 glsc3_nthrds(pow2, nt, 1);
+    const dim3 glsc3_nblcks(((*n)+nt - 1)/nt, 1, 1);
+    const int glsc3_nb = ((*n) + nt - 1)/nt;
+    if((*j)*glsc3_nb>proj_red_s){
+      proj_red_s = (*j)*glsc3_nb;
+      if (proj_bufred_d != NULL) {
+	CUDA_CHECK(cudaFree(proj_bufred_d));
+      }
+      CUDA_CHECK(cudaMalloc(&proj_bufred_d, (*j)*glsc3_nb*sizeof(real)));
+    }
+
+    /* First glsc3_many call */
+    glsc3_many_kernel<real>
+      <<<glsc3_nblcks, glsc3_nthrds>>>((const real *) b,
+                                       (const real **) xx,
+                                       (const real *) mult,
+                                       proj_bufred_d, *j, *n);
+    CUDA_CHECK(cudaGetLastError());
+    glsc3_reduce_kernel<<<(*j),1024>>> (proj_bufred_d, glsc3_nb, *j);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaMemcpy(alpha, proj_bufred_d, (*j) * sizeof(real),
+                          cudaMemcpyDeviceToDevice));
+    CUDA_CHECK(cudaMemsetAsync(xbar, 0, (*n) * sizeof(real)));
+
+    cudaDeviceSynchronize();
+    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
+
+    const dim3 vec_nthrds(1024, 1, 1);
+    const dim3 vec_nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
+
+    /* First vector operation block */
+    project_on_vec_kernel<<<vec_nblcks, vec_nthrds>>>((real *) xbar,
+                                                      (const real **) xx,
+                                                      (real *) b,
+                                                      (const real **) bb,
+                                                      (const real *) alpha,
+                                                      *j, *n);
+    /* Second glsc3_many call */
+    glsc3_many_kernel<real>
+      <<<glsc3_nblcks, glsc3_nthrds>>>((const real *) b,
+                                       (const real **) xx,
+                                       (const real *) mult,
+                                       proj_bufred_d, *j, *n);
+    CUDA_CHECK(cudaGetLastError());
+    glsc3_reduce_kernel<<<(*j),1024>>> (proj_bufred_d, glsc3_nb, *j);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaMemcpy(alpha, proj_bufred_d, (*j) * sizeof(real),
+                          cudaMemcpyDeviceToDevice));
+
+    cudaDeviceSynchronize();
+    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
+
+    /* Second vector operation block */
+    project_on_vec_kernel<<<vec_nblcks, vec_nthrds>>>((real *) xbar,
+                                                      (const real **) xx,
+                                                      (real *) b,
+                                                      (const real **) bb,
+                                                      (const real *) alpha,
+                                                      *j, *n);
+  }
+}
+

--- a/src/common/bcknd/device/cuda/projection.cu
+++ b/src/common/bcknd/device/cuda/projection.cu
@@ -88,7 +88,7 @@ extern "C" {
     const dim3 vec_nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     /* First vector operation block */
-    project_on_vec_kernel<<<vec_nblcks, vec_nthrds>>>((real *) xbar,
+    project_on_vec_kernel<real><<<vec_nblcks, vec_nthrds>>>((real *) xbar,
                                                       (const real **) xx,
                                                       (real *) b,
                                                       (const real **) bb,

--- a/src/common/bcknd/device/cuda/projection_kernel.h
+++ b/src/common/bcknd/device/cuda/projection_kernel.h
@@ -61,3 +61,32 @@ __global__ void project_on_vec_kernel(T * __restrict__ x,
 }
 
 
+/**
+ * Project ortho vector operations
+ */
+template< typename T >
+__global__ void project_ortho_vec_kernel(T * __restrict__ x,
+                                         const T ** xx,
+                                         T * __restrict__ y,
+                                         const T ** yy,
+                                         const T * __restrict__ alpha,
+                                         const int p_cur,
+                                         const int n) {
+  
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  for (int i = idx; i < n; i+= str) {
+    T tmp1 = 0.0;
+    T tmp2 = 0.0;
+    for (int j = 0; j < (p_cur - 1); j ++) {
+      tmp1 += xx[j][i] * -alpha[j];
+      tmp2 += yy[j][i] * -alpha[j];
+    }
+    x[i] += tmp1;
+    y[i] += tmp2;
+  }
+  
+}
+
+

--- a/src/common/bcknd/device/device_projection.F90
+++ b/src/common/bcknd/device/device_projection.F90
@@ -49,6 +49,20 @@ module device_projection
        integer(c_int) :: j, n
      end subroutine hip_project_on
   end interface
+
+  interface
+     subroutine hip_project_ortho(a_d, b_d, x_d_d, b_d_d, &
+                                   w_d, xm_d, j, n, nrm) &
+          bind(c, name='hip_project_ortho')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       implicit none
+       type(c_ptr), value :: a_d, b_d, x_d_d, b_d_d, w_d
+       type(c_ptr), value :: xm_d
+       integer(c_int) :: j, n
+       real(c_rp) :: nrm
+     end subroutine hip_project_ortho
+  end interface
 #elif HAVE_CUDA
   interface
      subroutine cuda_project_on(a_d, b_d, x_d_d, b_d_d, mult_d, x_d, j, n) &
@@ -99,7 +113,7 @@ contains
     real(c_rp) :: nrm
     integer :: ierr
 #ifdef HAVE_HIP
-!    call hip_project_on(alpha_d, b_d, x_d_d, b_d_d, mult_d, xbar_d, j, n)
+    call hip_project_ortho(alpha_d, b_d, x_d_d, b_d_d, w_d, xm_d, j, n, nrm)
 #elif HAVE_CUDA
     call cuda_project_ortho(alpha_d, b_d, x_d_d, b_d_d, w_d, xm_d, j, n, nrm)
 #else

--- a/src/common/bcknd/device/device_projection.F90
+++ b/src/common/bcknd/device/device_projection.F90
@@ -1,0 +1,71 @@
+! Copyright (c) 2020-2021, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Interface for device projection
+!! @note Requires device MPI
+module device_projection
+  use num_types
+  use utils
+  use, intrinsic :: iso_c_binding
+  implicit none
+
+#ifdef HAVE_HIP
+#elif HAVE_CUDA
+    interface
+       subroutine cuda_project_on(a_d, b_d, x_d_d, b_d_d, mult_d, x_d, j, n) &
+          bind(c, name='cuda_project_on')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       implicit none
+       type(c_ptr), value :: a_d, b_d, x_d_d, b_d_d, mult_d, x_d
+       integer(c_int) :: j, n
+     end subroutine cuda_project_on
+  end interface
+#elif HAVE_OPENCL
+#endif
+
+contains
+
+  subroutine device_proj_on(alpha_d, b_d, x_d_d, b_d_d, mult_d, xbar_d, j, n)
+    type(c_ptr), value :: alpha_d, b_d, x_d_d, b_d_d, mult_d, xbar_d
+    integer(c_int) :: j, n
+    integer :: ierr
+#ifdef HAVE_HIP
+#elif HAVE_CUDA
+    call cuda_project_on(alpha_d, b_d, x_d_d, b_d_d, mult_d, xbar_d, j, n)
+#elif HAVE_OPENCL
+#else
+    call neko_error('No device backend configured')
+#endif
+  end subroutine device_proj_on
+  
+end module device_projection

--- a/src/common/bcknd/device/device_projection.F90
+++ b/src/common/bcknd/device/device_projection.F90
@@ -60,6 +60,20 @@ module device_projection
        integer(c_int) :: j, n
      end subroutine cuda_project_on
   end interface
+
+  interface
+     subroutine cuda_project_ortho(a_d, b_d, x_d_d, b_d_d, &
+                                   w_d, xm_d, j, n, nrm) &
+          bind(c, name='cuda_project_ortho')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       implicit none
+       type(c_ptr), value :: a_d, b_d, x_d_d, b_d_d, w_d
+       type(c_ptr), value :: xm_d
+       integer(c_int) :: j, n
+       real(c_rp) :: nrm
+     end subroutine cuda_project_ortho
+  end interface
 #endif
 
 contains
@@ -76,5 +90,21 @@ contains
     call neko_error('No device backend configured')
 #endif
   end subroutine device_proj_on
+
+  subroutine device_project_ortho(alpha_d, b_d, x_d_d, b_d_d, &
+                                  w_d, xm_d, j, n, nrm)
+    type(c_ptr), value :: alpha_d, b_d, x_d_d, b_d_d
+    type(c_ptr), value :: w_d,  xm_d
+    integer(c_int) :: j, n
+    real(c_rp) :: nrm
+    integer :: ierr
+#ifdef HAVE_HIP
+!    call hip_project_on(alpha_d, b_d, x_d_d, b_d_d, mult_d, xbar_d, j, n)
+#elif HAVE_CUDA
+    call cuda_project_ortho(alpha_d, b_d, x_d_d, b_d_d, w_d, xm_d, j, n, nrm)
+#else
+    call neko_error('No device backend configured')
+#endif
+  end subroutine device_project_ortho
   
 end module device_projection

--- a/src/common/bcknd/device/device_projection.F90
+++ b/src/common/bcknd/device/device_projection.F90
@@ -39,9 +39,19 @@ module device_projection
   implicit none
 
 #ifdef HAVE_HIP
+  interface
+     subroutine hip_project_on(a_d, b_d, x_d_d, b_d_d, mult_d, x_d, j, n) &
+          bind(c, name='hip_project_on')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       implicit none
+       type(c_ptr), value :: a_d, b_d, x_d_d, b_d_d, mult_d, x_d
+       integer(c_int) :: j, n
+     end subroutine hip_project_on
+  end interface
 #elif HAVE_CUDA
-    interface
-       subroutine cuda_project_on(a_d, b_d, x_d_d, b_d_d, mult_d, x_d, j, n) &
+  interface
+     subroutine cuda_project_on(a_d, b_d, x_d_d, b_d_d, mult_d, x_d, j, n) &
           bind(c, name='cuda_project_on')
        use, intrinsic :: iso_c_binding
        import c_rp
@@ -50,7 +60,6 @@ module device_projection
        integer(c_int) :: j, n
      end subroutine cuda_project_on
   end interface
-#elif HAVE_OPENCL
 #endif
 
 contains
@@ -60,9 +69,9 @@ contains
     integer(c_int) :: j, n
     integer :: ierr
 #ifdef HAVE_HIP
+    call hip_project_on(alpha_d, b_d, x_d_d, b_d_d, mult_d, xbar_d, j, n)
 #elif HAVE_CUDA
     call cuda_project_on(alpha_d, b_d, x_d_d, b_d_d, mult_d, xbar_d, j, n)
-#elif HAVE_OPENCL
 #else
     call neko_error('No device backend configured')
 #endif

--- a/src/common/bcknd/device/hip/projection.hip
+++ b/src/common/bcknd/device/hip/projection.hip
@@ -1,0 +1,117 @@
+/*
+ Copyright (c) 2022, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <hip/hip_runtime.h>
+#include <device/device_config.h>
+#include <device/hip/check.h>
+
+#include "projection_kernel.h"
+#include <math/bcknd/device/hip/math_kernel.h>
+
+
+/*
+ * Reduction buffer
+ */
+int proj_red_s = 0;
+real * proj_bufred_d = NULL;
+
+extern "C" {
+
+#include <math/bcknd/device/device_mpi_reduce.h>
+
+  void hip_project_on(void *alpha, void * b, void *xx, void *bb, void *mult,
+                      void *xbar, int *j, int *n){ 
+    
+    int pow2 = 1;
+    while(pow2 < (*j)){
+      pow2 = 2*pow2;
+    }
+    const int nt = 1024/pow2;   
+    const dim3 glsc3_nthrds(pow2, nt, 1);
+    const dim3 glsc3_nblcks(((*n)+nt - 1)/nt, 1, 1);
+    const int glsc3_nb = ((*n) + nt - 1)/nt;
+    if((*j)*glsc3_nb>proj_red_s){
+      proj_red_s = (*j)*glsc3_nb;
+      if (proj_bufred_d != NULL) {
+	HIP_CHECK(hipFree(proj_bufred_d));
+      }
+      HIP_CHECK(hipMalloc(&proj_bufred_d, (*j)*glsc3_nb*sizeof(real)));
+    }
+
+    /* First glsc3_many call */
+    hipLaunchKernelGGL(HIP_KERNEL_NAME( glsc3_many_kernel<real> ),
+                       glsc3_nblcks, glsc3_nthrds, 0, 0,
+                       (const real *) b, (const real **) xx,
+                       (const real *) mult, proj_bufred_d, *j, *n);
+    HIP_CHECK(hipGetLastError());
+    glsc3_reduce_kernel<<<(*j),1024>>> (proj_bufred_d, glsc3_nb, *j);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipMemcpy(alpha, proj_bufred_d, (*j) * sizeof(real),
+                          hipMemcpyDeviceToDevice));
+    HIP_CHECK(hipMemsetAsync(xbar, 0, (*n) * sizeof(real)));
+
+    hipDeviceSynchronize();
+    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
+
+    const dim3 vec_nthrds(1024, 1, 1);
+    const dim3 vec_nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
+
+    /* First vector operation block */
+    hipLaunchKernelGGL(HIP_KERNEL_NAME( project_on_vec_kernel<real> ),
+                       vec_nblcks, vec_nthrds, 0, 0, (real *) xbar,
+                       (const real **) xx, (real *) b, (const real **) bb,
+                       (const real *) alpha, *j, *n);
+    /* Second glsc3_many call */
+    glsc3_many_kernel<real>
+      <<<glsc3_nblcks, glsc3_nthrds>>>((const real *) b,
+                                       (const real **) xx,
+                                       (const real *) mult,
+                                       proj_bufred_d, *j, *n);
+    HIP_CHECK(hipGetLastError());
+    glsc3_reduce_kernel<<<(*j),1024>>> (proj_bufred_d, glsc3_nb, *j);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipMemcpy(alpha, proj_bufred_d, (*j) * sizeof(real),
+                          hipMemcpyDeviceToDevice));
+
+    hipDeviceSynchronize();
+    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
+
+    /* Second vector operation block */
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(project_on_vec_kernel<real> ),
+                       vec_nblcks, vec_nthrds, 0, 0, (real *) xbar,
+                       (const real **) xx, (real *) b, (const real **) bb,
+                       (const real *) alpha, *j, *n);
+  }
+}
+

--- a/src/common/bcknd/device/hip/projection.hip
+++ b/src/common/bcknd/device/hip/projection.hip
@@ -75,7 +75,8 @@ extern "C" {
                        (const real *) b, (const real **) xx,
                        (const real *) mult, proj_bufred_d, *j, *n);
     HIP_CHECK(hipGetLastError());
-    glsc3_reduce_kernel<<<(*j),1024>>> (proj_bufred_d, glsc3_nb, *j);
+    hipLaunchKernelGGL(HIP_KERNEL_NAME( glsc3_reduce_kernel<real> ),
+                       (*j), 1024, 0 , 0, proj_bufred_d, glsc3_nb, *j);
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipMemcpy(alpha, proj_bufred_d, (*j) * sizeof(real),
                           hipMemcpyDeviceToDevice));
@@ -93,13 +94,13 @@ extern "C" {
                        (const real **) xx, (real *) b, (const real **) bb,
                        (const real *) alpha, *j, *n);
     /* Second glsc3_many call */
-    glsc3_many_kernel<real>
-      <<<glsc3_nblcks, glsc3_nthrds>>>((const real *) b,
-                                       (const real **) xx,
-                                       (const real *) mult,
-                                       proj_bufred_d, *j, *n);
+    hipLaunchKernelGGL(HIP_KERNEL_NAME( glsc3_many_kernel<real> ),
+                       glsc3_nblcks, glsc3_nthrds, 0, 0,
+                       (const real *) b, (const real **) xx,
+                       (const real *) mult, proj_bufred_d, *j, *n);
     HIP_CHECK(hipGetLastError());
-    glsc3_reduce_kernel<<<(*j),1024>>> (proj_bufred_d, glsc3_nb, *j);
+    hipLaunchKernelGGL(HIP_KERNEL_NAME( glsc3_reduce_kernel<real> ),
+                       (*j), 1024, 0, 0, proj_bufred_d, glsc3_nb, *j);
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipMemcpy(alpha, proj_bufred_d, (*j) * sizeof(real),
                           hipMemcpyDeviceToDevice));
@@ -113,5 +114,79 @@ extern "C" {
                        (const real **) xx, (real *) b, (const real **) bb,
                        (const real *) alpha, *j, *n);
   }
+
+  void hip_project_ortho(void *alpha, void * b, void *xx, void *bb,
+                         void *w, void *xm, int *j, int *n, real *nrm){
+
+    int pow2 = 1;
+    while(pow2 < (*j)){
+      pow2 = 2*pow2;
+    }
+    const int nt = 1024/pow2;   
+    const dim3 glsc3_nthrds(pow2, nt, 1);
+    const dim3 glsc3_nblcks(((*n)+nt - 1)/nt, 1, 1);
+    const int glsc3_nb = ((*n) + nt - 1)/nt;
+    if((*j)*glsc3_nb>proj_red_s){
+      proj_red_s = (*j)*glsc3_nb;
+      if (proj_bufred_d != NULL) {
+	HIP_CHECK(hipFree(proj_bufred_d));
+      }
+      HIP_CHECK(hipMalloc(&proj_bufred_d, (*j)*glsc3_nb*sizeof(real)));
+    }
+
+    /* First glsc3_many call */
+    hipLaunchKernelGGL(HIP_KERNEL_NAME( glsc3_many_kernel<real> ),
+                       glsc3_nblcks, glsc3_nthrds, 0, 0,
+                       (const real *) b, (const real **) xx,
+                       (const real *) w, proj_bufred_d, *j, *n);
+    HIP_CHECK(hipGetLastError());
+    hipLaunchKernelGGL(HIP_KERNEL_NAME( glsc3_reduce_kernel<real> ),
+                       (*j), 1024, 0 , 0, proj_bufred_d, glsc3_nb, *j);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipMemcpy(alpha, proj_bufred_d, (*j) * sizeof(real),
+                          hipMemcpyDeviceToDevice));
+
+    hipDeviceSynchronize();
+    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
+
+    HIP_CHECK(hipMemcpy(nrm, (real *) alpha + (*j - 1),
+                          sizeof(real), hipMemcpyDeviceToHost));
+    (*nrm) = sqrt(*nrm);
+
+
+    const dim3 vec_nthrds(1024, 1, 1);
+    const dim3 vec_nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
+
+    /* First vector operation block */
+    hipLaunchKernelGGL( HIP_KERNEL_NAME( project_ortho_vec_kernel<real> ),
+                        vec_nblcks, vec_nthrds, 0, 0,
+                        (real *) xm, (const real **) xx,
+                        (real *) b, (const real **) bb,
+                        (const real *) alpha, *j, *n);
+
+    /* Second glsc3_many call */
+    hipLaunchKernelGGL(HIP_KERNEL_NAME( glsc3_many_kernel<real> ),
+                       glsc3_nblcks, glsc3_nthrds, 0, 0,
+                       (const real *) b, (const real **) xx,
+                       (const real *) w, proj_bufred_d, *j, *n);
+    HIP_CHECK(hipGetLastError());
+    hipLaunchKernelGGL(HIP_KERNEL_NAME( glsc3_reduce_kernel<real> ),
+                       (*j), 1024, 0 , 0, proj_bufred_d, glsc3_nb, *j);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipMemcpy(alpha, proj_bufred_d, (*j) * sizeof(real),
+                          hipMemcpyDeviceToDevice));
+
+    hipDeviceSynchronize();
+    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
+
+    /* Second vector operation block */
+    hipLaunchKernelGGL( HIP_KERNEL_NAME( project_ortho_vec_kernel<real> ),
+                        vec_nblcks, vec_nthrds, 0, 0,
+                        (real *) xm, (const real **) xx,
+                        (real *) b, (const real **) bb,
+                        (const real *) alpha, *j, *n);
+    
+  }
+  
 }
 

--- a/src/common/bcknd/device/hip/projection_kernel.h
+++ b/src/common/bcknd/device/hip/projection_kernel.h
@@ -1,0 +1,63 @@
+/*
+ Copyright (c) 2022, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/**
+ * Project on vector operations
+ */
+template< typename T >
+__global__ void project_on_vec_kernel(T * __restrict__ x,
+                                      const T ** xx,
+                                      T * __restrict__ y,
+                                      const T ** yy,
+                                      const T * __restrict__ alpha,
+                                      const int p_cur,
+                                      const int n) {
+  
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  for (int i = idx; i < n; i+= str) {
+    T tmp1 = 0.0;
+    T tmp2 = 0.0;
+    for (int j = 0; j < p_cur; j ++) {
+      tmp1 += xx[j][i] * alpha[j];
+      tmp2 += yy[j][i] * -alpha[j];
+    }
+    x[i] += tmp1;
+    y[i] += tmp2;
+  }
+  
+}
+
+

--- a/src/common/bcknd/device/hip/projection_kernel.h
+++ b/src/common/bcknd/device/hip/projection_kernel.h
@@ -61,3 +61,30 @@ __global__ void project_on_vec_kernel(T * __restrict__ x,
 }
 
 
+/**
+ * Project ortho vector operations
+ */
+template< typename T >
+__global__ void project_ortho_vec_kernel(T * __restrict__ x,
+                                         const T ** xx,
+                                         T * __restrict__ y,
+                                         const T ** yy,
+                                         const T * __restrict__ alpha,
+                                         const int p_cur,
+                                         const int n) {
+  
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  for (int i = idx; i < n; i+= str) {
+    T tmp1 = 0.0;
+    T tmp2 = 0.0;
+    for (int j = 0; j < (p_cur - 1); j ++) {
+      tmp1 += xx[j][i] * -alpha[j];
+      tmp2 += yy[j][i] * -alpha[j];
+    }
+    x[i] += tmp1;
+    y[i] += tmp2;
+  }
+  
+}

--- a/src/common/projection.f90
+++ b/src/common/projection.f90
@@ -328,7 +328,7 @@ contains
 
       this%proj_res = device_glsc3(b_d,b_d,coef%mult_d,n)
       this%proj_m = this%m
-      if (NEKO_DEVICE_MPI) then
+      if (NEKO_DEVICE_MPI .and. (NEKO_BCKND_OPENCL .ne. 1)) then
          call device_proj_on(alpha_d, b_d, xx_d_d, bb_d_d, &
               coef%mult_d, xbar_d, this%m, n)
       else

--- a/src/common/projection.f90
+++ b/src/common/projection.f90
@@ -361,20 +361,25 @@ contains
               bb_d_d => this%bb_d_d, alpha_d => this%alpha_d)
       
       if(m .le. 0) return
-
-      call device_glsc3_many(alpha,bb_d(m),xx_d_d,w_d,m,n)
-      nrm = sqrt(alpha(m))
-      call cmult(alpha, -1.0_rp,m)
-      call device_memcpy(alpha, alpha_d, this%m, HOST_TO_DEVICE) 
-      call device_add2s2_many(xx_d(m),xx_d_d,alpha_d,m-1,n)
-      call device_add2s2_many(bb_d(m),bb_d_d,alpha_d,m-1,n)
-    
-      call device_glsc3_many(alpha,bb_d(m),xx_d_d,w_d,m,n)
-      call cmult(alpha, -1.0_rp,m)
-      call device_memcpy(alpha, alpha_d, m, HOST_TO_DEVICE) 
-      call device_add2s2_many(xx_d(m),xx_d_d,alpha_d,m-1,n)
-      call device_add2s2_many(bb_d(m),bb_d_d,alpha_d,m-1,n)
-      call device_glsc3_many(alpha,bb_d(m),xx_d_d,w_d,m,n)
+      if (NEKO_DEVICE_MPI .and. (NEKO_BCKND_OPENCL .ne. 1)) then
+         call device_project_ortho(alpha_d, bb_d(m), xx_d_d, bb_d_d, &
+              w_d, xx_d(m), this%m, n, nrm)
+      else
+         call device_glsc3_many(alpha,bb_d(m),xx_d_d,w_d,m,n)
+         nrm = sqrt(alpha(m))
+         call cmult(alpha, -1.0_rp,m)
+         call device_memcpy(alpha, alpha_d, this%m, HOST_TO_DEVICE) 
+         call device_add2s2_many(xx_d(m),xx_d_d,alpha_d,m-1,n)
+         call device_add2s2_many(bb_d(m),bb_d_d,alpha_d,m-1,n)
+         
+         call device_glsc3_many(alpha,bb_d(m),xx_d_d,w_d,m,n)
+         call cmult(alpha, -1.0_rp,m)
+         call device_memcpy(alpha, alpha_d, m, HOST_TO_DEVICE) 
+         call device_add2s2_many(xx_d(m),xx_d_d,alpha_d,m-1,n)
+         call device_add2s2_many(bb_d(m),bb_d_d,alpha_d,m-1,n)
+         call device_glsc3_many(alpha,bb_d(m),xx_d_d,w_d,m,n)
+      end if
+      
       alpha(m) = device_glsc3(xx_d(m), w_d, bb_d(m), n)
       alpha(m) = sqrt(alpha(m))
 

--- a/src/math/bcknd/device/cuda/math.cu
+++ b/src/math/bcknd/device/cuda/math.cu
@@ -417,8 +417,13 @@ extern "C" {
     glsc3_reduce_kernel<<<(*j),1024>>> (bufred_d, nb, *j);
     CUDA_CHECK(cudaGetLastError());
 
+#ifdef HAVE_DEVICE_MPI
+    cudaDeviceSynchronize();
+    device_mpi_allreduce(bufred_d, h, (*j), sizeof(real));
+#else    
     CUDA_CHECK(cudaMemcpy(h, bufred_d, (*j) * sizeof(real),
                           cudaMemcpyDeviceToHost));
+#endif
   }
 
   /**

--- a/src/math/bcknd/device/device_math.F90
+++ b/src/math/bcknd/device/device_math.F90
@@ -1187,10 +1187,13 @@ contains
 #else
     call neko_error('No device backend configured')
 #endif
+
+#ifndef HAVE_DEVICE_MPI
     if (pe_size .gt. 1) then
        call MPI_Allreduce(MPI_IN_PLACE, h, j, &
             MPI_REAL_PRECISION, MPI_SUM, NEKO_COMM, ierr)
     end if
+#endif
   end subroutine device_glsc3_many
   
   subroutine device_add2s2_many(y_d,x_d_d,a_d,j,n)

--- a/src/math/bcknd/device/device_mpi_reduce.h
+++ b/src/math/bcknd/device/device_mpi_reduce.h
@@ -6,4 +6,6 @@
 
 extern "C" {
   void device_mpi_allreduce(void *buf_d, void *buf, int count, size_t nbytes);
+
+  void device_mpi_allreduce_inplace(void *buf_d, int count, size_t nbytes);
 }

--- a/src/math/bcknd/device/hip/math.hip
+++ b/src/math/bcknd/device/hip/math.hip
@@ -411,9 +411,13 @@ extern "C" {
                        0, 0, bufred_d, nb, *j);
     HIP_CHECK(hipGetLastError());
 
-
+#ifdef HAVE_DEVICE_MPI
+    hipDeviceSynchronize();
+    device_mpi_allreduce(bufred_d, h, (*j), sizeof(real));
+#else
     HIP_CHECK(hipMemcpy(h, bufred_d, (*j)* sizeof(real),
                         hipMemcpyDeviceToHost));
+#endif    
   }
 
   /**


### PR DESCRIPTION
- Remove redundant HtoD copies in project on (iff device MPI is present) (CUDA)
- Fix missing template argument
- Add HIP backend
- Disable for unfinished OpenCL part
- Avoid redudant DtoH copies
- Remove redundant HtoD transfers in project ortho (CUDA)
- Fix missing template arguments
- Remove redundant HtoD transfers in project ortho (HIP)
