### PR TITLE
Tensor docstring

### DIFF
--- a/src/math/tensor.f90
+++ b/src/math/tensor.f90
@@ -198,8 +198,7 @@ contains
     
   end subroutine tnsr3d
 
-  !> v = [C (x) B (x) A] u
-  ! @TODO: Clarify the docstring
+  !> Inplace tensor product \f$ v =(C \otimes B \otimes A) v \f$
   subroutine tnsr1_3d(v, nv, nu, A, Bt, Ct, nelv)
     integer, intent(inout) :: nv, nu, nelv
     real(kind=rp), intent(inout) :: v(nv*nv*nv*nelv)

--- a/src/math/tensor.f90
+++ b/src/math/tensor.f90
@@ -158,7 +158,8 @@ contains
     
   end subroutine tnsr2d_el
 
-
+  !> Tensor product \f$ v =(C \otimes B \otimes A) u \f$
+  !! performed on a single element
   subroutine tnsr3d_el(v, nv, u, nu, A, Bt, Ct)
     integer, intent(in) :: nv, nu
     real(kind=rp), intent(inout) :: v(nv*nv*nv), u(nu*nu*nu)
@@ -173,7 +174,9 @@ contains
     end if
     
   end subroutine tnsr3d_el
- 
+
+  !> Tensor product \f$ v =(C \otimes B \otimes A) u \f$ performed on
+  !!`nelv` elements
   subroutine tnsr3d(v, nv, u, nu, A, Bt, Ct, nelv)
     integer, intent(inout) :: nv, nu, nelv
     real(kind=rp), intent(inout) :: v(nv*nv*nv,nelv), u(nu*nu*nu,nelv)
@@ -198,7 +201,7 @@ contains
     
   end subroutine tnsr3d
 
-  !> Inplace tensor product \f$ v =(C \otimes B \otimes A) v \f$
+  !> In place tensor product \f$ v =(C \otimes B \otimes A) v \f$
   subroutine tnsr1_3d(v, nv, nu, A, Bt, Ct, nelv)
     integer, intent(inout) :: nv, nu, nelv
     real(kind=rp), intent(inout) :: v(nv*nv*nv*nelv)

--- a/src/math/tensor.f90
+++ b/src/math/tensor.f90
@@ -141,9 +141,8 @@ contains
     end do
     
   end subroutine trsp1
-!      computes
-!              T
-!     v = A u B
+
+  !> Computes \f$ v = A u B^T \f$
   subroutine tnsr2d_el(v, nv, u, nu, A, Bt)
     integer, intent(in) :: nv, nu
     real(kind=rp), intent(inout) :: v(nv*nv), u(nu*nu)
@@ -199,7 +198,9 @@ contains
     
   end subroutine tnsr3d
 
-  subroutine tnsr1_3d(v, nv, nu, A, Bt, Ct, nelv) ! v = [C (x) B (x) A] u
+  !> v = [C (x) B (x) A] u
+  ! @TODO: Clarify the docstring
+  subroutine tnsr1_3d(v, nv, nu, A, Bt, Ct, nelv)
     integer, intent(inout) :: nv, nu, nelv
     real(kind=rp), intent(inout) :: v(nv*nv*nv*nelv)
     real(kind=rp), intent(inout) :: A(nv,nu), Bt(nu, nv), Ct(nu,nv)
@@ -214,10 +215,10 @@ contains
 
   end subroutine tnsr1_3d
 
+  !> Maps and adds to S a tensor product form of the three functions H1,H2,H3.
+  !! This is a single element routine used for deforming geometry.
   subroutine addtnsr(s, h1, h2, h3, nx, ny, nz)
 
-    !Map and add to S a tensor product form of the three functions H1,H2,H3.
-    !This is a single element routine used for deforming geometry.
     integer, intent(in) :: nx, ny, nz
     real(kind=rp), intent(in) :: h1(nx), h2(ny), h3(nz) 
     real(kind=rp), intent(inout) ::  s(nx, ny, nz)


### PR DESCRIPTION
Just reformatted some of the docstring. 

Can someone confirm that `tnsr1_3d` indeed performs an **in place** tensor product on `v`? At least from what I understand in `tensor_cpu.f90` and the `tnsr1_3d_nvnu_cpu` subroutine ([link](https://extremeflow.github.io/neko/d4/d59/namespacetensor__cpu.html#a76c565e69f284712e065de8ccb82082c))