### PR TITLE
Improvements and tests for fd_weights_full 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -300,7 +300,9 @@ AC_CONFIG_FILES([tests/stack/Makefile\
 		 tests/device_mathops/Makefile\
 		 tests/octree/Makefile\
        tests/vector/Makefile\
-       tests/scratch_registry/Makefile])
+       tests/scratch_registry/Makefile\
+       tests/fast3d/Makefile
+       ])
 
 if test "x${enable_contrib}" = xyes; then
    AC_CONFIG_FILES([contrib/Makefile\

--- a/src/math/fast3d.f90
+++ b/src/math/fast3d.f90
@@ -63,28 +63,54 @@ module fast3d
   use speclib
   use math
   implicit none
-  private
 
   public :: fd_weights_full, semhat, setup_intp
 
 contains
 
-  !> Evaluates the derivative based on all points in the stencils  
+  !> Compute finite-difference stencil weights for evaluating derivatives up to
+  !! order \f$m\f$ at a point.
   !! @details
-  !! This set of routines comes from the appendix of                       
-  !! A Practical Guide to Pseudospectral Methods, B. Fornberg              
-  !! Cambridge Univ. Press, 1996.
-  subroutine fd_weights_full(xx, x, n, m, c)
+  !! This routine comes from the Appendix C of
+  !! "A Practical Guide to Pseudospectral Methods" by B. Fornberg,
+  !! Cambridge University Press, 1996.
+  !!
+  !! Given gridpoints \f$ x_0, x_1, \dots x_n \f$ and some point \f$\xi\f$
+  !! (not necessarily a grid point!) find weights \f$ c_{j, k} \f$, such that
+  !! the expansions 
+  !! \f$ \frac{d^k f}{d x^k}|_{x=\xi} \approx \sum_{j=0}^n c_{j,k} f(x_j)\f$,
+  !! \f$k=0, \dots m\f$ are optimal.
+  !! Note that finite-difference stencils are exactly such type of expansions.
+  !! For the derivation of the algorithm, refer to 3.1 in the reference above.
+  !!
+  !! @note - Setting \f$m=0\f$ makes is this a polynomial interpolation routine.
+  !! It is the fastest such routine possible for a single interpolation point,
+  !! according to the above reference.
+  !! @note - The name `_full` refers to the fact that we use the values \f$f(x_j)\f$
+  !! at all available nodes \f$x\f$ to construct the expansion. So we always
+  !! get the finite difference stencil of maximum order possible.
+  !!
+  !! @warning The calculation of the wieghts is numerically stable.
+  !! But applying the weights to a function can be ill-conditioned in the case
+  !! of high-order derivatives. 
+  !!
+  !! @param xi Point at which the approximations are to be accurate
+  !! @param x The coordinates for the grid points
+  !! @param[in] n The size of `x` is `n + 1`
+  !! @param[in] m Highest order of derivative to be approximated
+  !! @param c The stencil weights. Row j corresponds to weight of \f$f(x_j)\f$
+  !! and column k to the kth derivative.
+  subroutine fd_weights_full(xi, x, n, m, c)
     integer, intent(in) :: n
     integer, intent(in) :: m
     real(kind=rp), intent(in) :: x(0:n)
     real(kind=rp), intent(out) :: c(0:n,0:m)
-    real(kind=rp), intent(in) :: xx
+    real(kind=rp), intent(in) :: xi
     real(kind=rp) :: c1, c2, c3, c4, c5
     integer :: i, j, k, mn
 
     c1 = 1d0
-    c4 = x(0) - xx
+    c4 = x(0) - xi
 
     do k = 0, m
        do j = 0, n
@@ -98,7 +124,7 @@ contains
        mn = min(i,m)
        c2 = 1d0  
        c5 = c4                                                       
-       c4 = x(i) - xx
+       c4 = x(i) - xi
        do j = 0, i - 1                                                  
           c3 = x(i) - x(j)
           c2 = c2 * c3                                                    

--- a/src/math/fast3d.f90
+++ b/src/math/fast3d.f90
@@ -83,7 +83,7 @@ contains
   !! Note that finite-difference stencils are exactly such type of expansions.
   !! For the derivation of the algorithm, refer to 3.1 in the reference above.
   !!
-  !! @note - Setting \f$m=0\f$ makes is this a polynomial interpolation routine.
+  !! @note - Setting \f$m=0\f$ makes this a polynomial interpolation routine.
   !! It is the fastest such routine possible for a single interpolation point,
   !! according to the above reference.
   !! @note - The name `_full` refers to the fact that we use the values \f$f(x_j)\f$

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -28,3 +28,4 @@ gather_scatter/gather_scatter_suite
 jobctrl/jobctrl_suite
 mean_sqr_field/mean_sqr_field_suite
 scratch_registry/scratch_registry_test
+fast3d/fast3d_test

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -25,7 +25,8 @@ SUBDIRS = tuple\
 	  device_mathops\
 	  octree\
 	  vector\
-	  scratch_registry
+	  scratch_registry\
+	  fast3d
 
 TESTS = device/device_test\
 	tuple/tuple_test\
@@ -54,7 +55,8 @@ TESTS = device/device_test\
 	device_mathops/device_mathops_test\
     octree/octree_test\
 	vector/vector_test\
-	scratch_registry/scratch_registry_test
+	scratch_registry/scratch_registry_test\
+	fast3d/fast3d_test
 
 # Note we need to list .pf and runner scripts manually
 EXTRA_DIST = \
@@ -110,4 +112,5 @@ EXTRA_DIST = \
 	device_math/device_math_test\
 	octree/octree.pf\
 	vector/vector_parallel.pf\
-	scratch_registry/test_scratch_registry.pf
+	scratch_registry/test_scratch_registry.pf\
+    fast3d/test_fd_weights_full.pf

--- a/tests/fast3d/Makefile.in
+++ b/tests/fast3d/Makefile.in
@@ -1,0 +1,27 @@
+USEMPI=YES
+ifneq ("$(wildcard @PFUNIT_DIR@/include/PFUNIT.mk)", "")
+include @PFUNIT_DIR@/include/PFUNIT.mk
+endif
+FFLAGS += $(PFUNIT_EXTRA_FFLAGS) -I@top_builddir@/src
+FC = @FC@
+
+%.o : %.F90
+	$(FC) -c $(FFLAGS) $<
+
+
+check: fast3d_test
+
+fast3d_test_TESTS := test_fd_weights_full.pf
+fast3d_test_OTHER_LIBRARIES = -L@top_builddir@/src -lneko @LDFLAGS@ @LIBS@
+$(eval $(call make_pfunit_test,fast3d_test))
+
+
+clean:
+	$(RM) *.o *.mod *.a  *.inc *.F90  fast3d_test
+
+
+
+all:
+html:
+install:
+distdir:

--- a/tests/fast3d/Makefile.in
+++ b/tests/fast3d/Makefile.in
@@ -1,4 +1,3 @@
-USEMPI=YES
 ifneq ("$(wildcard @PFUNIT_DIR@/include/PFUNIT.mk)", "")
 include @PFUNIT_DIR@/include/PFUNIT.mk
 endif

--- a/tests/fast3d/test_fd_weights_full.pf
+++ b/tests/fast3d/test_fd_weights_full.pf
@@ -1,0 +1,47 @@
+ @test
+ subroutine test_linear_midpoint()
+   use pfunit
+   use fast3d
+   use num_types
+   implicit none
+   
+   integer, parameter :: n=1, m=0
+   real(kind=rp) :: xi, x(0:n), c(0:n,0:m)
+
+   ! middle of [0, 1], expect weights [0.5 0.5]
+   xi = 0.5_rp
+   x(0) = 0_rp
+   x(1) = 1_rp
+   
+   call fd_weights_full(xi, x, n, m, c)
+   @assertEqual(c(0, 0), 0.5_rp)
+   @assertEqual(c(1, 0), 0.5_rp)
+end subroutine test_linear_midpoint
+
+ @test
+ subroutine test_central_difference()
+   use pfunit
+   use fast3d
+   use num_types
+   implicit none
+   
+   integer, parameter :: n=2, m=1
+   real(kind=rp) :: xi, x(0:n), c(0:n,0:m)
+
+   ! middle of [0, 1] with 3 grid points
+   xi = 0.5_rp
+   x(0) = 0_rp
+   x(1) = 0.5_rp
+   x(2) = 1.0_rp
+   
+   call fd_weights_full(xi, x, n, m, c)
+   ! xi is a grid point, so for interpolation we should have [0, 1, 0]
+   @assertEqual(c(0, 0), 0.0_rp)
+   @assertEqual(c(1, 0), 1.0_rp)
+   @assertEqual(c(2, 0), 0.0_rp)
+
+   ! for the derivative we expect a standard central difference [-1, 0, 1] 
+   @assertEqual(c(0, 1), -1.0_rp)
+   @assertEqual(c(1, 1), 0.0_rp)
+   @assertEqual(c(2, 1), 1.0_rp)
+end subroutine test_central_difference


### PR DESCRIPTION
* Improves the documentation a lot. The previous one is simply wrong, this routine does not evaluate anything, just computes weights! All the info is taken from Fornberg's book, which seems very nice, by the way.
* Added 2 simple tests that serve as documentation as well. Weights for simple linear interpolation and a classical 2nd order central difference.
* Refactored `xx` to `xi`. Sorry, couldn't resist. `xi` corresponds nicely to the $\xi$ in the mathematical formulation.