### PR TITLE
Put check on whether to execute an action based on time value in a separate class

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -319,6 +319,7 @@ AC_CONFIG_FILES([tests/stack/Makefile\
                  tests/fast3d/Makefile\
                  tests/time_scheme/Makefile\
                  tests/time_scheme_controller/Makefile\
+                 tests/time_based_controller/Makefile\
                  tests/point_interpolation/Makefile])
 
 if test "x${enable_contrib}" = xyes; then

--- a/src/.depends
+++ b/src/.depends
@@ -106,7 +106,7 @@ io/mean_flow_output.o : io/mean_flow_output.f90 io/output.o device/device.o conf
 io/fluid_stats_output.o : io/fluid_stats_output.f90 io/output.o device/device.o config/num_types.o config/neko_config.o fluid/fluid_stats.o 
 io/field_list_output.o : io/field_list_output.f90 io/output.o config/num_types.o field/field_list.o field/field.o 
 io/mean_sqr_flow_output.o : io/mean_sqr_flow_output.f90 io/output.o config/num_types.o fluid/mean_sqr_flow.o 
-common/sampler.o : common/sampler.f90 common/profiler.o common/utils.o common/log.o comm/comm.o io/output.o config/num_types.o 
+common/sampler.o : common/sampler.f90 common/time_based_controller.o common/profiler.o common/utils.o common/log.o comm/comm.o io/output.o config/num_types.o 
 common/profiler.o : common/profiler.F90 common/craypat.o device/hip/roctx.o device/cuda/nvtx.o common/utils.o device/device.o config/neko_config.o 
 common/craypat.o : common/craypat.F90 common/utils.o adt/stack.o 
 bc/bc.o : bc/bc.f90 common/utils.o adt/tuple.o adt/stack.o mesh/zone.o mesh/mesh.o sem/space.o sem/dofmap.o device/device.o config/num_types.o config/neko_config.o 
@@ -145,6 +145,7 @@ time_schemes/bdf_time_scheme.o : time_schemes/bdf_time_scheme.f90 common/utils.o
 time_schemes/ext_time_scheme.o : time_schemes/ext_time_scheme.f90 common/utils.o math/math.o time_schemes/time_scheme.o config/num_types.o config/neko_config.o 
 time_schemes/ab_time_scheme.o : time_schemes/ab_time_scheme.f90 common/utils.o math/math.o time_schemes/time_scheme.o config/num_types.o config/neko_config.o 
 time_schemes/time_scheme_controller.o : time_schemes/time_scheme_controller.f90 device/device.o time_schemes/ab_time_scheme.o time_schemes/ext_time_scheme.o time_schemes/bdf_time_scheme.o config/num_types.o config/neko_config.o 
+common/time_based_controller.o : common/time_based_controller.f90 common/utils.o config/num_types.o 
 common/source.o : common/source.f90 math/bcknd/device/device_math.o device/device.o common/utils.o sem/dofmap.o config/num_types.o config/neko_config.o 
 common/stats_quant.o : common/stats_quant.f90 config/num_types.o 
 common/statistics.o : common/statistics.f90 comm/comm.o common/log.o common/stats_quant.o config/num_types.o 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -148,6 +148,7 @@ neko_fortran_SOURCES = \
 	time_schemes/ext_time_scheme.f90\
 	time_schemes/ab_time_scheme.f90\
 	time_schemes/time_scheme_controller.f90\
+	common/time_based_controller.f90\
 	common/source.f90\
 	common/stats_quant.f90\
 	common/statistics.f90\

--- a/src/common/sampler.f90
+++ b/src/common/sampler.f90
@@ -38,6 +38,7 @@ module sampler
   use logger
   use utils
   use profiler
+  use time_based_controller, only : time_based_controller_t
   implicit none
   private
 
@@ -48,19 +49,26 @@ module sampler
 
   !> Sampler
   type, public :: sampler_t
-     type(outp_t), allocatable :: output_list(:) !< List of outputs
-     real(kind=rp), allocatable :: freq_list(:) !< Write frequency (sim time)
-     real(kind=rp), allocatable :: T_list(:) !< List of times before write
-     integer, allocatable :: tstep_interval_list(:) !< Sample every tstep interval
-     integer, allocatable :: nsample_list(:) !< Sample number
-     integer :: n !< number of outputs
-     integer :: size !< number of entries in list
+     !> List of outputs.
+     type(outp_t), allocatable :: output_list(:)
+     !> List of controllers for determining wether we should write.
+     type(time_based_controller_t), allocatable :: controllers(:)
+     !> Number of outputs.
+     integer :: n
+     !> Number of entries in the list.
+     integer :: size 
+     !> Final time of the simulation.
      real(kind=rp) :: T_end
    contains
+     !> Constructor.
      procedure, pass(this) :: init => sampler_init
+     !> Destructor.
      procedure, pass(this) :: free => sampler_free
+     !> Add an output to the sampler.
      procedure, pass(this) :: add => sampler_add
+     !> Sample the fields and output.
      procedure, pass(this) :: sample => sampler_sample
+     !> Set sampling counter based on time (after restart)
      procedure, pass(this) :: set_counter => sampler_set_counter
   end type sampler_t
 
@@ -84,17 +92,10 @@ contains
     end if
 
     allocate(this%output_list(n))
-    allocate(this%freq_list(n))
-    allocate(this%T_list(n))
-    allocate(this%tstep_interval_list(n))
-    allocate(this%nsample_list(n))
+    allocate(this%controllers(n))
 
     do i = 1, n
        this%output_list(i)%outp => null()
-       this%nsample_list(i) = 0
-       this%tstep_interval_list(i) = 0
-       this%freq_list(i) = 0
-       this%T_list(i) = 0
     end do
 
     this%size = n
@@ -110,17 +111,8 @@ contains
     if (allocated(this%output_list)) then
        deallocate(this%output_list)       
     end if
-    if (allocated(this%freq_list)) then
-       deallocate(this%freq_list)       
-    end if
-    if (allocated(this%T_list)) then
-       deallocate(this%T_list)       
-    end if
-    if (allocated(this%tstep_interval_list)) then
-       deallocate(this%tstep_interval_list)       
-    end if
-    if (allocated(this%nsample_list)) then
-       deallocate(this%nsample_list)       
+    if (allocated(this%controllers)) then
+       deallocate(this%controllers)       
     end if
 
     this%n = 0
@@ -135,8 +127,7 @@ contains
     real(kind=rp), intent(in) :: write_par
     character(len=*), intent(in) :: write_control
     type(outp_t), allocatable :: tmp(:)
-    integer, allocatable :: tmpi(:)
-    real(kind=rp), allocatable :: tmpr(:)
+    type(time_based_controller_t), allocatable :: tmp_ctrl(:)
     character(len=LOG_SIZE) :: log_buf
     integer :: n
 
@@ -144,62 +135,53 @@ contains
        allocate(tmp(this%size * 2))
        tmp(1:this%size) = this%output_list
        call move_alloc(tmp, this%output_list)
-       allocate(tmpr(this%size * 2))
-       tmpr(1:this%size) = this%freq_list
-       call move_alloc(tmpr, this%freq_list)
-       allocate(tmpr(this%size * 2))
-       tmpr(1:this%size) = this%T_list
-       call move_alloc(tmpr, this%T_list)
-       allocate(tmpi(this%size * 2))
-       tmpi(1:this%size) = this%tstep_interval_list
-       call move_alloc(tmpi, this%tstep_interval_list)
-       allocate(tmpi(this%size * 2))
-       tmpi(1:this%size) = this%nsample_list
-       call move_alloc(tmpi, this%nsample_list)
+
+       allocate(tmp_ctrl(this%size * 2))
+       tmp_ctrl(1:this%size) = this%controllers
+       call move_alloc(tmp_ctrl, this%controllers)
+
        this%size = this%size * 2
     end if
 
     this%n = this%n + 1
     n = this%n
     this%output_list(this%n)%outp => out
+
+    if (trim(write_control) .eq. "org") then
+       this%controllers(n) = this%controllers(1)
+    else
+       call this%controllers(n)%init(this%T_end, write_control, write_par)
+    end if
     
+    ! The code below only prints to console
     call neko_log%section('Adding write output')
     call neko_log%message('File name: '// &
           trim(this%output_list(this%n)%outp%file_%file_type%fname))
     call neko_log%message( 'Write control: '//trim(write_control))
     if (trim(write_control) .eq. 'simulationtime') then
-        this%T_list(n) = write_par
-        this%freq_list(n) = 1.0_rp/this%T_list(n)
-        this%tstep_interval_list(n) = 0
         write(log_buf, '(A,ES13.6)') 'Writes per time unit (Freq.): ', &
-             this%freq_list(n)
+             this%controllers(n)%frequency
         call neko_log%message(log_buf)
-        write(log_buf, '(A,ES13.6)') 'Time between writes: ',  this%T_list(n)
+        write(log_buf, '(A,ES13.6)') 'Time between writes: ', & 
+          this%controllers(n)%time_interval
         call neko_log%message(log_buf)
     else if (trim(write_control) .eq. 'nsamples') then
-        this%freq_list(n) = ( write_par / this%T_end )
-        this%T_list(n) = real(1d0,rp) / this%freq_list(n)
-        this%tstep_interval_list(n) = 0
         write(log_buf, '(A,I13)') 'Total samples: ',  int(write_par)
         call neko_log%message(log_buf)
         write(log_buf, '(A,ES13.6)') 'Writes per time unit (Freq.): ',  &
-             this%freq_list(n)
+             this%controllers(n)%frequency
         call neko_log%message(log_buf)
-        write(log_buf, '(A,ES13.6)') 'Time between writes: ',  this%T_list(n)
+        write(log_buf, '(A,ES13.6)') 'Time between writes: ', & 
+          this%controllers(n)%time_interval
         call neko_log%message(log_buf)
     else if (trim(write_control) .eq. 'tsteps') then 
-        this%tstep_interval_list(n) = int(write_par)
         write(log_buf, '(A,I13)') 'Time step interval: ',  int(write_par)
         call neko_log%message(log_buf)
     else if (trim(write_control) .eq. 'org') then
-        this%tstep_interval_list(n) = this%tstep_interval_list(1)
-        this%freq_list(n) = this%freq_list(1)
-        this%T_list(n) = this%T_list(1)
         write(log_buf, '(A)') &
              'Write control not set, defaulting to first output settings'
         call neko_log%message(log_buf)
     end if
-    this%nsample_list(n) = 0
     
     call neko_log%end_section()
   end subroutine sampler_add
@@ -214,7 +196,7 @@ contains
     real(kind=dp) :: sample_time
     character(len=LOG_SIZE) :: log_buf
     integer :: i, ierr
-    logical :: force, write_output
+    logical :: force, write_output, write_output_test
 
     if (present(ifforce)) then
        force = ifforce
@@ -228,63 +210,43 @@ contains
     sample_start_time = MPI_WTIME()
 
     write_output = .false.
+    ! Determine if at least one output needs to be written
     ! We should not need this extra select block, and it works great
     ! without it for GNU, Intel and NEC, but breaks horribly on Cray         
     ! (>11.0.x) when using high opt. levels.  
     select type (samp => this)
     type is (sampler_t)
        do i = 1, samp%n
-          if (force) then
+          if (this%controllers(i)%check(t, tstep, force)) then
              write_output = .true.            
-          else if ((samp%tstep_interval_list(i) .eq. 0) .and. &               
-               (t .ge. (samp%nsample_list(i) * samp%T_list(i)))) then
-             write_output = .true.            
-          else if (samp%tstep_interval_list(i) .gt. 0) then
-             if (mod(tstep,samp%tstep_interval_list(i)) .eq. 0) then
-                write_output = .true.
-             end if
+             exit
           end if
        end do
     end select
-    
+
     if (write_output) then
        call neko_log%section('Writer output ')
     end if
 
-
+    ! Loop through the outputs and write if necessary.
     ! We should not need this extra select block, and it works great
     ! without it for GNU, Intel and NEC, but breaks horribly on Cray         
     ! (>11.0.x) when using high opt. levels.  
     select type (samp => this)
     type is (sampler_t)
        do i = 1, this%n
-          if (force) then
+          if (this%controllers(i)%check(t, tstep, force)) then
              call neko_log%message('File name: '// &
                   trim(samp%output_list(i)%outp%file_%file_type%fname))
+
              write(log_buf, '(A,I6)') 'Output number:', &
-                  int(samp%nsample_list(i))
+                  int(this%controllers(i)%nexecutions)
              call neko_log%message(log_buf)
+
              call samp%output_list(i)%outp%sample(t)
-             samp%nsample_list(i) = samp%nsample_list(i) + 1
-          else if ((samp%tstep_interval_list(i) .eq. 0) .and. &               
-               (t .ge. (samp%nsample_list(i) * samp%T_list(i)))) then
-             call neko_log%message('File name: '// &
-                  trim(samp%output_list(i)%outp%file_%file_type%fname))
-             write(log_buf, '(A,I6)') 'Output number:',  &
-                  int(samp%nsample_list(i))
-             call neko_log%message(log_buf)
-             call samp%output_list(i)%outp%sample(t)
-             samp%nsample_list(i) = samp%nsample_list(i) + 1
-          else if (samp%tstep_interval_list(i) .gt. 0) then
-             if (mod(tstep,samp%tstep_interval_list(i)) .eq. 0) then
-                call neko_log%message('File name: '// &
-                     trim(samp%output_list(i)%outp%file_%file_type%fname))
-                write(log_buf, '(A,I6)') 'Output number:', &
-                     int(samp%nsample_list(i))
-                call neko_log%message(log_buf)
-                call samp%output_list(i)%outp%sample(t)
-                samp%nsample_list(i) = samp%nsample_list(i) + 1
-             end if
+
+             this%controllers(i)%nexecutions = &
+               this%controllers(i)%nexecutions + 1
           end if
        end do
     class default
@@ -312,10 +274,12 @@ contains
 
 
     do i = 1, this%n
-       if (this%tstep_interval_list(i) .eq. 0) then
-          this%nsample_list(i) = int(t / this%T_list(i)) + 1
-          call this%output_list(i)%outp%set_counter(this%nsample_list(i))
-          call this%output_list(i)%outp%set_start_counter(this%nsample_list(i))
+       if (this%controllers(i)%nsteps .eq. 0) then
+          this%controllers(i)%nexecutions = &
+            int(t / this%controllers(i)%time_interval) + 1
+
+          call this%output_list(i)%outp%set_counter(this%controllers(i)%nexecutions)
+          call this%output_list(i)%outp%set_start_counter(this%controllers(i)%nexecutions)
        end if
     end do
     
@@ -328,9 +292,9 @@ contains
     integer :: i
 
     do i = 1, this%n
-       this%nsample_list(i) = sample_number
-       call this%output_list(i)%outp%set_counter(this%nsample_list(i))
-       call this%output_list(i)%outp%set_start_counter(this%nsample_list(i))
+       this%controllers(i)%nexecutions = sample_number
+       call this%output_list(i)%outp%set_counter(this%controllers(i)%nexecutions)
+       call this%output_list(i)%outp%set_start_counter(this%controllers(i)%nexecutions)
     end do
     
   end subroutine sampler_set_sample_count

--- a/src/common/sampler.f90
+++ b/src/common/sampler.f90
@@ -245,8 +245,7 @@ contains
 
              call samp%output_list(i)%outp%sample(t)
 
-             this%controllers(i)%nexecutions = &
-               this%controllers(i)%nexecutions + 1
+             call this%controllers(i)%register_execution()
           end if
        end do
     class default

--- a/src/common/time_based_controller.f90
+++ b/src/common/time_based_controller.f90
@@ -1,0 +1,152 @@
+! Copyright (c) 2023, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Contains the `time_based_controller_t` type.
+module time_based_controller
+  use num_types, only : rp
+  use utils, only : neko_error
+  implicit none
+  private
+
+  !> A utility type for determening whether an action should be exectuted based
+  !! on the current time value. Used to e.g. control whether we should write a
+  !! file or exectue a simcomp.
+  !! Note that the nexpections variable should be incremented externally.
+  !! This is to allow running the the `check` multiple times at the same time
+  !! step.
+  type, public :: time_based_controller_t
+     !> Frequency of execution.
+     real(kind=rp) :: frequency = 0
+     !> Time interval between executions.
+     real(kind=rp) :: time_interval = 0
+     !> Number of timesteps in between executions.
+     integer :: nsteps = 0
+     !> Simulation end time.
+     real(kind=rp) :: end_time = 0
+     !> Number of times already executed.
+     integer :: nexecutions = 0
+
+   contains
+    !> Constructor.
+     procedure, pass(this) :: init => time_based_controller_init
+    !> Check if the execution should be performed.
+     procedure, pass(this) :: check => time_based_controller_check
+
+  end type time_based_controller_t
+
+  interface assignment(=)
+     module procedure time_based_controller_assignment
+  end interface assignment(=)
+
+contains
+  
+  !> Constructor.
+  !! @param end_time The final simulation time.
+  !! @param control_mode The way to interpret the `control_value` parameter.
+  !! @param control_value The value definining the execution frequency.
+  subroutine time_based_controller_init(this, end_time, control_mode, &
+     control_value)
+    class(time_based_controller_t), intent(inout) :: this
+    real(kind=rp), intent(in) :: end_time
+    character(len=*), intent(in) :: control_mode
+    real(kind=rp), intent(in) :: control_value
+
+    this%end_time = end_time
+
+    if (trim(control_mode) .eq. 'simulationtime') then
+        this%time_interval = control_value
+        this%frequency = 1/this%time_interval
+        this%nsteps = 0 
+    else if (trim(control_mode) .eq. 'nsamples') then
+        this%frequency = control_value / end_time
+        this%time_interval = 1.0_rp / this%frequency
+        this%nsteps = 0
+    else if (trim(control_mode) .eq. 'tsteps') then 
+        this%nsteps = control_value
+        ! if the timestep will be variable, we cannot compute these.
+        this%frequency = 0
+        this%time_interval = 0
+    else
+        call neko_error("The control parameter must be simulationtime, nsamples&
+          & or tsteps, but received "//trim(control_mode))
+    end if
+  end subroutine time_based_controller_init
+
+  !> Check if the execution should be performed.
+  !! @param t Time value.
+  !! @param tstep Current timestep.
+  !! @param force Whether to force returning true. Optional.
+  function time_based_controller_check(this, t, tstep, force) result(check)
+    class(time_based_controller_t), intent(inout) :: this
+    real(kind=rp), intent(in) :: t
+    integer, intent(in) :: tstep
+    logical, intent(in), optional :: force
+    logical :: check
+    logical :: ifforce
+
+    if (present(force)) then
+       ifforce = force
+    else
+       ifforce = .false.
+    end if
+
+    check = .false.
+    if (ifforce) then
+        check = .true.
+    else if ( (this%nsteps .eq. 0) .and. &
+              (t .ge. this%nexecutions * this%time_interval) ) then
+        check = .true.
+    else if (this%nsteps .gt. 0) then
+       if (mod(tstep, this%nsteps) .eq. 0) then
+        check = .true.
+       end if
+    end if
+  end function
+
+  !> Assignment operator. Simply copies attribute values.
+  !! @param ctrl1 Left-hand side.
+  !! @param ctrl2 Right-hand side.
+  subroutine time_based_controller_assignment(ctrl1, ctrl2)
+    type(time_based_controller_t), intent(inout) :: ctrl1
+    type(time_based_controller_t), intent(in) :: ctrl2
+
+    ctrl1%end_time = ctrl2%end_time
+    ctrl1%frequency = ctrl2%frequency
+    ctrl1%nsteps = ctrl2%nsteps
+    ctrl1%time_interval = ctrl2%time_interval
+    ctrl1%nexecutions = ctrl2%nexecutions
+
+  end subroutine time_based_controller_assignment
+
+
+
+end module time_based_controller

--- a/src/common/time_based_controller.f90
+++ b/src/common/time_based_controller.f90
@@ -37,10 +37,11 @@ module time_based_controller
   implicit none
   private
 
-  !> A utility type for determening whether an action should be exectuted based
+  !> A utility type for determening whether an action should be executed based
   !! on the current time value. Used to e.g. control whether we should write a
-  !! file or exectue a simcomp.
-  !! Note that the nexpections variable should be incremented externally.
+  !! file or execute a simcomp.
+  !! Note that the nexecutions variable should be incremented externally by
+  !! calling the `register_execution` procedure.
   !! This is to allow running the the `check` multiple times at the same time
   !! step.
   type, public :: time_based_controller_t
@@ -60,6 +61,9 @@ module time_based_controller
      procedure, pass(this) :: init => time_based_controller_init
     !> Check if the execution should be performed.
      procedure, pass(this) :: check => time_based_controller_check
+    !> Increment `nexectutions`.
+     procedure, pass(this) :: register_execution => &
+       time_based_controller_register_execution
 
   end type time_based_controller_t
 
@@ -105,6 +109,9 @@ contains
   !! @param t Time value.
   !! @param tstep Current timestep.
   !! @param force Whether to force returning true. Optional.
+  !! @note In the logic, `nsteps` being zero corresponds to us not knowing the
+  !! number of time-steps between executions and thus having to rely on
+  !! `nexecutions`. This is done in anticipation of having a variable timestep.
   function time_based_controller_check(this, t, tstep, force) result(check)
     class(time_based_controller_t), intent(inout) :: this
     real(kind=rp), intent(in) :: t
@@ -146,6 +153,14 @@ contains
     ctrl1%nexecutions = ctrl2%nexecutions
 
   end subroutine time_based_controller_assignment
+
+  !> Increment `nexectutions`.
+  subroutine time_based_controller_register_execution(this)
+    class(time_based_controller_t), intent(inout) :: this
+
+    this%nexecutions = this%nexecutions + 1
+
+  end subroutine time_based_controller_register_execution
 
 
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -31,4 +31,5 @@ scratch_registry/scratch_registry_test
 fast3d/fast3d_test
 time_scheme/time_scheme_test
 time_scheme_controller/time_scheme_controller_test
+time_based_controller/time_based_controller_test
 point_interpolation/point_interpolation_suite

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,6 +29,7 @@ SUBDIRS = tuple\
 	  fast3d\
 	  time_scheme\
 	  time_scheme_controller\
+	  time_based_controller\
 	  point_interpolation
 
 TESTS = device/device_test\
@@ -62,6 +63,7 @@ TESTS = device/device_test\
 	fast3d/fast3d_test\
 	time_scheme/time_scheme_test\
 	time_scheme_controller/time_scheme_controller_test\
+	time_based_controller/time_based_controller_test\
 	point_interpolation/point_interpolation_test
 
 # Note we need to list .pf and runner scripts manually
@@ -125,5 +127,6 @@ EXTRA_DIST = \
 	time_scheme/test_ext.pf\
 	time_scheme/test_ab.pf\
 	time_scheme_controller/test_time_scheme_controller.pf\
+	time_based_controller/test_time_based_controller.pf\
 	point_interpolation/point_interpolation_parallel.pf\
 	point_interpolation/point_interpolation_test

--- a/tests/time_based_controller/Makefile.in
+++ b/tests/time_based_controller/Makefile.in
@@ -1,0 +1,27 @@
+ifneq ("$(wildcard @PFUNIT_DIR@/include/PFUNIT.mk)", "")
+include @PFUNIT_DIR@/include/PFUNIT.mk
+endif
+FFLAGS += $(PFUNIT_EXTRA_FFLAGS) -I@top_builddir@/src
+FC = @FC@
+
+%.o : %.F90
+	$(FC) -c $(FFLAGS) $<
+
+
+check: time_based_controller_test
+
+time_based_controller_test_TESTS := test_time_based_controller.pf
+
+time_based_controller_test_OTHER_LIBRARIES = -L@top_builddir@/src -lneko @LDFLAGS@ @LIBS@
+$(eval $(call make_pfunit_test,time_based_controller_test))
+
+
+clean:
+	$(RM) *.o *.mod *.a  *.inc *.F90  time_based_controller_test
+
+
+
+all:
+html:
+install:
+distdir:

--- a/tests/time_based_controller/test_time_based_controller.pf
+++ b/tests/time_based_controller/test_time_based_controller.pf
@@ -1,0 +1,134 @@
+!> Test the constructor
+@test
+subroutine test_init()
+  use pfunit
+  use time_based_controller, only : time_based_controller_t
+  use num_types, only : rp
+  implicit none
+  
+  type(time_based_controller_t) ctrl
+
+  call ctrl%init(1.0_rp, "simulationtime", 10.0_rp)
+  @assertEqual(ctrl%end_time, 1.0_rp, tolerance=1e-6_rp)
+  @assertEqual(ctrl%time_interval, 10.0_rp, tolerance=1e-6_rp)
+  @assertEqual(ctrl%frequency, 0.1_rp, tolerance=1e-6_rp)
+  @assertEqual(ctrl%nsteps, 0)
+
+  call ctrl%init(1.0_rp, "nsamples", 10.0_rp)
+  @assertEqual(ctrl%end_time, 1.0_rp, tolerance=1e-6_rp)
+  @assertEqual(ctrl%time_interval, 0.1_rp, tolerance=1e-6_rp)
+  @assertEqual(ctrl%frequency, 10.0_rp, tolerance=1e-6_rp)
+  @assertEqual(ctrl%nsteps, 0)
+
+  call ctrl%init(1.0_rp, "tsteps", 10.0_rp)
+  @assertEqual(ctrl%end_time, 1.0_rp, tolerance=1e-6_rp)
+  @assertEqual(ctrl%time_interval, 0.0_rp, tolerance=1e-6_rp)
+  @assertEqual(ctrl%frequency, 0.0_rp, tolerance=1e-6_rp)
+  @assertEqual(ctrl%nsteps, 10)
+end subroutine test_init
+
+!> Test assignment
+@test
+subroutine test_assign()
+  use pfunit
+  use time_based_controller, only : time_based_controller_t
+  use num_types, only : rp
+  implicit none
+  
+  type(time_based_controller_t) ctrl1
+  type(time_based_controller_t) ctrl2
+
+  call ctrl1%init(1.0_rp, "simulationtime", 10.0_rp)
+  ctrl2 = ctrl1
+  @assertEqual(ctrl1%end_time, ctrl2%end_time, tolerance=1e-6_rp)
+  @assertEqual(ctrl1%time_interval, ctrl2%time_interval, tolerance=1e-6_rp)
+  @assertEqual(ctrl1%frequency, ctrl2%frequency, tolerance=1e-6_rp)
+  @assertEqual(ctrl1%nsteps, ctrl2%nsteps)
+  @assertEqual(ctrl1%nexecutions, ctrl2%nexecutions)
+
+end subroutine test_assign
+
+!> Test check simulationtime
+@test
+subroutine test_check_simulationtime()
+  use pfunit
+  use time_based_controller, only : time_based_controller_t
+  use num_types, only : rp
+  implicit none
+  
+  type(time_based_controller_t) ctrl
+
+  call ctrl%init(10.0_rp, "simulationtime", 1.0_rp)
+
+  ! Expect true on first execution
+  @assertEqual(ctrl%check(0.0_rp, 0), .true.)
+  call ctrl%register_execution()
+
+  @assertEqual(ctrl%check(1.1_rp, 0), .true.)
+  call ctrl%register_execution()
+
+  @assertEqual(ctrl%check(1.5_rp, 0), .false.)
+
+end subroutine test_check_simulationtime
+
+!> Test check nsamples
+@test
+subroutine test_check_nsamples()
+  use pfunit
+  use time_based_controller, only : time_based_controller_t
+  use num_types, only : rp
+  implicit none
+  
+  type(time_based_controller_t) ctrl
+
+  call ctrl%init(10.0_rp, "nsamples", 10.0_rp)
+
+  ! Expect true on first execution
+  @assertEqual(ctrl%check(0.0_rp, 0), .true.)
+  call ctrl%register_execution()
+
+  @assertEqual(ctrl%check(1.1_rp, 0), .true.)
+  call ctrl%register_execution()
+
+  @assertEqual(ctrl%check(1.5_rp, 0), .false.)
+
+end subroutine test_check_nsamples
+
+!> Test check tsteps
+@test
+subroutine test_check_tsteps()
+  use pfunit
+  use time_based_controller, only : time_based_controller_t
+  use num_types, only : rp
+  implicit none
+  
+  type(time_based_controller_t) ctrl
+
+  call ctrl%init(10.0_rp, "tsteps", 10.0_rp)
+
+  ! Expect true on first execution
+  @assertEqual(ctrl%check(0.0_rp, 0), .true.)
+  call ctrl%register_execution()
+
+  @assertEqual(ctrl%check(0.0_rp, 10), .true.)
+  call ctrl%register_execution()
+
+  @assertEqual(ctrl%check(0.0_rp, 15), .false.)
+
+end subroutine test_check_tsteps
+
+!> Test register
+@test
+subroutine test_register()
+  use pfunit
+  use time_based_controller, only : time_based_controller_t
+  use num_types, only : rp
+  implicit none
+  
+  type(time_based_controller_t) ctrl
+
+  call ctrl%init(1.0_rp, "simulationtime", 10.0_rp)
+  call ctrl%register_execution()
+  @assertEqual(ctrl%nexecutions, 1)
+
+end subroutine test_register


### PR DESCRIPTION
* The `sampler` class implemented the logic for determining whether we need to write or not.
* I put this in a separate class, called `time_based_controller`.
* The reason is that we may want to use this in other contexts. Basically for anything, which should not be executed at each time-step, but rather based on user input. One immediate application is execution of `simcomps`.
* This makes the `sampler` class less heavy as bonus.

Not sure to be honest if the sampler works correctly atm, I just want to commit WIP, therefore, the don't merge label. But it *seems* to work :-), and the code is clean enough to review.
 