### PR TITLE
Refactor ext_bdf_scheme_t

### DIFF
--- a/src/case.f90
+++ b/src/case.f90
@@ -265,7 +265,7 @@ contains
     !
     ! Set order of timestepper
     !
-    call C%ext_bdf%set_time_order(C%params%time_order)
+    call C%ext_bdf%init(C%params%time_order)
 
     !
     ! Save boundary markings for fluid (if requested)

--- a/src/common/ext_bdf_scheme.f90
+++ b/src/common/ext_bdf_scheme.f90
@@ -67,43 +67,56 @@ module ext_bdf_scheme
   use, intrinsic :: iso_c_binding
   implicit none
   private
-
-  !> Class storing time-integration coefficients for the explicit extrapolation
-  !! and Backward-differencing schemes. 
-  type, public :: ext_bdf_scheme_t
-     real(kind=rp), dimension(10) :: ext
-     real(kind=rp), dimension(10) :: bdf
-     integer :: nab = 0
-     integer :: nbd = 0
-     integer :: time_order  !< Default is 3
-     type(c_ptr) :: ext_d = C_NULL_PTR !< dev. ptr for coefficients
-     type(c_ptr) :: bdf_d = C_NULL_PTR !< dev. ptr for coefficients
+  
+  !> Base abstract class for time integration schemes
+  type, abstract, public :: time_scheme_t
+     !> The coefficients of the scheme
+     real(kind=rp), dimension(10) :: coeffs 
+     integer :: n
+     !> Order of the scheme, defaults to 3
+     integer :: time_order
+     !> Device pointer for `coeffs`
+     type(c_ptr) :: coeffs_d = C_NULL_PTR 
    contains
-     procedure, pass(this) :: set_bd => ext_bdf_scheme_set_bdf
-     procedure, pass(this) :: set_abbd => ext_bdf_scheme_set_ext
-     procedure, pass(this) :: set_time_order => ext_bdf_scheme_set_time_order
-     final :: ext_bdf_scheme_free
+     procedure(set_coeffs), deferred, pass(this) :: set_coeffs
+     procedure, pass(this) :: init => time_scheme_init 
+     procedure, pass(this) :: free => time_scheme_free
+  end type time_scheme_t
+  
+  abstract interface
+     subroutine set_coeffs(this, dt)
+       import time_scheme_t
+       import rp
+       class(time_scheme_t), intent(inout) :: this
+       real(kind=rp), intent(inout), dimension(10) :: dt !< timestep values
+     end subroutine
+  end interface
+  
+  type, public, extends(time_scheme_t) :: ext_time_scheme_t 
+     contains
+       procedure, pass(this) :: set_coeffs => ext_time_scheme_set_coeffs
+  end type ext_time_scheme_t
+
+  type, public, extends(time_scheme_t) :: bdf_time_scheme_t 
+     contains
+       procedure, pass(this) :: set_coeffs => bdf_time_scheme_set_coeffs
+  end type bdf_time_scheme_t
+  
+  type, public :: ext_bdf_scheme_t
+     type(ext_time_scheme_t) :: ext
+     type(bdf_time_scheme_t) :: bdf
+     
+     contains
+       procedure, pass(this) :: init => ext_bdf_scheme_init
+       procedure, pass(this) :: free => ext_bdf_scheme_free
   end type ext_bdf_scheme_t
 
-
 contains
+  !> Constructor for a time_scheme_t
+  subroutine time_scheme_init(this, torder)
+    class(time_scheme_t), intent(inout) :: this
+    integer, intent(in) :: torder !< Desired order of the scheme: 1, 2 or 3.
 
-  subroutine ext_bdf_scheme_free(this)
-    type(ext_bdf_scheme_t), intent(inout) :: this
-
-    if (c_associated(this%ext_d)) then
-       call device_free(this%ext_d)
-    end if
-       
-    if (c_associated(this%bdf_d)) then
-       call device_free(this%bdf_d)
-    end if
-    
-  end subroutine ext_bdf_scheme_free
-
-  subroutine ext_bdf_scheme_set_time_order(this,torder)
-    integer, intent(in) :: torder
-    class(ext_bdf_scheme_t), intent(inout) :: this
     if(torder .le. 3 .and. torder .gt. 0) then
        this%time_order = torder
     else
@@ -112,63 +125,20 @@ contains
     end if
 
     if (NEKO_BCKND_DEVICE .eq. 1) then
-       call device_map(this%ext, this%ext_d, 10)
-       call device_map(this%bdf, this%bdf_d, 10)
+       call device_map(this%coeffs, this%coeffs_d, 10)
     end if
+  end subroutine time_scheme_init
 
-  end subroutine ext_bdf_scheme_set_time_order
+  !> Destructor for time_scheme_t
+  subroutine time_scheme_free(this)
+    class(time_scheme_t), intent(inout) :: this
 
-  !>Compute backward-differentiation coefficients of order NBD
-  subroutine ext_bdf_scheme_set_bdf(this, dtbd)
-    class(ext_bdf_scheme_t), intent(inout) :: this
-    real(kind=rp), intent(inout), dimension(10) :: dtbd
-    real(kind=rp), dimension(10,10) :: bdmat
-    real(kind=rp), dimension(10) :: bdrhs
-    real(kind=rp), dimension(10) :: bd_old
-    real(kind=rp) :: bdf
-    integer, parameter :: ldim = 10
-    integer, dimension(10) :: ir, ic
-    integer :: ibd, nsys, i
+    if (c_associated(this%coeffs_d)) then
+       call device_free(this%coeffs_d)
+    end if
+  end subroutine time_scheme_free
 
-    associate(nbd => this%nbd, bd => this%bdf, bdf_d => this%bdf_d)
-      bd_old = bd
-      nbd = nbd + 1
-      nbd = min(nbd, this%time_order)
-      call rzero(bd, 10)
-      if (nbd .eq. 1) then
-         bd(1) = 1.0_rp
-         bdf = 1.0_rp
-      else if (nbd .ge. 2) then
-         nsys = nbd + 1
-         call bdsys(bdmat, bdrhs, dtbd, nbd, ldim)
-         call lu(bdmat, nsys, ldim, ir, ic)
-         call solve(bdrhs, bdmat, 1, nsys, ldim, ir, ic)
-         do i = 1, nbd
-            bd(i) = bdrhs(i)
-         end do
-         bdf = bdrhs(nbd + 1)
-      endif
-      
-      !Normalize
-      do ibd = nbd, 1, -1
-         bd(ibd + 1) = bd(ibd)
-      end do
-      bd(1) = 1.0_rp
-      do ibd= 1, nbd + 1
-         bd(ibd) = bd(ibd)/bdf
-      end do
-
-      if (c_associated(bdf_d)) then
-         if (maxval(abs(bd - bd_old)) .gt. 1e-10_rp) then
-            call device_memcpy(bd, bdf_d, 10, HOST_TO_DEVICE)
-         end if
-      end if
-    end associate
-    
-  end subroutine ext_bdf_scheme_set_bdf
-
-  !>
-  !! Compute Adams-Bashforth coefficients (order NAB, less or equal to 3)
+  !> Compute Adams-Bashforth coefficients (order NAB, less or equal to 3)
   !!   
   !! NBD .EQ. 1
   !! Standard Adams-Bashforth coefficients 
@@ -177,19 +147,19 @@ contains
   !! Modified Adams-Bashforth coefficients to be used in con-
   !! junction with Backward Differentiation schemes (order NBD)
   !!
-  subroutine ext_bdf_scheme_set_ext(this, dtlag)
-    class(ext_bdf_scheme_t), intent(inout)  :: this
-    real(kind=rp), intent(inout), dimension(10) :: dtlag
+  subroutine ext_time_scheme_set_coeffs(this, dt)
+    class(ext_time_scheme_t), intent(inout)  :: this
+    real(kind=rp), intent(inout), dimension(10) :: dt
     real(kind=rp) :: dt0, dt1, dt2, dts, dta, dtb, dtc, dtd, dte
     real(kind=rp), dimension(10) :: ab_old
-    associate(nab => this%nab, nbd => this%nbd, ext => this%ext, ext_d => this%ext_d)
+    associate(nab => this%n, nbd => this%n, ext => this%coeffs, ext_d => this%coeffs_d)
       ab_old = ext
       nab = nab + 1
       nab = min(nab, this%time_order)
     
-      dt0 = dtlag(1)
-      dt1 = dtlag(2)
-      dt2 = dtlag(3)
+      dt0 = dt(1)
+      dt1 = dt(2)
+      dt2 = dt(3)
       call rzero(ext, 10)
       
       if (nab .eq. 1) then
@@ -232,14 +202,75 @@ contains
       end if
     end associate
     
-  end subroutine ext_bdf_scheme_set_ext
+  end subroutine ext_time_scheme_set_coeffs
 
+  !>Compute backward-differentiation coefficients of order NBD
+  subroutine bdf_time_scheme_set_coeffs(this, dt)
+    class(bdf_time_scheme_t), intent(inout) :: this
+    real(kind=rp), intent(inout), dimension(10) :: dt
+    real(kind=rp), dimension(10,10) :: bdmat
+    real(kind=rp), dimension(10) :: bdrhs
+    real(kind=rp), dimension(10) :: bd_old
+    real(kind=rp) :: bdf
+    integer, parameter :: ldim = 10
+    integer, dimension(10) :: ir, ic
+    integer :: ibd, nsys, i
+
+    associate(nbd => this%n, bd => this%coeffs, bdf_d => this%coeffs_d)
+      bd_old = bd
+      nbd = nbd + 1
+      nbd = min(nbd, this%time_order)
+      call rzero(bd, 10)
+      if (nbd .eq. 1) then
+         bd(1) = 1.0_rp
+         bdf = 1.0_rp
+      else if (nbd .ge. 2) then
+         nsys = nbd + 1
+         call bdsys(bdmat, bdrhs, dt, nbd, ldim)
+         call lu(bdmat, nsys, ldim, ir, ic)
+         call solve(bdrhs, bdmat, 1, nsys, ldim, ir, ic)
+         do i = 1, nbd
+            bd(i) = bdrhs(i)
+         end do
+         bdf = bdrhs(nbd + 1)
+      endif
+      
+      !Normalize
+      do ibd = nbd, 1, -1
+         bd(ibd + 1) = bd(ibd)
+      end do
+      bd(1) = 1.0_rp
+      do ibd= 1, nbd + 1
+         bd(ibd) = bd(ibd)/bdf
+      end do
+
+      if (c_associated(bdf_d)) then
+         if (maxval(abs(bd - bd_old)) .gt. 1e-10_rp) then
+            call device_memcpy(bd, bdf_d, 10, HOST_TO_DEVICE)
+         end if
+      end if
+    end associate
+    
+  end subroutine bdf_time_scheme_set_coeffs
+
+  !> Contructor for ext_bdf_scheme_t
+  subroutine ext_bdf_scheme_init(this, torder)
+     class(ext_bdf_scheme_t) :: this
+     integer :: torder !< Desired order of the scheme: 1, 2 or 3.
+     call time_scheme_init(this%ext, torder)
+     call time_scheme_init(this%bdf, torder)
+  end subroutine ext_bdf_scheme_init
+
+  !> Destructor for ext_bdf_scheme_t
+  subroutine ext_bdf_scheme_free(this)
+     class(ext_bdf_scheme_t) :: this
+     call time_scheme_free(this%ext)
+     call time_scheme_free(this%bdf)
+  end subroutine ext_bdf_scheme_free
+  
   !
   ! todo: CLEAN UP THIS MESS BELOW, USE LAPACK OR SIMILAR
   !
-
-
-  
   subroutine bdsys (a, b, dt, nbd, ldim)
     integer :: ldim, j, n, k, i, nsys, nbd
     real(kind=rp) ::  A(ldim,9),B(9),DT(9)
@@ -376,8 +407,7 @@ contains
          END DO
       END DO
     END SUBROUTINE SOLVE
-
-  
+    
 
   
 end module ext_bdf_scheme

--- a/src/fluid/bcknd/device/device_fluid_plan4.f90
+++ b/src/fluid/bcknd/device/device_fluid_plan4.f90
@@ -43,10 +43,10 @@ contains
          ulag => this%ulag, vlag => this%vlag, wlag => this%wlag, &
          params => this%params, msh => this%msh)
 
-      call device_fluid_plan4_sumab(u_e%x, u%x, ulag ,n, ext_bdf%ext, ext_bdf%nab)
-      call device_fluid_plan4_sumab(v_e%x, v%x, vlag ,n, ext_bdf%ext, ext_bdf%nab)
+      call device_fluid_plan4_sumab(u_e%x, u%x, ulag ,n, ext_bdf%ext%coeffs, ext_bdf%ext%n)
+      call device_fluid_plan4_sumab(v_e%x, v%x, vlag ,n, ext_bdf%ext%coeffs, ext_bdf%ext%n)
       if (msh%gdim .eq. 3) then
-         call device_fluid_plan4_sumab(w_e%x, w%x, wlag,n, ext_bdf%ext, ext_bdf%nab)
+         call device_fluid_plan4_sumab(w_e%x, w%x, wlag,n, ext_bdf%ext%coeffs, ext_bdf%ext%n)
       end if
 
       call f_Xh%eval(t)
@@ -62,13 +62,13 @@ contains
                           this%abx1, this%aby1, this%abz1,&
                           this%abx2, this%aby2, this%abz2, &
                           f_Xh%u_d, f_Xh%v_d, f_Xh%w_d,&
-                          params%rho, ext_bdf%ext, n, msh%gdim)
+                          params%rho, ext_bdf%ext%coeffs, n, msh%gdim)
       call device_makebdf(ta1, ta2, ta3,&
                           this%wa1, this%wa2, this%wa3,&
                           c_Xh%h2_d, ulag, vlag, wlag, &
                           f_Xh%u_d, f_Xh%v_d, f_Xh%w_d, u, v, w,&
                           c_Xh%B_d, params%rho, params%dt, &
-                          ext_bdf%bdf, ext_bdf%nbd, n, msh%gdim)
+                          ext_bdf%bdf%coeffs, ext_bdf%bdf%n, n, msh%gdim)
 
       call ulag%update()
       call vlag%update()
@@ -88,7 +88,7 @@ contains
                                             this%wa1, this%wa2, this%wa3, &
                                             this%work1, this%work2, f_Xh, &
                                             c_Xh, gs_Xh, this%bc_prs_surface, &
-                                            Ax, ext_bdf%bdf(1), params%dt, &
+                                            Ax, ext_bdf%bdf%coeffs(1), params%dt, &
                                             params%Re, params%rho)
 
       !Sets tolerances
@@ -109,7 +109,7 @@ contains
 
       !We only need to update h2 once I think then use the flag to switch on/off
       call device_fluid_plan4_vel_setup(c_Xh%h1_d, c_Xh%h2_d, &
-                                        params%Re, params%rho, ext_bdf%bdf(1), &
+                                        params%Re, params%rho, ext_bdf%bdf%coeffs(1), &
                                         params%dt, dm_Xh%size(), c_Xh%ifh2)
     
       call device_fluid_plan4_vel_residual(Ax, u, v, w, &

--- a/src/fluid/fluid_plan4.f90
+++ b/src/fluid/fluid_plan4.f90
@@ -293,10 +293,13 @@ contains
          ulag => this%ulag, vlag => this%vlag, wlag => this%wlag, &
          params => this%params, msh => this%msh)
 
-      call fluid_plan4_sumab(u_e%x, u%x, ulag ,n, ext_bdf%ext, ext_bdf%nab)
-      call fluid_plan4_sumab(v_e%x, v%x, vlag ,n, ext_bdf%ext, ext_bdf%nab)
+      call fluid_plan4_sumab(u_e%x, u%x, ulag ,n, ext_bdf%ext%coeffs, &
+                             ext_bdf%ext%n)
+      call fluid_plan4_sumab(v_e%x, v%x, vlag ,n, ext_bdf%ext%coeffs, &
+                             ext_bdf%ext%n)
       if (msh%gdim .eq. 3) then
-         call fluid_plan4_sumab(w_e%x, w%x, wlag,n, ext_bdf%ext, ext_bdf%nab)
+         call fluid_plan4_sumab(w_e%x, w%x, wlag,n, ext_bdf%ext%coeffs, &
+                                ext_bdf%ext%n)
       end if
 
       call f_Xh%eval(t)
@@ -309,13 +312,13 @@ contains
                   this%abx1, this%aby1, this%abz1,&
                   this%abx2, this%aby2, this%abz2, &
                   f_Xh%u, f_Xh%v, f_Xh%w,&
-                  params%rho, ext_bdf%ext, n, msh%gdim)
+                  params%rho, ext_bdf%ext%coeffs, n, msh%gdim)
       call makebdf(ta1, ta2, ta3,&
                    this%wa1, this%wa2, this%wa3,&
                    c_Xh%h2, ulag, vlag, wlag, &
                    f_Xh%u, f_Xh%v, f_Xh%w, u, v, w,&
                    c_Xh%B, params%rho, params%dt, &
-                   ext_bdf%bdf, ext_bdf%nbd, n, msh%gdim)
+                   ext_bdf%bdf%coeffs, ext_bdf%bdf%n, n, msh%gdim)
 
       call ulag%update()
       call vlag%update()
@@ -334,7 +337,7 @@ contains
                                      this%wa1, this%wa2, this%wa3, &
                                      this%work1, this%work2, f_Xh, &
                                      c_Xh, gs_Xh, this%bc_prs_surface, &
-                                     Ax, ext_bdf%bdf(1), params%dt, &
+                                     Ax, ext_bdf%bdf%coeffs(1), params%dt, &
                                      params%Re, params%rho)
 
       !Sets tolerances
@@ -353,7 +356,7 @@ contains
     
       !We only need to update h2 once I think then use the flag to switch on/off
       call fluid_plan4_vel_setup(c_Xh%h1, c_Xh%h2, &
-                                 params%Re, params%rho, ext_bdf%bdf(1), &
+                                 params%Re, params%rho, ext_bdf%bdf%coeffs(1), &
                                  params%dt, dm_Xh%size(), c_Xh%ifh2)
     
       call fluid_plan4_vel_residual(Ax, u, v, w, &
@@ -683,7 +686,7 @@ contains
 
       call fluid_plan4_vel_setup(c%h1, c%h2, &
                                  this%params%Re, this%params%rho,&
-                                 ext_bdf%bdf(1), &
+                                 ext_bdf%bdf%coeffs(1), &
                                  this%params%dt, n, c%ifh2)
       call gs_op(this%gs_Xh, u_res, GS_OP_ADD) 
       call gs_op(this%gs_Xh, v_res, GS_OP_ADD) 
@@ -739,12 +742,12 @@ contains
 
       ifcomp = 0.0_rp
 
-      if (this%params%dt .ne. this%dtlag .or. ext_bdf%bdf(1) .ne. this%bdlag) then
+      if (this%params%dt .ne. this%dtlag .or. ext_bdf%bdf%coeffs(1) .ne. this%bdlag) then
          ifcomp = 1.0_rp
       end if
 
       this%dtlag = this%params%dt
-      this%bdlag = ext_bdf%bdf(1)
+      this%bdlag = ext_bdf%bdf%coeffs(1)
 
       call MPI_Allreduce(MPI_IN_PLACE, ifcomp, 1, &
            MPI_REAL_PRECISION, MPI_SUM, NEKO_COMM, ierr)

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -379,7 +379,7 @@ contains
          
 
       call sumab%compute_fluid(u_e, v_e, w_e, u, v, w, &
-           ulag, vlag, wlag, ext_bdf%ext, ext_bdf%nab)
+           ulag, vlag, wlag, ext_bdf%ext%coeffs, ext_bdf%ext%n)
      
       call f_Xh%eval(t)
 
@@ -397,12 +397,12 @@ contains
                            this%abx1, this%aby1, this%abz1,&
                            this%abx2, this%aby2, this%abz2, &
                            f_Xh%u, f_Xh%v, f_Xh%w,&
-                           params%rho, ext_bdf%ext, n)
+                           params%rho, ext_bdf%ext%coeffs, n)
 
       call makebdf%compute_fluid(ta1, ta2, ta3, this%wa1, this%wa2, this%wa3,&
                            ulag, vlag, wlag, f_Xh%u, f_Xh%v, f_Xh%w, &
                            u, v, w, c_Xh%B, params%rho, params%dt, &
-                           ext_bdf%bdf, ext_bdf%nbd, n)
+                           ext_bdf%bdf%coeffs, ext_bdf%bdf%n, n)
 
       call ulag%update()
       call vlag%update()
@@ -419,7 +419,7 @@ contains
                            ta1, ta2, ta3, wa1, wa2, wa3, &
                            this%work1, this%work2, f_Xh, &
                            c_Xh, gs_Xh, this%bc_prs_surface, &
-                           this%bc_sym_surface, Ax, ext_bdf%bdf(1), &
+                           this%bc_sym_surface, Ax, ext_bdf%bdf%coeffs(1), &
                            params%dt, params%Re, params%rho)
       
       call gs_op(gs_Xh, p_res, GS_OP_ADD) 
@@ -455,7 +455,7 @@ contains
                            u_res, v_res, w_res, &
                            p, ta1, ta2, ta3, &
                            f_Xh, c_Xh, msh, Xh, &
-                           params%Re, params%rho, ext_bdf%bdf(1), &
+                           params%Re, params%rho, ext_bdf%bdf%coeffs(1), &
                            params%dt, dm_Xh%size())
       
       call gs_op(gs_Xh, u_res, GS_OP_ADD) 

--- a/src/fluid/fluid_volflow.f90
+++ b/src/fluid/fluid_volflow.f90
@@ -335,19 +335,19 @@ contains
       
       ifcomp = 0.0_rp
 
-      if (dt .ne. this%dtlag .or. ext_bdf%bdf(1) .ne. this%bdlag) then
+      if (dt .ne. this%dtlag .or. ext_bdf%bdf%coeffs(1) .ne. this%bdlag) then
          ifcomp = 1.0_rp
       end if
       
       this%dtlag = dt
-      this%bdlag = ext_bdf%bdf(1)
+      this%bdlag = ext_bdf%bdf%coeffs(1)
 
       call MPI_Allreduce(MPI_IN_PLACE, ifcomp, 1, &
            MPI_REAL_PRECISION, MPI_SUM, NEKO_COMM, ierr)
     
       if (ifcomp .gt. 0d0) then
          call this%compute(u_res, v_res, w_res, p_res, &
-              ta1, ta2, ta3, ext_bdf, gs_Xh, c_Xh, rho, Re, ext_bdf%bdf(1), dt, &
+              ta1, ta2, ta3, ext_bdf, gs_Xh, c_Xh, rho, Re, ext_bdf%bdf%coeffs(1), dt, &
               bclst_dp, bclst_du, bclst_dv, bclst_dw, bclst_vel_res, &
               Ax, ksp_vel, ksp_prs, pc_prs, pc_vel, niter)
       end if

--- a/src/scalar/scalar_pnpn.f90
+++ b/src/scalar/scalar_pnpn.f90
@@ -240,10 +240,10 @@ contains
                                  Xh, this%c_Xh, dm_Xh%size())
 
       call makeext%compute_scalar(ta1, this%abx1, this%abx2, f_Xh%s, &
-           params%rho, ext_bdf%ext, n)
+           params%rho, ext_bdf%ext%coeffs, n)
 
       call makebdf%compute_scalar(ta1, wa1, slag, f_Xh%s, s, c_Xh%B, &
-           params%rho, params%dt, ext_bdf%bdf, ext_bdf%nbd, n)
+           params%rho, params%dt, ext_bdf%bdf%coeffs, ext_bdf%bdf%n, n)
 
       call slag%update()
       !> We assume that no change of boundary conditions 
@@ -254,7 +254,7 @@ contains
       ! compute scalar residual
       call profiler_start_region('Scalar residual')
       call res%compute(Ax, s,  s_res, f_Xh, c_Xh, msh, Xh, params%Pr, &
-          params%Re, params%rho, ext_bdf%bdf(1), params%dt, &
+          params%Re, params%rho, ext_bdf%bdf%coeffs(1), params%dt, &
           dm_Xh%size())
 
       call gs_op(gs_Xh, s_res, GS_OP_ADD) 

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -158,8 +158,8 @@ contains
 
     t = t + dt
 
-    call ext_bdf%set_bd(dtlag)
-    call ext_bdf%set_abbd(dtlag)
+    call ext_bdf%bdf%set_coeffs(dtlag)
+    call ext_bdf%ext%set_coeffs(dtlag)
     
   end subroutine simulation_settime
 


### PR DESCRIPTION
This is the beginning of the effort towards issue #114 and the cleanup of the BDF class.

* I introduce  a `time_scheme_t` as an ABC for both BDF and EXT, which also get their own type. This is done mainly to make it possible to test schemes individually, but I think there is a certain elegance in having them both sharing a common interface.
* I have, however, kept everything in the same module for now, since the change of us adding more schemes seems minimal.
* To minimally change the rest of Neko, `ext_bdf_scheme_t` remains, but is now just a composition of a `bdf_time_scheme_t` and `ext_time_scheme_t`. 
* `set_time_order` is changed to `init` because it not only set the order, but also took care of the device pointer, so it is typical a constructor.
* As a side-bonus, `nab` is gone, which is at this point mysterious: it's a remnant of referring to the EXT schemes as Adam-Bashforth. 