### PR TITLE
Fix race condition in gather-scatter (strtgy > 2)

### DIFF
--- a/src/gs/bcknd/device/gs_device_mpi.F90
+++ b/src/gs/bcknd/device/gs_device_mpi.F90
@@ -468,6 +468,10 @@ contains
                                         this%event(done_req), 0)
        end do
 
+       !> @todo Remove as soon as the new gather-scatter
+       !! formulation is ready to be merged
+       call device_sync(C_NULL_PTR)
+       
     end if
 
   end subroutine gs_device_mpi_nbwait


### PR DESCRIPTION
This is a temporary fix, of a possible race condition when using a GS strategy of 3 or more. The fix will be removed once we can merge in the new device and gather-scatter work from the ENCCS hackathon.
