### PR TITLE
Check if CrayPE wrappers are used on Cray EX systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -211,7 +211,7 @@ if (test "x${have_cuda}" = xyes ||
     test "x${have_opencl}" = xyes); then
    if test "x${enable_device_mpi}" = xyes; then
 
-      # Check that necessary acceleator modules are loaded
+      # Check that necessary accelerator modules are loaded
       if (test "x${is_cray}" = xyes || test "x${is_hpe_cray}" = xyes); then    
       	 AX_CRAY_ACCEL
       fi

--- a/m4/ax_cray.m4
+++ b/m4/ax_cray.m4
@@ -36,7 +36,16 @@ AC_DEFUN([AX_HPE_CRAY],[
 	[is_hpe_cray="no"
 	AC_MSG_RESULT([no])])
 	AC_LANG_POP([C])
-	AC_SUBST(is_hpe_cray)])
+        if test x"${is_hpe_cray}" = xyes; then
+           AC_MSG_CHECKING([if CrayPE wrappers are used])
+           if test "${FC}" = "ftn"; then
+              AC_MSG_RESULT([yes])
+           else
+              is_hpe_cray="no"
+              AC_MSG_RESULT([no])
+           fi
+        fi
+      	AC_SUBST(is_hpe_cray)]) 
 
 AC_DEFUN([AX_CRAY_PETSC],[
 	AC_MSG_CHECKING([Cray PETSc])


### PR DESCRIPTION
Don't check loaded modules on a Cray EX unless CrayPE wrappers are used, fixes #855

Note if CrayPE wrappers aren't used, full search paths has to be given to e.g. `--with-hip`, `--with-blas` etc 