### PR TITLE
Adds output control "never" and throw for non-positive nsamples

### DIFF
--- a/doc/pages/case-file.md
+++ b/doc/pages/case-file.md
@@ -49,6 +49,7 @@ The three following options are possible.
 2. `tsteps`, then `_value` is the number of time steps between the outputs.
 3. `nsamples`, then `_value` is the total number of outputs that will be
    performed in the course of the simulation.
+4. `never`, then `_value` is ignored and output is never performed.
 
 
 ## The `case` object 

--- a/reframe/src/rayleigh.case.template
+++ b/reframe/src/rayleigh.case.template
@@ -6,7 +6,6 @@
     "output_boundary": true,
     "end_time": 100,
     "timestep": 0.01,
-    "nsamples": 0,
     "numerics": {
         "time_order": 3,
         "polynomial_order": 7,
@@ -44,7 +43,9 @@
             "",
             "w",
             "w"
-        ]
+        ],
+        "output_control": "never",
+        "output_value": 0
     },
     "scalar": {
         "enabled": true,

--- a/src/case.f90
+++ b/src/case.f90
@@ -51,7 +51,7 @@ module case
   use utils
   use mesh
   use comm
-  use time_scheme_controller
+  use time_scheme_controller, only : time_scheme_controller_t
   use logger
   use jobctrl
   use user_intf  
@@ -360,6 +360,9 @@ contains
        ! yes, it should be real_val below for type compatibility
        call json_get(C%params, 'case.nsamples', real_val)
        call C%s%add(C%f_out, real_val, 'nsamples')
+    else if (trim(string_val) .eq. 'never') then
+       ! Fix a dummy 0.0 output_value
+       call C%s%add(C%f_out, 0.0_rp, string_val)
     else 
        call json_get(C%params, 'case.fluid.output_value', real_val)
        call C%s%add(C%f_out, real_val, string_val)

--- a/src/common/time_based_controller.f90
+++ b/src/common/time_based_controller.f90
@@ -93,9 +93,14 @@ contains
         this%frequency = 1/this%time_interval
         this%nsteps = 0 
     else if (trim(control_mode) .eq. 'nsamples') then
+        if (control_value .le. 0) then
+           call neko_error("nsamples must be positive")
+        end if
+
         this%frequency = control_value / end_time
         this%time_interval = 1.0_rp / this%frequency
         this%nsteps = 0
+        write(*,*) control_value, this%frequency, this%time_interval
     else if (trim(control_mode) .eq. 'tsteps') then 
         this%nsteps = control_value
         ! if the timestep will be variable, we cannot compute these.
@@ -105,7 +110,7 @@ contains
         this%never = .true.
     else
         call neko_error("The control parameter must be simulationtime, nsamples&
-          & or tsteps, but received "//trim(control_mode))
+          & tsteps, or never, but received "//trim(control_mode))
     end if
   end subroutine time_based_controller_init
 

--- a/src/common/time_based_controller.f90
+++ b/src/common/time_based_controller.f90
@@ -55,6 +55,8 @@ module time_based_controller
      real(kind=rp) :: end_time = 0
      !> Number of times already executed.
      integer :: nexecutions = 0
+     !> Whether to never output.
+     logical :: never = .false.
 
    contains
     !> Constructor.
@@ -99,6 +101,8 @@ contains
         ! if the timestep will be variable, we cannot compute these.
         this%frequency = 0
         this%time_interval = 0
+    else if (trim(control_mode) .eq. 'never') then 
+        this%never = .true.
     else
         call neko_error("The control parameter must be simulationtime, nsamples&
           & or tsteps, but received "//trim(control_mode))
@@ -129,6 +133,8 @@ contains
     check = .false.
     if (ifforce) then
         check = .true.
+    else if (this%never) then
+        check = .false.
     else if ( (this%nsteps .eq. 0) .and. &
               (t .ge. this%nexecutions * this%time_interval) ) then
         check = .true.

--- a/src/common/time_based_controller.f90
+++ b/src/common/time_based_controller.f90
@@ -100,7 +100,6 @@ contains
         this%frequency = control_value / end_time
         this%time_interval = 1.0_rp / this%frequency
         this%nsteps = 0
-        write(*,*) control_value, this%frequency, this%time_interval
     else if (trim(control_mode) .eq. 'tsteps') then 
         this%nsteps = control_value
         ! if the timestep will be variable, we cannot compute these.


### PR DESCRIPTION
* Adds `never` as an option for the `time_based_controller`.  Useful for benchmarking or having a simcomp do no output, for example.
* Forces `nsamples` to be positive.