### PR TITLE
Fix tnsr3d w. OpenCL bcknd

### DIFF
--- a/src/math/bcknd/device/opencl/tensor.c
+++ b/src/math/bcknd/device/opencl/tensor.c
@@ -63,7 +63,6 @@ void opencl_tnsr3d(void *v, int *nv, void *u, int *nu,
   CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), (void *) &A));
   CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_mem), (void *) &Bt));
   CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_mem), (void *) &Ct));
-  CL_CHECK(clSetKernelArg(kernel, 7, sizeof(int), nel));
   
   const size_t global_item_size = 256 * (*nel);
   const size_t local_item_size = 256;

--- a/src/math/tensor.f90
+++ b/src/math/tensor.f90
@@ -186,7 +186,7 @@ contains
        call tnsr3d_sx(v, nv, u, nu, A, Bt, Ct, nelv)
     else if (NEKO_BCKND_XSMM .eq. 1) then
        call tnsr3d_xsmm(v, nv, u, nu, A, Bt, Ct, nelv)
-    else if (NEKO_BCKND_CUDA .eq. 1 .or. NEKO_BCKND_HIP .eq. 1) then
+    else if (NEKO_BCKND_DEVICE .eq. 1) then
       ! The length nelv should not matter here. It is just a stapleholder
        v_d = device_get_ptr(v)
        u_d = device_get_ptr(u)

--- a/src/math/tensor.f90
+++ b/src/math/tensor.f90
@@ -187,7 +187,6 @@ contains
     else if (NEKO_BCKND_XSMM .eq. 1) then
        call tnsr3d_xsmm(v, nv, u, nu, A, Bt, Ct, nelv)
     else if (NEKO_BCKND_DEVICE .eq. 1) then
-      ! The length nelv should not matter here. It is just a stapleholder
        v_d = device_get_ptr(v)
        u_d = device_get_ptr(u)
        A_d = device_get_ptr(A)


### PR DESCRIPTION
This fixes a bug in the tensor interface, preventing the OpenCL backend to be called. 

Also, this pr fixes the hsmg precon for the OpenCL backend (related to #373)

