### PR TITLE
Scratch registry improvements

### DIFF
--- a/src/field/scratch_registry.f90
+++ b/src/field/scratch_registry.f90
@@ -109,12 +109,15 @@ contains
     class(scratch_registry_t), intent(inout):: this
     integer :: i
 
-    do i=1, this%nfields
-       call field_free(this%fields(i)%field)
-       deallocate(this%fields(i)%field)
-    end do
-    deallocate(this%fields)
-    deallocate(this%inuse)
+    if (allocated(this%fields)) then
+       do i=1, this%nfields
+          call field_free(this%fields(i)%field)
+          deallocate(this%fields(i)%field)
+       end do
+    
+       deallocate(this%fields)
+       deallocate(this%inuse)
+    end if
   end subroutine scratch_registry_free
 
 

--- a/src/field/scratch_registry.f90
+++ b/src/field/scratch_registry.f90
@@ -61,7 +61,9 @@ module scratch_registry
      procedure, pass(this) :: get_size                      !< return size of allocated fields
      procedure, pass(this) :: get_inuse                     !< get value of inuse for a given index
      procedure, pass(this) :: request_field                 !< get a new scratch field
-     procedure, pass(this) :: relinquish_field              !< free a field for later reuse
+     procedure, pass(this) :: relinquish_field_single
+     procedure, pass(this) :: relinquish_field_multiple
+     generic :: relinquish_field => relinquish_field_single, relinquish_field_multiple  !< free a field for later reuse
   end type scratch_registry_t
 
   interface scratch_registry_t
@@ -215,13 +217,24 @@ contains
   end subroutine request_field
   
   !> Relinquish the use of a field in the registry
-  subroutine relinquish_field(this, index)
+  subroutine relinquish_field_single(this, index)
     class(scratch_registry_t), target, intent(inout) :: this
     integer, intent(inout) :: index !< The index of the field to free
     
     this%inuse(index) = .false.
     this%nfields_inuse = this%nfields_inuse - 1
-  end subroutine relinquish_field
+  end subroutine relinquish_field_single
+
+  subroutine relinquish_field_multiple(this, indices)
+    class(scratch_registry_t), target, intent(inout) :: this
+    integer, intent(inout) :: indices(:) !< The indices of the field to free
+    integer :: i
+
+    do i=1, size(indices)
+      this%inuse(indices(i)) = .false.
+    end do
+    this%nfields_inuse = this%nfields_inuse - size(indices) 
+  end subroutine relinquish_field_multiple
 
   logical function get_inuse(this, index)
     class(scratch_registry_t), target, intent(inout) :: this

--- a/tests/scratch_registry/test_scratch_registry.pf
+++ b/tests/scratch_registry/test_scratch_registry.pf
@@ -257,4 +257,54 @@ contains
     
     
 end subroutine test_scratch_registry_combo
+
+ @test
+ subroutine test_scratch_registry_array_indices()
+   type(space_t) :: Xh
+   type(mesh_t) :: msh
+   type(dofmap_t) :: dm
+   type(scratch_registry_t), target :: scratch
+   type(field_t), pointer :: f1, f2, f3
+   integer :: ierr
+   integer :: indices(3)
+     
+   integer, parameter :: LX = 2
+
+   call test_scratch_registry_gen_msh(msh)
+   call space_init(Xh, GLL, lx, lx, lx)
+   dm = dofmap_t(msh, Xh)
+    
+  !  write(*,*) "TEST COMBO"
+   scratch = scratch_registry_t(dm, 2, 2) 
+    
+   ! add 2 fields, no expansion
+   call scratch%request_field(f1, indices(1))
+   call scratch%request_field(f2, indices(2))
+   call scratch%request_field(f3, indices(3))
+
+   @assertEqual(indices(1), 1)
+   @assertEqual(indices(2), 2)
+   @assertEqual(indices(3), 3)
+   
+   call cfill(f1%x, 1.0_rp, f1%dof%size())
+   call cfill(f2%x, 2.0_rp, f2%dof%size())
+   call cfill(f3%x, 2.0_rp, f2%dof%size())
+
+   ! get rid of the fields
+   call scratch%relinquish_field(indices)
+   @assertEqual(scratch%get_inuse(indices(1)), .false.)
+   @assertEqual(scratch%get_inuse(indices(2)), .false.)
+   @assertEqual(scratch%get_inuse(indices(3)), .false.)
+   @assertEqual(scratch%get_nfields(), 3)
+   @assertEqual(scratch%get_nfields_inuse(), 0)
+    
+   ! get a new field, should get index 1
+   call scratch%request_field(f1, indices(1))
+   call cfill(f1%x, 1.5_rp, f1%dof%size())
+   @assertEqual(indices(1), 1)
+   @assertEqual(scratch%get_inuse(indices(1)), .true.)
+   @assertEqual(scratch%get_nfields(), 3)
+   @assertEqual(scratch%get_nfields_inuse(), 1)
+    
+end subroutine test_scratch_registry_array_indices
 end module test_scratch_registry


### PR DESCRIPTION
This cherry-picks commits pertaining to the scratch registry from #809, so that #809 does not become a monster PR.

- Adds possibility to relinquish several fields at once by passing an array of indices.
- Adds a test for the above.
- Fixes a bug in the destructor, now checks if stuff has been allocated before attempting to free it.
