### PR TITLE
Hotfix time_scheme%n initialization

### DIFF
--- a/src/common/ext_bdf_scheme.f90
+++ b/src/common/ext_bdf_scheme.f90
@@ -72,7 +72,8 @@ module ext_bdf_scheme
   type, abstract, public :: time_scheme_t
      !> The coefficients of the scheme
      real(kind=rp), dimension(10) :: coeffs 
-     integer :: n
+     !> Controls the actual order of the scheme, e.g. 1 at the first time-step
+     integer :: n = 0
      !> Order of the scheme, defaults to 3
      integer :: time_order
      !> Device pointer for `coeffs`


### PR DESCRIPTION
Initializes the counter in the `time_scheme_t` class to 0. Missed in the refactoring and now discovered during testing. Since this totally breaks the code unless it magically inits to 0, we gotta merge this asap, so separate PR.