### PR TITLE
Add output fields from examples to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,7 @@ tests/*/*.trs
 Doxyfile
 doxygen.stamp
 doc/html
+examples/*/*.nek5000
+examples/*/*0.f0*
 
 


### PR DESCRIPTION
Cherry-picked out of #809, so this can be merged and just better PR granularity.