### PR TITLE
Update all coefficients in time_scheme_controller

### DIFF
--- a/src/time_schemes/time_scheme_controller.f90
+++ b/src/time_schemes/time_scheme_controller.f90
@@ -74,9 +74,9 @@ module time_scheme_controller
      type(bdf_time_scheme_t) :: bdf
   
      !> Time coefficients for the advection operator
-     real(kind=rp) advection_coeffs(4)
+     real(kind=rp) :: advection_coeffs(4) = 0
      !> Time coefficients for the diffusion operator
-     real(kind=rp) diffusion_coeffs(4)
+     real(kind=rp) :: diffusion_coeffs(4) = 0
      !> Controls the actual order of the diffusion scheme,
      !!  e.g. 1 at the first time-step
      integer :: ndiff = 0
@@ -155,6 +155,9 @@ module time_scheme_controller
       adv_coeffs_d  => this%advection_coeffs_d, &
       diff_coeffs   => this%diffusion_coeffs, &
       diff_coeffs_d => this%diffusion_coeffs_d)
+   
+      adv_coeffs_old = adv_coeffs
+      diff_coeffs_old = diff_coeffs
     
       ! Increment the order of the scheme if below time_order
       ndiff = ndiff + 1


### PR DESCRIPTION
* It was forgotten to assign the variables for the old scheme coeffs, `adv_coeffs_old` and `diff_coeffs_old`.
* I now also init the coeff class attributes to 0, so that one does not assign garbage to `adv_coeffs_old` and `diff_coeffs_old` at the first iteration.