### PR TITLE
Probes with point interpolator

### DIFF
--- a/examples/rayleigh-benard-cylinder-probes/rayleigh.f90
+++ b/examples/rayleigh-benard-cylinder-probes/rayleigh.f90
@@ -217,7 +217,7 @@ contains
     call pb%interpolate(t,tstep, write_output)
     !! Write if the interpolate function returs write_output=.true.
     if (write_output) then
-       call transpose(mat_out%x, pb%n_probes, pb%out_fields, pb%n_fields)
+       mat_out%x = pb%out_fields
        call fout%write(mat_out, t)
        write_output = .false.
     end if

--- a/src/.depends
+++ b/src/.depends
@@ -23,7 +23,7 @@ sem/dofmap.o : sem/dofmap.f90 math/math.o device/device.o math/tensor.o math/fas
 sem/coef.o : sem/coef.f90 math/mxm_wrapper.o sem/bcknd/device/device_coef.o device/device.o mesh/mesh.o math/math.o sem/space.o config/num_types.o config/neko_config.o gs/gather_scatter.o 
 sem/cpr.o : sem/cpr.f90 math/mxm_wrapper.o math/tensor.o sem/coef.o mesh/mesh.o math/math.o sem/space.o field/field.o config/num_types.o config/neko_config.o gs/gather_scatter.o 
 sem/interpolation.o : sem/interpolation.f90 mesh/point.o sem/coef.o math/mxm_wrapper.o sem/space.o math/bcknd/cpu/tensor_cpu.o math/tensor.o field/field.o math/fast3d.o math/math.o common/utils.o device/device.o sem/speclib.o 
-sem/point_interpolator.o : sem/point_interpolator.f90 common/utils.o math/fast3d.o math/math.o mesh/point.o config/num_types.o sem/space.o sem/coef.o math/tensor.o 
+sem/point_interpolator.o : sem/point_interpolator.f90 common/utils.o math/fast3d.o math/math.o mesh/point.o config/num_types.o sem/space.o math/tensor.o 
 sem/bcknd/device/device_coef.o : sem/bcknd/device/device_coef.F90 common/utils.o config/num_types.o 
 gs/gs_bcknd.o : gs/gs_bcknd.f90 config/num_types.o 
 gs/bcknd/cpu/gs_cpu.o : gs/bcknd/cpu/gs_cpu.f90 gs/gs_ops.o gs/gs_bcknd.o config/num_types.o 
@@ -149,7 +149,7 @@ common/stats_quant.o : common/stats_quant.f90 config/num_types.o
 common/statistics.o : common/statistics.f90 comm/comm.o common/log.o common/stats_quant.o config/num_types.o 
 common/rhs_maker.o : common/rhs_maker.f90 field/field.o field/field_series.o config/num_types.o 
 common/rhs_maker_fctry.o : common/rhs_maker_fctry.f90 config/neko_config.o common/bcknd/device/rhs_maker_device.o common/bcknd/sx/rhs_maker_sx.o common/bcknd/cpu/rhs_maker_cpu.o common/rhs_maker.o 
-common/probes.o : common/probes.F90 math/tensor.o io/csv_file.o io/file.o device/device.o common/json_utils.o field/field_registry.o common/time_based_controller.o field/field_list.o sem/coef.o field/field.o comm/mpi_types.o comm/comm.o common/utils.o common/log.o math/matrix.o config/num_types.o 
+common/probes.o : common/probes.F90 sem/space.o mesh/point.o sem/point_interpolator.o math/tensor.o io/csv_file.o math/math.o io/file.o device/device.o common/json_utils.o field/field_registry.o common/time_based_controller.o field/field_list.o sem/coef.o field/field.o comm/mpi_types.o comm/comm.o common/utils.o common/log.o math/matrix.o config/num_types.o 
 common/bcknd/cpu/rhs_maker_cpu.o : common/bcknd/cpu/rhs_maker_cpu.f90 field/scratch_registry.o common/rhs_maker.o 
 common/bcknd/sx/rhs_maker_sx.o : common/bcknd/sx/rhs_maker_sx.f90 field/scratch_registry.o common/rhs_maker.o 
 common/bcknd/device/rhs_maker_device.o : common/bcknd/device/rhs_maker_device.F90 common/utils.o device/device.o common/rhs_maker.o 
@@ -214,7 +214,7 @@ scalar/scalar_residual_fctry.o : scalar/scalar_residual_fctry.f90 scalar/bcknd/s
 scalar/bcknd/cpu/scalar_residual_cpu.o : scalar/bcknd/cpu/scalar_residual_cpu.f90 math/operators.o scalar/scalar_residual.o gs/gather_scatter.o 
 scalar/bcknd/sx/scalar_residual_sx.o : scalar/bcknd/sx/scalar_residual_sx.f90 math/operators.o scalar/scalar_residual.o gs/gather_scatter.o 
 scalar/source_scalar.o : scalar/source_scalar.f90 math/bcknd/device/device_math.o device/device.o common/utils.o sem/dofmap.o config/num_types.o config/neko_config.o 
-simulation_components/simulation_component.o : simulation_components/simulation_component.f90 case.o config/num_types.o 
+simulation_components/simulation_component.o : simulation_components/simulation_component.f90 common/json_utils.o common/time_based_controller.o case.o config/num_types.o 
 simulation_components/simulation_component_global.o : simulation_components/simulation_component_global.f90 case.o simulation_components/simulation_component_factory.o simulation_components/simulation_component.o 
 simulation_components/vorticity.o : simulation_components/vorticity.f90 case.o math/operators.o field/field.o field/field_registry.o simulation_components/simulation_component.o config/num_types.o 
 simulation_components/simulation_component_factory.o : simulation_components/simulation_component_factory.f90 common/json_utils.o case.o simulation_components/vorticity.o simulation_components/simulation_component.o 

--- a/src/common/probes.F90
+++ b/src/common/probes.F90
@@ -56,7 +56,6 @@ module probes
   use point_interpolator
   use point, only: point_t
   use space, only: space_t
-  use dofmap, only: dofmap_t
   implicit none
   private
   

--- a/src/common/probes.F90
+++ b/src/common/probes.F90
@@ -50,8 +50,12 @@ module probes
   use json_utils, only : json_get
   use device
   use file
+  use math, only: rzero
   use csv_file
   use tensor
+  use point_interpolator
+  use point, only: point_t
+  use space, only: space_t
   implicit none
   private
   
@@ -71,7 +75,7 @@ module probes
      !> Error code for each point
      integer, allocatable :: error_code(:)
      !> r,s,t coordinates, findpts format
-     real(kind=rp), allocatable :: rst(:)
+     type(point_t), allocatable :: rst(:)
      !> x,y,z coordinates, findpts format
      real(kind=rp), allocatable :: xyz(:,:)
      !> interpolated fields
@@ -81,6 +85,8 @@ module probes
      !> Fields to be probed
      type(field_list_t) :: sampled_fields
      character(len=20), allocatable  :: which_fields(:)
+     !> Interpolator instead of findpts_eval
+     type(point_interpolator_t) :: interpolator
 
      contains
        !> Initialize probes object.
@@ -107,10 +113,13 @@ contains
   !> Initialize user defined variables.
   !! @param t Current simulation time.
   !! @param params case file.
-  subroutine probes_init(this, t, params)
+  !! @coef Xh Function space.
+  subroutine probes_init(this, t, params, xh)
     class(probes_t), intent(inout) :: this
     real(kind=rp), intent(in) :: t
     type(json_file), intent(inout) :: params
+    type(space_t), intent(in) :: xh
+
     ! Counter
     integer :: i
     ! Controller parameters 
@@ -150,6 +159,9 @@ contains
     !> Read file
     call read_probe_locations(this, points_file)
 
+    !> Initialize the interpolator with a function space
+    call this%interpolator%init(xh)
+
   end subroutine probes_init
 
 
@@ -166,15 +178,15 @@ contains
     if (allocated(this%out_fields)) deallocate(this%out_fields)
     if (allocated(this%sampled_fields%fields)) deallocate(this%sampled_fields%fields)
 
+    call this%interpolator%free
+
 #ifdef HAVE_GSLIB
     call fgslib_findpts_free(this%handle)
 #else
     call neko_error('NEKO needs to be built with GSLIB support')
 #endif
-    
 
   end subroutine probes_free
-
 
   !> Print current probe status, with number of probes and coordinates
   subroutine probes_show(this)
@@ -258,6 +270,8 @@ contains
     class(probes_t), intent(inout) :: this
     type(coef_t), intent(in) :: coef 
 
+    real(kind=rp) :: rst_gslib_raw(3*this%n_probes)
+
     real(kind=rp) :: tol_dist = 5d-6
     integer :: i
 
@@ -266,14 +280,24 @@ contains
          this%error_code, 1, &
          this%proc_owner, 1, &
          this%el_owner, 1, &
-         this%rst, coef%msh%gdim, &
+         rst_gslib_raw, coef%msh%gdim, &
          this%dist2, 1, &
          this%xyz(1,1), coef%msh%gdim, &
          this%xyz(2,1), coef%msh%gdim, &
          this%xyz(3,1), coef%msh%gdim, this%n_probes)
 
-    ! Final check to see if there are any problems
+    !
+    ! Reformat the rst_raw array and
+    ! final check to see if there are any problems
+    !
     do i=1,this%n_probes
+
+       ! Reformat the rst array into points
+       this%rst(i)%x(1) = rst_gslib_raw(3*i)
+       this%rst(i)%x(2) = rst_gslib_raw(3*i + 1)
+       this%rst(i)%x(3) = rst_gslib_raw(3*i + 2)
+
+       ! Check validity of points
        if (this%error_code(i) .eq. 1) then
           if (this%dist2(i) .gt. tol_dist) then
              call neko_warning("Point on boundary or outside the mesh!")
@@ -291,6 +315,7 @@ contains
 
 
   !> Interpolate each probe from its `r,s,t` coordinates.
+  !! @note The final interpolated field is only available on rank 0.
   !! @param t Current simulation time.
   !! @param tstep Current time step.
   !! @param write_output Flag for writing output data.
@@ -301,31 +326,55 @@ contains
     logical, intent(inout) :: write_output
 
     !> Supporting variables
-    integer :: il 
+    integer :: il, i
     integer :: n
+    integer :: ierr
+    !> Will store the local interpolated field for each rank
+    real(kind=rp) :: local_out_field(this%n_probes)
+    type(point_t) :: my_rst(1)
+    real(kind=rp) :: my_interpolated_field(1)
 
 #ifdef HAVE_GSLIB
+
+
     n = this%sampled_fields%fields(1)%f%dof%size()
 
     !> Check controller to determine if we must write
     if (this%controller%check(t, tstep, .false.)) then
 
-       !! Interpolate the fields
+       !
+       ! Interpolate the fields
+       !
        do il = 1, this%n_fields
 
           ! Copy the field to the CPU if the data is in the device
-          if (NEKO_BCKND_DEVICE .eq. 1) then 
+          if (NEKO_BCKND_DEVICE .eq. 1) then
              call device_memcpy(this%sampled_fields%fields(il)%f%x, &
                              this%sampled_fields%fields(il)%f%x_d, &
                              n, DEVICE_TO_HOST)
           end if
 
-          call fgslib_findpts_eval(this%handle, this%out_fields(il,1), this%n_fields, &
-                                   this%error_code, 1, &
-                                   this%proc_owner, 1, &
-                                   this%el_owner, 1, &
-                                   this%rst, this%sampled_fields%fields(il)%f%msh%gdim, &
-                                   this%n_probes, this%sampled_fields%fields(il)%f%x)
+          ! Initialize the local interpolated field with 0 since we are
+          ! Reducing later with MPI_MAX
+          call rzero(local_out_field, this%n_probes)
+
+          do i = 1, this%n_probes
+
+             ! Each rank interpolates their own points
+             if (pe_rank .eq. this%proc_owner(i)) then
+                my_rst(1) = this%rst(i)
+
+                my_interpolated_field = this%interpolator%interpolate(my_rst, &
+                     this%sampled_fields%fields(il)%f%x(:,:,:,this%el_owner(i)))
+
+                local_out_field(i) = my_interpolated_field(1)
+             end if
+          end do
+
+          ! Artificial way to gather all values to rank 0
+          call MPI_Reduce(local_out_field, this%out_fields(il,1), this%n_probes, &
+               MPI_REAL_PRECISION, MPI_SUM, 0, NEKO_COMM, ierr)
+
        end do
 
        !! Turn on flag to write output
@@ -411,8 +460,7 @@ contains
     allocate(this%el_owner(n_probes))
     allocate(this%dist2(n_probes))
     allocate(this%error_code(n_probes))
-    ! Size of rst as used in gslib
-    allocate(this%rst(3*n_probes))     
+    allocate(this%rst(n_probes))
     allocate(this%out_fields(n_fields, n_probes))
 
   end subroutine probes_allocate_fields

--- a/src/sem/point_interpolator.f90
+++ b/src/sem/point_interpolator.f90
@@ -70,16 +70,16 @@ contains
 
   !> Initialization of point interpolation.
   !! @param xh Function space.
-  subroutine point_interpolator_init(this, xh)
+  subroutine point_interpolator_init(this, Xh)
     class(point_interpolator_t), intent(inout), target :: this
-    type(space_t), intent(in), target :: xh
+    type(space_t), intent(in), target :: Xh
 
-    if ((xh%t .eq. GL) .or. (xh%t .eq. GLL)) then
+    if ((Xh%t .eq. GL) .or. (Xh%t .eq. GLL)) then
     else
        call neko_error('Unsupported interpolation')
     end if
 
-    this%Xh => xh
+    this%Xh => Xh
 
   end subroutine point_interpolator_init
 
@@ -87,7 +87,7 @@ contains
   subroutine point_interpolator_free(this)
     class(point_interpolator_t), intent(inout) :: this
 
-    if (associated(this%xh)) this%xh => null()
+    if (associated(this%Xh)) this%Xh => null()
 
   end subroutine point_interpolator_free
 
@@ -169,9 +169,9 @@ contains
     real(kind=rp) :: hr(this%Xh%lx), hs(this%Xh%ly), ht(this%Xh%lz)
     integer :: lx,ly,lz, i
     integer :: N
-    lx = this%xh%lx
-    ly = this%xh%ly
-    lz = this%xh%lz
+    lx = this%Xh%lx
+    ly = this%Xh%ly
+    lz = this%Xh%lz
     
     N = size(rst)
     allocate(res(N))
@@ -294,9 +294,9 @@ contains
 
     real(kind=rp) :: hr(this%Xh%lx, 2), hs(this%Xh%ly, 2), ht(this%Xh%lz, 2)
     integer :: lx, ly, lz
-    lx = this%xh%lx
-    ly = this%xh%ly
-    lz = this%xh%lz
+    lx = this%Xh%lx
+    ly = this%Xh%ly
+    lz = this%Xh%lz
 
     ! Weights
     call fd_weights_full(real(rst%x(1), rp), this%Xh%zg(:,1), lx-1, 1, hr)

--- a/tests/point_interpolation/point_interpolation_parallel.pf
+++ b/tests/point_interpolation/point_interpolation_parallel.pf
@@ -89,9 +89,8 @@ contains
     call gs_init(gs, dof)
     call coef_init(coef, gs)
 
-    call interp%init(coef) ! initialize the interpolator object
+    call interp%init(coef%Xh) ! initialize the interpolator object
 
-    @assertTrue(associated(interp%coef))
     @assertTrue(associated(interp%Xh))
 
     call device_finalize
@@ -143,7 +142,7 @@ contains
     xyz_equal(3)%x = (/1.0_rp, 1.0_rp, 1.0_rp/)
     xyz_equal(4)%x = (/ 2.0_rp,  2.0_rp,  2.0_rp/)
 
-    call interp%init(coef) ! initialize the interpolator object
+    call interp%init(coef%Xh) ! initialize the interpolator object
     
     ! We use the interpolation for a vector field, interpolating the coordinates
     ! themselves
@@ -202,7 +201,7 @@ contains
 
     xyz_equal(1)%x = (/2.0_rp,  1.5_rp , 1.25_rp/)
 
-    call interp%init(coef) ! initialize the interpolator object
+    call interp%init(coef%Xh) ! initialize the interpolator object
     
     ! We use the interpolation for a vector field, interpolating the coordinates
     ! themselves


### PR DESCRIPTION
Got rid of `findpts_eval` for the interpolation in `probes%interpolate`. Also removed `coef_t` from point_interpolator as it is not using it, and adjusted the RBC example.