### PR TITLE
Feature/user finalize

### DIFF
--- a/examples/lid/lid.f90
+++ b/examples/lid/lid.f90
@@ -19,6 +19,7 @@ module user
     user%fluid_user_if => user_bc
     user%user_check => user_calc_quantities
     user%user_init_modules => user_initialize
+    user%user_finalize_modules => user_finalize
   end subroutine user_setup
 
   ! user-defined boundary condition
@@ -137,5 +138,24 @@ module user
     end if
 
   end function step
-  
+
+  ! User-defined finalization routine called at the end of the simulation
+  subroutine user_finalize(t, u, v, w, p, coef, params)
+    real(kind=rp) :: t
+    type(field_t), intent(inout) :: u
+    type(field_t), intent(inout) :: v
+    type(field_t), intent(inout) :: w
+    type(field_t), intent(inout) :: p
+    type(coef_t), intent(inout) :: coef
+    type(param_t), intent(inout) :: params
+
+    ! Deallocate the fields
+    call field_free(om1)
+    call field_free(om2)
+    call field_free(om3)
+    call field_free(w1)
+    call field_free(w2)
+
+  end subroutine user_finalize
+
 end module user

--- a/examples/lid/lid.f90
+++ b/examples/lid/lid.f90
@@ -19,7 +19,7 @@ module user
     user%fluid_user_if => user_bc
     user%user_check => user_calc_quantities
     user%user_init_modules => user_initialize
-    user%user_final_modules => user_finalize
+    user%user_finalize_modules => user_finalize
   end subroutine user_setup
 
   ! user-defined boundary condition

--- a/examples/lid/lid.f90
+++ b/examples/lid/lid.f90
@@ -140,13 +140,8 @@ module user
   end function step
 
   ! User-defined finalization routine called at the end of the simulation
-  subroutine user_finalize(t, u, v, w, p, coef, params)
+  subroutine user_finalize(t, params)
     real(kind=rp) :: t
-    type(field_t), intent(inout) :: u
-    type(field_t), intent(inout) :: v
-    type(field_t), intent(inout) :: w
-    type(field_t), intent(inout) :: p
-    type(coef_t), intent(inout) :: coef
     type(param_t), intent(inout) :: params
 
     ! Deallocate the fields

--- a/examples/lid/lid.f90
+++ b/examples/lid/lid.f90
@@ -19,7 +19,7 @@ module user
     user%fluid_user_if => user_bc
     user%user_check => user_calc_quantities
     user%user_init_modules => user_initialize
-    user%user_finalize_modules => user_finalize
+    user%user_final_modules => user_finalize
   end subroutine user_setup
 
   ! user-defined boundary condition

--- a/examples/lid/lid2d.f90
+++ b/examples/lid/lid2d.f90
@@ -19,6 +19,7 @@ module user
     user%fluid_user_if => user_bc
     user%user_check => user_calc_quantities
     user%user_init_modules => user_initialize
+    user%user_finalize_modules => user_finalize
   end subroutine user_setup
 
   ! user-defined boundary condition
@@ -137,5 +138,24 @@ module user
     end if
 
   end function step
-  
+
+  ! User-defined finalization routine called at the end of the simulation
+  subroutine user_finalize(t, u, v, w, p, coef, params)
+    real(kind=rp) :: t
+    type(field_t), intent(inout) :: u
+    type(field_t), intent(inout) :: v
+    type(field_t), intent(inout) :: w
+    type(field_t), intent(inout) :: p
+    type(coef_t), intent(inout) :: coef
+    type(param_t), intent(inout) :: params
+
+    ! Deallocate the fields
+    call field_free(om1)
+    call field_free(om2)
+    call field_free(om3)
+    call field_free(w1)
+    call field_free(w2)
+
+  end subroutine user_finalize
+
 end module user

--- a/examples/lid/lid2d.f90
+++ b/examples/lid/lid2d.f90
@@ -19,7 +19,7 @@ module user
     user%fluid_user_if => user_bc
     user%user_check => user_calc_quantities
     user%user_init_modules => user_initialize
-    user%user_final_modules => user_finalize
+    user%user_finalize_modules => user_finalize
   end subroutine user_setup
 
   ! user-defined boundary condition

--- a/examples/lid/lid2d.f90
+++ b/examples/lid/lid2d.f90
@@ -140,13 +140,8 @@ module user
   end function step
 
   ! User-defined finalization routine called at the end of the simulation
-  subroutine user_finalize(t, u, v, w, p, coef, params)
+  subroutine user_finalize(t, params)
     real(kind=rp) :: t
-    type(field_t), intent(inout) :: u
-    type(field_t), intent(inout) :: v
-    type(field_t), intent(inout) :: w
-    type(field_t), intent(inout) :: p
-    type(coef_t), intent(inout) :: coef
     type(param_t), intent(inout) :: params
 
     ! Deallocate the fields

--- a/examples/lid/lid2d.f90
+++ b/examples/lid/lid2d.f90
@@ -19,7 +19,7 @@ module user
     user%fluid_user_if => user_bc
     user%user_check => user_calc_quantities
     user%user_init_modules => user_initialize
-    user%user_finalize_modules => user_finalize
+    user%user_final_modules => user_finalize
   end subroutine user_setup
 
   ! user-defined boundary condition

--- a/examples/tgv/tgv.case
+++ b/examples/tgv/tgv.case
@@ -7,8 +7,8 @@ initial_condition = 'user'
 /
 &NEKO_PARAMETERS
 dt = 1d-2
-T_end = 1
-nsamples = 2
+T_end = 20
+nsamples = 100
 uinf= 0.0,0.0,0.0
 output_bdry = .true.
 Re = 360

--- a/examples/tgv/tgv.case
+++ b/examples/tgv/tgv.case
@@ -7,8 +7,8 @@ initial_condition = 'user'
 /
 &NEKO_PARAMETERS
 dt = 1d-2
-T_end = 20
-nsamples = 100
+T_end = 1
+nsamples = 2
 uinf= 0.0,0.0,0.0
 output_bdry = .true.
 Re = 360

--- a/examples/tgv/tgv.f90
+++ b/examples/tgv/tgv.f90
@@ -20,7 +20,7 @@ contains
     user%user_mesh_setup => user_mesh_scale
     user%user_check => user_calc_quantities
     user%user_init_modules => user_initialize
-    user%user_final_modules => user_finalize
+    user%user_finalize_modules => user_finalize
   end subroutine user_setup
 
   ! Rescale mesh

--- a/examples/tgv/tgv.f90
+++ b/examples/tgv/tgv.f90
@@ -20,7 +20,7 @@ contains
     user%user_mesh_setup => user_mesh_scale
     user%user_check => user_calc_quantities
     user%user_init_modules => user_initialize
-    user%user_finalize_modules => user_finalize
+    user%user_final_modules => user_finalize
   end subroutine user_setup
 
   ! Rescale mesh

--- a/examples/tgv/tgv.f90
+++ b/examples/tgv/tgv.f90
@@ -20,6 +20,7 @@ contains
     user%user_mesh_setup => user_mesh_scale
     user%user_check => user_calc_quantities
     user%user_init_modules => user_initialize
+    user%user_finalize_modules => user_finalize
   end subroutine user_setup
 
   ! Rescale mesh
@@ -37,7 +38,7 @@ contains
        msh%points(i)%x(2) = (msh%points(i)%x(2) - d) / d * pi
        msh%points(i)%x(3) = (msh%points(i)%x(3) - d) / d * pi
     end do
-    
+
   end subroutine user_mesh_scale
 
   ! User-defined initial condition
@@ -60,7 +61,7 @@ contains
     end do
     p = 0._rp
   end subroutine user_ic
-  
+
   function tgv_ic(x, y, z) result(uvw)
     real(kind=rp) :: x, y, z
     real(kind=rp) :: ux, uy, uz
@@ -170,5 +171,27 @@ contains
          &  'POST: t:', t, ' Ekin:', e1, ' enst:', e2
     
   end subroutine user_calc_quantities
+
+  ! User-defined finalization routine called at the end of the simulation
+  subroutine user_finalize(t, u, v, w, p, coef, params)
+    real(kind=rp) :: t
+    type(field_t), intent(inout) :: u
+    type(field_t), intent(inout) :: v
+    type(field_t), intent(inout) :: w
+    type(field_t), intent(inout) :: p
+    type(coef_t), intent(inout) :: coef
+    type(param_t), intent(inout) :: params
+
+    call neko_log%message("Deallocating fields")
+
+    ! Deallocate the fields
+    call field_free(om1)
+    call field_free(om2)
+    call field_free(om3)
+    call field_free(w1)
+    call field_free(w2)
+
+  end subroutine user_finalize
+
 
 end module user

--- a/examples/tgv/tgv.f90
+++ b/examples/tgv/tgv.f90
@@ -182,8 +182,6 @@ contains
     type(coef_t), intent(inout) :: coef
     type(param_t), intent(inout) :: params
 
-    call neko_log%message("Deallocating fields")
-
     ! Deallocate the fields
     call field_free(om1)
     call field_free(om2)
@@ -192,6 +190,5 @@ contains
     call field_free(w2)
 
   end subroutine user_finalize
-
 
 end module user

--- a/examples/tgv/tgv.f90
+++ b/examples/tgv/tgv.f90
@@ -173,13 +173,8 @@ contains
   end subroutine user_calc_quantities
 
   ! User-defined finalization routine called at the end of the simulation
-  subroutine user_finalize(t, u, v, w, p, coef, params)
+  subroutine user_finalize(t, params)
     real(kind=rp) :: t
-    type(field_t), intent(inout) :: u
-    type(field_t), intent(inout) :: v
-    type(field_t), intent(inout) :: w
-    type(field_t), intent(inout) :: p
-    type(coef_t), intent(inout) :: coef
     type(param_t), intent(inout) :: params
 
     ! Deallocate the fields

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -100,7 +100,7 @@ module user_intf
 
   !> Abstract interface for finalizating user variables
   abstract interface
-     subroutine userfinalize(t, u, v, w, p, coef, param)
+     subroutine user_finalize_modules(t, u, v, w, p, coef, param)
        import field_t
        import param_t
        import coef_t
@@ -112,7 +112,7 @@ module user_intf
        type(field_t), intent(inout) :: p
        type(coef_t), intent(inout) :: coef
        type(param_t), intent(inout) :: param
-     end subroutine userfinalize
+     end subroutine user_finalize_modules
   end interface
 
   type :: user_t
@@ -120,7 +120,7 @@ module user_intf
      procedure(user_initialize_modules), nopass, pointer :: user_init_modules => null()
      procedure(usermsh), nopass, pointer :: user_mesh_setup => null()
      procedure(usercheck), nopass, pointer :: user_check => null()
-     procedure(userfinalize), nopass, pointer :: user_finalize_modules => null()
+     procedure(user_finalize_modules), nopass, pointer :: user_final_modules => null()
      procedure(source_term_pw), nopass, pointer :: fluid_user_f => null()
      procedure(source_term), nopass, pointer :: fluid_user_f_vector => null()
      procedure(source_scalar_term_pw), nopass, pointer :: scalar_user_f => null()
@@ -172,8 +172,8 @@ contains
        u%user_init_modules => dummy_user_init_no_modules
     end if
 
-    if (.not. associated(u%user_finalize_modules)) then
-       u%user_finalize_modules => dummy_user_dont_finalize
+    if (.not. associated(u%user_final_modules)) then
+       u%user_final_modules => dummy_user_final_no_modules
     end if
   end subroutine user_intf_init
 
@@ -274,7 +274,7 @@ contains
     type(param_t), intent(inout) :: params
   end subroutine dummy_user_init_no_modules
 
-  subroutine dummy_user_dont_finalize(t, u, v, w, p, coef, params)
+  subroutine dummy_user_final_no_modules(t, u, v, w, p, coef, params)
     real(kind=rp) :: t
     type(field_t), intent(inout) :: u
     type(field_t), intent(inout) :: v
@@ -282,6 +282,6 @@ contains
     type(field_t), intent(inout) :: p
     type(coef_t), intent(inout) :: coef
     type(param_t), intent(inout) :: params
-  end subroutine dummy_user_dont_finalize
+  end subroutine dummy_user_final_no_modules
 
 end module user_intf

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -282,9 +282,6 @@ contains
     type(field_t), intent(inout) :: p
     type(coef_t), intent(inout) :: coef
     type(param_t), intent(inout) :: params
-
-    print *, "HEYOOOOOOOOOO"
-
   end subroutine dummy_user_dont_finalize
 
 end module user_intf

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -100,19 +100,12 @@ module user_intf
 
   !> Abstract interface for finalizating user variables
   abstract interface
-     subroutine user_finalize_modules(t, u, v, w, p, coef, param)
-       import field_t
+     subroutine user_final_modules(t, param)
        import param_t
-       import coef_t
        import rp
        real(kind=rp) :: t
-       type(field_t), intent(inout) :: u
-       type(field_t), intent(inout) :: v
-       type(field_t), intent(inout) :: w
-       type(field_t), intent(inout) :: p
-       type(coef_t), intent(inout) :: coef
        type(param_t), intent(inout) :: param
-     end subroutine user_finalize_modules
+     end subroutine user_final_modules
   end interface
 
   type :: user_t
@@ -120,7 +113,7 @@ module user_intf
      procedure(user_initialize_modules), nopass, pointer :: user_init_modules => null()
      procedure(usermsh), nopass, pointer :: user_mesh_setup => null()
      procedure(usercheck), nopass, pointer :: user_check => null()
-     procedure(user_finalize_modules), nopass, pointer :: user_final_modules => null()
+     procedure(user_final_modules), nopass, pointer :: user_finalize_modules => null()
      procedure(source_term_pw), nopass, pointer :: fluid_user_f => null()
      procedure(source_term), nopass, pointer :: fluid_user_f_vector => null()
      procedure(source_scalar_term_pw), nopass, pointer :: scalar_user_f => null()
@@ -172,8 +165,8 @@ contains
        u%user_init_modules => dummy_user_init_no_modules
     end if
 
-    if (.not. associated(u%user_final_modules)) then
-       u%user_final_modules => dummy_user_final_no_modules
+    if (.not. associated(u%user_finalize_modules)) then
+       u%user_finalize_modules => dummy_user_final_no_modules
     end if
   end subroutine user_intf_init
 
@@ -274,13 +267,8 @@ contains
     type(param_t), intent(inout) :: params
   end subroutine dummy_user_init_no_modules
 
-  subroutine dummy_user_final_no_modules(t, u, v, w, p, coef, params)
+  subroutine dummy_user_final_no_modules(t, params)
     real(kind=rp) :: t
-    type(field_t), intent(inout) :: u
-    type(field_t), intent(inout) :: v
-    type(field_t), intent(inout) :: w
-    type(field_t), intent(inout) :: p
-    type(coef_t), intent(inout) :: coef
     type(param_t), intent(inout) :: params
   end subroutine dummy_user_final_no_modules
 

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -120,7 +120,7 @@ module user_intf
      procedure(user_initialize_modules), nopass, pointer :: user_init_modules => null()
      procedure(usermsh), nopass, pointer :: user_mesh_setup => null()
      procedure(usercheck), nopass, pointer :: user_check => null()
-     procedure(userfinalize), nopass, pointer :: user_finalize => null()
+     procedure(userfinalize), nopass, pointer :: user_finalize_modules => null()
      procedure(source_term_pw), nopass, pointer :: fluid_user_f => null()
      procedure(source_term), nopass, pointer :: fluid_user_f_vector => null()
      procedure(source_scalar_term_pw), nopass, pointer :: scalar_user_f => null()
@@ -172,8 +172,8 @@ contains
        u%user_init_modules => dummy_user_init_no_modules
     end if
 
-    if (.not. associated(u%user_finalize)) then
-       u%user_finalize => dummy_user_dont_finalize
+    if (.not. associated(u%user_finalize_modules)) then
+       u%user_finalize_modules => dummy_user_dont_finalize
     end if
   end subroutine user_intf_init
 

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -98,11 +98,29 @@ module user_intf
      end subroutine usercheck
   end interface
 
+  !> Abstract interface for finalizating user variables
+  abstract interface
+     subroutine userfinalize(t, u, v, w, p, coef, param)
+       import field_t
+       import param_t
+       import coef_t
+       import rp
+       real(kind=rp) :: t
+       type(field_t), intent(inout) :: u
+       type(field_t), intent(inout) :: v
+       type(field_t), intent(inout) :: w
+       type(field_t), intent(inout) :: p
+       type(coef_t), intent(inout) :: coef
+       type(param_t), intent(inout) :: param
+     end subroutine userfinalize
+  end interface
+
   type :: user_t
      procedure(useric), nopass, pointer :: fluid_user_ic => null()
      procedure(user_initialize_modules), nopass, pointer :: user_init_modules => null()
      procedure(usermsh), nopass, pointer :: user_mesh_setup => null()
      procedure(usercheck), nopass, pointer :: user_check => null()
+     procedure(userfinalize), nopass, pointer :: user_finalize => null()
      procedure(source_term_pw), nopass, pointer :: fluid_user_f => null()
      procedure(source_term), nopass, pointer :: fluid_user_f_vector => null()
      procedure(source_scalar_term_pw), nopass, pointer :: scalar_user_f => null()
@@ -149,10 +167,14 @@ contains
     if (.not. associated(u%user_check)) then
        u%user_check => dummy_user_check
     end if
+
     if (.not. associated(u%user_init_modules)) then
        u%user_init_modules => dummy_user_init_no_modules
     end if
-    
+
+    if (.not. associated(u%user_finalize)) then
+       u%user_finalize => dummy_user_dont_finalize
+    end if
   end subroutine user_intf_init
 
   
@@ -251,5 +273,18 @@ contains
     type(coef_t), intent(inout) :: coef
     type(param_t), intent(inout) :: params
   end subroutine dummy_user_init_no_modules
+
+  subroutine dummy_user_dont_finalize(t, u, v, w, p, coef, params)
+    real(kind=rp) :: t
+    type(field_t), intent(inout) :: u
+    type(field_t), intent(inout) :: v
+    type(field_t), intent(inout) :: w
+    type(field_t), intent(inout) :: p
+    type(coef_t), intent(inout) :: coef
+    type(param_t), intent(inout) :: params
+
+    print *, "HEYOOOOOOOOOO"
+
+  end subroutine dummy_user_dont_finalize
 
 end module user_intf

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -135,8 +135,8 @@ contains
        call simulation_joblimit_chkp(C, t)
     end if
 
-    call C%usr%user_finalize(t, C%fluid%u, C%fluid%v, C%fluid%w,&
-                                 C%fluid%p, C%fluid%c_Xh, C%params)
+    call C%usr%user_finalize_modules(t, C%fluid%u, C%fluid%v, C%fluid%w, &
+         C%fluid%p, C%fluid%c_Xh, C%params)
 
     call neko_log%end_section('Normal end.')
     

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -134,7 +134,10 @@ contains
     if (.not. (C%params%write_at_end) .and. t .lt. C%params%T_end) then
        call simulation_joblimit_chkp(C, t)
     end if
-    
+
+    call C%usr%user_finalize(t, C%fluid%u, C%fluid%v, C%fluid%w,&
+                                 C%fluid%p, C%fluid%c_Xh, C%params)
+
     call neko_log%end_section('Normal end.')
     
   end subroutine neko_solve

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -135,8 +135,7 @@ contains
        call simulation_joblimit_chkp(C, t)
     end if
 
-    call C%usr%user_finalize_modules(t, C%fluid%u, C%fluid%v, C%fluid%w, &
-         C%fluid%p, C%fluid%c_Xh, C%params)
+    call C%usr%user_finalize_modules(t, C%params)
 
     call neko_log%end_section('Normal end.')
     


### PR DESCRIPTION
Added functionality to finalize modules started by the user.

An example would be that a user starts ADIOS2 in the user file and needs to close it to release the MPI ranks in asynchronous execution.

Examples TGV, LID have been modified to illustrate the use.

The naming convention is open to discussion.