### PR TITLE
Ensure memcopies sync on the correct stream

### DIFF
--- a/src/device/device.F90
+++ b/src/device/device.F90
@@ -417,84 +417,48 @@ contains
     logical, intent(in) :: sync_device
     type(c_ptr), intent(inout) :: stream
 #ifdef HAVE_HIP
-    if (sync_device) then
-       if (dir .eq. HOST_TO_DEVICE) then
-          if (hipMemcpy(x_d, ptr_h, s, hipMemcpyHostToDevice) &
-               .ne. hipSuccess) then
-             call neko_error('Device memcpy (host-to-device) failed')
-          end if
-       else if (dir .eq. DEVICE_TO_HOST) then       
-          if (hipMemcpy(ptr_h, x_d, s, hipMemcpyDeviceToHost) &
-               .ne. hipSuccess) then
-             call neko_error('Device memcpy (device-to-host) failed')
-          end if
-       else if (dir .eq. DEVICE_TO_DEVICE) then       
-          if (hipMemcpy(ptr_h, x_d, s, hipMemcpyDeviceToDevice) &
-               .ne. hipSuccess) then
-             call neko_error('Device memcpy (device-to-device) failed')
-          end if
-       else
-          call neko_error('Device memcpy failed (invalid direction')
+    if (dir .eq. HOST_TO_DEVICE) then
+       if (hipMemcpyAsync(x_d, ptr_h, s, &
+            hipMemcpyHostToDevice, stream) .ne. hipSuccess) then
+          call neko_error('Device memcpy async (host-to-device) failed')
+       end if
+    else if (dir .eq. DEVICE_TO_HOST) then       
+       if (hipMemcpyAsync(ptr_h, x_d, s, &
+            hipMemcpyDeviceToHost, stream) .ne. hipSuccess) then
+          call neko_error('Device memcpy async (device-to-host) failed')
+       end if
+    else if (dir .eq. DEVICE_TO_DEVICE) then       
+       if (hipMemcpyAsync(ptr_h, x_d, s, &
+            hipMemcpyDeviceToDevice, stream) .ne. hipSuccess) then
+          call neko_error('Device memcpy async (device-to-device) failed')
        end if
     else
-       if (dir .eq. HOST_TO_DEVICE) then
-          if (hipMemcpyAsync(x_d, ptr_h, s, &
-               hipMemcpyHostToDevice, stream) .ne. hipSuccess) then
-             call neko_error('Device memcpy async (host-to-device) failed')
-          end if
-       else if (dir .eq. DEVICE_TO_HOST) then       
-          if (hipMemcpyAsync(ptr_h, x_d, s, &
-               hipMemcpyDeviceToHost, stream) .ne. hipSuccess) then
-             call neko_error('Device memcpy async (device-to-host) failed')
-          end if
-       else if (dir .eq. DEVICE_TO_DEVICE) then       
-          if (hipMemcpyAsync(ptr_h, x_d, s, &
-               hipMemcpyDeviceToDevice, stream) .ne. hipSuccess) then
-             call neko_error('Device memcpy async (device-to-device) failed')
-          end if
-       else
-          call neko_error('Device memcpy failed (invalid direction')
-       end if
+       call neko_error('Device memcpy failed (invalid direction')
+    end if
+    if (sync_device) then
+       call device_sync_stream(stream)
     end if
 #elif HAVE_CUDA
-    if (sync_device) then
-       if (dir .eq. HOST_TO_DEVICE) then
-          if (cudaMemcpy(x_d, ptr_h, s, cudaMemcpyHostToDevice) &
-               .ne. cudaSuccess) then
-             call neko_error('Device memcpy (host-to-device) failed')
-          end if
-       else if (dir .eq. DEVICE_TO_HOST) then       
-          if (cudaMemcpy(ptr_h, x_d, s, cudaMemcpyDeviceToHost) &
-               .ne. cudaSuccess) then
-             call neko_error('Device memcpy (device-to-host) failed')
-          end if
-       else if (dir .eq. DEVICE_TO_DEVICE) then       
-          if (cudaMemcpy(ptr_h, x_d, s, cudaMemcpyDeviceToDevice) &
-               .ne. cudaSuccess) then
-             call neko_error('Device memcpy (device-to-device) failed')
-          end if
-       else
-          call neko_error('Device memcpy failed (invalid direction')
+    if (dir .eq. HOST_TO_DEVICE) then
+       if (cudaMemcpyAsync(x_d, ptr_h, s, &
+            cudaMemcpyHostToDevice, stream) .ne. cudaSuccess) then
+          call neko_error('Device memcpy async (host-to-device) failed')
+       end if
+    else if (dir .eq. DEVICE_TO_HOST) then       
+       if (cudaMemcpyAsync(ptr_h, x_d, s, &
+            cudaMemcpyDeviceToHost, stream) .ne. cudaSuccess) then
+          call neko_error('Device memcpy async (device-to-host) failed')
+       end if
+    else if (dir .eq. DEVICE_TO_DEVICE) then       
+       if (cudaMemcpyAsync(ptr_h, x_d, s, &
+            cudaMemcpyDeviceToDevice, stream) .ne. cudaSuccess) then
+          call neko_error('Device memcpy async (device-to-device) failed')
        end if
     else
-       if (dir .eq. HOST_TO_DEVICE) then
-          if (cudaMemcpyAsync(x_d, ptr_h, s, &
-               cudaMemcpyHostToDevice, stream) .ne. cudaSuccess) then
-             call neko_error('Device memcpy async (host-to-device) failed')
-          end if
-       else if (dir .eq. DEVICE_TO_HOST) then       
-          if (cudaMemcpyAsync(ptr_h, x_d, s, &
-               cudaMemcpyDeviceToHost, stream) .ne. cudaSuccess) then
-             call neko_error('Device memcpy async (device-to-host) failed')
-          end if
-       else if (dir .eq. DEVICE_TO_DEVICE) then       
-          if (cudaMemcpyAsync(ptr_h, x_d, s, &
-               cudaMemcpyDeviceToDevice, stream) .ne. cudaSuccess) then
-             call neko_error('Device memcpy async (device-to-device) failed')
-          end if
-       else
-          call neko_error('Device memcpy failed (invalid direction')
-       end if
+       call neko_error('Device memcpy failed (invalid direction')
+    end if
+    if (sync_device) then
+       call device_sync_stream(stream)
     end if
 #elif HAVE_OPENCL
     if (sync_device) then

--- a/tests/device/device.pf
+++ b/tests/device/device.pf
@@ -191,7 +191,7 @@ subroutine test_device_memcpy
 
      x = 0
 
-     call device_memcpy(x, x_d, size(x), DEVICE_TO_HOST)
+     call device_memcpy(x, x_d, size(x), DEVICE_TO_HOST, sync=.true.)
      
      do i = 1, size(x)
         @assertEqual(x(i), i)
@@ -203,7 +203,7 @@ subroutine test_device_memcpy
 
      x = 0
 
-     call device_memcpy(x, y_d, size(x), DEVICE_TO_HOST)
+     call device_memcpy(x, y_d, size(x), DEVICE_TO_HOST, sync=.true.)
      
      do i = 1, size(x)
         @assertEqual(x(i), i)

--- a/tests/device_math/device_math_parallel.pf
+++ b/tests/device_math/device_math_parallel.pf
@@ -47,7 +47,7 @@ contains
        
        call device_rzero(a_d, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
        
        do i = 1, n
           @assertEqual(0.0_rp, a(i), tolerance=NEKO_EPS)
@@ -61,7 +61,7 @@ contains
        
        call device_rzero(a_d, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
        
        do i = 1, n
           @assertEqual(0.0_rp, a(i), tolerance=NEKO_EPS)
@@ -86,7 +86,7 @@ contains
        
        call device_rone(a_d, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
        
        do i = 1, n
           @assertEqual(1.0_rp, a(i), tolerance=NEKO_EPS)
@@ -100,7 +100,7 @@ contains
        
        call device_rone(a_d, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
        
        do i = 1, n
           @assertEqual(1.0_rp, a(i), tolerance=NEKO_EPS)
@@ -135,7 +135,7 @@ contains
        call device_copy(b_d, a_d, n)
        
        call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
-       call device_memcpy(b, b_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(b, b_d, size(a), DEVICE_TO_HOST, sync=.true.)
     
        do i = 1, n
           @assertEqual(a(i), b(i))
@@ -161,7 +161,7 @@ contains
        
        call device_cfill(a_d, c, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
        
        do i = 1, n
           @assertEqual(42.0_rp, a(i), tolerance=NEKO_EPS)
@@ -188,7 +188,7 @@ contains
        
        call device_cadd(a_d, c, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
        
        do i = 1, n
           @assertEqual(42.0_rp, a(i), tolerance=NEKO_EPS)
@@ -221,7 +221,7 @@ contains
        
        call device_add2(a_d, b_d, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
        
        do i = 1, n
           @assertEqual(42.0_rp, a(i))
@@ -254,7 +254,7 @@ contains
        
        call device_add2s1(a_d, b_d, c1, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
        
        do i = 1, n
           @assertEqual(42.0_rp, a(i))
@@ -287,7 +287,7 @@ contains
        
        call device_add2s2(a_d, b_d, c1, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
 
        do i = 1, n
           @assertEqual(24.0_rp, a(i))
@@ -325,7 +325,7 @@ contains
        
        call device_add3s2(a_d, b_d, c_d, c1, c2, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
 
        do i = 1, n
           @assertEqual(84.0_rp, a(i))
@@ -353,7 +353,7 @@ contains
        
        call device_invcol1(a_d, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
        
        do i = 1, n
           @assertEqual(0.5_rp, a(i))
@@ -385,7 +385,7 @@ contains
        
        call device_invcol2(a_d, b_d, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
        
        do i = 1, n
           @assertEqual(10.5_rp, a(i))
@@ -417,7 +417,7 @@ contains
        
        call device_col2(a_d, b_d, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
        
        do i = 1, n
           @assertEqual(42.0_rp, a(i))
@@ -453,7 +453,7 @@ contains
        
        call device_col3(a_d, b_d, c_d, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
        
        do i = 1, n
           @assertEqual(42.0_rp, a(i))
@@ -485,7 +485,7 @@ contains
        
        call device_sub2(a_d, b_d, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
        
        do i = 1, n
           @assertEqual(42.0_rp, a(i))
@@ -521,7 +521,7 @@ contains
        
        call device_sub3(a_d, b_d, c_d, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
        
        do i = 1, n
           @assertEqual(-19.0_rp, a(i))
@@ -557,7 +557,7 @@ contains
        
        call device_addcol3(a_d, b_d, c_d, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
        
        do i = 1, n
           @assertEqual(4711.0_rp, a(i))
@@ -597,7 +597,7 @@ contains
        
        call device_addcol4(a_d, b_d, c_d, d_d, n)
        
-       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST)
+       call device_memcpy(a, a_d, size(a), DEVICE_TO_HOST, sync=.true.)
        
        do i = 1, n
           @assertEqual(4711.0_rp, a(i))


### PR DESCRIPTION
Ensure that synchronised device memcpy calls are syncing on the calling stream and not the (unused) NULL stream. 

If `sync=.true.` and no stream is given for `device_memcpy`, it will default to synchronise on the (Neko default) `glb_cmd_queue` stream.

This hopefully solves the sync. issues observed in #972 