### PR TITLE
Add methods to pass down simulation time and/or time-step to bcs

### DIFF
--- a/examples/cyl_boundary_layer/cyl_bl.f90
+++ b/examples/cyl_boundary_layer/cyl_bl.f90
@@ -64,7 +64,7 @@ contains
     end do
   end subroutine cylinder_gen_curve
   
-  subroutine user_inflow_eval(u, v, w, x, y, z, nx, ny, nz, ix, iy, iz, ie)
+  subroutine user_inflow_eval(u, v, w, x, y, z, nx, ny, nz, ix, iy, iz, ie, t, tstep)
     real(kind=rp), intent(inout) :: u
     real(kind=rp), intent(inout) :: v
     real(kind=rp), intent(inout) :: w
@@ -78,6 +78,8 @@ contains
     integer, intent(in) :: iy
     integer, intent(in) :: iz
     integer, intent(in) :: ie
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
     real(kind=rp) ::  u_th,dist,th, yy
     real(kind=rp) ::  arg
 

--- a/examples/lid/lid.f90
+++ b/examples/lid/lid.f90
@@ -26,7 +26,7 @@ module user
   end subroutine user_setup
 
   ! user-defined boundary condition
-  subroutine user_bc(u, v, w, x, y, z, nx, ny, nz, ix, iy, iz, ie)
+  subroutine user_bc(u, v, w, x, y, z, nx, ny, nz, ix, iy, iz, ie, t, tstep)
     real(kind=rp), intent(inout) :: u
     real(kind=rp), intent(inout) :: v
     real(kind=rp), intent(inout) :: w
@@ -40,6 +40,8 @@ module user
     integer, intent(in) :: iy
     integer, intent(in) :: iz
     integer, intent(in) :: ie
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
 
     real(kind=rp) lsmoothing
     lsmoothing = 0.05_rp    ! length scale of smoothing at the edges

--- a/examples/lid/lid2d.f90
+++ b/examples/lid/lid2d.f90
@@ -25,7 +25,7 @@ module user
   end subroutine user_setup
 
   ! user-defined boundary condition
-  subroutine user_bc(u, v, w, x, y, z, nx, ny, nz, ix, iy, iz, ie)
+  subroutine user_bc(u, v, w, x, y, z, nx, ny, nz, ix, iy, iz, ie, t, tstep)
     real(kind=rp), intent(inout) :: u
     real(kind=rp), intent(inout) :: v
     real(kind=rp), intent(inout) :: w
@@ -39,6 +39,8 @@ module user
     integer, intent(in) :: iy
     integer, intent(in) :: iz
     integer, intent(in) :: ie
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
 
     real(kind=rp) lsmoothing
     lsmoothing = 0.05_rp    ! length scale of smoothing at the edges

--- a/examples/rayleigh-benard-cylinder/rayleigh.f90
+++ b/examples/rayleigh-benard-cylinder/rayleigh.f90
@@ -17,7 +17,7 @@ contains
     u%fluid_user_f_vector => forcing
   end subroutine user_setup
    
-  subroutine scalar_bc(s, x, y, z, nx, ny, nz, ix, iy, iz, ie)
+  subroutine scalar_bc(s, x, y, z, nx, ny, nz, ix, iy, iz, ie, t, tstep)
     real(kind=rp), intent(inout) :: s
     real(kind=rp), intent(in) :: x
     real(kind=rp), intent(in) :: y
@@ -29,6 +29,8 @@ contains
     integer, intent(in) :: iy
     integer, intent(in) :: iz
     integer, intent(in) :: ie
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
     ! This will be used on all zones without labels
     ! e.g. the ones hardcoded to 'v', 'w', etcetc
     s = 1.0_rp-z

--- a/examples/rayleigh-benard-cylinder/rayleigh.f90
+++ b/examples/rayleigh-benard-cylinder/rayleigh.f90
@@ -29,8 +29,8 @@ contains
     integer, intent(in) :: iy
     integer, intent(in) :: iz
     integer, intent(in) :: ie
-    real(kind=rp), intent(in), optional :: t
-    integer, intent(in), optional :: tstep
+    real(kind=rp), intent(in) :: t
+    integer, intent(in) :: tstep
     ! This will be used on all zones without labels
     ! e.g. the ones hardcoded to 'v', 'w', etcetc
     s = 1.0_rp-z

--- a/examples/rayleigh-benard/rayleigh.f90
+++ b/examples/rayleigh-benard/rayleigh.f90
@@ -16,7 +16,7 @@ contains
     u%scalar_user_bc => scalar_bc
   end subroutine user_setup
 
-  subroutine scalar_bc(s, x, y, z, nx, ny, nz, ix, iy, iz, ie)
+  subroutine scalar_bc(s, x, y, z, nx, ny, nz, ix, iy, iz, ie, t, tstep)
     real(kind=rp), intent(inout) :: s
     real(kind=rp), intent(in) :: x
     real(kind=rp), intent(in) :: y
@@ -28,6 +28,8 @@ contains
     integer, intent(in) :: iy
     integer, intent(in) :: iz
     integer, intent(in) :: ie
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
     ! If we set scalar_bcs(*) = 'user' instead 
     ! this will be used instead on that zone
     s = 1.0_rp-z

--- a/examples/rayleigh-benard/rayleigh.f90
+++ b/examples/rayleigh-benard/rayleigh.f90
@@ -28,8 +28,8 @@ contains
     integer, intent(in) :: iy
     integer, intent(in) :: iz
     integer, intent(in) :: ie
-    real(kind=rp), intent(in), optional :: t
-    integer, intent(in), optional :: tstep
+    real(kind=rp), intent(in) :: t
+    integer, intent(in) :: tstep
     ! If we set scalar_bcs(*) = 'user' instead 
     ! this will be used instead on that zone
     s = 1.0_rp-z

--- a/reframe/src/rayleigh.f90
+++ b/reframe/src/rayleigh.f90
@@ -30,8 +30,8 @@ contains
     integer, intent(in) :: iy
     integer, intent(in) :: iz
     integer, intent(in) :: ie
-    real(kind=rp), intent(in), optional :: t
-    integer, intent(in), optional :: tstep
+    real(kind=rp), intent(in) :: t
+    integer, intent(in) :: tstep
     ! If we set scalar_bcs(*) = 'user' instead 
     ! this will be used instead on that zone
     s = 1.0_rp-z

--- a/reframe/src/rayleigh.f90
+++ b/reframe/src/rayleigh.f90
@@ -18,7 +18,7 @@ contains
     u%scalar_user_bc => scalar_bc
   end subroutine user_setup
 
-  subroutine scalar_bc(s, x, y, z, nx, ny, nz, ix, iy, iz, ie)
+  subroutine scalar_bc(s, x, y, z, nx, ny, nz, ix, iy, iz, ie, t, tstep)
     real(kind=rp), intent(inout) :: s
     real(kind=rp), intent(in) :: x
     real(kind=rp), intent(in) :: y
@@ -30,6 +30,8 @@ contains
     integer, intent(in) :: iy
     integer, intent(in) :: iz
     integer, intent(in) :: ie
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
     ! If we set scalar_bcs(*) = 'user' instead 
     ! this will be used instead on that zone
     s = 1.0_rp-z

--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -106,8 +106,8 @@ module bc
      !> Apply the boundary condition to a scalar field
      !! @param x The field for which to apply the boundary condition.
      !! @param n The size of x.
-     !! @param t Current time
-     !! @param tstep Current time-step
+     !! @param t Current time.
+     !! @param tstep Current time-step.
      subroutine bc_apply_scalar(this, x, n, t, tstep)
        import :: bc_t
        import :: rp
@@ -124,9 +124,9 @@ module bc
      !! @param x The x comp of the field for which to apply the bc.
      !! @param y The y comp of the field for which to apply the bc.
      !! @param z The z comp of the field for which to apply the bc.
-     !! @param n The size of x, y, and z
-     !! @param t Current time
-     !! @param tstep Current time-step
+     !! @param n The size of x, y, and z.
+     !! @param t Current time.
+     !! @param tstep Current time-step.
      subroutine bc_apply_vector(this, x, y, z, n, t, tstep)
        import :: bc_t
        import :: rp
@@ -473,6 +473,8 @@ contains
   !> Apply a list of boundary conditions to a scalar field
   !! @param x The field to apply the boundary conditions to.
   !! @param n The size of x.
+  !! @param t Current time.
+  !! @param tstep Current time-step.
   subroutine bc_list_apply_scalar(bclst, x, n, t, tstep)
     type(bc_list_t), intent(inout) :: bclst
     integer, intent(in) :: n
@@ -526,6 +528,8 @@ contains
   !! @param y The y comp of the field for which to apply the bcs.
   !! @param z The z comp of the field for which to apply the bcs.
   !! @param n The size of x, y, z.
+  !! @param t Current time.
+  !! @param tstep Current time-step.
   subroutine bc_list_apply_vector(bclst, x, y, z, n, t, tstep)
     type(bc_list_t), intent(inout) :: bclst
     integer, intent(in) :: n

--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -106,7 +106,7 @@ module bc
      !> Apply the boundary condition to a scalar field
      !! @param x The field for which to apply the boundary condition.
      !! @param n The size of x.
-     !! @param t Current ime
+     !! @param t Current time
      !! @param tstep Current time-step
      subroutine bc_apply_scalar(this, x, n, t, tstep)
        import :: bc_t
@@ -125,7 +125,7 @@ module bc
      !! @param y The y comp of the field for which to apply the bc.
      !! @param z The z comp of the field for which to apply the bc.
      !! @param n The size of x, y, and z
-     !! @param t Current ime
+     !! @param t Current time
      !! @param tstep Current time-step
      subroutine bc_apply_vector(this, x, y, z, n, t, tstep)
        import :: bc_t

--- a/src/bc/blasius.f90
+++ b/src/bc/blasius.f90
@@ -82,25 +82,31 @@ contains
   end subroutine blasius_free
   
   !> No-op scalar apply
-  subroutine blasius_apply_scalar(this, x, n)
+  subroutine blasius_apply_scalar(this, x, n, t, tstep)
     class(blasius_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout),  dimension(n) :: x
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
   end subroutine blasius_apply_scalar
 
   !> No-op scalar apply (device version)
-  subroutine blasius_apply_scalar_dev(this, x_d)
+  subroutine blasius_apply_scalar_dev(this, x_d, t, tstep)
     class(blasius_t), intent(inout), target :: this
     type(c_ptr) :: x_d
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
   end subroutine blasius_apply_scalar_dev
   
   !> Apply blasius conditions (vector valued)
-  subroutine blasius_apply_vector(this, x, y, z, n)
+  subroutine blasius_apply_vector(this, x, y, z, n, t, tstep)
     class(blasius_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout),  dimension(n) :: x
     real(kind=rp), intent(inout),  dimension(n) :: y
     real(kind=rp), intent(inout),  dimension(n) :: z
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
     integer :: i, m, k, idx(4), facet
 
     associate(xc => this%c%dof%x, yc => this%c%dof%y, zc => this%c%dof%z, &
@@ -133,11 +139,13 @@ contains
   end subroutine blasius_apply_vector
 
   !> Apply blasius conditions (vector valued) (device version)
-  subroutine blasius_apply_vector_dev(this, x_d, y_d, z_d)
+  subroutine blasius_apply_vector_dev(this, x_d, y_d, z_d, t, tstep)
     class(blasius_t), intent(inout), target :: this
     type(c_ptr) :: x_d
     type(c_ptr) :: y_d
     type(c_ptr) :: z_d
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
     integer :: i, m, k, idx(4), facet
     integer(c_size_t) :: s
     real(kind=rp), allocatable :: bla_x(:), bla_y(:), bla_z(:)

--- a/src/bc/dirichlet.f90
+++ b/src/bc/dirichlet.f90
@@ -55,10 +55,12 @@ contains
 
   !> Boundary condition apply for a generic Dirichlet condition
   !! to a vector @a x
-  subroutine dirichlet_apply_scalar(this, x, n)
+  subroutine dirichlet_apply_scalar(this, x, n, t, tstep)
     class(dirichlet_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout),  dimension(n) :: x
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
     integer :: i, m, k
 
     m = this%msk(0)
@@ -70,12 +72,14 @@ contains
 
   !> Boundary condition apply for a generic Dirichlet condition
   !! to vectors @a x, @a y and @a z
-  subroutine dirichlet_apply_vector(this, x, y, z, n)
+  subroutine dirichlet_apply_vector(this, x, y, z, n, t, tstep)
     class(dirichlet_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout),  dimension(n) :: x
     real(kind=rp), intent(inout),  dimension(n) :: y
     real(kind=rp), intent(inout),  dimension(n) :: z
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
     integer :: i, m, k
 
     m = this%msk(0)
@@ -90,9 +94,11 @@ contains
 
   !> Boundary condition apply for a generic Dirichlet condition
   !! to a vector @a x (device version)
-  subroutine dirichlet_apply_scalar_dev(this, x_d)
+  subroutine dirichlet_apply_scalar_dev(this, x_d, t, tstep)
     class(dirichlet_t), intent(inout), target :: this
     type(c_ptr) :: x_d
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
 
     call device_dirichlet_apply_scalar(this%msk_d, x_d, &
                                        this%g, size(this%msk))
@@ -101,11 +107,13 @@ contains
   
   !> Boundary condition apply for a generic Dirichlet condition 
   !! to vectors @a x, @a y and @a z (device version)
-  subroutine dirichlet_apply_vector_dev(this, x_d, y_d, z_d)
+  subroutine dirichlet_apply_vector_dev(this, x_d, y_d, z_d, t, tstep)
     class(dirichlet_t), intent(inout), target :: this
     type(c_ptr) :: x_d
     type(c_ptr) :: y_d
     type(c_ptr) :: z_d
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
 
     call device_dirichlet_apply_vector(this%msk_d, x_d, y_d, z_d, &
                                        this%g, size(this%msk))

--- a/src/bc/dong_outflow.f90
+++ b/src/bc/dong_outflow.f90
@@ -120,10 +120,12 @@ contains
 
   !> Boundary condition apply for a generic Dirichlet condition
   !! to a vector @a x
-  subroutine dong_outflow_apply_scalar(this, x, n)
+  subroutine dong_outflow_apply_scalar(this, x, n, t, tstep)
     class(dong_outflow_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout),  dimension(n) :: x
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
     integer :: i, m, k, facet, idx(4)
     real(kind=rp) :: vn, S0, ux, uy, uz, normal_xyz(3)
 
@@ -146,20 +148,24 @@ end subroutine dong_outflow_apply_scalar
 
   !> Boundary condition apply for a generic Dirichlet condition
   !! to vectors @a x, @a y and @a z
-  subroutine dong_outflow_apply_vector(this, x, y, z, n)
+  subroutine dong_outflow_apply_vector(this, x, y, z, n, t, tstep)
     class(dong_outflow_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout),  dimension(n) :: x
     real(kind=rp), intent(inout),  dimension(n) :: y
     real(kind=rp), intent(inout),  dimension(n) :: z
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
     
   end subroutine dong_outflow_apply_vector
 
   !> Boundary condition apply for a generic Dirichlet condition
   !! to a vector @a x (device version)
-  subroutine dong_outflow_apply_scalar_dev(this, x_d)
+  subroutine dong_outflow_apply_scalar_dev(this, x_d, t, tstep)
     class(dong_outflow_t), intent(inout), target :: this
     type(c_ptr) :: x_d
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
 
     call device_dong_outflow_apply_scalar(this%msk_d,x_d, this%normal_x_d, &
                                           this%normal_y_d, this%normal_z_d,&
@@ -171,11 +177,13 @@ end subroutine dong_outflow_apply_scalar
   
   !> Boundary condition apply for a generic Dirichlet condition 
   !! to vectors @a x, @a y and @a z (device version)
-  subroutine dong_outflow_apply_vector_dev(this, x_d, y_d, z_d)
+  subroutine dong_outflow_apply_vector_dev(this, x_d, y_d, z_d, t, tstep)
     class(dong_outflow_t), intent(inout), target :: this
     type(c_ptr) :: x_d
     type(c_ptr) :: y_d
     type(c_ptr) :: z_d
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
 
     !call device_dong_outflow_apply_vector(this%msk_d, x_d, y_d, z_d, &
     !                                   this%g, size(this%msk))

--- a/src/bc/facet_normal.f90
+++ b/src/bc/facet_normal.f90
@@ -56,23 +56,27 @@ module facet_normal
 contains
 
   !> No-op scalar apply
-  subroutine facet_normal_apply_scalar(this, x, n)
+  subroutine facet_normal_apply_scalar(this, x, n, t, tstep)
     class(facet_normal_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout), dimension(n) :: x
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
   end subroutine facet_normal_apply_scalar
 
   !> No-op vector apply
-  subroutine facet_normal_apply_vector(this, x, y, z, n)
+  subroutine facet_normal_apply_vector(this, x, y, z, n, t, tstep)
     class(facet_normal_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout), dimension(n) :: x
     real(kind=rp), intent(inout), dimension(n) :: y
     real(kind=rp), intent(inout), dimension(n) :: z
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
   end subroutine facet_normal_apply_vector
 
   !> Apply in facet normal direction (vector valued)
-  subroutine facet_normal_apply_surfvec(this, x, y, z, u, v, w, n)
+  subroutine facet_normal_apply_surfvec(this, x, y, z, u, v, w, n, t, tstep)
     class(facet_normal_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout), dimension(n) :: x
@@ -81,6 +85,8 @@ contains
     real(kind=rp), intent(inout), dimension(n) :: u
     real(kind=rp), intent(inout), dimension(n) :: v
     real(kind=rp), intent(inout), dimension(n) :: w
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
     integer :: i, m, k, idx(4), facet
     
     if (.not. associated(this%c)) then
@@ -128,9 +134,12 @@ contains
   end subroutine facet_normal_set_coef
 
   !> Apply in facet normal direction (vector valued, device version)
-  subroutine facet_normal_apply_surfvec_dev(this, x_d, y_d, z_d, u_d, v_d, w_d)
+  subroutine facet_normal_apply_surfvec_dev(this, x_d, y_d, z_d, &
+                                            u_d, v_d, w_d, t, tstep)
     class(facet_normal_t), intent(inout), target :: this
     type(c_ptr) :: x_d, y_d, z_d, u_d, v_d, w_d
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
 
     if (.not. associated(this%c)) then
        call neko_error('No coefficients assigned')

--- a/src/bc/inflow.f90
+++ b/src/bc/inflow.f90
@@ -53,25 +53,31 @@ module inflow
 contains
 
   !> No-op scalar apply
-  subroutine inflow_apply_scalar(this, x, n)
+  subroutine inflow_apply_scalar(this, x, n, t, tstep)
     class(inflow_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout),  dimension(n) :: x
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
   end subroutine inflow_apply_scalar
 
   !> No-op scalar apply (device version)
-  subroutine inflow_apply_scalar_dev(this, x_d)
+  subroutine inflow_apply_scalar_dev(this, x_d, t, tstep)
     class(inflow_t), intent(inout), target :: this
     type(c_ptr) :: x_d
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
   end subroutine inflow_apply_scalar_dev
   
   !> Apply inflow conditions (vector valued)
-  subroutine inflow_apply_vector(this, x, y, z, n)
+  subroutine inflow_apply_vector(this, x, y, z, n, t, tstep)
     class(inflow_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout),  dimension(n) :: x
     real(kind=rp), intent(inout),  dimension(n) :: y
     real(kind=rp), intent(inout),  dimension(n) :: z
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
     integer :: i, m, k
 
     m = this%msk(0)
@@ -84,13 +90,17 @@ contains
   end subroutine inflow_apply_vector
 
   !> Apply inflow conditions (vector valued) (device version)
-  subroutine inflow_apply_vector_dev(this, x_d, y_d, z_d)
+  subroutine inflow_apply_vector_dev(this, x_d, y_d, z_d, t, tstep)
     class(inflow_t), intent(inout), target :: this
     type(c_ptr) :: x_d
     type(c_ptr) :: y_d
     type(c_ptr) :: z_d
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
+    
     call device_inflow_apply_vector(this%msk_d, x_d, y_d, z_d, &
                                     c_loc(this%x), this%msk(0))
+    
   end subroutine inflow_apply_vector_dev
 
   !> Set inflow vector

--- a/src/bc/symmetry.f90
+++ b/src/bc/symmetry.f90
@@ -150,19 +150,23 @@ contains
   end subroutine symmetry_free
   
   !> No-op scalar apply
-  subroutine symmetry_apply_scalar(this, x, n)
+  subroutine symmetry_apply_scalar(this, x, n, t, tstep)
     class(symmetry_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout), dimension(n) :: x
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
   end subroutine symmetry_apply_scalar
 
   !> Apply symmetry conditions (axis aligned)
-  subroutine symmetry_apply_vector(this, x, y, z, n)
+  subroutine symmetry_apply_vector(this, x, y, z, n, t, tstep)
     class(symmetry_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout),  dimension(n) :: x
     real(kind=rp), intent(inout),  dimension(n) :: y
     real(kind=rp), intent(inout),  dimension(n) :: z
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
     integer :: i, m, k
 
     call this%bc_x%apply_scalar(x,n)
@@ -172,17 +176,21 @@ contains
   end subroutine symmetry_apply_vector
 
   !> No-op scalar apply (device version)
-  subroutine symmetry_apply_scalar_dev(this, x_d)
+  subroutine symmetry_apply_scalar_dev(this, x_d, t, tstep)
     class(symmetry_t), intent(inout), target :: this
     type(c_ptr) :: x_d
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
   end subroutine symmetry_apply_scalar_dev
 
   !> Apply symmetry conditions (axis aligned) (device version)
-  subroutine symmetry_apply_vector_dev(this, x_d, y_d, z_d)
+  subroutine symmetry_apply_vector_dev(this, x_d, y_d, z_d, t, tstep)
     class(symmetry_t), intent(inout), target :: this
     type(c_ptr) :: x_d
     type(c_ptr) :: y_d
     type(c_ptr) :: z_d
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
 
     call device_symmetry_apply_vector(this%bc_x%msk_d, this%bc_y%msk_d, &
                                       this%bc_z%msk_d, x_d, y_d, z_d, &

--- a/src/bc/usr_inflow.f90
+++ b/src/bc/usr_inflow.f90
@@ -74,7 +74,10 @@ module usr_inflow
      !! @param iy The s idx of this point
      !! @param iz The t idx of this point
      !! @param ie The element idx of this point
-     subroutine usr_inflow_eval(u, v, w, x, y, z, nx, ny, nz, ix, iy, iz, ie)
+     !! @param t Current time
+     !! @param tstep Current time-step
+     subroutine usr_inflow_eval(u, v, w, x, y, z, nx, ny, nz, &
+                                ix, iy, iz, ie, t, tstep)
        import rp
        real(kind=rp), intent(inout) :: u
        real(kind=rp), intent(inout) :: v
@@ -89,6 +92,8 @@ module usr_inflow
        integer, intent(in) :: iy
        integer, intent(in) :: iz
        integer, intent(in) :: ie
+       real(kind=rp), intent(in) :: t
+       integer, intent(in) :: tstep
      end subroutine usr_inflow_eval
   end interface
 
@@ -114,26 +119,45 @@ contains
   end subroutine usr_inflow_free
   
   !> No-op scalar apply 
-  subroutine usr_inflow_apply_scalar(this, x, n)
+  subroutine usr_inflow_apply_scalar(this, x, n, t, tstep)
     class(usr_inflow_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout),  dimension(n) :: x
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
   end subroutine usr_inflow_apply_scalar
   
   !> No-op scalar apply (device version)
-  subroutine usr_inflow_apply_scalar_dev(this, x_d)
+  subroutine usr_inflow_apply_scalar_dev(this, x_d, t, tstep)
     class(usr_inflow_t), intent(inout), target :: this
     type(c_ptr) :: x_d
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
   end subroutine usr_inflow_apply_scalar_dev
 
   !> Apply user defined inflow conditions (vector valued)
-  subroutine usr_inflow_apply_vector(this, x, y, z, n)
+  subroutine usr_inflow_apply_vector(this, x, y, z, n, t, tstep)
     class(usr_inflow_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout),  dimension(n) :: x
     real(kind=rp), intent(inout),  dimension(n) :: y
     real(kind=rp), intent(inout),  dimension(n) :: z
-    integer :: i, m, k, idx(4), facet
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
+    integer :: i, m, k, idx(4), facet, tstep_
+    real(kind=rp) :: t_
+
+    if (present(t)) then
+       t_ = t
+    else
+       t_ = 0.0_rp
+    end if
+
+    if (present(tstep)) then
+       tstep_ = tstep
+    else
+       tstep_ = 0
+    end if
 
     associate(xc => this%c%dof%x, yc => this%c%dof%y, zc => this%c%dof%z, &
          nx => this%c%nx, ny => this%c%ny, nz => this%c%nz, &
@@ -152,7 +176,8 @@ contains
                  nx(idx(2), idx(3), facet, idx(4)), &
                  ny(idx(2), idx(3), facet, idx(4)), &
                  nz(idx(2), idx(3), facet, idx(4)), &
-                 idx(1), idx(2), idx(3), idx(4))
+                 idx(1), idx(2), idx(3), idx(4), &
+                 t_, tstep_)
          case(3,4)
             call this%eval(x(k), y(k), z(k), &
                  xc(idx(1), idx(2), idx(3), idx(4)), &
@@ -161,7 +186,8 @@ contains
                  nx(idx(1), idx(3), facet, idx(4)), &
                  ny(idx(1), idx(3), facet, idx(4)), &
                  nz(idx(1), idx(3), facet, idx(4)), &
-                 idx(1), idx(2), idx(3), idx(4))
+                 idx(1), idx(2), idx(3), idx(4), &
+                 t_, tstep_)
          case(5,6)
             call this%eval(x(k), y(k), z(k), &
                  xc(idx(1), idx(2), idx(3), idx(4)), &
@@ -170,23 +196,39 @@ contains
                  nx(idx(1), idx(2), facet, idx(4)), &
                  ny(idx(1), idx(2), facet, idx(4)), &
                  nz(idx(1), idx(2), facet, idx(4)), &
-                 idx(1), idx(2), idx(3), idx(4))
+                 idx(1), idx(2), idx(3), idx(4), &
+                 t_, tstep_)
          end select
       end do
     end associate
     
   end subroutine usr_inflow_apply_vector
 
-  subroutine usr_inflow_apply_vector_dev(this, x_d, y_d, z_d)
+  subroutine usr_inflow_apply_vector_dev(this, x_d, y_d, z_d, t, tstep)
     class(usr_inflow_t), intent(inout), target :: this
     type(c_ptr) :: x_d
     type(c_ptr) :: y_d
     type(c_ptr) :: z_d
-    integer :: i, m, k, idx(4), facet
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
+    integer :: i, m, k, idx(4), facet, tstep_
     integer(c_size_t) :: s
+    real(kind=rp) :: t_
     real(kind=rp), allocatable :: x(:)
     real(kind=rp), allocatable :: y(:)
     real(kind=rp), allocatable :: z(:)
+
+    if (present(t)) then
+       t_ = t
+    else
+       t_ = 0.0_rp
+    end if
+
+    if (present(tstep)) then
+       tstep_ = tstep
+    else
+       tstep_ = 0
+    end if
 
     associate(xc => this%c%dof%x, yc => this%c%dof%y, zc => this%c%dof%z, &
          nx => this%c%nx, ny => this%c%ny, nz => this%c%nz, &
@@ -222,7 +264,8 @@ contains
                       nx(idx(2), idx(3), facet, idx(4)), &
                       ny(idx(2), idx(3), facet, idx(4)), &
                       nz(idx(2), idx(3), facet, idx(4)), &
-                      idx(1), idx(2), idx(3), idx(4))
+                      idx(1), idx(2), idx(3), idx(4), &
+                      t_, tstep_)
               case(3,4)
                  call this%eval(x(i), y(i), z(i), &
                       xc(idx(1), idx(2), idx(3), idx(4)), &
@@ -231,7 +274,8 @@ contains
                       nx(idx(1), idx(3), facet, idx(4)), &
                       ny(idx(1), idx(3), facet, idx(4)), &
                       nz(idx(1), idx(3), facet, idx(4)), &
-                      idx(1), idx(2), idx(3), idx(4))
+                      idx(1), idx(2), idx(3), idx(4), &
+                      t_, tstep_)
               case(5,6)
                  call this%eval(x(i), y(i), z(i), &
                       xc(idx(1), idx(2), idx(3), idx(4)), &
@@ -240,7 +284,8 @@ contains
                       nx(idx(1), idx(2), facet, idx(4)), &
                       ny(idx(1), idx(2), facet, idx(4)), &
                       nz(idx(1), idx(2), facet, idx(4)), &
-                      idx(1), idx(2), idx(3), idx(4))
+                      idx(1), idx(2), idx(3), idx(4), &
+                      t_, tstep_)
               end select
            end do
          end associate

--- a/src/bc/usr_inflow.f90
+++ b/src/bc/usr_inflow.f90
@@ -156,7 +156,7 @@ contains
     if (present(tstep)) then
        tstep_ = tstep
     else
-       tstep_ = 0
+       tstep_ = 1
     end if
 
     associate(xc => this%c%dof%x, yc => this%c%dof%y, zc => this%c%dof%z, &
@@ -227,7 +227,7 @@ contains
     if (present(tstep)) then
        tstep_ = tstep
     else
-       tstep_ = 0
+       tstep_ = 1
     end if
 
     associate(xc => this%c%dof%x, yc => this%c%dof%y, zc => this%c%dof%z, &

--- a/src/bc/usr_scalar.f90
+++ b/src/bc/usr_scalar.f90
@@ -130,7 +130,7 @@ contains
     if (present(tstep)) then
        tstep_ = tstep
     else
-       tstep_ = 0
+       tstep_ = 1
     end if
 
     associate(xc => this%c%dof%x, yc => this%c%dof%y, zc => this%c%dof%z, &
@@ -202,7 +202,7 @@ contains
     if (present(tstep)) then
        tstep_ = tstep
     else
-       tstep_ = 0
+       tstep_ = 1
     end if
 
     associate(xc => this%c%dof%x, yc => this%c%dof%y, zc => this%c%dof%z, &

--- a/src/bc/wall.f90
+++ b/src/bc/wall.f90
@@ -52,10 +52,12 @@ contains
 
   !> Boundary condition apply for a no-slip wall condition
   !! to a vector @a x
-  subroutine no_slip_wall_apply_scalar(this, x, n)
+  subroutine no_slip_wall_apply_scalar(this, x, n, t, tstep)
     class(no_slip_wall_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout),  dimension(n) :: x
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
     integer :: i, m, k
 
     m = this%msk(0)
@@ -68,12 +70,14 @@ contains
   
   !> Boundary condition apply for a no-slip wall condition
   !! to vectors @a x, @a y and @a z
-  subroutine no_slip_wall_apply_vector(this, x, y, z, n)
+  subroutine no_slip_wall_apply_vector(this, x, y, z, n, t, tstep)
     class(no_slip_wall_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), intent(inout),  dimension(n) :: x
-    real(kind=rp), intent(inout),  dimension(n) :: y
+    real(kind=rp), intent(inout),  dimension(n) :: y    
     real(kind=rp), intent(inout),  dimension(n) :: z
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
     integer :: i, m, k
 
     m = this%msk(0)
@@ -88,9 +92,11 @@ contains
 
   !> Boundary condition apply for a no-slip wall condition
   !! to a vector @a x (device version)
-  subroutine no_slip_wall_apply_scalar_dev(this, x_d)
+  subroutine no_slip_wall_apply_scalar_dev(this, x_d, t, tstep)
     class(no_slip_wall_t), intent(inout), target :: this
     type(c_ptr) :: x_d
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
 
     call device_no_slip_wall_apply_scalar(this%msk_d, x_d, size(this%msk))
     
@@ -98,11 +104,13 @@ contains
   
   !> Boundary condition apply for a no-slip wall condition
   !! to vectors @a x, @a y and @a z (device version)
-  subroutine no_slip_wall_apply_vector_dev(this, x_d, y_d, z_d)
+  subroutine no_slip_wall_apply_vector_dev(this, x_d, y_d, z_d, t, tstep)
     class(no_slip_wall_t), intent(inout), target :: this
     type(c_ptr) :: x_d
     type(c_ptr) :: y_d
     type(c_ptr) :: z_d
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
 
     call device_no_slip_wall_apply_vector(this%msk_d, x_d, y_d, z_d, &
                                           size(this%msk))

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -226,7 +226,7 @@ contains
   end subroutine dummy_scalar_user_f
  
   !> Dummy user boundary condition for scalar
-  subroutine dummy_scalar_user_bc(s, x, y, z, nx, ny, nz, ix, iy, iz, ie)
+  subroutine dummy_scalar_user_bc(s, x, y, z, nx, ny, nz, ix, iy, iz, ie, t, tstep)
     real(kind=rp), intent(inout) :: s
     real(kind=rp), intent(in) :: x
     real(kind=rp), intent(in) :: y
@@ -238,6 +238,8 @@ contains
     integer, intent(in) :: iy
     integer, intent(in) :: iz
     integer, intent(in) :: ie
+    real(kind=rp), intent(in), optional :: t
+    integer, intent(in), optional :: tstep
     call neko_warning('Dummy scalar user bc set, applied on all non-labeled zones')    
   end subroutine dummy_scalar_user_bc
  

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -238,8 +238,8 @@ contains
     integer, intent(in) :: iy
     integer, intent(in) :: iz
     integer, intent(in) :: ie
-    real(kind=rp), intent(in), optional :: t
-    integer, intent(in), optional :: tstep
+    real(kind=rp), intent(in) :: t
+    integer, intent(in) :: tstep
     call neko_warning('Dummy scalar user bc set, applied on all non-labeled zones')    
   end subroutine dummy_scalar_user_bc
  

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -416,8 +416,8 @@ contains
       !> We assume that no change of boundary conditions 
       !! occurs between elements. I.e. we do not apply gsop here like in Nek5000
       !> Apply dirichlet
-      call this%bc_apply_vel()
-      call this%bc_apply_prs()
+      call this%bc_apply_vel(t, tstep)
+      call this%bc_apply_prs(t, tstep)
 
       ! Compute pressure.
       call profiler_start_region('Pressure residual')
@@ -427,7 +427,7 @@ contains
                            dt, Re, rho)
       
       call gs_op(gs_Xh, p_res, GS_OP_ADD) 
-      call bc_list_apply_scalar(this%bclst_dp, p_res%x, p%dof%size())
+      call bc_list_apply_scalar(this%bclst_dp, p_res%x, p%dof%size(), t, tstep)
       call profiler_end_region
 
       if( tstep .gt. 5 .and. pr_projection_dim .gt. 0) then
@@ -468,7 +468,9 @@ contains
       call gs_op(gs_Xh, w_res, GS_OP_ADD) 
 
       call bc_list_apply_vector(this%bclst_vel_res,&
-                                u_res%x, v_res%x, w_res%x, dm_Xh%size())
+                                u_res%x, v_res%x, w_res%x, dm_Xh%size(),&
+                                t, tstep)
+      
       call profiler_end_region
       
       if (tstep .gt. 5 .and. vel_projection_dim .gt. 0) then 

--- a/src/fluid/fluid_scheme.f90
+++ b/src/fluid/fluid_scheme.f90
@@ -679,17 +679,22 @@ contains
 
   !> Apply all boundary conditions defined for velocity
   !! @todo Why can't we call the interface here?
-  subroutine fluid_scheme_bc_apply_vel(this)
+  subroutine fluid_scheme_bc_apply_vel(this, t, tstep)
     class(fluid_scheme_t), intent(inout) :: this
+    real(kind=rp), intent(in) :: t
+    integer, intent(in) :: tstep
     call bc_list_apply_vector(this%bclst_vel,&
-         this%u%x, this%v%x, this%w%x, this%dm_Xh%size())
+         this%u%x, this%v%x, this%w%x, this%dm_Xh%size(), t, tstep)
   end subroutine fluid_scheme_bc_apply_vel
   
   !> Apply all boundary conditions defined for pressure
   !! @todo Why can't we call the interface here?
-  subroutine fluid_scheme_bc_apply_prs(this)
+  subroutine fluid_scheme_bc_apply_prs(this, t, tstep)
     class(fluid_scheme_t), intent(inout) :: this
-    call bc_list_apply_scalar(this%bclst_prs, this%p%x, this%p%dof%size())
+    real(kind=rp), intent(in) :: t
+    integer, intent(in) :: tstep
+    call bc_list_apply_scalar(this%bclst_prs, this%p%x, &
+                              this%p%dof%size(), t, tstep)
   end subroutine fluid_scheme_bc_apply_prs
   
   !> Initialize a linear solver


### PR DESCRIPTION
This extends the bc definition to allow for (optional) passing down current simulation time and/or time-step, fixes #902.

**Note** this breaks most user provided bcs
