### PR TITLE
Scalar user bc

### DIFF
--- a/examples/rayleigh-benard/rayleigh.case
+++ b/examples/rayleigh-benard/rayleigh.case
@@ -9,10 +9,12 @@ scalar_source_term = 'noforce'
 /
 &NEKO_PARAMETERS
 dt = 1d-2
-T_end = 250
+T_end = 1000
 nsamples = 50
 uinf= 0.0,0.0,0.0
 output_bdry = .true.
+fluid_write_control = 'simulationtime'
+fluid_write_par = 10.0
 pc_vel = 'jacobi'
 pc_prs = 'hsmg'
 bc_labels(5) = 'w'

--- a/examples/rayleigh-benard/rayleigh.case
+++ b/examples/rayleigh-benard/rayleigh.case
@@ -10,7 +10,6 @@ scalar_source_term = 'noforce'
 &NEKO_PARAMETERS
 dt = 1d-2
 T_end = 1000
-nsamples = 50
 uinf= 0.0,0.0,0.0
 output_bdry = .true.
 fluid_write_control = 'simulationtime'

--- a/examples/rayleigh-benard/rayleigh.f90
+++ b/examples/rayleigh-benard/rayleigh.f90
@@ -13,8 +13,26 @@ contains
     u%user_init_modules => set_Pr
     u%fluid_user_ic => set_ic
     u%fluid_user_f_vector => forcing
+    u%scalar_user_bc => scalar_bc
   end subroutine user_setup
 
+  subroutine scalar_bc(s, x, y, z, nx, ny, nz, ix, iy, iz, ie)
+    real(kind=rp), intent(inout) :: s
+    real(kind=rp), intent(in) :: x
+    real(kind=rp), intent(in) :: y
+    real(kind=rp), intent(in) :: z
+    real(kind=rp), intent(in) :: nx
+    real(kind=rp), intent(in) :: ny
+    real(kind=rp), intent(in) :: nz
+    integer, intent(in) :: ix
+    integer, intent(in) :: iy
+    integer, intent(in) :: iz
+    integer, intent(in) :: ie
+    ! If we set scalar_bcs(*) = 'user' instead 
+    ! this will be used instead on that zone
+    s = 1.0_rp-z
+  end subroutine scalar_bc
+ 
   !> Dummy user initial condition
   subroutine set_ic(u, v, w, p, params)
     type(field_t), intent(inout) :: u
@@ -23,8 +41,8 @@ contains
     type(field_t), intent(inout) :: p
     type(param_t), intent(inout) :: params
     type(field_t), pointer :: s
-    integer :: i
-    real(kind=rp) :: rand
+    integer :: i, e, k, j
+    real(kind=rp) :: rand, z
     s => neko_field_registry%get_field('s')
 
     call rzero(u%x,u%dof%size())
@@ -32,9 +50,28 @@ contains
     call rzero(w%x,w%dof%size())
     
     do i = 1, s%dof%size()
-       s%x(i,1,1,1) = 1-s%dof%z(i,1,1,1) + 0.1*sin(4*pi/4.5*s%dof%x(i,1,1,1)) &
-                 * sin(4*pi/4.5*s%dof%y(i,1,1,1))*sqrt((0.5**2-(0.5_rp-s%dof%z(i,1,1,1))**2))
+       s%x(i,1,1,1) = 1-s%dof%z(i,1,1,1)
     end do
+    ! perturb not on element boundaries
+    ! Maybe not necessary, but lets be safe
+    do e = 1, s%msh%nelv
+       do k = 2,s%Xh%lx-1
+          do j = 2,s%Xh%lx-1
+             do i = 2,s%Xh%lx-1
+
+                !call random_number(rand)
+                !Somewhat random
+                rand = cos(real(e+s%msh%offset_el,rp)*real(i*j*k,rp))
+                z = s%dof%z(i,j,k,e)
+                s%x(i,j,k,e) = 1-z + 0.0001* rand*&
+                                     sin(4*pi/4.5*s%dof%x(i,j,k,e)) &
+                * sin(4*pi/4.5*s%dof%y(i,j,k,e))
+
+            end do
+          end do
+       end do
+    end do
+
     if ((NEKO_BCKND_CUDA .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
        .or. (NEKO_BCKND_OPENCL .eq. 1)) then
        call device_memcpy(s%x,s%x_d,s%dof%size(),HOST_TO_DEVICE)

--- a/src/bc/bcknd/device/cuda/inhom_dirichlet.cu
+++ b/src/bc/bcknd/device/cuda/inhom_dirichlet.cu
@@ -55,4 +55,22 @@ extern "C" {
     CUDA_CHECK(cudaGetLastError());
   }
  
+  /** 
+   * Fortran wrapper for device inhom_dirichlet apply scalar
+   */
+  void cuda_inhom_dirichlet_apply_scalar(void *msk, void *x,
+                                 void *bla_x, int *m) {
+    
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks(((*m)+1024 - 1)/ 1024, 1, 1);
+
+    inhom_dirichlet_apply_scalar_kernel<real>
+      <<<nblcks, nthrds>>>((int *) msk,
+                           (real *) x, 
+                           (real *) bla_x,
+                           *m);
+    CUDA_CHECK(cudaGetLastError());
+  }
+ 
+
 }

--- a/src/bc/bcknd/device/cuda/inhom_dirichlet_kernel.h
+++ b/src/bc/bcknd/device/cuda/inhom_dirichlet_kernel.h
@@ -55,3 +55,20 @@ __global__ void inhom_dirichlet_apply_vector_kernel(const int * __restrict__ msk
     z[k] = bla_z[i];
   }
 }
+/**
+ * Device kernel for scalar apply for an inhomogeneous Dirichlet condition
+ */
+template< typename T >
+__global__ void inhom_dirichlet_apply_scalar_kernel(const int * __restrict__ msk,
+                                            T * __restrict__ x,
+                                            const T * __restrict__ bla_x,
+                                            const int m) {
+
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  for (int i = idx; i < m; i += str) {
+    const int k = msk[i + 1] - 1;
+    x[k] = bla_x[i];
+  }
+}

--- a/src/bc/bcknd/device/cuda/inhom_dirichlet_kernel.h
+++ b/src/bc/bcknd/device/cuda/inhom_dirichlet_kernel.h
@@ -55,6 +55,7 @@ __global__ void inhom_dirichlet_apply_vector_kernel(const int * __restrict__ msk
     z[k] = bla_z[i];
   }
 }
+
 /**
  * Device kernel for scalar apply for an inhomogeneous Dirichlet condition
  */

--- a/src/bc/bcknd/device/device_inhom_dirichlet.F90
+++ b/src/bc/bcknd/device/device_inhom_dirichlet.F90
@@ -69,7 +69,43 @@ module device_inhom_dirichlet
        type(c_ptr), value :: msk, x, y, z, bla_x, bla_y, bla_z
      end subroutine opencl_inhom_dirichlet_apply_vector
   end interface
+
 #endif
+
+#ifdef HAVE_HIP
+  interface
+     subroutine hip_inhom_dirichlet_apply_scalar(msk, x, bla_x, m) &
+          bind(c, name='hip_inhom_dirichlet_apply_scalar')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       implicit none
+       integer(c_int) :: m
+       type(c_ptr), value :: msk, x, bla_x
+     end subroutine hip_inhom_dirichlet_apply_scalar
+  end interface
+#elif HAVE_CUDA
+  interface
+     subroutine cuda_inhom_dirichlet_apply_scalar(msk, x, bla_x, m) &
+          bind(c, name='cuda_inhom_dirichlet_apply_scalar')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       implicit none
+       integer(c_int) :: m
+       type(c_ptr), value :: msk, x, bla_x
+     end subroutine cuda_inhom_dirichlet_apply_scalar
+  end interface
+#elif HAVE_OPENCL
+  interface
+     subroutine opencl_inhom_dirichlet_apply_scalar(msk, x, bla_x, m) &
+          bind(c, name='opencl_inhom_dirichlet_apply_scalar')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       implicit none
+       integer(c_int) :: m
+       type(c_ptr), value :: msk, x, bla_x
+     end subroutine opencl_inhom_dirichlet_apply_scalar
+  end interface
+#endif 
 
 contains
 
@@ -88,5 +124,21 @@ contains
 #endif
     
   end subroutine device_inhom_dirichlet_apply_vector
+ 
+  subroutine device_inhom_dirichlet_apply_scalar(msk, x, bla_x, m)
+    integer, intent(in) :: m
+    type(c_ptr) :: msk, x, bla_x
+
+#ifdef HAVE_HIP
+    call hip_inhom_dirichlet_apply_scalar(msk, x, bla_x, m)
+#elif HAVE_CUDA
+    call cuda_inhom_dirichlet_apply_scalar(msk, x, bla_x, m)
+#elif HAVE_OPENCL
+    call opencl_inhom_dirichlet_apply_scalar(msk, x, bla_x, m)
+#else
+    call neko_error('No device backend configured')
+#endif
+    
+  end subroutine device_inhom_dirichlet_apply_scalar
   
 end module device_inhom_dirichlet

--- a/src/bc/bcknd/device/hip/inhom_dirichlet.hip
+++ b/src/bc/bcknd/device/hip/inhom_dirichlet.hip
@@ -56,4 +56,22 @@ extern "C" {
     HIP_CHECK(hipGetLastError());
   }
  
+  /** 
+   * Fortran wrapper for device inhom_dirichlet apply scalar
+   */
+  void hip_inhom_dirichlet_apply_scalar(void *msk, void *x, 
+				                        void *bla_x,  int *m) {
+    
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks(((*m)+1024 - 1)/ 1024, 1, 1);
+
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(inhom_dirichlet_apply_scalar_kernel<real>),
+		       nblcks, nthrds, 0, 0, (int *) msk, 
+			   (real *) x,
+			   (real *) bla_x,
+			   *m);
+    HIP_CHECK(hipGetLastError());
+  }
+ 
+
 }

--- a/src/bc/bcknd/device/hip/inhom_dirichlet_kernel.h
+++ b/src/bc/bcknd/device/hip/inhom_dirichlet_kernel.h
@@ -55,3 +55,20 @@ __global__ void inhom_dirichlet_apply_vector_kernel(const int * __restrict__ msk
     z[k] = bla_z[i];
   }
 }
+/**
+ * Device kernel for scalar apply for an inhomogeneous Dirichlet condition
+ */
+template< typename T >
+__global__ void inhom_dirichlet_apply_scalar_kernel(const int * __restrict__ msk,
+					    T * __restrict__ x,
+					    const T * __restrict__ bla_x,
+					    const int m) {
+
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  for (int i = idx; i < m; i += str) {
+    const int k = msk[i + 1] - 1;
+    x[k] = bla_x[i];
+  }
+}

--- a/src/bc/bcknd/device/hip/inhom_dirichlet_kernel.h
+++ b/src/bc/bcknd/device/hip/inhom_dirichlet_kernel.h
@@ -55,6 +55,7 @@ __global__ void inhom_dirichlet_apply_vector_kernel(const int * __restrict__ msk
     z[k] = bla_z[i];
   }
 }
+
 /**
  * Device kernel for scalar apply for an inhomogeneous Dirichlet condition
  */

--- a/src/bc/bcknd/device/opencl/inhom_dirichlet.c
+++ b/src/bc/bcknd/device/opencl/inhom_dirichlet.c
@@ -84,7 +84,7 @@ void opencl_inhom_dirichlet_apply_vector(void *msk,
 /** 
  * Fortran wrapper for device dirichlet apply scalar
  */
-void opencl_inhom_dirichlet_apply_vector(void *msk,
+void opencl_inhom_dirichlet_apply_scalar(void *msk,
                                  void *x,
                                  void *bla_x, 
                                  int *m) {

--- a/src/bc/bcknd/device/opencl/inhom_dirichlet_kernel.cl
+++ b/src/bc/bcknd/device/opencl/inhom_dirichlet_kernel.cl
@@ -54,3 +54,20 @@ __kernel void inhom_dirichlet_apply_vector_kernel(__global const int *msk,
     z[k] = bla_z[i];
   }
 }
+
+/**
+ * Device kernel for scalar apply for an inhomogeneous Dirichlet condition
+ */
+__kernel void inhom_dirichlet_apply_scalar_kernel(__global const int *msk,
+					  __global real *x,
+					  __global real *bla_x,
+					  const int m) {
+  
+  const int idx = get_global_id(0);
+  const int str = get_global_size(0);
+
+  for (int i = idx; i < m; i += str) {
+    const int k = msk[i + 1] -1;
+    x[k] = bla_x[i];
+  }
+}

--- a/src/bc/usr_inflow.f90
+++ b/src/bc/usr_inflow.f90
@@ -80,6 +80,7 @@ module usr_inflow
        integer, intent(in) :: ie
      end subroutine usr_inflow_eval
   end interface
+
   !> Abstract interface defining a user defined scalar boundary condition (pointwise)
   !! JUst imitating inflow for now, but we should update this
   !! Probably passing the whole field, params, coef, etcetc would be good

--- a/src/bc/usr_inflow.f90
+++ b/src/bc/usr_inflow.f90
@@ -100,7 +100,6 @@ module usr_inflow
      !! Just imitating inflow for now, but we should update this
      !! Probably passing the whole field, params, coef, etcetc would be good
      !! @param s The scalar's value in this point
-     !! @param v The y componenet of the velocity in this point
      !! @param w The w componenet of the velocity in this point
      !! @param x The x coord in this point
      !! @param y The y coord in this point

--- a/src/bc/usr_inflow.f90
+++ b/src/bc/usr_inflow.f90
@@ -97,7 +97,7 @@ module usr_inflow
 
   abstract interface
      !> Abstract interface defining a user defined scalar boundary condition (pointwise)
-     !! JUst imitating inflow for now, but we should update this
+     !! Just imitating inflow for now, but we should update this
      !! Probably passing the whole field, params, coef, etcetc would be good
      !! @param u The x componenet of the velocity in this point
      !! @param v The y componenet of the velocity in this point

--- a/src/bc/usr_inflow.f90
+++ b/src/bc/usr_inflow.f90
@@ -151,6 +151,8 @@ contains
   !> Scalar apply
   !! Just imitating inflow for now, but we should look this over
   !! Applies boundary conditions in eval_scalar_bc on x
+  !! @param x The array of values to apply.
+  !! @param n The size of x.
   subroutine usr_inflow_apply_scalar(this, x, n)
     class(usr_inflow_t), intent(inout) :: this
     integer, intent(in) :: n

--- a/src/bc/usr_inflow.f90
+++ b/src/bc/usr_inflow.f90
@@ -134,7 +134,6 @@ contains
          nx => this%c%nx, ny => this%c%ny, nz => this%c%nz, &
          lx => this%c%Xh%lx)
       m = this%msk(0)
-      print *, m
       do i = 1, m
          k = this%msk(i)
          facet = this%facet(i)
@@ -314,7 +313,6 @@ contains
     integer(c_size_t) :: s
     real(kind=rp), allocatable :: x(:)
       m = this%msk(0)
-      print *, m, m*rp
 
     associate(xc => this%c%dof%x, yc => this%c%dof%y, zc => this%c%dof%z, &
          nx => this%c%nx, ny => this%c%ny, nz => this%c%nz, &

--- a/src/bc/usr_inflow.f90
+++ b/src/bc/usr_inflow.f90
@@ -61,8 +61,22 @@ module usr_inflow
      final :: usr_inflow_free
   end type usr_inflow_t
 
-  !> Abstract interface defining a user defined inflow condition (pointwise)
   abstract interface
+   
+     !> Abstract interface defining a user defined inflow condition (pointwise)
+     !! @param u The x componenet of the velocity in this point
+     !! @param v The y componenet of the velocity in this point
+     !! @param w The w componenet of the velocity in this point
+     !! @param x The x coord in this point
+     !! @param y The y coord in this point
+     !! @param z The z coord in this point
+     !! @param nx The x component of the facet normal in this point
+     !! @param ny The y component of the facet normal in this point
+     !! @param nz The z component of the facet normal in this point
+     !! @param ix The r idx of this point
+     !! @param iy The s idx of this point
+     !! @param iz The t idx of this point
+     !! @param ie The element idx of this point
      subroutine usr_inflow_eval(u, v, w, x, y, z, nx, ny, nz, ix, iy, iz, ie)
        import rp
        real(kind=rp), intent(inout) :: u
@@ -81,10 +95,23 @@ module usr_inflow
      end subroutine usr_inflow_eval
   end interface
 
-  !> Abstract interface defining a user defined scalar boundary condition (pointwise)
-  !! JUst imitating inflow for now, but we should update this
-  !! Probably passing the whole field, params, coef, etcetc would be good
   abstract interface
+     !> Abstract interface defining a user defined scalar boundary condition (pointwise)
+     !! JUst imitating inflow for now, but we should update this
+     !! Probably passing the whole field, params, coef, etcetc would be good
+     !! @param u The x componenet of the velocity in this point
+     !! @param v The y componenet of the velocity in this point
+     !! @param w The w componenet of the velocity in this point
+     !! @param x The x coord in this point
+     !! @param y The y coord in this point
+     !! @param z The z coord in this point
+     !! @param nx The x component of the facet normal in this point
+     !! @param ny The y component of the facet normal in this point
+     !! @param nz The z component of the facet normal in this point
+     !! @param ix The r idx of this point
+     !! @param iy The s idx of this point
+     !! @param iz The t idx of this point
+     !! @param ie The element idx of this point
      subroutine usr_scalar_bc_eval(s, x, y, z, nx, ny, nz, ix, iy, iz, ie)
        import rp
        real(kind=rp), intent(inout) :: s
@@ -125,6 +152,7 @@ contains
   
   !> Scalar apply
   !! Just imitating inflow for now, but we should look this over
+  !! Applies boundary conditions in eval_scalar_bc on x
   subroutine usr_inflow_apply_scalar(this, x, n)
     class(usr_inflow_t), intent(inout) :: this
     integer, intent(in) :: n
@@ -385,6 +413,7 @@ contains
   end subroutine usr_inflow_set_coef
 
   !> Assign user provided eval function
+  !! @param user_eval User specified boundary condition for u,v,w (vector)
   subroutine usr_inflow_set_eval(this, usr_eval)
     class(usr_inflow_t), intent(inout) :: this
     procedure(usr_inflow_eval) :: usr_eval
@@ -392,6 +421,7 @@ contains
   end subroutine usr_inflow_set_eval
 
   !> Assign user provided eval function
+  !! @param user_scalar_bc User specified scalar boundary condition
   subroutine usr_set_scalar_bc(this, user_scalar_bc)
     class(usr_inflow_t), intent(inout) :: this
     procedure(usr_scalar_bc_eval) :: user_scalar_bc

--- a/src/bc/usr_inflow.f90
+++ b/src/bc/usr_inflow.f90
@@ -100,7 +100,6 @@ module usr_inflow
      !! Just imitating inflow for now, but we should update this
      !! Probably passing the whole field, params, coef, etcetc would be good
      !! @param s The scalar's value in this point
-     !! @param w The w componenet of the velocity in this point
      !! @param x The x coord in this point
      !! @param y The y coord in this point
      !! @param z The z coord in this point

--- a/src/bc/usr_inflow.f90
+++ b/src/bc/usr_inflow.f90
@@ -313,7 +313,7 @@ contains
     integer :: i, m, k, idx(4), facet
     integer(c_size_t) :: s
     real(kind=rp), allocatable :: x(:)
-      m = this%msk(0)
+    m = this%msk(0)
 
     associate(xc => this%c%dof%x, yc => this%c%dof%y, zc => this%c%dof%z, &
          nx => this%c%nx, ny => this%c%ny, nz => this%c%nz, &

--- a/src/bc/usr_inflow.f90
+++ b/src/bc/usr_inflow.f90
@@ -99,7 +99,7 @@ module usr_inflow
      !> Abstract interface defining a user defined scalar boundary condition (pointwise)
      !! Just imitating inflow for now, but we should update this
      !! Probably passing the whole field, params, coef, etcetc would be good
-     !! @param u The x componenet of the velocity in this point
+     !! @param s The scalar's value in this point
      !! @param v The y componenet of the velocity in this point
      !! @param w The w componenet of the velocity in this point
      !! @param x The x coord in this point

--- a/src/bc/usr_inflow.f90
+++ b/src/bc/usr_inflow.f90
@@ -45,6 +45,7 @@ module usr_inflow
   type, public, extends(inflow_t) :: usr_inflow_t
      type(coef_t), pointer :: c => null()
      procedure(usr_inflow_eval), nopass, pointer :: eval => null()
+     procedure(usr_scalar_bc_eval), nopass, pointer :: eval_scalar_bc => null()
      type(c_ptr), private :: usr_x_d = C_NULL_PTR
      type(c_ptr), private :: usr_y_d = C_NULL_PTR
      type(c_ptr), private :: usr_z_d = C_NULL_PTR
@@ -54,6 +55,7 @@ module usr_inflow
      procedure, pass(this) :: validate => usr_inflow_validate
      procedure, pass(this) :: set_coef => usr_inflow_set_coef
      procedure, pass(this) :: set_eval => usr_inflow_set_eval
+     procedure, pass(this) :: set_scalar_bc => usr_set_scalar_bc
      procedure, pass(this) :: apply_vector_dev => usr_inflow_apply_vector_dev
      procedure, pass(this) :: apply_scalar_dev => usr_inflow_apply_scalar_dev
      final :: usr_inflow_free
@@ -78,8 +80,28 @@ module usr_inflow
        integer, intent(in) :: ie
      end subroutine usr_inflow_eval
   end interface
+  !> Abstract interface defining a user defined scalar boundary condition (pointwise)
+  !! JUst imitating inflow for now, but we should update this
+  !! Probably passing the whole field, params, coef, etcetc would be good
+  abstract interface
+     subroutine usr_scalar_bc_eval(s, x, y, z, nx, ny, nz, ix, iy, iz, ie)
+       import rp
+       real(kind=rp), intent(inout) :: s
+       real(kind=rp), intent(in) :: x
+       real(kind=rp), intent(in) :: y
+       real(kind=rp), intent(in) :: z
+       real(kind=rp), intent(in) :: nx
+       real(kind=rp), intent(in) :: ny
+       real(kind=rp), intent(in) :: nz
+       integer, intent(in) :: ix
+       integer, intent(in) :: iy
+       integer, intent(in) :: iz
+       integer, intent(in) :: ie
+     end subroutine usr_scalar_bc_eval
+  end interface
 
-  public :: usr_inflow_eval
+
+  public :: usr_inflow_eval, usr_scalar_bc_eval
 
 contains
      
@@ -100,11 +122,54 @@ contains
     
   end subroutine usr_inflow_free
   
-  !> No-op scalar apply
+  !> Scalar apply
+  !! Just imitating inflow for now, but we should look this over
   subroutine usr_inflow_apply_scalar(this, x, n)
     class(usr_inflow_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout),  dimension(n) :: x
+    integer :: i, m, k, idx(4), facet
+
+    associate(xc => this%c%dof%x, yc => this%c%dof%y, zc => this%c%dof%z, &
+         nx => this%c%nx, ny => this%c%ny, nz => this%c%nz, &
+         lx => this%c%Xh%lx)
+      m = this%msk(0)
+      print *, m
+      do i = 1, m
+         k = this%msk(i)
+         facet = this%facet(i)
+         idx = nonlinear_index(k, lx, lx, lx)
+         select case(facet)
+         case(1,2)          
+            call this%eval_scalar_bc(x(k), &
+                 xc(idx(1), idx(2), idx(3), idx(4)), &
+                 yc(idx(1), idx(2), idx(3), idx(4)), &
+                 zc(idx(1), idx(2), idx(3), idx(4)), &
+                 nx(idx(2), idx(3), facet, idx(4)), &
+                 ny(idx(2), idx(3), facet, idx(4)), &
+                 nz(idx(2), idx(3), facet, idx(4)), &
+                 idx(1), idx(2), idx(3), idx(4))
+         case(3,4)
+            call this%eval_scalar_bc(x(k), &
+                 xc(idx(1), idx(2), idx(3), idx(4)), &
+                 yc(idx(1), idx(2), idx(3), idx(4)), &
+                 zc(idx(1), idx(2), idx(3), idx(4)), &       
+                 nx(idx(1), idx(3), facet, idx(4)), &
+                 ny(idx(1), idx(3), facet, idx(4)), &
+                 nz(idx(1), idx(3), facet, idx(4)), &
+                 idx(1), idx(2), idx(3), idx(4))
+         case(5,6)
+            call this%eval_scalar_bc(x(k), &
+                 xc(idx(1), idx(2), idx(3), idx(4)), &
+                 yc(idx(1), idx(2), idx(3), idx(4)), &
+                 zc(idx(1), idx(2), idx(3), idx(4)), &                     
+                 nx(idx(1), idx(2), facet, idx(4)), &
+                 ny(idx(1), idx(2), facet, idx(4)), &
+                 nz(idx(1), idx(2), facet, idx(4)), &
+                 idx(1), idx(2), idx(3), idx(4))
+         end select
+      end do
+    end associate
   end subroutine usr_inflow_apply_scalar
 
   !> Apply user defined inflow conditions (vector valued)
@@ -245,6 +310,70 @@ contains
   subroutine usr_inflow_apply_scalar_dev(this, x_d)
     class(usr_inflow_t), intent(inout), target :: this
     type(c_ptr) :: x_d
+    integer :: i, m, k, idx(4), facet
+    integer(c_size_t) :: s
+    real(kind=rp), allocatable :: x(:)
+      m = this%msk(0)
+      print *, m, m*rp
+
+    associate(xc => this%c%dof%x, yc => this%c%dof%y, zc => this%c%dof%z, &
+         nx => this%c%nx, ny => this%c%ny, nz => this%c%nz, &
+         lx => this%c%Xh%lx, usr_x_d => this%usr_x_d)
+
+
+      ! Pretabulate values during first call to apply
+      if (.not. c_associated(usr_x_d)) then
+         allocate(x(m)) ! Temp arrays
+         s = m*rp
+
+         call device_alloc(this%usr_x_d, s)
+
+         do i = 1, m
+            k = this%msk(i)
+            facet = this%facet(i)
+            idx = nonlinear_index(k, lx, lx, lx)
+            select case(facet)
+            case(1,2)          
+               call this%eval_scalar_bc(x(i), &
+                    xc(idx(1), idx(2), idx(3), idx(4)), &
+                    yc(idx(1), idx(2), idx(3), idx(4)), &
+                    zc(idx(1), idx(2), idx(3), idx(4)), &
+                    nx(idx(2), idx(3), facet, idx(4)), &
+                    ny(idx(2), idx(3), facet, idx(4)), &
+                    nz(idx(2), idx(3), facet, idx(4)), &
+                    idx(1), idx(2), idx(3), idx(4))
+            case(3,4)
+               call this%eval_scalar_bc(x(i), &
+                    xc(idx(1), idx(2), idx(3), idx(4)), &
+                    yc(idx(1), idx(2), idx(3), idx(4)), &
+                    zc(idx(1), idx(2), idx(3), idx(4)), &       
+                    nx(idx(1), idx(3), facet, idx(4)), &
+                    ny(idx(1), idx(3), facet, idx(4)), &
+                    nz(idx(1), idx(3), facet, idx(4)), &
+                    idx(1), idx(2), idx(3), idx(4))
+            case(5,6)
+               call this%eval_scalar_bc(x(i), &
+                    xc(idx(1), idx(2), idx(3), idx(4)), &
+                    yc(idx(1), idx(2), idx(3), idx(4)), &
+                    zc(idx(1), idx(2), idx(3), idx(4)), &                     
+                    nx(idx(1), idx(2), facet, idx(4)), &
+                    ny(idx(1), idx(2), facet, idx(4)), &
+                    nz(idx(1), idx(2), facet, idx(4)), &
+                    idx(1), idx(2), idx(3), idx(4))
+            end select
+         end do
+ 
+        
+         call device_memcpy(x, this%usr_x_d, m, HOST_TO_DEVICE)
+
+         deallocate(x)
+      end if
+
+      call device_inhom_dirichlet_apply_scalar(this%msk_d, x_d, &
+                                               this%usr_x_d, m)
+    end associate
+
+
   end subroutine usr_inflow_apply_scalar_dev
   
 
@@ -262,6 +391,14 @@ contains
     procedure(usr_inflow_eval) :: usr_eval
     this%eval => usr_eval
   end subroutine usr_inflow_set_eval
+
+  !> Assign user provided eval function
+  subroutine usr_set_scalar_bc(this, user_scalar_bc)
+    class(usr_inflow_t), intent(inout) :: this
+    procedure(usr_scalar_bc_eval) :: user_scalar_bc
+    this%eval_scalar_bc => user_scalar_bc
+  end subroutine usr_set_scalar_bc
+
 
   !> Validate user inflow condition
   subroutine usr_inflow_validate(this)

--- a/src/case.f90
+++ b/src/case.f90
@@ -223,6 +223,7 @@ contains
        else
           call C%scalar%set_source(trim(scalar_source_term))
        end if
+       call C%scalar%set_user_bc(C%usr%scalar_user_bc)
     end if
 
     !

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -108,6 +108,7 @@ module user_intf
      procedure(source_scalar_term_pw), nopass, pointer :: scalar_user_f => null()
      procedure(source_scalar_term), nopass, pointer :: scalar_user_f_vector => null()
      procedure(usr_inflow_eval), nopass, pointer :: fluid_user_if => null()
+     procedure(usr_scalar_bc_eval), nopass, pointer :: scalar_user_bc => null()
    contains
      procedure, pass(u) :: init => user_intf_init
   end type user_t
@@ -135,6 +136,10 @@ contains
     
     if (.not. associated(u%scalar_user_f_vector)) then
        u%scalar_user_f_vector => dummy_user_scalar_f_vector
+    end if
+
+    if (.not. associated(u%scalar_user_bc)) then
+       u%scalar_user_bc => dummy_scalar_user_bc
     end if
     
     if (.not. associated(u%user_mesh_setup)) then
@@ -203,6 +208,22 @@ contains
     real(kind=rp), intent(in) :: t
     call neko_error('Dummy user defined forcing set')    
   end subroutine dummy_scalar_user_f
+ 
+  !> Dummy user boundary condition for scalar
+  subroutine dummy_scalar_user_bc(s, x, y, z, nx, ny, nz, ix, iy, iz, ie)
+    real(kind=rp), intent(inout) :: s
+    real(kind=rp), intent(in) :: x
+    real(kind=rp), intent(in) :: y
+    real(kind=rp), intent(in) :: z
+    real(kind=rp), intent(in) :: nx
+    real(kind=rp), intent(in) :: ny
+    real(kind=rp), intent(in) :: nz
+    integer, intent(in) :: ix
+    integer, intent(in) :: iy
+    integer, intent(in) :: iz
+    integer, intent(in) :: ie
+    call neko_warning('Dummy scalar user bc set, applied on all non-labeled zones')    
+  end subroutine dummy_scalar_user_bc
  
   !> Dummy user mesh apply
   subroutine dummy_user_mesh_setup(msh)

--- a/src/scalar/scalar_pnpn.f90
+++ b/src/scalar/scalar_pnpn.f90
@@ -144,6 +144,10 @@ contains
     do i = 1, this%n_dir_bcs
        call this%bc_res%mark_facets(this%dir_bcs(i)%marked_facet)
     end do
+    ! Check for user bcs
+    if (this%user_bc%msk(0) .gt. 0) then
+       call this%bc_res%mark_facets(this%user_bc%marked_facet)
+    end if
     call this%bc_res%finalize()
     call this%bc_res%set_g(0.0_rp)
     call bc_list_init(this%bclst_ds)

--- a/src/scalar/scalar_pnpn.f90
+++ b/src/scalar/scalar_pnpn.f90
@@ -144,6 +144,7 @@ contains
     do i = 1, this%n_dir_bcs
        call this%bc_res%mark_facets(this%dir_bcs(i)%marked_facet)
     end do
+
     ! Check for user bcs
     if (this%user_bc%msk(0) .gt. 0) then
        call this%bc_res%mark_facets(this%user_bc%marked_facet)

--- a/src/scalar/scalar_scheme.f90
+++ b/src/scalar/scalar_scheme.f90
@@ -54,6 +54,7 @@ module scalar_scheme
   use time_scheme_controller
   use logger
   use field_registry
+  use usr_inflow
   implicit none
 
   type, abstract :: scalar_scheme_t
@@ -69,6 +70,7 @@ module scalar_scheme
      class(ksp_t), allocatable  :: ksp         !< Krylov solver
      class(pc_t), allocatable :: pc            !< Preconditioner
      type(dirichlet_t) :: dir_bcs(NEKO_MSH_MAX_ZLBLS)   !< Dirichlet conditions
+     type(usr_inflow_t) :: user_bc   !< Dirichlet conditions
      integer :: n_dir_bcs = 0
      type(bc_list_t) :: bclst                  !< List of boundary conditions
      type(param_t), pointer :: params          !< Parameters          
@@ -80,6 +82,7 @@ module scalar_scheme
      procedure, pass(this) :: validate => scalar_scheme_validate
      procedure, pass(this) :: bc_apply => scalar_scheme_bc_apply
      procedure, pass(this) :: set_source => scalar_scheme_set_source
+     procedure, pass(this) :: set_user_bc => scalar_scheme_set_user_bc
      procedure(scalar_scheme_init_intrf), pass(this), deferred :: init
      procedure(scalar_scheme_free_intrf), pass(this), deferred :: free
      procedure(scalar_scheme_step_intrf), pass(this), deferred :: step
@@ -157,6 +160,10 @@ contains
             call this%dir_bcs(this%n_dir_bcs)%set_g(dir_value)
          end if
        end if
+       !> Check if user bc on this zone
+       if (bc_label(1:4) .eq. 'user') then
+          call this%user_bc%mark_zone(zones(i))
+       end if
     end do
 
     do i = 1, this%n_dir_bcs
@@ -205,7 +212,17 @@ contains
     !
     call bc_list_init(this%bclst)
 
+    call this%user_bc%init(this%dm_Xh)
     call scalar_scheme_add_bcs(this, msh%labeled_zones, this%params%scalar_bcs) 
+
+    call this%user_bc%mark_zone(msh%wall)
+    call this%user_bc%mark_zone(msh%inlet)
+    call this%user_bc%mark_zone(msh%outlet)
+    call this%user_bc%mark_zone(msh%outlet_normal)
+    call this%user_bc%mark_zone(msh%sympln)
+    call this%user_bc%finalize()
+    call this%user_bc%set_coef(this%c_Xh)
+    if (this%user_bc%msk(0) .gt. 0) call bc_list_add(this%bclst, this%user_bc)
   
     ! todo parameter file ksp tol should be added
     call scalar_scheme_solver_factory(this%ksp, this%dm_Xh%size(), &
@@ -365,5 +382,15 @@ contains
     end if
 
   end subroutine scalar_scheme_set_source
-     
+ 
+  !> Initialize a user defined scalar bc
+  subroutine scalar_scheme_set_user_bc(this, usr_eval)
+    class(scalar_scheme_t), intent(inout) :: this
+    procedure(usr_scalar_bc_eval) :: usr_eval
+
+    call this%user_bc%set_scalar_bc(usr_eval)
+    
+  end subroutine scalar_scheme_set_user_bc
+
+    
 end module scalar_scheme

--- a/src/scalar/scalar_scheme.f90
+++ b/src/scalar/scalar_scheme.f90
@@ -160,6 +160,7 @@ contains
             call this%dir_bcs(this%n_dir_bcs)%set_g(dir_value)
          end if
        end if
+
        !> Check if user bc on this zone
        if (bc_label(1:4) .eq. 'user') then
           call this%user_bc%mark_zone(zones(i))

--- a/src/scalar/scalar_scheme.f90
+++ b/src/scalar/scalar_scheme.f90
@@ -129,6 +129,9 @@ module scalar_scheme
 contains
 
   !> Initialize boundary conditions
+  !! @param zones List of zones
+  !! @param bc_labels List of user specified bcs from the parameter file
+  !! currently dirichlet 'd=X' and 'user' supported
   subroutine scalar_scheme_add_bcs(this, zones, bc_labels) 
     class(scalar_scheme_t), intent(inout) :: this 
     type(zone_t), intent(inout) :: zones(NEKO_MSH_MAX_ZLBLS)
@@ -385,6 +388,7 @@ contains
   end subroutine scalar_scheme_set_source
  
   !> Initialize a user defined scalar bc
+  !! @param usr_eval User specified boundary condition for scalar field
   subroutine scalar_scheme_set_user_bc(this, usr_eval)
     class(scalar_scheme_t), intent(inout) :: this
     procedure(usr_scalar_bc_eval) :: usr_eval


### PR DESCRIPTION
Enables user boundary conditions for the scalar. We should look over the structure of the BCs as we have discussed, but that would be rather intrusive.

User bcs for the scalar is enabled by default for all zones that are not labeled, meaning that one gets a warning if one runs with scalar enabled on a mesh with hardcoded bcs in the mesh without setting the scalar user bc.

I will add an example RBC case in another PR to show the usage.

I have not tested on HIP and OpenCL.