### PR TITLE
Don't pass all C++ related LDFLAGS to nvcc

### DIFF
--- a/m4/ax_cuda.m4
+++ b/m4/ax_cuda.m4
@@ -25,7 +25,7 @@ AC_DEFUN([AX_CUDA],[
 	   	   CPPFLAGS_SAVED="$CPPFLAGS"
 		   LDFLAGS_SAVED="$LDFLAGS"
 		   CPPFLAGS="$CUDA_CPPFLAGS $CPPFLAGS"
-		   LDFLAGS="$CUDA_LDFLAGS $LDFLAGS"
+		   LDFLAGS="$CUDA_LDFLAGS"
 		   export CPPFLAGS
 		   export LDFLAGS
 		   AC_PATH_PROG(NVCC, nvcc, "no")
@@ -46,6 +46,7 @@ AC_DEFUN([AX_CUDA],[
                    cuda_bcknd="1"
 		   AC_DEFINE(HAVE_CUDA,1,[Define if you have CUDA.])
 		   LIBS="$CUDA_LIBS $_LIBS"
+		   LDFLAGS="$CUDA_LDFLAGS $LDFLAGS_SAVED"
 		else
 		   AC_MSG_ERROR([CUDA not found])
 		fi


### PR DESCRIPTION
This problems occurs if Neko is built with ADIOS2 (under certain conditions), fixes #717
