### PR TITLE
Fix/point interpolator warnings

### DIFF
--- a/src/math/tensor.f90
+++ b/src/math/tensor.f90
@@ -269,7 +269,7 @@ contains
     ! Artificially reshape v into a 1-dimensional array
     ! since this is what tnsr3d_el needs as input argument
     real(kind=rp) :: vv(1)
-    vv(1) = v
+    ! vv(1) = v
 
     call tnsr3d_el(vv,1,u,nu,Hr,Hs,Ht)
 

--- a/src/sem/point_interpolator.f90
+++ b/src/sem/point_interpolator.f90
@@ -264,8 +264,8 @@ contains
     !
     ! Interpolate
     !
-    tmp = real(res%x, rp) ! Cast from point_t dp -> rp
     call triple_tensor_product(tmp, X, Y, Z, lx, hr(:,1), hs(:,1), ht(:,1))
+    res%x = real(tmp, dp) ! Cast from point_t dp -> rp
 
     !
     ! Build jacobian

--- a/src/sem/point_interpolator.f90
+++ b/src/sem/point_interpolator.f90
@@ -265,7 +265,7 @@ contains
     ! Interpolate
     !
     call triple_tensor_product(tmp, X, Y, Z, lx, hr(:,1), hs(:,1), ht(:,1))
-    res%x = real(tmp, dp) ! Cast from point_t dp -> rp
+    res%x = dble(tmp)! Cast from rp -> point_t dp 
 
     !
     ! Build jacobian


### PR DESCRIPTION
Some fixes in the following modules:
- **`tensor` module** : For some reason we were assigning `vv(1) = v` before having done anything on `v`.
- **`point_interpolator` module**: casting from `dp` to `rp` was throwing some warnings, @njansson used some of his magic to fix :)

