### PR TITLE
Add freeze parameter to fluid

### DIFF
--- a/src/fluid/fluid_plan1.f90
+++ b/src/fluid/fluid_plan1.f90
@@ -76,6 +76,8 @@ contains
     integer, intent(inout) :: tstep
     type(time_scheme_controller_t), intent(inout) :: ext_bdf
 
+    if (this%freeze) return
+
   end subroutine fluid_plan1_step
   
 end module fluid_plan1

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -352,6 +352,8 @@ contains
     ! Indices for tracking temporary fields 
     integer :: temp_indices(3)
 
+    if (this%freeze) return
+
     n = this%dm_Xh%size()
 
     call profiler_start_region('Fluid')

--- a/src/fluid/fluid_scheme.f90
+++ b/src/fluid/fluid_scheme.f90
@@ -102,6 +102,7 @@ module fluid_scheme
      type(fluid_stats_t) :: stats              !< Fluid statistics
      type(mean_sqr_flow_t) :: mean_sqr         !< Mean squared flow field
      logical :: forced_flow_rate = .false.     !< Is the flow rate forced?
+     logical :: freeze = .false.               !< Freeze velocity at initial condition?
      !> The Reynolds number
      real(kind=rp) :: Re
      !> Dynamic viscosity
@@ -248,6 +249,8 @@ contains
     call json_get_or_default(params, &
                             'case.fluid.pressure_solver.projection_space_size',&
                             this%pr_projection_dim, 20)
+
+    call json_get_or_default(params, 'case.fluid.freeze', this%freeze, .false.)
 
    if (params%valid_path("case.fluid.flow_rate_force")) then
       this%forced_flow_rate = .true.


### PR DESCRIPTION
See #854 .
- Adds a "freeze" boolean parameter to the "fluid" JSON object.
- `fluid_scheme`'s `step` subroutines return immediately if the freeze is active.
- Useful for having a constant velocity field defined by the ICs. For example, to test pure scalar convection/diffusion.