### PR TITLE
Disable nvhpc builds for develop CI

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -214,50 +214,50 @@ jobs:
           ./configure FC=${FC} CC=${CC} MPIFC"=mpiifort -fc=${FC}" --enable-real=${RP} 
           make FCFLAGS="-O2 -stand f08 -warn errors" -j$(nproc)
   
-  NVIDIA:
-    needs: linting
-    runs-on: ${{matrix.os}}
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ubuntu-20.04]
-        compiler: [nvfortran]
-        backend: [cpu, cuda]
-        precision: [dp]
-        include:
-        - os: ubuntu-20.04
-          setup-env: sudo apt-get update && sudo apt-get install -y autoconf automake autotools-dev make git m4 libopenblas-dev && curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg && echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list && sudo apt-get update -y && sudo apt-get install -y nvhpc-23-3 &&  NVARCH=`uname -s`_`uname -m`; export NVARCH && NVCOMPILERS=/opt/nvidia/hpc_sdk; export NVCOMPILERS && PATH=$NVCOMPILERS/$NVARCH/23.3/compilers/bin:$PATH; export PATH &&  export PATH=$NVCOMPILERS/$NVARCH/23.3/comm_libs/mpi/bin:$PATH && printenv >> $GITHUB_ENV 
-    env:
-      CC: gcc
-      FC: ${{ matrix.compiler }}
-      OMPI_FC: ${{ matrix.compiler }}
-      OMPI_CC: gcc
-      OMPI_ALLOW_RUN_AS_ROOT: 1
-      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
-      OMPI_MCA_btl_vader_single_copy_mechanism: none
-      RP: ${{ matrix.precision }}
-    name: ${{ matrix.os }} / ${{ matrix.compiler }} / ${{ matrix.backend }} / ${{ matrix.precision }}
-    steps:
-      - name: Setup env.
-        run: ${{ matrix.setup-env }}
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-      - name: Build (CPU backend)
-        if: matrix.backend == 'cpu'
-        run: |
-          git apply patches/nvhpc_bge.patch
-          ./regen.sh
-          ./configure FC=${FC} FCFLAGS="-O3" --enable-real=${RP}
-          make
-      - name: Build (CUDA backend)
-        if: matrix.backend == 'cuda'
-        run: |
-          git apply patches/nvhpc_bge.patch
-          ./regen.sh
-          ./configure FC=${FC} FCFLAGS="-O3" --enable-real=${RP} --with-cuda=/opt/nvidia/hpc_sdk/Linux_x86_64/23.3/cuda/
-          make          
+#  NVIDIA:
+#    needs: linting
+#    runs-on: ${{matrix.os}}
+#    strategy:
+#      fail-fast: true
+#      matrix:
+#        os: [ubuntu-20.04]
+#        compiler: [nvfortran]
+#        backend: [cpu, cuda]
+#        precision: [dp]
+#        include:
+#        - os: ubuntu-20.04
+#          setup-env: sudo apt-get update && sudo apt-get install -y autoconf automake autotools-dev make git m4 libopenblas-dev && curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg && echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list && sudo apt-get update -y && sudo apt-get install -y nvhpc-23-3 &&  NVARCH=`uname -s`_`uname -m`; export NVARCH && NVCOMPILERS=/opt/nvidia/hpc_sdk; export NVCOMPILERS && PATH=$NVCOMPILERS/$NVARCH/23.3/compilers/bin:$PATH; export PATH &&  export PATH=$NVCOMPILERS/$NVARCH/23.3/comm_libs/mpi/bin:$PATH && printenv >> $GITHUB_ENV
+#    env:
+#      CC: gcc
+#      FC: ${{ matrix.compiler }}
+#      OMPI_FC: ${{ matrix.compiler }}
+#      OMPI_CC: gcc
+#      OMPI_ALLOW_RUN_AS_ROOT: 1
+#      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+#      OMPI_MCA_btl_vader_single_copy_mechanism: none
+#      RP: ${{ matrix.precision }}
+#    name: ${{ matrix.os }} / ${{ matrix.compiler }} / ${{ matrix.backend }} / ${{ matrix.precision }}
+#    steps:
+#      - name: Setup env.
+#        run: ${{ matrix.setup-env }}
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#        with:
+#          fetch-depth: 1
+#      - name: Build (CPU backend)
+#        if: matrix.backend == 'cpu'
+#        run: |
+#          git apply patches/nvhpc_bge.patch
+#          ./regen.sh
+#          ./configure FC=${FC} FCFLAGS="-O3" --enable-real=${RP}
+#          make
+#      - name: Build (CUDA backend)
+#        if: matrix.backend == 'cuda'
+#        run: |
+#          git apply patches/nvhpc_bge.patch
+#          ./regen.sh
+#          ./configure FC=${FC} FCFLAGS="-O3" --enable-real=${RP} --with-cuda=/opt/nvidia/hpc_sdk/Linux_x86_64/23.3/cuda/
+#          make
   ReFrame:
       needs: GNU
       runs-on: ubuntu-20.04


### PR DESCRIPTION
Temporarly disable nvhpc builds in CI until the ICE is fixed.
