### PR TITLE
Cleanup of bdf_time_scheme_t; adding its docs and tests

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -140,7 +140,7 @@ jobs:
         if: matrix.backend == 'cpu' && failure()
         uses: actions/upload-artifact@v2
         with:
-          name: Test report / ${{ matrix.os }} / ${{ matrix.compiler }}
+          name: Test report_${{ matrix.os }}_${{ matrix.compiler }}
           path: tests/test-suite.log
           retention-days: 2
       - name: Dist (CPU backend)

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -136,6 +136,13 @@ jobs:
         if: matrix.backend == 'cpu'
         run: |
           make -j$(nproc) check
+      - name: Archive test report
+        if: matrix.backend == 'cpu' && failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Test report / ${{ matrix.os }} / ${{ matrix.compiler }}
+          path: tests/test-suite.log
+          retention-days: 2
       - name: Dist (CPU backend)
         if: matrix.backend == 'cpu'
         run: |

--- a/configure.ac
+++ b/configure.ac
@@ -301,7 +301,8 @@ AC_CONFIG_FILES([tests/stack/Makefile\
 		 tests/octree/Makefile\
        tests/vector/Makefile\
        tests/scratch_registry/Makefile\
-       tests/fast3d/Makefile
+       tests/fast3d/Makefile\
+       tests/ext_bdf_scheme/Makefile
        ])
 
 if test "x${enable_contrib}" = xyes; then

--- a/src/common/bcknd/cpu/rhs_maker_cpu.f90
+++ b/src/common/bcknd/cpu/rhs_maker_cpu.f90
@@ -54,7 +54,7 @@ contains
     type(field_t), intent(inout) :: temp1, temp2, temp3
     type(field_t), intent(inout) :: fx_lag, fy_lag, fz_lag
     type(field_t), intent(inout) :: fx_laglag, fy_laglag, fz_laglag
-    real(kind=rp), intent(inout) :: rho, ext_coeffs(10)
+    real(kind=rp), intent(inout) :: rho, ext_coeffs(4)
     integer, intent(in) :: n
     real(kind=rp), intent(inout) :: fx(n), fy(n), fz(n)
     integer :: i
@@ -90,7 +90,7 @@ contains
     type(field_t), intent(inout) :: temp1
     type(field_t), intent(inout) :: fs_lag
     type(field_t), intent(inout) :: fs_laglag
-    real(kind=rp), intent(inout) :: rho, ext_coeffs(10)
+    real(kind=rp), intent(inout) :: rho, ext_coeffs(4)
     integer, intent(in) :: n
     real(kind=rp), intent(inout) :: fs(n)
     integer :: i
@@ -121,7 +121,7 @@ contains
     type(field_series_t), intent(in) :: ulag, vlag, wlag        
     real(kind=rp), intent(inout) :: bfx(n), bfy(n), bfz(n)
     real(kind=rp), intent(in) :: B(n)
-    real(kind=rp), intent(in) :: dt, rho, bd(10)
+    real(kind=rp), intent(in) :: dt, rho, bd(4)
     integer :: i, ilag
 
     do i = 1, n
@@ -160,7 +160,7 @@ contains
     type(field_series_t), intent(in) :: s_lag
     real(kind=rp), intent(inout) :: fs(n)
     real(kind=rp), intent(in) :: B(n)
-    real(kind=rp), intent(in) :: dt, rho, bd(10)
+    real(kind=rp), intent(in) :: dt, rho, bd(4)
     integer :: i, ilag
 
     do i = 1, n

--- a/src/common/bcknd/device/rhs_maker_device.F90
+++ b/src/common/bcknd/device/rhs_maker_device.F90
@@ -295,7 +295,7 @@ contains
     type(field_t), intent(inout) :: temp1, temp2, temp3
     type(field_t), intent(inout) :: fx_lag, fy_lag, fz_lag
     type(field_t), intent(inout) :: fx_laglag, fy_laglag, fz_laglag
-    real(kind=rp), intent(inout) :: rho, ext_coeffs(10)
+    real(kind=rp), intent(inout) :: rho, ext_coeffs(4)
     integer, intent(in) :: n
     real(kind=rp), intent(inout) :: fx(n), fy(n), fz(n)
     type(c_ptr) :: fx_d, fy_d, fz_d
@@ -328,7 +328,7 @@ contains
     type(field_t), intent(inout) :: temp1
     type(field_t), intent(inout) :: fs_lag
     type(field_t), intent(inout) :: fs_laglag
-    real(kind=rp), intent(inout) :: rho, ext_coeffs(10)
+    real(kind=rp), intent(inout) :: rho, ext_coeffs(4)
     integer, intent(in) :: n
     real(kind=rp), intent(inout) :: fs(n)
     type(c_ptr) :: fs_d
@@ -358,7 +358,7 @@ contains
     type(field_series_t), intent(in) :: ulag, vlag, wlag        
     real(kind=rp), intent(inout) :: bfx(n), bfy(n), bfz(n)
     real(kind=rp), intent(in) :: B(n)
-    real(kind=rp), intent(in) :: dt, rho, bd(10)
+    real(kind=rp), intent(in) :: dt, rho, bd(4)
     type(c_ptr) :: bfx_d, bfy_d, bfz_d, B_d
 
     bfx_d = device_get_ptr(bfx)
@@ -397,7 +397,7 @@ contains
     type(field_series_t), intent(in) :: s_lag
     real(kind=rp), intent(inout) :: fs(n)
     real(kind=rp), intent(in) :: B(n)
-    real(kind=rp), intent(in) :: dt, rho, bd(10)
+    real(kind=rp), intent(in) :: dt, rho, bd(4)
     type(c_ptr) :: fs_d, B_d
 
     fs_d = device_get_ptr(fs)

--- a/src/common/bcknd/sx/rhs_maker_sx.f90
+++ b/src/common/bcknd/sx/rhs_maker_sx.f90
@@ -54,7 +54,7 @@ contains
     type(field_t), intent(inout) :: temp1, temp2, temp3
     type(field_t), intent(inout) :: fx_lag, fy_lag, fz_lag
     type(field_t), intent(inout) :: fx_laglag, fy_laglag, fz_laglag
-    real(kind=rp), intent(inout) :: rho, ext_coeffs(10)
+    real(kind=rp), intent(inout) :: rho, ext_coeffs(4)
     integer, intent(in) :: n
     real(kind=rp), intent(inout) :: fx(n), fy(n), fz(n)
     integer :: i
@@ -90,7 +90,7 @@ contains
     type(field_t), intent(inout) :: temp1
     type(field_t), intent(inout) :: fs_lag
     type(field_t), intent(inout) :: fs_laglag
-    real(kind=rp), intent(inout) :: rho, ext_coeffs(10)
+    real(kind=rp), intent(inout) :: rho, ext_coeffs(4)
     integer, intent(in) :: n
     real(kind=rp), intent(inout) :: fs(n)
     integer :: i
@@ -121,7 +121,7 @@ contains
     type(field_series_t), intent(in) :: ulag, vlag, wlag        
     real(kind=rp), intent(inout) :: bfx(n), bfy(n), bfz(n)
     real(kind=rp), intent(in) :: B(n)
-    real(kind=rp), intent(in) :: dt, rho, bd(10)
+    real(kind=rp), intent(in) :: dt, rho, bd(4)
     integer :: i, ilag
 
     do i = 1, n
@@ -160,7 +160,7 @@ contains
     type(field_series_t), intent(in) :: s_lag
     real(kind=rp), intent(inout) :: fs(n)
     real(kind=rp), intent(in) :: B(n)
-    real(kind=rp), intent(in) :: dt, rho, bd(10)
+    real(kind=rp), intent(in) :: dt, rho, bd(4)
     integer :: i, ilag
 
     do i = 1, n

--- a/src/common/ext_bdf_scheme.f90
+++ b/src/common/ext_bdf_scheme.f90
@@ -69,8 +69,14 @@ module ext_bdf_scheme
   private
   
   !> Base abstract class for time integration schemes
+  !! @details
+  !! An important detail here is the handling of the first timesteps where a 
+  !! high-order scheme cannot be constructed. The parameters `n`, which is
+  !! initialized to 0, must be incremented by 1 in the beggining of the 
+  !! `set_coeffs` routine to determine the current scheme order.
+  !! When `n == time_order`, the incrementation should stop.
   type, abstract, public :: time_scheme_t
-     !> The coefficients of the scheme
+     !> The coefficients of the scheme, the size 10 is larger than necessary
      real(kind=rp), dimension(10) :: coeffs 
      !> Controls the actual order of the scheme, e.g. 1 at the first time-step
      integer :: n = 0
@@ -79,17 +85,22 @@ module ext_bdf_scheme
      !> Device pointer for `coeffs`
      type(c_ptr) :: coeffs_d = C_NULL_PTR 
    contains
+     !> Controls current scheme order and computes the coefficients
      procedure(set_coeffs), deferred, pass(this) :: set_coeffs
+     !> Constructor
      procedure, pass(this) :: init => time_scheme_init 
+     !> Destructor
      procedure, pass(this) :: free => time_scheme_free
   end type time_scheme_t
   
   abstract interface
+     !> Interface for setting the scheme coefficients
+     !! @param t Timestep values, first element is the current timestep.
      subroutine set_coeffs(this, dt)
        import time_scheme_t
        import rp
        class(time_scheme_t), intent(inout) :: this
-       real(kind=rp), intent(inout), dimension(10) :: dt !< timestep values
+       real(kind=rp), intent(inout), dimension(10) :: dt
      end subroutine
   end interface
   
@@ -98,6 +109,39 @@ module ext_bdf_scheme
        procedure, pass(this) :: set_coeffs => ext_time_scheme_set_coeffs
   end type ext_time_scheme_t
 
+  !> Implicit backward-differencing scheme for time integration.
+  !! @details
+  !! The explicit forumlas for the coefficients are taken from the following
+  !! techincal note:
+  !! "Derivation of BDF2/BDF3 for Variable Step Size" by Hiroaki Nishikawa,
+  !! which can be found on ResearchGate.
+  !!
+  !! For a contant time-step this corresponds to the following schemes for
+  !! order 1 to 3:
+  !! - Order 1: \f$ \frac{1}{\Delta t} u^{n+1} - \frac{1}{\Delta t} u^{n} \f$ 
+  !! - Order 2: \f$ \frac{3}{2\Delta t} u^{n+1} - \frac{4}{2\Delta t} u^{n}  + 
+  !!                \frac{1}{2\Delta t} u^{n-1}\f$ 
+  !! - Order 3: \f$ \frac{11}{6\Delta t} u^{n+1} - \frac{18}{6\Delta t} u^{n}  + 
+  !!                \frac{9}{6\Delta t} u^{n-1} - \frac{2}{6\Delta t} u^{n-2}\f$ 
+  !!
+  !! It is assumed that all the coefficients but the first one premultiply terms
+  !! that go to the right-hand side of the equation. 
+  !! Accordingly, the signs of these coefficients are reversed in the `coeffs`
+  !! array. This is taken into account, for example, in the implemeation of the
+  !! `rhs_maker` class.
+  !!
+  !! Another important convention is that the coefficients are meant to be
+  !! later divided by the current value of the timestep.
+  !!
+  !! In line with the above assumptions, the first order scheme always returns
+  !! the array \f$[1, 1]\f$, and **not** \f$[1/\Delta t, -1/\Delta t]\f$, as one
+  !! might expect. Similar for the second and third order.
+  !!
+  !! @remark 
+  !! The current implementation can be easily extended to schemes of arbitrary
+  !! order, by using the `fd_weights_full` subroutine to compute the
+  !! coefficients. A demonstration of this is implemented in a test in
+  !! `tests/ext_bdf_scheme/test_bdf.pf`
   type, public, extends(time_scheme_t) :: bdf_time_scheme_t 
      contains
        procedure, pass(this) :: set_coeffs => bdf_time_scheme_set_coeffs
@@ -113,7 +157,7 @@ module ext_bdf_scheme
   end type ext_bdf_scheme_t
 
 contains
-  !> Constructor for a time_scheme_t
+  !> Constructor
   subroutine time_scheme_init(this, torder)
     class(time_scheme_t), intent(inout) :: this
     integer, intent(in) :: torder !< Desired order of the scheme: 1, 2 or 3.
@@ -130,7 +174,7 @@ contains
     end if
   end subroutine time_scheme_init
 
-  !> Destructor for time_scheme_t
+  !> Destructor
   subroutine time_scheme_free(this)
     class(time_scheme_t), intent(inout) :: this
 
@@ -205,49 +249,45 @@ contains
     
   end subroutine ext_time_scheme_set_coeffs
 
-  !>Compute backward-differentiation coefficients of order NBD
   subroutine bdf_time_scheme_set_coeffs(this, dt)
+    implicit none
     class(bdf_time_scheme_t), intent(inout) :: this
     real(kind=rp), intent(inout), dimension(10) :: dt
-    real(kind=rp), dimension(10,10) :: bdmat
-    real(kind=rp), dimension(10) :: bdrhs
-    real(kind=rp), dimension(10) :: bd_old
-    real(kind=rp) :: bdf
-    integer, parameter :: ldim = 10
-    integer, dimension(10) :: ir, ic
-    integer :: ibd, nsys, i
+    real(kind=rp), dimension(10) :: coeffs_old
 
-    associate(nbd => this%n, bd => this%coeffs, bdf_d => this%coeffs_d)
-      bd_old = bd
-      nbd = nbd + 1
-      nbd = min(nbd, this%time_order)
-      call rzero(bd, 10)
-      if (nbd .eq. 1) then
-         bd(1) = 1.0_rp
-         bdf = 1.0_rp
-      else if (nbd .ge. 2) then
-         nsys = nbd + 1
-         call bdsys(bdmat, bdrhs, dt, nbd, ldim)
-         call lu(bdmat, nsys, ldim, ir, ic)
-         call solve(bdrhs, bdmat, 1, nsys, ldim, ir, ic)
-         do i = 1, nbd
-            bd(i) = bdrhs(i)
-         end do
-         bdf = bdrhs(nbd + 1)
-      endif
+    associate(n => this%n, coeffs => this%coeffs, coeffs_d => this%coeffs_d)
+      ! will be used to check whether the coefficients changed
+      coeffs_old = coeffs
       
-      !Normalize
-      do ibd = nbd, 1, -1
-         bd(ibd + 1) = bd(ibd)
-      end do
-      bd(1) = 1.0_rp
-      do ibd= 1, nbd + 1
-         bd(ibd) = bd(ibd)/bdf
-      end do
+      ! Increment the order of the scheme if below time_order
+      n = n + 1
+      n = min(n, this%time_order)
 
-      if (c_associated(bdf_d)) then
-         if (maxval(abs(bd - bd_old)) .gt. 1e-10_rp) then
-            call device_memcpy(bd, bdf_d, 10, HOST_TO_DEVICE)
+      call rzero(coeffs, 10)
+      
+      ! Note, these are true coeffs, multiplied by dt(1)
+      select case (n)
+      case (1)
+         coeffs(1) = 1.0_rp
+         coeffs(2) = 1.0_rp
+      case (2)
+         coeffs(1) = (1 + dt(1)/(dt(1) + dt(2)))
+         coeffs(3) = -dt(1)**2/dt(2)/(dt(1) + dt(2))
+         coeffs(2) =  coeffs(1) - coeffs(3)
+      case (3)
+         coeffs(2) = (dt(1) + dt(2)) * (dt(1) + dt(2) + dt(3)) / &
+                     (dt(1) * dt(2) * (dt(2) + dt(3)))
+         coeffs(3) = -dt(1) * (dt(1) + dt(2) + dt(3)) / &
+                     (dt(2) * dt(3) * (dt(1) + dt(2)))
+         coeffs(4) = dt(1) * (dt(1) + dt(2)) / &
+                     (dt(3) * (dt(2) + dt(3)) * (dt(1) + dt(2) + dt(3)))
+         coeffs(1) = coeffs(2) + coeffs(3) + coeffs(4)
+         coeffs = coeffs * dt(1)
+      end select
+      
+      if (c_associated(coeffs_d)) then
+         if (maxval(abs(coeffs - coeffs_old)) .gt. 1e-10_rp) then
+            call device_memcpy(coeffs, coeffs_d, 10, HOST_TO_DEVICE)
          end if
       end if
     end associate
@@ -268,147 +308,5 @@ contains
      call time_scheme_free(this%ext)
      call time_scheme_free(this%bdf)
   end subroutine ext_bdf_scheme_free
-  
-  !
-  ! todo: CLEAN UP THIS MESS BELOW, USE LAPACK OR SIMILAR
-  !
-  subroutine bdsys (a, b, dt, nbd, ldim)
-    integer :: ldim, j, n, k, i, nsys, nbd
-    real(kind=rp) ::  A(ldim,9),B(9),DT(9)
-    real(kind=rp) :: SUMDT
-
-    CALL RZERO (A, ldim**2)
-    N = NBD + 1
-    DO J = 1, NBD
-       A(1,J) = 1.0_rp
-    end DO
-    A(1,NBD+1) = 0.0_rp
-    B(1) = 1.0_rp
-    DO J = 1, NBD
-       SUMDT = 0.0_rp
-       DO  K = 1, J
-          SUMDT = SUMDT + DT(K)
-       end DO
-       A(2,J) = SUMDT
-    end DO
-    A(2,NBD+1) = -DT(1)
-    B(2) = 0.0_rp
-    DO I = 3, NBD + 1
-       DO J = 1, NBD
-          SUMDT = 0.0_rp
-          DO K = 1, J
-             SUMDT = SUMDT + DT(K)
-          end DO
-          A(I,J) = SUMDT**(I-1)
-       end DO
-       A(I,NBD+1) = 0.0_rp
-       B(I) = 0.0_rp
-    end DO
-      
-    end subroutine bdsys
-
-
-    SUBROUTINE LU(A, N, ldim, IR, IC)
-      integer :: n, ldim, IR(10), IC(10)
-      real(kind=rp) :: A(ldim,10), xmax, ymax, B, Y, C
-      integer :: i, j, k, l, m, icm, irl, k1
-
-      DO I = 1, N
-         IR(I) = I
-         IC(I) = I
-      end DO
-      K = 1
-      L = K
-      M = K
-      XMAX = ABS(A(K,K))
-      DO I = K, N
-         DO J = K, N
-            Y = ABS(A(I,J))
-            IF(XMAX .GE. Y) GOTO 100
-            XMAX = Y
-            L = I
-            M = J
-100      END DO
-      END DO
-      DO K = 1, N
-         IRL = IR(L)
-         IR(L) = IR(K)
-         IR(K) = IRL
-         ICM = IC(M)
-         IC(M) = IC(K)
-         IC(K) = ICM
-         IF(L .EQ. K) GOTO 300
-         DO J = 1, N
-            B = A(K,J)
-            A(K,J) = A(L,J)
-            A(L,J) = B
-         END DO
-300      IF(M .EQ. K) GOTO 500
-         DO I = 1, N
-            B = A(I,K)
-            A(I,K) = A(I,M)
-            A(I,M) = B
-         END DO
-500      C = 1.0_rp / A(K,K)
-         A(K,K) = C
-         IF(K .EQ. N) GOTO 1000
-         K1 = K + 1
-         XMAX = ABS(A(K1,K1))
-         L = K1
-         M = K1
-         DO I = K1, N
-            A(I,K) = C * A(I,K)
-         END DO
-         DO I = K1, N
-            B = A(I,K)
-            DO J = K1, N
-               A(I,J) = A(I,J) - B * A(K,J)
-               Y = ABS(A(I,J))
-               IF(XMAX .GE. Y) GOTO 800
-               XMAX = Y
-               L = I
-               M = J
-800         END DO
-         END DO
-1000  END DO
-    end subroutine lu
-   
-    SUBROUTINE SOLVE(F, A, K, N, ldim, IR, IC)
-      integer :: IR(10),IC(10), N, N1, k, kk, i, j, ldim, ICM, URL, K1, ICI
-      integer :: I1, IRI,IRL, IT
-      real(kind=rp) ::  A(ldim,10), F(ldim,10), G(2000), B, Y
-
-      N1 = N + 1
-      DO KK = 1, K
-         DO I = 1, N
-            IRI = IR(I)
-            G(I) = F(IRI,KK)
-         END DO
-         DO I = 2, N
-            I1 = I - 1
-            B = G(I)
-            DO J = 1, I1
-               B = B - A(I,J) * G(J)
-            END DO
-            G(I) = B
-         END DO
-         DO IT = 1, N
-            I = N1 - IT
-            I1 = I + 1
-            B = G(I)
-            IF(I .EQ. N) GOTO 701
-            DO J = I1, N
-               B = B - A(I,J) * G(J)
-            END DO
-701         G(I) = B * A(I,I)
-         END DO
-         DO I = 1, N
-            ICI = IC(I)
-            F(ICI,KK) = G(I)
-         END DO
-      END DO
-    END SUBROUTINE SOLVE
-    
-
   
 end module ext_bdf_scheme

--- a/src/common/rhs_maker.f90
+++ b/src/common/rhs_maker.f90
@@ -84,7 +84,7 @@ module rhs_maker
        type(field_t), intent(inout) :: temp1, temp2, temp3
        type(field_t), intent(inout) :: fx_lag, fy_lag, fz_lag
        type(field_t), intent(inout) :: fx_laglag, fy_laglag, fz_laglag
-       real(kind=rp), intent(inout) :: rho, ext_coeffs(10)
+       real(kind=rp), intent(inout) :: rho, ext_coeffs(4)
        integer, intent(in) :: n
        real(kind=rp), intent(inout) :: fx(n), fy(n), fz(n)
      end subroutine rhs_maker_ext
@@ -98,7 +98,7 @@ module rhs_maker
        type(field_t), intent(inout) :: temp1
        type(field_t), intent(inout) :: fs_lag
        type(field_t), intent(inout) :: fs_laglag
-       real(kind=rp), intent(inout) :: rho, ext_coeffs(10)
+       real(kind=rp), intent(inout) :: rho, ext_coeffs(4)
        integer, intent(in) :: n
        real(kind=rp), intent(inout) :: fs(n)
      end subroutine scalar_rhs_maker_ext
@@ -118,7 +118,7 @@ module rhs_maker
        type(field_series_t), intent(in) :: ulag, vlag, wlag        
        real(kind=rp), intent(inout) :: bfx(n), bfy(n), bfz(n)
        real(kind=rp), intent(in) :: B(n)
-       real(kind=rp), intent(in) :: dt, rho, bd(10)
+       real(kind=rp), intent(in) :: dt, rho, bd(4)
      end subroutine rhs_maker_bdf
   end interface
 
@@ -134,7 +134,7 @@ module rhs_maker
        type(field_series_t), intent(in) :: s_lag
        real(kind=rp), intent(inout) :: fs(n)
        real(kind=rp), intent(in) :: B(n)
-       real(kind=rp), intent(in) :: dt, rho, bd(10)
+       real(kind=rp), intent(in) :: dt, rho, bd(4)
      end subroutine scalar_rhs_maker_bdf
   end interface
 

--- a/src/fluid/bcknd/device/fluid_abbdf_device.F90
+++ b/src/fluid/bcknd/device/fluid_abbdf_device.F90
@@ -218,7 +218,7 @@ contains
     type(field_t), intent(inout) :: temp1, temp2, temp3
     type(field_t), intent(inout) :: fx_lag, fy_lag, fz_lag
     type(field_t), intent(inout) :: fx_laglag, fy_laglag, fz_laglag
-    real(kind=rp), intent(inout) :: rho, ext_coeffs(10)
+    real(kind=rp), intent(inout) :: rho, ext_coeffs(4)
     integer, intent(in) :: n
     real(kind=rp), intent(inout) :: fx(n), fy(n), fz(n)
     type(c_ptr) :: fx_d, fy_d, fz_d

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -29,3 +29,4 @@ jobctrl/jobctrl_suite
 mean_sqr_field/mean_sqr_field_suite
 scratch_registry/scratch_registry_test
 fast3d/fast3d_test
+ext_bdf_scheme/ext_bdf_scheme_test

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -26,7 +26,8 @@ SUBDIRS = tuple\
 	  octree\
 	  vector\
 	  scratch_registry\
-	  fast3d
+	  fast3d\
+	  ext_bdf_scheme
 
 TESTS = device/device_test\
 	tuple/tuple_test\
@@ -56,7 +57,8 @@ TESTS = device/device_test\
     octree/octree_test\
 	vector/vector_test\
 	scratch_registry/scratch_registry_test\
-	fast3d/fast3d_test
+	fast3d/fast3d_test\
+	ext_bdf_scheme/ext_bdf_scheme_test
 
 # Note we need to list .pf and runner scripts manually
 EXTRA_DIST = \
@@ -113,4 +115,5 @@ EXTRA_DIST = \
 	octree/octree.pf\
 	vector/vector_parallel.pf\
 	scratch_registry/test_scratch_registry.pf\
-    fast3d/test_fd_weights_full.pf
+    fast3d/test_fd_weights_full.pf\
+	ext_bdf_scheme/test_bdf.pf

--- a/tests/ext_bdf_scheme/Makefile.in
+++ b/tests/ext_bdf_scheme/Makefile.in
@@ -1,0 +1,26 @@
+ifneq ("$(wildcard @PFUNIT_DIR@/include/PFUNIT.mk)", "")
+include @PFUNIT_DIR@/include/PFUNIT.mk
+endif
+FFLAGS += $(PFUNIT_EXTRA_FFLAGS) -I@top_builddir@/src
+FC = @FC@
+
+%.o : %.F90
+	$(FC) -c $(FFLAGS) $<
+
+
+check: ext_bdf_scheme_test
+
+ext_bdf_scheme_test_TESTS := test_bdf.pf
+ext_bdf_scheme_test_OTHER_LIBRARIES = -L@top_builddir@/src -lneko @LDFLAGS@ @LIBS@
+$(eval $(call make_pfunit_test,ext_bdf_scheme_test))
+
+
+clean:
+	$(RM) *.o *.mod *.a  *.inc *.F90  ext_bdf_scheme_test
+
+
+
+all:
+html:
+install:
+distdir:

--- a/tests/ext_bdf_scheme/test_bdf.pf
+++ b/tests/ext_bdf_scheme/test_bdf.pf
@@ -1,0 +1,322 @@
+ @test
+ subroutine test_constant_dt()
+   use pfunit
+   use ext_bdf_scheme
+   use num_types
+   implicit none
+   
+   type(bdf_time_scheme_t) bdf
+   real(kind=rp) :: dt(10), x
+   
+   ! Equal timesteps
+   dt = 1.00_rp
+
+   ! Init to 3rd order
+   call bdf%init(3)
+   
+   ! Firt call, should be 1st order scheme, [1, 1]
+   call bdf%set_coeffs(dt)
+   @assertEqual(bdf%n, 1)
+   @assertEqual(bdf%coeffs(1), 1.0_rp, tolerance=1e-6_rp)
+   @assertEqual(bdf%coeffs(2), 1.0_rp, tolerance=1e-6_rp)
+
+   ! Second call, should be 2st order scheme, [1.5, 2, -0.5]
+   call bdf%set_coeffs(dt)
+   @assertEqual(bdf%n, 2)
+   @assertEqual(bdf%coeffs(1), 1.5_rp, tolerance=1e-6_rp)
+   @assertEqual(bdf%coeffs(2), 2.0_rp, tolerance=1e-6_rp)
+   @assertEqual(bdf%coeffs(3), -0.5_rp, tolerance=1e-6_rp)
+
+   ! Third call, should be 3st order scheme, [11/6, 3, -3/2, 1/3]
+   call bdf%set_coeffs(dt)
+   @assertEqual(bdf%n, 3)
+   x = 11.0_rp/6.0_rp
+   @assertRelativelyEqual(bdf%coeffs(1), x, tolerance=1e-3_rp)
+   @assertEqual(bdf%coeffs(2), 3.0_rp, tolerance=1e-6_rp)
+   @assertEqual(bdf%coeffs(3), -1.5_rp, tolerance=1e-6_rp)
+   @assertRelativelyEqual(bdf%coeffs(4), 0.3333_rp, tolerance=1e-3_rp)
+
+   ! Fourth call, nothing should change
+   call bdf%set_coeffs(dt)
+   @assertEqual(bdf%n, 3)
+   @assertRelativelyEqual(bdf%coeffs(1), x, tolerance=1e-3_rp)
+   @assertEqual(bdf%coeffs(2), 3.0_rp, tolerance=1e-6_rp)
+   @assertEqual(bdf%coeffs(3), -1.5_rp, tolerance=1e-6_rp)
+   @assertRelativelyEqual(bdf%coeffs(4), 0.3333_rp, tolerance=1e-3_rp)
+
+   call bdf%free()
+end subroutine test_constant_dt
+
+ @test
+ subroutine test_variable_dt()
+   use pfunit
+   use ext_bdf_scheme
+   use num_types
+   implicit none
+   
+   type(bdf_time_scheme_t) bdf
+   real(kind=rp) :: dt(10), coeffs(10)
+   integer :: nbdf
+   
+   call bdf%init(3)
+   ! Some random dt values
+   dt = 4.3_rp
+   dt(1) = 2_rp
+   dt(2) = 0.05_rp
+   dt(3) = 1.34_rp
+
+   ! order 1
+   nbdf = 0
+   call old_bdf(nbdf, coeffs, 3, dt)
+   call bdf%set_coeffs(dt)
+   @assertEqual(coeffs(1), bdf%coeffs(1), tolerance=1e-6_rp)
+   @assertEqual(coeffs(2), bdf%coeffs(2), tolerance=1e-6_rp)
+
+   ! order 2
+   nbdf = 1
+   call old_bdf(nbdf, coeffs, 3, dt)
+   call bdf%set_coeffs(dt)
+   @assertEqual(coeffs(1), bdf%coeffs(1), tolerance=1e-6_rp)
+   @assertEqual(coeffs(2), bdf%coeffs(2), tolerance=1e-6_rp)
+   @assertEqual(coeffs(3), bdf%coeffs(3), tolerance=1e-6_rp)
+
+   ! order 3
+   nbdf = 2
+   call old_bdf(nbdf, coeffs, 3, dt)
+   call bdf%set_coeffs(dt)
+   @assertEqual(coeffs(1), bdf%coeffs(1), tolerance=1e-6_rp)
+   @assertEqual(coeffs(2), bdf%coeffs(2), tolerance=1e-6_rp)
+   @assertEqual(coeffs(3), bdf%coeffs(3), tolerance=1e-6_rp)
+   @assertEqual(coeffs(4), bdf%coeffs(4), tolerance=1e-6_rp)
+   
+   call bdf%free()
+end subroutine test_variable_dt
+
+
+!> Shows that we can use df_weights_full to get a scheme of arbitrary order
+ @test
+ subroutine test_with_df_weights_full()
+   use pfunit
+   use ext_bdf_scheme
+   use fast3d
+   use num_types
+   implicit none
+   
+   type(bdf_time_scheme_t) bdf
+   integer, parameter :: n=3, m=1
+   real(kind=rp) :: dt(10)
+   real(kind=rp) :: x(0:n), c(0:n,0:m)
+   
+   call bdf%init(3)
+   ! Some random dt values
+   dt = 4.3_rp
+   dt(1) = 2_rp
+   dt(2) = 0.05_rp
+   dt(3) = 1.34_rp
+
+   ! order 3
+   bdf%n = 2
+   call bdf%set_coeffs(dt)
+   
+   ! set the coordinates for fd_weights_full, corresponing to our dts
+   x(0) = 0_rp
+   x(1) = dt(3)
+   x(2) = x(1) + dt(2)
+   x(3) = x(2) + dt(1)
+   call fd_weights_full(x(3), x, n, m, c)
+
+   ! df_weights_full returns the true coeffs, so we need to multiply
+   ! with dt(1) and change signs
+
+   @assertEqual(bdf%coeffs(1),  c(3, 1) * dt(1), tolerance=1e-6_rp)
+   @assertEqual(bdf%coeffs(2), -c(2, 1) * dt(1), tolerance=1e-6_rp)
+   @assertEqual(bdf%coeffs(3), -c(1, 1) * dt(1), tolerance=1e-6_rp)
+   @assertEqual(bdf%coeffs(4), -c(0, 1) * dt(1), tolerance=1e-6_rp)
+   
+   call bdf%free()
+end subroutine test_with_df_weights_full
+
+!! OLD BDF ROUTINES BELOW FOR TESTING NEW IMPLEMENTATIONS
+  subroutine old_bdf(nbd, bd, time_order, dt)
+    use num_types
+    use math
+    implicit none
+    integer, intent(inout) :: nbd, time_order
+    real(kind=rp), dimension(10) :: bd
+    real(kind=rp), intent(inout), dimension(10) :: dt
+    real(kind=rp), dimension(10,10) :: bdmat
+    real(kind=rp), dimension(10) :: bdrhs
+    real(kind=rp), dimension(10) :: bd_old
+    real(kind=rp) :: bdf
+    integer, parameter :: ldim = 10
+    integer, dimension(10) :: ir, ic
+    integer :: ibd, nsys, i
+
+      bd_old = bd
+      nbd = nbd + 1
+      nbd = min(nbd, time_order)
+      call rzero(bd, 10)
+      if (nbd .eq. 1) then
+         bd(1) = 1.0_rp
+         bdf = 1.0_rp
+      else if (nbd .ge. 2) then
+         nsys = nbd + 1
+         call bdsys(bdmat, bdrhs, dt, nbd, ldim)
+         call lu(bdmat, nsys, ldim, ir, ic)
+         call solve(bdrhs, bdmat, 1, nsys, ldim, ir, ic)
+         do i = 1, nbd
+            bd(i) = bdrhs(i)
+         end do
+         bdf = bdrhs(nbd + 1)
+      endif
+      
+      !Normalize
+      do ibd = nbd, 1, -1
+         bd(ibd + 1) = bd(ibd)
+      end do
+      bd(1) = 1.0_rp
+      do ibd= 1, nbd + 1
+         bd(ibd) = bd(ibd)/bdf
+      end do
+  end subroutine old_bdf
+
+subroutine bdsys (a, b, dt, nbd, ldim)
+  use num_types
+  use math
+  integer :: ldim, j, n, k, i, nsys, nbd
+  real(kind=rp) ::  A(ldim,9),B(9),DT(9)
+  real(kind=rp) :: SUMDT
+
+  CALL RZERO (A, ldim**2)
+  N = NBD + 1
+  DO J = 1, NBD
+     A(1,J) = 1.0_rp
+  end DO
+  A(1,NBD+1) = 0.0_rp
+  B(1) = 1.0_rp
+  DO J = 1, NBD
+     SUMDT = 0.0_rp
+     DO  K = 1, J
+        SUMDT = SUMDT + DT(K)
+     end DO
+     A(2,J) = SUMDT
+  end DO
+  A(2,NBD+1) = -DT(1)
+  B(2) = 0.0_rp
+  DO I = 3, NBD + 1
+     DO J = 1, NBD
+        SUMDT = 0.0_rp
+        DO K = 1, J
+           SUMDT = SUMDT + DT(K)
+        end DO
+        A(I,J) = SUMDT**(I-1)
+     end DO
+     A(I,NBD+1) = 0.0_rp
+     B(I) = 0.0_rp
+  end DO
+    
+  end subroutine bdsys
+
+
+  SUBROUTINE LU(A, N, ldim, IR, IC)
+    use num_types
+    integer :: n, ldim, IR(10), IC(10)
+    real(kind=rp) :: A(ldim,10), xmax, ymax, B, Y, C
+    integer :: i, j, k, l, m, icm, irl, k1
+
+    DO I = 1, N
+       IR(I) = I
+       IC(I) = I
+    end DO
+    K = 1
+    L = K
+    M = K
+    XMAX = ABS(A(K,K))
+    DO I = K, N
+       DO J = K, N
+          Y = ABS(A(I,J))
+          IF(XMAX .GE. Y) GOTO 100
+          XMAX = Y
+          L = I
+          M = J
+100      END DO
+    END DO
+    DO K = 1, N
+       IRL = IR(L)
+       IR(L) = IR(K)
+       IR(K) = IRL
+       ICM = IC(M)
+       IC(M) = IC(K)
+       IC(K) = ICM
+       IF(L .EQ. K) GOTO 300
+       DO J = 1, N
+          B = A(K,J)
+          A(K,J) = A(L,J)
+          A(L,J) = B
+       END DO
+300      IF(M .EQ. K) GOTO 500
+       DO I = 1, N
+          B = A(I,K)
+          A(I,K) = A(I,M)
+          A(I,M) = B
+       END DO
+500      C = 1.0_rp / A(K,K)
+       A(K,K) = C
+       IF(K .EQ. N) GOTO 1000
+       K1 = K + 1
+       XMAX = ABS(A(K1,K1))
+       L = K1
+       M = K1
+       DO I = K1, N
+          A(I,K) = C * A(I,K)
+       END DO
+       DO I = K1, N
+          B = A(I,K)
+          DO J = K1, N
+             A(I,J) = A(I,J) - B * A(K,J)
+             Y = ABS(A(I,J))
+             IF(XMAX .GE. Y) GOTO 800
+             XMAX = Y
+             L = I
+             M = J
+800         END DO
+       END DO
+1000  END DO
+  end subroutine lu
+ 
+  SUBROUTINE SOLVE(F, A, K, N, ldim, IR, IC)
+    use num_types
+    integer :: IR(10),IC(10), N, N1, k, kk, i, j, ldim, ICM, URL, K1, ICI
+    integer :: I1, IRI,IRL, IT
+    real(kind=rp) ::  A(ldim,10), F(ldim,10), G(2000), B, Y
+
+    N1 = N + 1
+    DO KK = 1, K
+       DO I = 1, N
+          IRI = IR(I)
+          G(I) = F(IRI,KK)
+       END DO
+       DO I = 2, N
+          I1 = I - 1
+          B = G(I)
+          DO J = 1, I1
+             B = B - A(I,J) * G(J)
+          END DO
+          G(I) = B
+       END DO
+       DO IT = 1, N
+          I = N1 - IT
+          I1 = I + 1
+          B = G(I)
+          IF(I .EQ. N) GOTO 701
+          DO J = I1, N
+             B = B - A(I,J) * G(J)
+          END DO
+701         G(I) = B * A(I,I)
+       END DO
+       DO I = 1, N
+          ICI = IC(I)
+          F(ICI,KK) = G(I)
+       END DO
+    END DO
+  END SUBROUTINE SOLVE

--- a/tests/ext_bdf_scheme/test_bdf.pf
+++ b/tests/ext_bdf_scheme/test_bdf.pf
@@ -128,10 +128,10 @@ end subroutine test_variable_dt
    ! df_weights_full returns the true coeffs, so we need to multiply
    ! with dt(1) and change signs
 
-   @assertEqual(bdf%coeffs(1),  c(3, 1) * dt(1), tolerance=1e-6_rp)
-   @assertEqual(bdf%coeffs(2), -c(2, 1) * dt(1), tolerance=1e-6_rp)
-   @assertEqual(bdf%coeffs(3), -c(1, 1) * dt(1), tolerance=1e-6_rp)
-   @assertEqual(bdf%coeffs(4), -c(0, 1) * dt(1), tolerance=1e-6_rp)
+   @assertRelativelyEqual(bdf%coeffs(1),  c(3, 1) * dt(1), tolerance=1e-3_rp)
+   @assertRelativelyEqual(bdf%coeffs(2), -c(2, 1) * dt(1), tolerance=1e-3_rp)
+   @assertRelativelyEqual(bdf%coeffs(3), -c(1, 1) * dt(1), tolerance=1e-3_rp)
+   @assertRelativelyEqual(bdf%coeffs(4), -c(0, 1) * dt(1), tolerance=1e-3_rp)
    
    call bdf%free()
 end subroutine test_with_df_weights_full

--- a/tests/ext_bdf_scheme/test_bdf.pf
+++ b/tests/ext_bdf_scheme/test_bdf.pf
@@ -69,25 +69,25 @@ end subroutine test_constant_dt
    nbdf = 0
    call old_bdf(nbdf, coeffs, 3, dt)
    call bdf%set_coeffs(dt)
-   @assertEqual(coeffs(1), bdf%coeffs(1), tolerance=1e-6_rp)
-   @assertEqual(coeffs(2), bdf%coeffs(2), tolerance=1e-6_rp)
+   @assertRelativelyEqual(coeffs(1), bdf%coeffs(1), tolerance=1e-3_rp)
+   @assertRelativelyEqual(coeffs(2), bdf%coeffs(2), tolerance=1e-3_rp)
 
    ! order 2
    nbdf = 1
    call old_bdf(nbdf, coeffs, 3, dt)
    call bdf%set_coeffs(dt)
-   @assertEqual(coeffs(1), bdf%coeffs(1), tolerance=1e-6_rp)
-   @assertEqual(coeffs(2), bdf%coeffs(2), tolerance=1e-6_rp)
-   @assertEqual(coeffs(3), bdf%coeffs(3), tolerance=1e-6_rp)
+   @assertRelativelyEqual(coeffs(1), bdf%coeffs(1), tolerance=1e-3_rp)
+   @assertRelativelyEqual(coeffs(2), bdf%coeffs(2), tolerance=1e-3_rp)
+   @assertRelativelyEqual(coeffs(3), bdf%coeffs(3), tolerance=1e-3_rp)
 
    ! order 3
    nbdf = 2
    call old_bdf(nbdf, coeffs, 3, dt)
    call bdf%set_coeffs(dt)
-   @assertEqual(coeffs(1), bdf%coeffs(1), tolerance=1e-6_rp)
-   @assertEqual(coeffs(2), bdf%coeffs(2), tolerance=1e-6_rp)
-   @assertEqual(coeffs(3), bdf%coeffs(3), tolerance=1e-6_rp)
-   @assertEqual(coeffs(4), bdf%coeffs(4), tolerance=1e-6_rp)
+   @assertRelativelyEqual(coeffs(1), bdf%coeffs(1), tolerance=1e-3_rp)
+   @assertRelativelyEqual(coeffs(2), bdf%coeffs(2), tolerance=1e-3_rp)
+   @assertRelativelyEqual(coeffs(3), bdf%coeffs(3), tolerance=1e-3_rp)
+   @assertRelativelyEqual(coeffs(4), bdf%coeffs(4), tolerance=1e-3_rp)
    
    call bdf%free()
 end subroutine test_variable_dt

--- a/tests/ext_bdf_scheme/test_bdf.pf
+++ b/tests/ext_bdf_scheme/test_bdf.pf
@@ -141,7 +141,8 @@ end subroutine test_with_df_weights_full
     use num_types
     use math
     implicit none
-    integer, intent(inout) :: nbd, time_order
+    integer, intent(inout) :: nbd
+    integer, intent(in) :: time_order
     real(kind=rp), dimension(10) :: bd
     real(kind=rp), intent(inout), dimension(10) :: dt
     real(kind=rp), dimension(10,10) :: bdmat


### PR DESCRIPTION
- The computation of the coeffs for the BDF scheme no longer uses a messy linear solver. Instead, they are computed using explicit formulas, taken from a [technical note by Nishikawa](https://www.researchgate.net/publication/351082535_Derivation_of_BDF2BDF3_for_Variable_Step_Size). 
- The above fixes the maximum order to 3, which anyway is the maximum used. 
- However, we can easily extend to higher order later if we want, because the subroutine `fd_weights_full` that we have can be used to compute the coefficients for arbitrary order. I am surprised Nek5000 did not use that, actually! It requires a bit of array reordering, etc, so for now I went for the explicit formulas.
- Quite detailed documentation for the BDF scheme is provided. There are two somewhat surprising conventions one should be aware of.
- Added tests for constant and variable dt cases.

I would say this closes #114 for now.