### PR TITLE
Better temporaries handling in fluid

### DIFF
--- a/src/case.f90
+++ b/src/case.f90
@@ -58,6 +58,7 @@ module case
   use jobctrl
   use user_intf  
   use scalar_pnpn ! todo directly load the pnpn? can we have other
+  use scratch_registry, only : scratch_registry_t, neko_scratch_registry
   implicit none
 
   type :: case_t
@@ -183,6 +184,12 @@ contains
     !
     call fluid_scheme_factory(C%fluid, trim(fluid_scheme))
     call C%fluid%init(C%msh, lx, C%params)
+
+    
+    !
+    ! Setup scratch registry
+    !
+    neko_scratch_registry = scratch_registry_t(C%fluid%dm_Xh, 10, 10)
 
     !
     ! Setup scalar scheme

--- a/src/common/bcknd/cpu/rhs_maker_cpu.f90
+++ b/src/common/bcknd/cpu/rhs_maker_cpu.f90
@@ -1,5 +1,6 @@
 module rhs_maker_cpu
   use rhs_maker
+  use scratch_registry
   implicit none
   private
   
@@ -48,16 +49,21 @@ contains
     
   end subroutine rhs_maker_sumab_cpu
 
-  subroutine rhs_maker_ext_cpu(temp1, temp2, temp3, fx_lag, fy_lag, fz_lag, &
+  subroutine rhs_maker_ext_cpu(fx_lag, fy_lag, fz_lag, &
                              fx_laglag, fy_laglag, fz_laglag, fx, fy, fz, &
                              rho, ext_coeffs, n)
-    type(field_t), intent(inout) :: temp1, temp2, temp3
     type(field_t), intent(inout) :: fx_lag, fy_lag, fz_lag
     type(field_t), intent(inout) :: fx_laglag, fy_laglag, fz_laglag
     real(kind=rp), intent(inout) :: rho, ext_coeffs(4)
     integer, intent(in) :: n
     real(kind=rp), intent(inout) :: fx(n), fy(n), fz(n)
     integer :: i
+    type(field_t), pointer :: temp1, temp2, temp3
+    integer :: temp_indices(3)
+    
+    call neko_scratch_registry%request_field(temp1, temp_indices(1))
+    call neko_scratch_registry%request_field(temp2, temp_indices(2))
+    call neko_scratch_registry%request_field(temp3, temp_indices(3))
 
     do i = 1, n
        temp1%x(i,1,1,1) = ext_coeffs(2) * fx_lag%x(i,1,1,1) + &
@@ -82,6 +88,8 @@ contains
        fy(i) = (ext_coeffs(1) * fy(i) + temp2%x(i,1,1,1)) * rho
        fz(i) = (ext_coeffs(1) * fz(i) + temp3%x(i,1,1,1)) * rho
     end do
+    
+    call neko_scratch_registry%relinquish_field(temp_indices)
     
   end subroutine rhs_maker_ext_cpu
 
@@ -111,18 +119,25 @@ contains
     
   end subroutine scalar_rhs_maker_ext_cpu
 
-  subroutine rhs_maker_bdf_cpu(ta1, ta2, ta3, tb1, tb2, tb3, &
-                               ulag, vlag, wlag, bfx, bfy, bfz, &
+  subroutine rhs_maker_bdf_cpu(ulag, vlag, wlag, bfx, bfy, bfz, &
                                u, v, w, B, rho, dt, bd, nbd, n)    
     integer, intent(in) :: n, nbd
-    type(field_t), intent(inout) :: ta1, ta2, ta3
     type(field_t), intent(in) :: u, v, w
-    type(field_t), intent(inout) :: tb1, tb2, tb3
     type(field_series_t), intent(in) :: ulag, vlag, wlag        
     real(kind=rp), intent(inout) :: bfx(n), bfy(n), bfz(n)
     real(kind=rp), intent(in) :: B(n)
     real(kind=rp), intent(in) :: dt, rho, bd(4)
+    type(field_t), pointer :: tb1, tb2, tb3
+    type(field_t), pointer :: ta1, ta2, ta3
+    integer :: temp_indices(6)
     integer :: i, ilag
+
+    call neko_scratch_registry%request_field(ta1, temp_indices(1))
+    call neko_scratch_registry%request_field(ta2, temp_indices(2))
+    call neko_scratch_registry%request_field(ta3, temp_indices(3))
+    call neko_scratch_registry%request_field(tb1, temp_indices(4))
+    call neko_scratch_registry%request_field(tb2, temp_indices(5))
+    call neko_scratch_registry%request_field(tb3, temp_indices(6))
 
     do i = 1, n
        tb1%x(i,1,1,1) = u%x(i,1,1,1) * B(i) * bd(2)
@@ -149,6 +164,8 @@ contains
        bfy(i) = bfy(i) + tb2%x(i,1,1,1) * (rho / dt)
        bfz(i) = bfz(i) + tb3%x(i,1,1,1) * (rho / dt)
     end do
+
+    call neko_scratch_registry%relinquish_field(temp_indices)
 
   end subroutine rhs_maker_bdf_cpu
 

--- a/src/common/bcknd/device/rhs_maker_device.F90
+++ b/src/common/bcknd/device/rhs_maker_device.F90
@@ -289,10 +289,9 @@ contains
     
   end subroutine rhs_maker_sumab_device
 
-  subroutine rhs_maker_ext_device(temp1, temp2, temp3, fx_lag, fy_lag, fz_lag, &
+  subroutine rhs_maker_ext_device(fx_lag, fy_lag, fz_lag, &
                            fx_laglag, fy_laglag, fz_laglag, fx, fy, fz, &
                            rho, ext_coeffs, n)
-    type(field_t), intent(inout) :: temp1, temp2, temp3
     type(field_t), intent(inout) :: fx_lag, fy_lag, fz_lag
     type(field_t), intent(inout) :: fx_laglag, fy_laglag, fz_laglag
     real(kind=rp), intent(inout) :: rho, ext_coeffs(4)
@@ -348,13 +347,10 @@ contains
     
   end subroutine scalar_rhs_maker_ext_device
 
-  subroutine rhs_maker_bdf_device(ta1, ta2, ta3, tb1, tb2, tb3, &
-                               ulag, vlag, wlag, bfx, bfy, bfz, &
+  subroutine rhs_maker_bdf_device(ulag, vlag, wlag, bfx, bfy, bfz, &
                                u, v, w, B, rho, dt, bd, nbd, n)    
     integer, intent(in) :: n, nbd
-    type(field_t), intent(inout) :: ta1, ta2, ta3
     type(field_t), intent(in) :: u, v, w
-    type(field_t), intent(inout) :: tb1, tb2, tb3
     type(field_series_t), intent(in) :: ulag, vlag, wlag        
     real(kind=rp), intent(inout) :: bfx(n), bfy(n), bfz(n)
     real(kind=rp), intent(in) :: B(n)

--- a/src/common/bcknd/sx/rhs_maker_sx.f90
+++ b/src/common/bcknd/sx/rhs_maker_sx.f90
@@ -1,6 +1,6 @@
 module rhs_maker_sx
   use rhs_maker
-  use scratch_registry
+  use scratch_registry, only : neko_scratch_registry
   implicit none
   private
   

--- a/src/common/bcknd/sx/rhs_maker_sx.f90
+++ b/src/common/bcknd/sx/rhs_maker_sx.f90
@@ -1,5 +1,6 @@
 module rhs_maker_sx
   use rhs_maker
+  use scratch_registry
   implicit none
   private
   
@@ -48,16 +49,21 @@ contains
     
   end subroutine rhs_maker_sumab_sx
 
-  subroutine rhs_maker_ext_sx(temp1, temp2, temp3, fx_lag, fy_lag, fz_lag, &
+  subroutine rhs_maker_ext_sx(fx_lag, fy_lag, fz_lag, &
                              fx_laglag, fy_laglag, fz_laglag, fx, fy, fz, &
                              rho, ext_coeffs, n)
-    type(field_t), intent(inout) :: temp1, temp2, temp3
     type(field_t), intent(inout) :: fx_lag, fy_lag, fz_lag
     type(field_t), intent(inout) :: fx_laglag, fy_laglag, fz_laglag
     real(kind=rp), intent(inout) :: rho, ext_coeffs(4)
     integer, intent(in) :: n
     real(kind=rp), intent(inout) :: fx(n), fy(n), fz(n)
     integer :: i
+    type(field_t), pointer :: temp1, temp2, temp3
+    integer :: temp_indices(3)
+    
+    call neko_scratch_registry%request_field(temp1, temp_indices(1))
+    call neko_scratch_registry%request_field(temp2, temp_indices(2))
+    call neko_scratch_registry%request_field(temp3, temp_indices(3))
 
     do i = 1, n
        temp1%x(i,1,1,1) = ext_coeffs(2) * fx_lag%x(i,1,1,1) + &
@@ -82,6 +88,8 @@ contains
        fy(i) = (ext_coeffs(1) * fy(i) + temp2%x(i,1,1,1)) * rho
        fz(i) = (ext_coeffs(1) * fz(i) + temp3%x(i,1,1,1)) * rho
     end do
+
+    call neko_scratch_registry%relinquish_field(temp_indices)
     
   end subroutine rhs_maker_ext_sx
 
@@ -111,18 +119,25 @@ contains
     
   end subroutine scalar_rhs_maker_ext_sx
 
-  subroutine rhs_maker_bdf_sx(ta1, ta2, ta3, tb1, tb2, tb3, &
-                               ulag, vlag, wlag, bfx, bfy, bfz, &
-                               u, v, w, B, rho, dt, bd, nbd, n)    
+  subroutine rhs_maker_bdf_sx(ulag, vlag, wlag, bfx, bfy, bfz, &
+                              u, v, w, B, rho, dt, bd, nbd, n)    
     integer, intent(in) :: n, nbd
-    type(field_t), intent(inout) :: ta1, ta2, ta3
     type(field_t), intent(in) :: u, v, w
-    type(field_t), intent(inout) :: tb1, tb2, tb3
     type(field_series_t), intent(in) :: ulag, vlag, wlag        
     real(kind=rp), intent(inout) :: bfx(n), bfy(n), bfz(n)
     real(kind=rp), intent(in) :: B(n)
     real(kind=rp), intent(in) :: dt, rho, bd(4)
+    type(field_t), pointer :: tb1, tb2, tb3
+    type(field_t), pointer :: ta1, ta2, ta3
+    integer :: temp_indices(6)
     integer :: i, ilag
+
+    call neko_scratch_registry%request_field(ta1, temp_indices(1))
+    call neko_scratch_registry%request_field(ta2, temp_indices(2))
+    call neko_scratch_registry%request_field(ta3, temp_indices(3))
+    call neko_scratch_registry%request_field(tb1, temp_indices(4))
+    call neko_scratch_registry%request_field(tb2, temp_indices(5))
+    call neko_scratch_registry%request_field(tb3, temp_indices(6))
 
     do i = 1, n
        tb1%x(i,1,1,1) = u%x(i,1,1,1) * B(i) * bd(2)
@@ -149,6 +164,8 @@ contains
        bfy(i) = bfy(i) + tb2%x(i,1,1,1) * (rho / dt)
        bfz(i) = bfz(i) + tb3%x(i,1,1,1) * (rho / dt)
     end do
+
+    call neko_scratch_registry%relinquish_field(temp_indices)
 
   end subroutine rhs_maker_bdf_sx
 

--- a/src/common/rhs_maker.f90
+++ b/src/common/rhs_maker.f90
@@ -76,12 +76,11 @@ module rhs_maker
   end interface
 
   abstract interface
-     subroutine rhs_maker_ext(temp1, temp2, temp3, fx_lag, fy_lag, fz_lag, &
+     subroutine rhs_maker_ext(fx_lag, fy_lag, fz_lag, &
           fx_laglag, fy_laglag, fz_laglag, fx, fy, fz, &
           rho, ext_coeffs, n)
        import field_t
        import rp
-       type(field_t), intent(inout) :: temp1, temp2, temp3
        type(field_t), intent(inout) :: fx_lag, fy_lag, fz_lag
        type(field_t), intent(inout) :: fx_laglag, fy_laglag, fz_laglag
        real(kind=rp), intent(inout) :: rho, ext_coeffs(4)
@@ -105,16 +104,13 @@ module rhs_maker
   end interface
 
   abstract interface
-     subroutine rhs_maker_bdf(ta1, ta2, ta3, tb1, tb2, tb3, &
-          ulag, vlag, wlag, bfx, bfy, bfz, &
+     subroutine rhs_maker_bdf(ulag, vlag, wlag, bfx, bfy, bfz, &
           u, v, w, B, rho, dt, bd, nbd, n)
        import field_series_t
        import field_t
        import rp
        integer, intent(in) :: n, nbd
-       type(field_t), intent(inout) :: ta1, ta2, ta3
        type(field_t), intent(in) :: u, v, w
-       type(field_t), intent(inout) :: tb1, tb2, tb3
        type(field_series_t), intent(in) :: ulag, vlag, wlag        
        real(kind=rp), intent(inout) :: bfx(n), bfy(n), bfz(n)
        real(kind=rp), intent(in) :: B(n)

--- a/src/fluid/bcknd/cpu/pnpn_res_cpu.f90
+++ b/src/fluid/bcknd/cpu/pnpn_res_cpu.f90
@@ -18,14 +18,10 @@ module pnpn_res_cpu
 
 contains
 
-  subroutine pnpn_prs_res_cpu_compute(p, p_res, u, v, w, u_e, v_e, w_e, &
-       ta1, ta2, ta3, wa1, wa2, wa3, work1, work2, f_Xh, c_Xh, gs_Xh, &
-       bc_prs_surface,bc_sym_surface, Ax, bd, dt, Re, rho)
+  subroutine pnpn_prs_res_cpu_compute(p, p_res, u, v, w, u_e, v_e, w_e, f_Xh, &
+       c_Xh, gs_Xh, bc_prs_surface,bc_sym_surface, Ax, bd, dt, Re, rho)
     type(field_t), intent(inout) :: p, u, v, w
     type(field_t), intent(inout) :: u_e, v_e, w_e
-    type(field_t), intent(inout) :: ta1, ta2, ta3
-    type(field_t), intent(inout) :: wa1, wa2, wa3
-    type(field_t), intent(inout) :: work1, work2
     type(field_t), intent(inout) :: p_res
     type(source_t), intent(inout) :: f_Xh
     type(coef_t), intent(inout) :: c_Xh
@@ -40,6 +36,17 @@ contains
     real(kind=rp) :: dtbd
     integer :: n
     integer :: i
+    type(field_t), pointer :: ta1, ta2, ta3, wa1, wa2, wa3, work1, work2
+    integer :: temp_indices(8)
+
+    call neko_scratch_registry%request_field(ta1, temp_indices(1))
+    call neko_scratch_registry%request_field(ta2, temp_indices(2))
+    call neko_scratch_registry%request_field(ta3, temp_indices(3))
+    call neko_scratch_registry%request_field(wa1, temp_indices(4))
+    call neko_scratch_registry%request_field(wa2, temp_indices(5))
+    call neko_scratch_registry%request_field(wa3, temp_indices(6))
+    call neko_scratch_registry%request_field(work1, temp_indices(7))
+    call neko_scratch_registry%request_field(work2, temp_indices(8))
 
     n = c_Xh%dof%size()
 
@@ -107,6 +114,8 @@ contains
             - (dtbd * (ta1%x(i,1,1,1) + ta2%x(i,1,1,1) + ta3%x(i,1,1,1)))&
             - (wa1%x(i,1,1,1) + wa2%x(i,1,1,1) + wa3%x(i,1,1,1))
     end do
+    
+    call neko_scratch_registry%relinquish_field(temp_indices)
 
   end subroutine pnpn_prs_res_cpu_compute
 

--- a/src/fluid/bcknd/device/pnpn_res_device.F90
+++ b/src/fluid/bcknd/device/pnpn_res_device.F90
@@ -36,7 +36,9 @@ module pnpn_res_device
   use operators
   use device_math
   use device_mathops
+  use scratch_registry, only : neko_scratch_registry
   use, intrinsic :: iso_c_binding
+  use scratch_registry, only: neko_scratch_registry
   implicit none
   private
  
@@ -321,13 +323,12 @@ contains
   end subroutine pnpn_prs_res_device_compute
 
   subroutine pnpn_vel_res_device_compute(Ax, u, v, w, u_res, v_res, w_res, &
-       p, ta1, ta2, ta3, f_Xh, c_Xh, msh, Xh, Re, rho, bd, dt, n)
+       p, f_Xh, c_Xh, msh, Xh, Re, rho, bd, dt, n)
     class(ax_t), intent(in) :: Ax
     type(mesh_t), intent(inout) :: msh
     type(space_t), intent(inout) :: Xh    
     type(field_t), intent(inout) :: p, u, v, w
     type(field_t), intent(inout) :: u_res, v_res, w_res
-    type(field_t), intent(inout) :: ta1, ta2, ta3
     type(source_t), intent(inout) :: f_Xh
     type(coef_t), intent(inout) :: c_Xh
     real(kind=rp), intent(in) :: Re
@@ -335,7 +336,9 @@ contains
     real(kind=rp), intent(in) :: bd
     real(kind=rp), intent(in) :: dt
     integer, intent(in) :: n
-    
+    integer :: temp_indices(3)
+    type(field_t), pointer :: ta1, ta2, ta3
+
     call device_cfill(c_Xh%h1_d, (1.0_rp / Re), n)
     call device_cfill(c_Xh%h2_d, rho * (bd / dt), n)
     c_Xh%ifh2 = .true.
@@ -343,6 +346,10 @@ contains
     call Ax%compute(u_res%x, u%x, c_Xh, msh, Xh)
     call Ax%compute(v_res%x, v%x, c_Xh, msh, Xh)
     call Ax%compute(w_res%x, w%x, c_Xh, msh, Xh)
+
+    call neko_scratch_registry%request_field(ta1, temp_indices(1))
+    call neko_scratch_registry%request_field(ta2, temp_indices(2))
+    call neko_scratch_registry%request_field(ta3, temp_indices(3))
 
     call opgrad(ta1%x, ta2%x, ta3%x, p%x, c_Xh)
 
@@ -357,6 +364,7 @@ contains
          ta1%x_d, ta2%x_d, ta3%x_d, f_Xh%u_d, f_Xh%v_d, f_Xh%w_d, n)
 #endif
     
+    call neko_scratch_registry%relinquish_field(temp_indices)
   end subroutine pnpn_vel_res_device_compute
 
 end module pnpn_res_device

--- a/src/fluid/bcknd/device/pnpn_res_device.F90
+++ b/src/fluid/bcknd/device/pnpn_res_device.F90
@@ -212,13 +212,9 @@ module pnpn_res_device
 contains
 
   subroutine pnpn_prs_res_device_compute(p, p_res, u, v, w, u_e, v_e, w_e, &
-       ta1, ta2, ta3, wa1, wa2, wa3, work1, work2, f_Xh, c_Xh, gs_Xh, &
-       bc_prs_surface, bc_sym_surface, Ax, bd, dt, Re, rho)
+       f_Xh, c_Xh, gs_Xh, bc_prs_surface, bc_sym_surface, Ax, bd, dt, Re, rho)
     type(field_t), intent(inout) :: p, u, v, w
     type(field_t), intent(inout) :: u_e, v_e, w_e
-    type(field_t), intent(inout) :: ta1, ta2, ta3
-    type(field_t), intent(inout) :: wa1, wa2, wa3
-    type(field_t), intent(inout) :: work1, work2
     type(field_t), intent(inout) :: p_res
     type(source_t), intent(inout) :: f_Xh
     type(coef_t), intent(inout) :: c_Xh
@@ -232,6 +228,17 @@ contains
     real(kind=rp), intent(in) :: rho
     real(kind=rp) :: dtbd
     integer :: n, gdim
+    type(field_t), pointer :: ta1, ta2, ta3, wa1, wa2, wa3, work1, work2
+    integer :: temp_indices(8)
+
+    call neko_scratch_registry%request_field(ta1, temp_indices(1))
+    call neko_scratch_registry%request_field(ta2, temp_indices(2))
+    call neko_scratch_registry%request_field(ta3, temp_indices(3))
+    call neko_scratch_registry%request_field(wa1, temp_indices(4))
+    call neko_scratch_registry%request_field(wa2, temp_indices(5))
+    call neko_scratch_registry%request_field(wa3, temp_indices(6))
+    call neko_scratch_registry%request_field(work1, temp_indices(7))
+    call neko_scratch_registry%request_field(work2, temp_indices(8))
 
     n = u%dof%size()
     gdim = c_Xh%msh%gdim
@@ -309,6 +316,8 @@ contains
     call pnpn_prs_res_part3_opencl(p_res%x_d, ta1%x_d, ta2%x_d, ta3%x_d, dtbd, n);
 #endif
         
+  call neko_scratch_registry%relinquish_field(temp_indices)
+
   end subroutine pnpn_prs_res_device_compute
 
   subroutine pnpn_vel_res_device_compute(Ax, u, v, w, u_res, v_res, w_res, &

--- a/src/fluid/bcknd/sx/pnpn_res_sx.f90
+++ b/src/fluid/bcknd/sx/pnpn_res_sx.f90
@@ -18,14 +18,10 @@ module pnpn_res_sx
 
 contains
 
-  subroutine pnpn_prs_res_sx_compute(p, p_res, u, v, w, u_e, v_e, w_e, &
-       ta1, ta2, ta3, wa1, wa2, wa3, work1, work2, f_Xh, c_Xh, gs_Xh, &
-       bc_prs_surface, bc_sym_surface, Ax, bd, dt, Re, rho)
+  subroutine pnpn_prs_res_sx_compute(p, p_res, u, v, w, u_e, v_e, w_e, f_Xh, &
+       c_Xh, gs_Xh, bc_prs_surface, bc_sym_surface, Ax, bd, dt, Re, rho)
     type(field_t), intent(inout) :: p, u, v, w
     type(field_t), intent(inout) :: u_e, v_e, w_e
-    type(field_t), intent(inout) :: ta1, ta2, ta3
-    type(field_t), intent(inout) :: wa1, wa2, wa3
-    type(field_t), intent(inout) :: work1, work2
     type(field_t), intent(inout) :: p_res
     type(source_t), intent(inout) :: f_Xh
     type(coef_t), intent(inout) :: c_Xh
@@ -40,6 +36,17 @@ contains
     real(kind=rp) :: dtbd
     integer :: n
     integer :: i
+    type(field_t), pointer :: ta1, ta2, ta3, wa1, wa2, wa3, work1, work2
+    integer :: temp_indices(8)
+
+    call neko_scratch_registry%request_field(ta1, temp_indices(1))
+    call neko_scratch_registry%request_field(ta2, temp_indices(2))
+    call neko_scratch_registry%request_field(ta3, temp_indices(3))
+    call neko_scratch_registry%request_field(wa1, temp_indices(4))
+    call neko_scratch_registry%request_field(wa2, temp_indices(5))
+    call neko_scratch_registry%request_field(wa3, temp_indices(6))
+    call neko_scratch_registry%request_field(work1, temp_indices(7))
+    call neko_scratch_registry%request_field(work2, temp_indices(8))
 
     n = c_Xh%dof%size()
 
@@ -110,6 +117,7 @@ contains
             - (wa1%x(i,1,1,1) + wa2%x(i,1,1,1) + wa3%x(i,1,1,1))
     end do
 
+    call neko_scratch_registry%relinquish_field(temp_indices)
   end subroutine pnpn_prs_res_sx_compute
 
   subroutine pnpn_vel_res_sx_compute(Ax, u, v, w, u_res, v_res, w_res, &

--- a/src/fluid/bcknd/sx/pnpn_res_sx.f90
+++ b/src/fluid/bcknd/sx/pnpn_res_sx.f90
@@ -3,6 +3,7 @@ module pnpn_res_sx
   use gather_scatter
   use pnpn_residual
   use operators
+  use scratch_registry, only: neko_scratch_registry
   implicit none
   private
   
@@ -121,13 +122,12 @@ contains
   end subroutine pnpn_prs_res_sx_compute
 
   subroutine pnpn_vel_res_sx_compute(Ax, u, v, w, u_res, v_res, w_res, &
-       p, ta1, ta2, ta3, f_Xh, c_Xh, msh, Xh, Re, rho, bd, dt, n)
+       p, f_Xh, c_Xh, msh, Xh, Re, rho, bd, dt, n)
     class(ax_t), intent(in) :: Ax
     type(mesh_t), intent(inout) :: msh
     type(space_t), intent(inout) :: Xh    
     type(field_t), intent(inout) :: p, u, v, w
     type(field_t), intent(inout) :: u_res, v_res, w_res
-    type(field_t), intent(inout) :: ta1, ta2, ta3
     type(source_t), intent(inout) :: f_Xh
     type(coef_t), intent(inout) :: c_Xh
     real(kind=rp), intent(in) :: Re
@@ -135,6 +135,8 @@ contains
     real(kind=rp), intent(in) :: bd
     real(kind=rp), intent(in) :: dt
     integer, intent(in) :: n
+    integer :: temp_indices(3)
+    type(field_t), pointer :: ta1, ta2, ta3
     integer :: i
 
     do i = 1, n
@@ -147,6 +149,10 @@ contains
     call Ax%compute(v_res%x, v%x, c_Xh, msh, Xh)
     call Ax%compute(w_res%x, w%x, c_Xh, msh, Xh)
 
+    call neko_scratch_registry%request_field(ta1, temp_indices(1))
+    call neko_scratch_registry%request_field(ta2, temp_indices(2))
+    call neko_scratch_registry%request_field(ta3, temp_indices(3))
+
     call opgrad(ta1%x, ta2%x, ta3%x, p%x, c_Xh)
 
     do i = 1, n
@@ -155,6 +161,7 @@ contains
        w_res%x(i,1,1,1) = (-w_res%x(i,1,1,1)) - ta3%x(i,1,1,1) + f_Xh%w(i,1,1,1)
     end do
     
+    call neko_scratch_registry%relinquish_field(temp_indices)
   end subroutine pnpn_vel_res_sx_compute  
      
 end module pnpn_res_sx

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -360,10 +360,8 @@ contains
     integer, intent(inout) :: tstep
     integer :: n
     type(ksp_monitor_t) :: ksp_results(4)
-    type(field_t), pointer :: temp1, temp2, temp3, temp4
-    type(field_t), pointer :: temp5, temp6
     type(field_t), pointer :: u_e, v_e, w_e
-    integer :: temp_indices(9)
+    integer :: temp_indices(3)
 
     n = this%dm_Xh%size()
 
@@ -384,15 +382,9 @@ contains
          vel_max_iter => this%params%vel_max_iter)
          
       ! Get temporary arrays
-      call this%scratch%request_field(temp1, temp_indices(1))
-      call this%scratch%request_field(temp2, temp_indices(2))
-      call this%scratch%request_field(temp3, temp_indices(3))
-      call this%scratch%request_field(temp4, temp_indices(4))
-      call this%scratch%request_field(temp5, temp_indices(5))
-      call this%scratch%request_field(temp6, temp_indices(6))
-      call this%scratch%request_field(u_e, temp_indices(7))
-      call this%scratch%request_field(v_e, temp_indices(8))
-      call this%scratch%request_field(w_e, temp_indices(9))
+      call this%scratch%request_field(u_e, temp_indices(1))
+      call this%scratch%request_field(v_e, temp_indices(2))
+      call this%scratch%request_field(w_e, temp_indices(3))
 
       call sumab%compute_fluid(u_e, v_e, w_e, u, v, w, &
            ulag, vlag, wlag, ext_bdf%advection_coeffs, ext_bdf%nadv)
@@ -409,14 +401,12 @@ contains
                           f_Xh%u, f_Xh%v, f_Xh%w, &
                           Xh, this%c_Xh, dm_Xh%size())
 
-      call makeabf%compute_fluid(ta1, ta2, ta3,&
-                           this%abx1, this%aby1, this%abz1,&
+      call makeabf%compute_fluid(this%abx1, this%aby1, this%abz1,&
                            this%abx2, this%aby2, this%abz2, &
                            f_Xh%u, f_Xh%v, f_Xh%w,&
                            params%rho, ext_bdf%advection_coeffs, n)
 
-      call makebdf%compute_fluid(ta1, ta2, ta3, this%wa1, this%wa2, this%wa3,&
-                           ulag, vlag, wlag, f_Xh%u, f_Xh%v, f_Xh%w, &
+      call makebdf%compute_fluid(ulag, vlag, wlag, f_Xh%u, f_Xh%v, f_Xh%w, &
                            u, v, w, c_Xh%B, params%rho, params%dt, &
                            ext_bdf%diffusion_coeffs, ext_bdf%ndiff, n)
 
@@ -515,7 +505,7 @@ contains
 
       if (params%vol_flow_dir .ne. 0) then                 
          call this%vol_flow%adjust( u, v, w, p, u_res, v_res, w_res, p_res, &
-              ta1, ta2, ta3, c_Xh, gs_Xh, ext_bdf, params%rho, params%Re, &
+              c_Xh, gs_Xh, ext_bdf, params%rho, params%Re,&
               params%dt, this%bclst_dp, this%bclst_du, this%bclst_dv, &
               this%bclst_dw, this%bclst_vel_res, Ax, this%ksp_prs, &
               this%ksp_vel, this%pc_prs, this%pc_vel, prs_max_iter, vel_max_iter)

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -360,6 +360,11 @@ contains
     integer, intent(inout) :: tstep
     integer :: n
     type(ksp_monitor_t) :: ksp_results(4)
+    type(field_t), pointer :: temp1, temp2, temp3, temp4
+    type(field_t), pointer :: temp5, temp6
+    type(field_t), pointer :: u_e, v_e, w_e
+    integer :: temp_indices(9)
+
     n = this%dm_Xh%size()
 
     call profiler_start_region('Fluid')
@@ -378,6 +383,16 @@ contains
          prs_max_iter => this%params%prs_max_iter, &
          vel_max_iter => this%params%vel_max_iter)
          
+      ! Get temporary arrays
+      call this%scratch%request_field(temp1, temp_indices(1))
+      call this%scratch%request_field(temp2, temp_indices(2))
+      call this%scratch%request_field(temp3, temp_indices(3))
+      call this%scratch%request_field(temp4, temp_indices(4))
+      call this%scratch%request_field(temp5, temp_indices(5))
+      call this%scratch%request_field(temp6, temp_indices(6))
+      call this%scratch%request_field(u_e, temp_indices(7))
+      call this%scratch%request_field(v_e, temp_indices(8))
+      call this%scratch%request_field(w_e, temp_indices(9))
 
       call sumab%compute_fluid(u_e, v_e, w_e, u, v, w, &
            ulag, vlag, wlag, ext_bdf%advection_coeffs, ext_bdf%nadv)
@@ -417,9 +432,7 @@ contains
       ! compute pressure
       call profiler_start_region('Pressure residual')
       call prs_res%compute(p, p_res, u, v, w, u_e, v_e, w_e, &
-                           ta1, ta2, ta3, wa1, wa2, wa3, &
-                           this%work1, this%work2, f_Xh, &
-                           c_Xh, gs_Xh, this%bc_prs_surface, &
+                           f_Xh, c_Xh, gs_Xh, this%bc_prs_surface, &
                            this%bc_sym_surface, Ax, ext_bdf%diffusion_coeffs(1), &
                            params%dt, params%Re, params%rho)
       

--- a/src/fluid/fluid_scheme.f90
+++ b/src/fluid/fluid_scheme.f90
@@ -64,6 +64,7 @@ module fluid_scheme
   use operators, only : cfl
   use logger
   use field_registry
+  use scratch_registry, only : scratch_registry_t
   implicit none
   
   !> Base type of all fluid formulations
@@ -206,6 +207,8 @@ contains
     call coef_init(this%c_Xh, this%gs_Xh)
 
     call source_init(this%f_Xh, this%dm_Xh)
+    
+    this%scratch = scratch_registry_t(this%dm_Xh, 10, 2)
 
     !
     ! Setup velocity boundary conditions
@@ -463,6 +466,8 @@ contains
     call source_free(this%f_Xh)
 
     call bc_list_free(this%bclst_vel)
+    
+    call this%scratch%free()
 
     nullify(this%params)
 

--- a/src/fluid/fluid_scheme.f90
+++ b/src/fluid/fluid_scheme.f90
@@ -95,6 +95,7 @@ module fluid_scheme
      type(mean_flow_t) :: mean                 !< Mean flow field
      type(fluid_stats_t) :: stats                 !< Fluid statistics
      type(mean_sqr_flow_t) :: mean_sqr         !< Mean squared flow field
+     type(scratch_registry_t) :: scratch       !< Manager for temporary fields
    contains
      procedure, pass(this) :: fluid_scheme_init_all
      procedure, pass(this) :: fluid_scheme_init_uvw

--- a/src/fluid/fluid_volflow.f90
+++ b/src/fluid/fluid_volflow.f90
@@ -72,7 +72,7 @@ module fluid_volflow
   use neko_config
   use device_math
   use device_mathops
-  use scratch_registry
+  use scratch_registry, only : scratch_registry_t
   implicit none
   private
   

--- a/src/fluid/pnpn_res.f90
+++ b/src/fluid/pnpn_res.f90
@@ -57,9 +57,8 @@ module pnpn_residual
 
     
   abstract interface
-     subroutine prs_res(p, p_res, u, v, w, u_e, v_e, w_e, &
-       ta1, ta2, ta3, wa1, wa2, wa3, work1, work2, f_Xh, c_xh, gs_Xh, &
-       bc_prs_surface, bc_sym_surface, Ax, bd, dt, Re, rho)
+     subroutine prs_res(p, p_res, u, v, w, u_e, v_e, w_e, f_Xh, c_xh, gs_Xh, &
+          bc_prs_surface, bc_sym_surface, Ax, bd, dt, Re, rho)
        import field_t
        import Ax_t
        import gs_t
@@ -69,9 +68,6 @@ module pnpn_residual
        import rp
        type(field_t), intent(inout) :: p, u, v, w
        type(field_t), intent(inout) :: u_e, v_e, w_e !< time-extrapolated velocity
-       type(field_t), intent(inout) :: ta1, ta2, ta3 !< work arrays
-       type(field_t), intent(inout) :: wa1, wa2, wa3 !< work arrays 
-       type(field_t), intent(inout) :: work1, work2
        type(field_t), intent(inout) :: p_res
        type(source_t), intent(inout) :: f_Xh !< momentum source terms
        type(coef_t), intent(inout) :: c_Xh

--- a/src/fluid/pnpn_res.f90
+++ b/src/fluid/pnpn_res.f90
@@ -41,6 +41,7 @@ module pnpn_residual
   use space, only : space_t
   use mesh, only : mesh_t
   use num_types, only : rp
+  use scratch_registry, only : scratch_registry_t
   implicit none
   
   !> Abstract type to compute pressure residual
@@ -84,7 +85,7 @@ module pnpn_residual
 
   abstract interface
      subroutine vel_res(Ax, u, v, w, u_res, v_res, w_res, &
-          p, ta1, ta2, ta3, f_Xh, c_Xh, msh, Xh, Re, rho, bd, dt, n)
+          p, f_Xh, c_Xh, msh, Xh, Re, rho, bd, dt, n)
        import field_t
        import Ax_t
        import gs_t
@@ -99,7 +100,6 @@ module pnpn_residual
        type(space_t), intent(inout) :: Xh    
        type(field_t), intent(inout) :: p, u, v, w
        type(field_t), intent(inout) :: u_res, v_res, w_res
-       type(field_t), intent(inout) :: ta1, ta2, ta3
        type(source_t), intent(inout) :: f_Xh
        type(coef_t), intent(inout) :: c_Xh
        real(kind=rp), intent(in) :: Re

--- a/src/neko.f90
+++ b/src/neko.f90
@@ -81,6 +81,7 @@ module neko
   use field_registry
   use vector
   use system
+  use scratch_registry, only : neko_scratch_registry
   !$ use omp_lib
 
 contains
@@ -251,6 +252,7 @@ contains
     end if
     
     call neko_field_registry%free()
+    call neko_scratch_registry%free()
     call device_finalize
     call mpi_types_free
     call comm_free


### PR DESCRIPTION
Towards removing temporaries in fluid_pnpn.  WIP, but things seem to work. I don't like that one does a linear search through the scratch registry 8 times per time-step. But this should not be overthought, since the direction is to change the interfaces of the stuff called inside `step` in a way that I can just pass the registry to them.