### PR TITLE
Allow for different MPI_OP in device_mpi_allreduce wrappers

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -468,6 +468,7 @@ EXTRA_DIST = \
 	krylov/bcknd/device/opencl/jacobi_kernel.cl\
 	sem/bcknd/device/opencl/coef_kernel.cl\
 	math/bcknd/device/device_mpi_reduce.h\
+	math/bcknd/device/device_mpi_op.h\
 	device/opencl/jit.h\
 	device/opencl/prgm_lib.h\
 	device/opencl/check.h\

--- a/src/common/bcknd/device/cuda/projection.cu
+++ b/src/common/bcknd/device/cuda/projection.cu
@@ -48,6 +48,7 @@ real * proj_bufred_d = NULL;
 extern "C" {
 
 #include <math/bcknd/device/device_mpi_reduce.h>
+#include <math/bcknd/device/device_mpi_op.h>
 
   void cuda_project_on(void *alpha, void * b, void *xx, void *bb, void *mult,
                        void *xbar, int *j, int *n){ 
@@ -84,7 +85,7 @@ extern "C" {
     CUDA_CHECK(cudaMemsetAsync(xbar, 0, (*n) * sizeof(real), stream));
 
     cudaStreamSynchronize(stream);
-    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
+    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real), DEVICE_MPI_SUM);
 
     const dim3 vec_nthrds(1024, 1, 1);
     const dim3 vec_nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
@@ -111,7 +112,7 @@ extern "C" {
                                cudaMemcpyDeviceToDevice, stream));
 
     cudaStreamSynchronize(stream);
-    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
+    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real), DEVICE_MPI_SUM);
 
     /* Second vector operation block */
     project_on_vec_kernel<real>
@@ -158,7 +159,7 @@ extern "C" {
                                cudaMemcpyDeviceToDevice, stream));
 
     cudaStreamSynchronize(stream);
-    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
+    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real), DEVICE_MPI_SUM);
 
     CUDA_CHECK(cudaMemcpyAsync(nrm, (real *) alpha + (*j - 1),
                                sizeof(real), cudaMemcpyDeviceToHost, stream));
@@ -188,7 +189,7 @@ extern "C" {
                                cudaMemcpyDeviceToDevice, stream));
 
     cudaStreamSynchronize(stream);
-    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
+    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real), DEVICE_MPI_SUM);
 
     /* Second vector operation block */
     project_ortho_vec_kernel<real>

--- a/src/common/bcknd/device/hip/projection.hip
+++ b/src/common/bcknd/device/hip/projection.hip
@@ -49,6 +49,7 @@ real * proj_bufred_d = NULL;
 extern "C" {
 
 #include <math/bcknd/device/device_mpi_reduce.h>
+#include <math/bcknd/device/device_mpi_op.h>
 
   void hip_project_on(void *alpha, void * b, void *xx, void *bb, void *mult,
                       void *xbar, int *j, int *n){ 
@@ -86,7 +87,7 @@ extern "C" {
     HIP_CHECK(hipMemsetAsync(xbar, 0, (*n) * sizeof(real)));
 
     hipStreamSynchronize((hipStream_t) glb_cmd_queue);
-    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
+    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real), DEVICE_MPI_SUM);
 
     const dim3 vec_nthrds(1024, 1, 1);
     const dim3 vec_nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
@@ -113,7 +114,7 @@ extern "C" {
                              (hipStream_t) glb_cmd_queue));
 
     hipStreamSynchronize((hipStream_t) glb_cmd_queue);
-    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
+    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real), DEVICE_MPI_SUM);
 
     /* Second vector operation block */
     hipLaunchKernelGGL(HIP_KERNEL_NAME(project_on_vec_kernel<real> ),
@@ -158,7 +159,7 @@ extern "C" {
                              (hipStream_t) glb_cmd_queue));
 
     hipStreamSynchronize((hipStream_t) glb_cmd_queue);
-    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
+    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real), DEVICE_MPI_SUM);
 
     HIP_CHECK(hipMemcpyAsync(nrm, (real *) alpha + (*j - 1),
                              sizeof(real), hipMemcpyDeviceToHost,
@@ -191,7 +192,7 @@ extern "C" {
                              (hipStream_t) glb_cmd_queue));
 
     hipStreamSynchronize((hipStream_t) glb_cmd_queue);
-    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real));
+    device_mpi_allreduce_inplace(alpha, (*j), sizeof(real), DEVICE_MPI_SUM);
 
     /* Second vector operation block */
     hipLaunchKernelGGL( HIP_KERNEL_NAME( project_ortho_vec_kernel<real> ),

--- a/src/krylov/bcknd/device/cuda/gmres_aux.cu
+++ b/src/krylov/bcknd/device/cuda/gmres_aux.cu
@@ -40,6 +40,7 @@
 extern "C" {
 
 #include <math/bcknd/device/device_mpi_reduce.h>
+#include <math/bcknd/device/device_mpi_op.h>
   
   /**
    * @todo Make sure that this gets deleted at some point...
@@ -77,7 +78,7 @@ extern "C" {
 
 #ifdef HAVE_DEVICE_MPI
     cudaStreamSynchronize(stream);
-    device_mpi_allreduce(gmres_bfd1, gmres_bf1, 1, sizeof(real));
+    device_mpi_allreduce(gmres_bfd1, gmres_bf1, 1, sizeof(real), DEVICE_MPI_SUM);
 #else
     
     CUDA_CHECK(cudaMemcpyAsync(gmres_bf1, gmres_bfd1, sizeof(real),

--- a/src/krylov/bcknd/device/hip/gmres_aux.hip
+++ b/src/krylov/bcknd/device/hip/gmres_aux.hip
@@ -41,6 +41,7 @@
 extern "C" {
 
 #include <math/bcknd/device/device_mpi_reduce.h>
+#include <math/bcknd/device/device_mpi_op.h>
   
   /**
    * @todo Make sure that this gets deleted at some point...
@@ -78,7 +79,7 @@ extern "C" {
 
 #ifdef HAVE_DEVICE_MPI
     hipStreamSynchronize((hipStream_t) glb_cmd_queue);
-    device_mpi_allreduce(gmres_bfd1, gmres_bf1, 1, sizeof(real));
+    device_mpi_allreduce(gmres_bfd1, gmres_bf1, 1, sizeof(real), DEVICE_MPI_SUM);
 #else
     
     HIP_CHECK(hipMemcpyAsync(gmres_bf1, gmres_bfd1, sizeof(real),

--- a/src/math/bcknd/device/cuda/math.cu
+++ b/src/math/bcknd/device/cuda/math.cu
@@ -41,6 +41,7 @@
 extern "C" {
 
 #include <math/bcknd/device/device_mpi_reduce.h>
+#include <math/bcknd/device/device_mpi_op.h>
   
   /** Fortran wrapper for copy
    * Copy a vector \f$ a = b \f$
@@ -399,7 +400,7 @@ extern "C" {
 
 #ifdef HAVE_DEVICE_MPI
     cudaStreamSynchronize(stream);
-    device_mpi_allreduce(bufred_d, bufred, 1, sizeof(real));
+    device_mpi_allreduce(bufred_d, bufred, 1, sizeof(real), DEVICE_MPI_SUM);
 #else
     CUDA_CHECK(cudaMemcpyAsync(bufred, bufred_d, sizeof(real),
                                cudaMemcpyDeviceToHost, stream));
@@ -443,7 +444,7 @@ extern "C" {
 
 #ifdef HAVE_DEVICE_MPI
     cudaStreamSynchronize(stream);
-    device_mpi_allreduce(bufred_d, h, (*j), sizeof(real));
+    device_mpi_allreduce(bufred_d, h, (*j), sizeof(real), DEVICE_MPI_SUM);
 #else    
     CUDA_CHECK(cudaMemcpyAsync(h, bufred_d, (*j) * sizeof(real),
                                cudaMemcpyDeviceToHost, stream));
@@ -482,7 +483,7 @@ extern "C" {
 
 #ifdef HAVE_DEVICE_MPI
     cudaStreamSynchronize(stream);
-    device_mpi_allreduce(bufred_d, bufred, 1, sizeof(real));
+    device_mpi_allreduce(bufred_d, bufred, 1, sizeof(real), DEVICE_MPI_SUM);
 #else
     CUDA_CHECK(cudaMemcpyAsync(bufred, bufred_d, sizeof(real),
                                cudaMemcpyDeviceToHost, stream));
@@ -520,7 +521,7 @@ extern "C" {
 
 #ifdef HAVE_DEVICE_MPI
     cudaStreamSynchronize(stream);
-    device_mpi_allreduce(bufred_d, bufred, 1, sizeof(real));
+    device_mpi_allreduce(bufred_d, bufred, 1, sizeof(real), DEVICE_MPI_SUM);
 #else
     CUDA_CHECK(cudaMemcpyAsync(bufred, bufred_d, sizeof(real),
                                cudaMemcpyDeviceToHost, stream));

--- a/src/math/bcknd/device/cuda/opr_cfl.cu
+++ b/src/math/bcknd/device/cuda/opr_cfl.cu
@@ -41,6 +41,7 @@
 extern "C" {
 
 #include <math/bcknd/device/device_mpi_reduce.h>
+#include <math/bcknd/device/device_mpi_op.h>
 
   /**
    * @todo Make sure that this gets deleted at some point...
@@ -103,7 +104,7 @@ extern "C" {
     real cfl;
 #ifdef HAVE_DEVICE_MPI
     cudaStreamSynchronize(stream);
-    device_mpi_allreduce(cfl_d, &cfl, 1, sizeof(real));
+    device_mpi_allreduce(cfl_d, &cfl, 1, sizeof(real), DEVICE_MPI_MAX);
 #else
     CUDA_CHECK(cudaMemcpyAsync(&cfl, cfl_d, sizeof(real),
                                cudaMemcpyDeviceToHost, stream));

--- a/src/math/bcknd/device/cuda/opr_cfl.cu
+++ b/src/math/bcknd/device/cuda/opr_cfl.cu
@@ -98,7 +98,7 @@ extern "C" {
       }
     }
 
-    cfl_reduce_kernel<real><<<1, 1024>>> (cfl_d, (*nel));
+    cfl_reduce_kernel<real><<<1, 1024, 0, stream>>> (cfl_d, (*nel));
     CUDA_CHECK(cudaGetLastError());
 
     real cfl;

--- a/src/math/bcknd/device/device_mpi_op.h
+++ b/src/math/bcknd/device/device_mpi_op.h
@@ -1,0 +1,8 @@
+/** 
+ * Dummy defintion of device MPI reduce operations
+ * @note we can't put this in device_mpi_reduce.h and include it in device_mpi_reduce.c 
+ * due to the C++ interface
+ */
+
+#define DEVICE_MPI_SUM 0
+#define DEVICE_MPI_MAX 1

--- a/src/math/bcknd/device/device_mpi_reduce.c
+++ b/src/math/bcknd/device/device_mpi_reduce.c
@@ -41,13 +41,29 @@
 #include <stdio.h>
 #include <mpi.h>
 
-void device_mpi_allreduce(void *buf_d, void *buf, int count, int nbytes) {
+#include "device_mpi_op.h"
+
+void device_mpi_allreduce(void *buf_d, void *buf, int count, int nbytes, int op) {
 
   if (nbytes == sizeof(float)) {
-    MPI_Allreduce(buf_d, buf, count, MPI_FLOAT, MPI_SUM, MPI_COMM_WORLD);
+    if (op == DEVICE_MPI_SUM)
+      MPI_Allreduce(buf_d, buf, count, MPI_FLOAT, MPI_SUM, MPI_COMM_WORLD);
+    else if (op == DEVICE_MPI_MAX)
+      MPI_Allreduce(buf_d, buf, count, MPI_FLOAT, MPI_MAX, MPI_COMM_WORLD);
+    else {
+      fprintf(stderr, __FILE__ ": Invalid reduction op)\n");
+      exit(1);
+    }
   }
   else if (nbytes == sizeof(double)) {
-    MPI_Allreduce(buf_d, buf, count, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    if (op == DEVICE_MPI_SUM)
+      MPI_Allreduce(buf_d, buf, count, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    else if (op == DEVICE_MPI_MAX)
+      MPI_Allreduce(buf_d, buf, count, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+    else {
+      fprintf(stderr, __FILE__ ": Invalid reduction op)\n");
+      exit(1);
+    }
   }
   else {
     fprintf(stderr, __FILE__ ": Invalid data type)\n");
@@ -55,13 +71,27 @@ void device_mpi_allreduce(void *buf_d, void *buf, int count, int nbytes) {
   }
 }
 
-void device_mpi_allreduce_inplace(void *buf_d, int count, int nbytes) {
+void device_mpi_allreduce_inplace(void *buf_d, int count, int nbytes, int op) {
 
   if (nbytes == sizeof(float)) {
-    MPI_Allreduce(MPI_IN_PLACE, buf_d, count, MPI_FLOAT, MPI_SUM, MPI_COMM_WORLD);
+    if (op == DEVICE_MPI_SUM)
+      MPI_Allreduce(MPI_IN_PLACE, buf_d, count,
+                    MPI_FLOAT, MPI_SUM, MPI_COMM_WORLD);
+    else if (op == DEVICE_MPI_MAX)
+      MPI_Allreduce(MPI_IN_PLACE, buf_d, count,
+                    MPI_FLOAT, MPI_MAX, MPI_COMM_WORLD);
+    else {
+      fprintf(stderr, __FILE__ ": Invalid reduction op)\n");
+      exit(1);
+    }
   }
   else if (nbytes == sizeof(double)) {
-    MPI_Allreduce(MPI_IN_PLACE, buf_d, count, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    if (op == DEVICE_MPI_SUM)
+      MPI_Allreduce(MPI_IN_PLACE, buf_d, count,
+                    MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    else if (op == DEVICE_MPI_MAX)
+      MPI_Allreduce(MPI_IN_PLACE, buf_d, count,
+                    MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
   }
   else {
     fprintf(stderr, __FILE__ ": Invalid data type)\n");

--- a/src/math/bcknd/device/device_mpi_reduce.c
+++ b/src/math/bcknd/device/device_mpi_reduce.c
@@ -41,7 +41,7 @@
 #include <stdio.h>
 #include <mpi.h>
 
-#include "device_mpi_op.h"
+#include <math/bcknd/device/device_mpi_op.h>
 
 void device_mpi_allreduce(void *buf_d, void *buf, int count, int nbytes, int op) {
 

--- a/src/math/bcknd/device/device_mpi_reduce.c
+++ b/src/math/bcknd/device/device_mpi_reduce.c
@@ -41,7 +41,7 @@
 #include <stdio.h>
 #include <mpi.h>
 
-#include <math/bcknd/device/device_mpi_op.h>
+#include "device_mpi_op.h"
 
 void device_mpi_allreduce(void *buf_d, void *buf, int count, int nbytes, int op) {
 

--- a/src/math/bcknd/device/device_mpi_reduce.h
+++ b/src/math/bcknd/device/device_mpi_reduce.h
@@ -8,5 +8,6 @@ extern "C" {
   void device_mpi_allreduce(void *buf_d, void *buf, int count,
                             size_t nbytes, int op);
 
-  void device_mpi_allreduce_inplace(void *buf_d, int count, size_t nbytes, int op);
+  void device_mpi_allreduce_inplace(void *buf_d, int count,
+                                    size_t nbytes, int op);
 }

--- a/src/math/bcknd/device/device_mpi_reduce.h
+++ b/src/math/bcknd/device/device_mpi_reduce.h
@@ -5,7 +5,8 @@
  */
 
 extern "C" {
-  void device_mpi_allreduce(void *buf_d, void *buf, int count, size_t nbytes);
+  void device_mpi_allreduce(void *buf_d, void *buf, int count,
+                            size_t nbytes, int op);
 
-  void device_mpi_allreduce_inplace(void *buf_d, int count, size_t nbytes);
+  void device_mpi_allreduce_inplace(void *buf_d, int count, size_t nbytes, int op);
 }

--- a/src/math/bcknd/device/hip/math.hip
+++ b/src/math/bcknd/device/hip/math.hip
@@ -40,6 +40,7 @@
 extern "C" {
 
 #include <math/bcknd/device/device_mpi_reduce.h>
+#include <math/bcknd/device/device_mpi_op.h>
   
   /** Fortran wrapper for copy
    * Copy a vector \f$ a = b \f$
@@ -389,7 +390,7 @@ extern "C" {
 
 #ifdef HAVE_DEVICE_MPI
     hipStreamSynchronize(stream);
-    device_mpi_allreduce(bufred_d, bufred, 1, sizeof(real));
+    device_mpi_allreduce(bufred_d, bufred, 1, sizeof(real), DEVICE_MPI_SUM);
 #else
     HIP_CHECK(hipMemcpyAsync(bufred, bufred_d, sizeof(real),
                              hipMemcpyDeviceToHost, stream));
@@ -437,7 +438,7 @@ extern "C" {
 
 #ifdef HAVE_DEVICE_MPI
     hipStreamSynchronize(stream);
-    device_mpi_allreduce(bufred_d, h, (*j), sizeof(real));
+    device_mpi_allreduce(bufred_d, h, (*j), sizeof(real), DEVICE_MPI_SUM);
 #else
     HIP_CHECK(hipMemcpyAsync(h, bufred_d, (*j)* sizeof(real),
                              hipMemcpyDeviceToHost, stream));
@@ -494,7 +495,7 @@ extern "C" {
 
 #ifdef HAVE_DEVICE_MPI
     hipStreamSynchronize(stream);
-    device_mpi_allreduce(bufred_d, bufred, 1, sizeof(real));
+    device_mpi_allreduce(bufred_d, bufred, 1, sizeof(real), DEVICE_MPI_SUM);
 #else
     HIP_CHECK(hipMemcpyAsync(bufred, bufred_d, sizeof(real),
                              hipMemcpyDeviceToHost, stream));
@@ -533,7 +534,7 @@ extern "C" {
 
 #ifdef HAVE_DEVICE_MPI
     hipStreamSynchronize(stream);
-    device_mpi_allreduce(bufred_d, bufred, 1, sizeof(real));
+    device_mpi_allreduce(bufred_d, bufred, 1, sizeof(real), DEVICE_MPI_SUM);
 #else
     HIP_CHECK(hipMemcpyAsync(bufred, bufred_d,sizeof(real),
                              hipMemcpyDeviceToHost, stream));

--- a/src/math/bcknd/device/hip/opr_cfl.hip
+++ b/src/math/bcknd/device/hip/opr_cfl.hip
@@ -41,6 +41,7 @@
 extern "C" {
 
 #include <math/bcknd/device/device_mpi_reduce.h>
+#include <math/bcknd/device/device_mpi_op.h>
   
   /**
    * @todo Make sure that this gets deleted at some point...
@@ -103,9 +104,9 @@ extern "C" {
     HIP_CHECK(hipGetLastError());
 
     real cfl = 0.0;
-    #ifdef HAVE_DEVICE_MPI
+#ifdef HAVE_DEVICE_MPI
     hipStreamSynchronize((hipStream_t) glb_cmd_queue);
-    device_mpi_allreduce(cfl_d, &cfl, 1, sizeof(real));
+    device_mpi_allreduce(cfl_d, &cfl, 1, sizeof(real), DEVICE_MPI_MAX);
 #else
     HIP_CHECK(hipMemcpyAsync(&cfl, cfl_d, sizeof(real),
                              hipMemcpyDeviceToHost,


### PR DESCRIPTION
Add a dummy wrapper for `MPI_OP` for the `device_mpi_allreduce` wrapper.

This fixes #903.