### PR TITLE
Fix projections for OpenCL backend

### DIFF
--- a/src/common/projection.f90
+++ b/src/common/projection.f90
@@ -318,6 +318,7 @@ contains
     real(kind=rp), intent(inout), dimension(n) :: b 
     real(kind=rp) :: alpha(this%L)
     type(c_ptr) :: b_d
+    integer :: i
     b_d = device_get_ptr(b)
 
     associate(xbar_d => this%xbar_d, xx_d => this%xx_d, xx_d_d => this%xx_d_d, &
@@ -333,17 +334,47 @@ contains
          call device_proj_on(alpha_d, b_d, xx_d_d, bb_d_d, &
               coef%mult_d, xbar_d, this%m, n)
       else
-         call device_glsc3_many(alpha,b_d,xx_d_d,coef%mult_d,this%m,n)
-         call device_memcpy(alpha, alpha_d, this%m, HOST_TO_DEVICE) 
+         if (NEKO_BCKND_OPENCL .eq. 1) then
+            do i = 1, this%m
+               alpha(i) = device_glsc3(b_d,xx_d(i),coef%mult_d,n)
+            end do
+         else
+            call device_glsc3_many(alpha,b_d,xx_d_d,coef%mult_d,this%m,n)
+            call device_memcpy(alpha, alpha_d, this%m, HOST_TO_DEVICE) 
+         end if
          call device_rzero(xbar_d, n)
-         call device_add2s2_many(xbar_d, xx_d_d, alpha_d, this%m, n)
-         call device_cmult(alpha_d, -1.0_rp, this%m)
-         call device_add2s2_many(b_d, bb_d_d, alpha_d, this%m, n)
-         call device_glsc3_many(alpha,b_d,xx_d_d,coef%mult_d,this%m,n)
-         call device_memcpy(alpha, alpha_d, this%m, HOST_TO_DEVICE)     
-         call device_add2s2_many(xbar_d, xx_d_d, alpha_d, this%m, n)
-         call device_cmult(alpha_d, -1.0_rp, this%m)
-         call device_add2s2_many(b_d, bb_d_d, alpha_d, this%m, n)
+         if (NEKO_BCKND_OPENCL .eq. 1) then
+            do i = 1, this%m
+               call device_add2s2(xbar_d, xx_d(i), alpha(i), n)            
+            end do
+            call cmult(alpha, -1.0_rp, this%m)
+         else
+            call device_add2s2_many(xbar_d, xx_d_d, alpha_d, this%m, n)
+            call device_cmult(alpha_d, -1.0_rp, this%m)
+         end if
+
+         if (NEKO_BCKND_OPENCL .eq. 1) then
+            do i = 1, this%m
+               call device_add2s2(b_d, bb_d(i), alpha(i), n)
+               alpha(i) = device_glsc3(b_d,xx_d(i),coef%mult_d,n)
+            end do
+         else
+            call device_add2s2_many(b_d, bb_d_d, alpha_d, this%m, n)
+            call device_glsc3_many(alpha,b_d,xx_d_d,coef%mult_d,this%m,n)
+            call device_memcpy(alpha, alpha_d, this%m, HOST_TO_DEVICE)
+         end if
+
+         if (NEKO_BCKND_OPENCL .eq. 1) then
+            do i = 1, this%m
+               call device_add2s2(xbar_d, xx_d(i), alpha(i), n)
+               call cmult(alpha, -1.0_rp, this%m)
+               call device_add2s2(b_d, bb_d(i), alpha(i), n)
+            end do
+         else
+            call device_add2s2_many(xbar_d, xx_d_d, alpha_d, this%m, n)
+            call device_cmult(alpha_d, -1.0_rp, this%m)
+            call device_add2s2_many(b_d, bb_d_d, alpha_d, this%m, n)
+         end if
       end if
       
     end associate
@@ -357,6 +388,7 @@ contains
     type(c_ptr) :: w_d
     real(kind=rp) :: nrm, scl
     real(kind=rp) :: alpha(this%L)
+    integer :: i
 
     associate(m => this%m,  xx_d_d => this%xx_d_d, &
               bb_d_d => this%bb_d_d, alpha_d => this%alpha_d)
@@ -367,19 +399,42 @@ contains
          call device_project_ortho(alpha_d, bb_d(m), xx_d_d, bb_d_d, &
               w_d, xx_d(m), this%m, n, nrm)
       else
-         call device_glsc3_many(alpha,bb_d(m),xx_d_d,w_d,m,n)
+         if (NEKO_BCKND_OPENCL .eq. 1)then
+            do i = 1, m
+               alpha(i) = device_glsc3(bb_d(m),xx_d(i),w_d,n)
+            end do
+         else
+            call device_glsc3_many(alpha,bb_d(m),xx_d_d,w_d,m,n)
+         end if
          nrm = sqrt(alpha(m))
          call cmult(alpha, -1.0_rp,m)
-         call device_memcpy(alpha, alpha_d, this%m, HOST_TO_DEVICE) 
-         call device_add2s2_many(xx_d(m),xx_d_d,alpha_d,m-1,n)
-         call device_add2s2_many(bb_d(m),bb_d_d,alpha_d,m-1,n)
+         if (NEKO_BCKND_OPENCL .eq. 1)then
+            do i = 1, m - 1
+               call device_add2s2(xx_d(m),xx_d(i),alpha(i), n)
+               call device_add2s2(bb_d(m),bb_d(i),alpha(i),n)
          
-         call device_glsc3_many(alpha,bb_d(m),xx_d_d,w_d,m,n)
+               alpha(i) = device_glsc3(bb_d(m),xx_d(i),w_d,n)
+            end do
+         else
+            call device_memcpy(alpha, alpha_d, this%m, HOST_TO_DEVICE) 
+            call device_add2s2_many(xx_d(m),xx_d_d,alpha_d,m-1,n)
+            call device_add2s2_many(bb_d(m),bb_d_d,alpha_d,m-1,n)
+         
+            call device_glsc3_many(alpha,bb_d(m),xx_d_d,w_d,m,n)
+         end if
          call cmult(alpha, -1.0_rp,m)
-         call device_memcpy(alpha, alpha_d, m, HOST_TO_DEVICE) 
-         call device_add2s2_many(xx_d(m),xx_d_d,alpha_d,m-1,n)
-         call device_add2s2_many(bb_d(m),bb_d_d,alpha_d,m-1,n)
-         call device_glsc3_many(alpha,bb_d(m),xx_d_d,w_d,m,n)
+         if (NEKO_BCKND_OPENCL .eq. 1)then
+            do i = 1, m - 1
+               call device_add2s2(xx_d(m),xx_d(i),alpha(i),n)
+               call device_add2s2(bb_d(m),bb_d(i),alpha(i),n)
+               alpha(i) =  device_glsc3(bb_d(m),xx_d(i),w_d,n)
+            end do
+         else
+            call device_memcpy(alpha, alpha_d, m, HOST_TO_DEVICE) 
+            call device_add2s2_many(xx_d(m),xx_d_d,alpha_d,m-1,n)
+            call device_add2s2_many(bb_d(m),bb_d_d,alpha_d,m-1,n)
+            call device_glsc3_many(alpha,bb_d(m),xx_d_d,w_d,m,n)
+         end if
       end if
       
       alpha(m) = device_glsc3(xx_d(m), w_d, bb_d(m), n)


### PR DESCRIPTION

This is a temporary solution to enable the OpenCL backend in projections (refs #373). 

To be removed once the `_many` kernels has been reworked to support OpenCL
