### PR TITLE
Add support for OpenCL in GMRES solver

### DIFF
--- a/src/krylov/krylov_fctry.f90
+++ b/src/krylov/krylov_fctry.f90
@@ -73,6 +73,9 @@ contains
        if (NEKO_BCKND_SX .eq. 1) then
           allocate(sx_pipecg_t::ksp)
        else if (NEKO_BCKND_DEVICE .eq. 1) then
+          if (NEKO_BCKND_OPENCL .eq. 1) then
+             call neko_error('PipeCG not supported for OpenCL')
+          end if
           allocate(pipecg_device_t::ksp)
        else
           allocate(pipecg_t::ksp)


### PR DESCRIPTION
This add similar workarounds as in projections for OpenCL (to be removed once the `many` kernels are better supported). Furthermore, this also brings enough OpenCL functionality into Neko to efficiently run a full flow case (fixes #373)
