### PR TITLE
Add controllers to simcomps

### DIFF
--- a/examples/tgv/tgv.case
+++ b/examples/tgv/tgv.case
@@ -44,8 +44,8 @@
   [
     {
       "type": "vorticity",
-      "execution_control": "tsteps",
-      "execution_value": 50
+      "compute_control": "tsteps",
+      "compute_value": 50
     }
   ]
   }

--- a/examples/tgv/tgv.case
+++ b/examples/tgv/tgv.case
@@ -43,7 +43,9 @@
   "simulation_components": 
   [
     {
-      "type": "vorticity"
+      "type": "vorticity",
+      "execution_control": "tsteps",
+      "execution_value": 50
     }
   ]
   }

--- a/src/simulation_components/simulation_component.f90
+++ b/src/simulation_components/simulation_component.f90
@@ -39,22 +39,33 @@ module simulation_component
   use num_types, only : rp
   use json_module, only : json_file
   use case, only : case_t
+  use time_based_controller, only : time_based_controller_t
+  use json_utils, only : json_get_or_default
   implicit none
   private
   
   !> Base abstract class for simulation components.
   type, abstract, public :: simulation_component_t
      !> Pointer to the simulation case.
-     class(case_t), pointer :: case
+     type(case_t), pointer :: case
+     !> Controller for when to run `compute`.
+     type(time_based_controller_t) :: execution_controller
+     !> Controller for when to do output.
+     type(time_based_controller_t) :: output_controller
    contains
      !> Constructor for the simulation_component_t (base) class.
      procedure, pass(this) :: init_base => simulation_component_init_base
+     !> Destructor for the simulation_component_t (base) class.
+     procedure, pass(this) :: free_base => simulation_component_free_base
+     !> Wrapper for calling `compute_` based on the `execution_controller`.
+     !! Serves as the public interface.
+     procedure, pass(this) :: compute => simulation_component_compute_wrapper
      !> The common constructor using a JSON dictionary.
      procedure(simulation_component_init), pass(this), deferred :: init
      !> Destructor.
      procedure(simulation_component_free), pass(this), deferred :: free
      !> The main function to be executed during the run.
-     procedure(simulation_component_compute), pass(this), deferred :: compute
+     procedure(simulation_component_compute), pass(this), deferred :: compute_
   end type simulation_component_t
   
   !> A helper type that is needed to have an array of polymorphic objects
@@ -101,10 +112,48 @@ contains
     class(simulation_component_t), intent(inout) :: this
     type(json_file), intent(inout) :: json
     class(case_t), intent(inout), target :: case
+    character(len=:), allocatable :: execution_control, output_control
+    real(kind=rp) :: execution_value, output_value
 
     this%case => case
+    call json_get_or_default(json, "execution_control", execution_control, &
+                             "tsteps")
+    call json_get_or_default(json, "execution_value", execution_value, 1.0_rp) 
+
+    ! We default to output whenever we execute
+    call json_get_or_default(json, "output_control", output_control, &
+                             execution_control)
+    call json_get_or_default(json, "output_value", output_value, &
+                             execution_value)
+
+    call this%execution_controller%init(case%end_time, execution_control, &
+                                        execution_value)
+    call this%output_controller%init(case%end_time, output_control, &
+                                     output_value)
 
   end subroutine simulation_component_init_base
+
+  !> Destructor for the `simulation_component_t` (base) class.
+  subroutine simulation_component_free_base(this)  
+    class(simulation_component_t), intent(inout) :: this
+
+    nullify(this%case)
+  end subroutine simulation_component_free_base
+
+  !> Wrapper for calling `compute_` based on the `execution_controller`.
+  !! Serves as the public interface.
+  !! @param t The time value.
+  !! @param tstep The current time-step
+  subroutine simulation_component_compute_wrapper(this, t, tstep)  
+    class(simulation_component_t), intent(inout) :: this
+    real(kind=rp), intent(in) :: t
+    integer, intent(in) :: tstep
+
+    if (this%execution_controller%check(t, tstep)) then
+      call this%compute_(t, tstep)
+      call this%execution_controller%register_execution()
+    end if
+  end subroutine simulation_component_compute_wrapper
 
   
 end module simulation_component

--- a/src/simulation_components/vorticity.f90
+++ b/src/simulation_components/vorticity.f90
@@ -31,9 +31,7 @@
 ! POSSIBILITY OF SUCH DAMAGE.
 !
 !
-!> A simulation component that computes the vorticity field.
-!! The values are stored in the field registry under the names omega_x, omega_y
-!! and omega_z.
+!> Implements the `vorticity_t` type. 
 
 module vorticity
   use num_types, only : rp
@@ -46,6 +44,8 @@ module vorticity
   implicit none
   private
   
+  !> A simulation component that computes the vorticity field.
+  !! Added to the field registry as `omega_x`, `omega_y``, and `omega_z`.
   type, public, extends(simulation_component_t) :: vorticity_t
      !> X velocity component.
      type(field_t), pointer :: u
@@ -61,20 +61,21 @@ module vorticity
      !> Z vorticity component.
      type(field_t), pointer :: omega_z
 
-     !> Work arrays.
+     !> Work array.
      type(field_t) :: temp1
+     !> Work array.
      type(field_t) :: temp2
 
      contains
-      !> Constructor from json.
+      !> Constructor from json, wrapping the actual constructor.
       procedure, pass(this) :: init => vorticity_init_from_json
       !> Actual constructor.
       procedure, pass(this) :: init_from_attributes => &
         vorticity_init_from_attributes
       !> Destructor.
       procedure, pass(this) :: free => vorticity_free
-      !> Compute the vorticity field
-     procedure, pass(this) :: compute => vorticity_compute
+      !> Compute the vorticity field.
+      procedure, pass(this) :: compute_ => vorticity_compute
   end type vorticity_t
   
   contains
@@ -83,7 +84,7 @@ module vorticity
   subroutine vorticity_init_from_json(this, json, case)
        class(vorticity_t), intent(inout) :: this
        type(json_file), intent(inout) :: json
-       class(case_t), intent(inout), target ::case 
+       class(case_t), intent(inout), target :: case 
        
        call this%init_base(json, case)
 
@@ -118,6 +119,7 @@ module vorticity
   !> Destructor.
   subroutine vorticity_free(this)
        class(vorticity_t), intent(inout) :: this
+       call this%free_base()
        call field_free(this%temp1)
        call field_free(this%temp2)
   end subroutine vorticity_free


### PR DESCRIPTION
* Adds 2 `time_based_controller`s to the base simcomp type, one for compute, and one for output.
* For compute, default to every time step.
* For output, default to the same as the settings for compute.
* The actual implementation of the computation is now in the deferred `compute_` procedure, which is wrapped in the `compute` procedure in the base class, which serves as the public interface. The wrapper executes `compute_` based on the controller.
* No logic for output implemented for now, so the controller is just hanging there, but will surely be needed in a future update. 