### PR TITLE
Structure manual

### DIFF
--- a/doc/pages/index.md
+++ b/doc/pages/index.md
@@ -10,3 +10,18 @@ structure and numerical methods are adopted.
 
 Neko is currently maintained and developed at KTH Royal Institute of
 Technology.
+
+
+\tableofcontents
+
+\subpage case-file
+
+\subpage accelerators
+
+\subpage statistics-guide
+
+\subpage code-style
+
+\subpage testing
+
+\subpage appendix


### PR DESCRIPTION
Put all manual pages as subpages under the main Neko Manual page