### PR TITLE
modified the intent of coef in _init

### DIFF
--- a/src/io/data_streamer.F90
+++ b/src/io/data_streamer.F90
@@ -78,7 +78,7 @@ contains
   !! is to be enabled.
   subroutine data_streamer_init(this, coef, if_asynch)
     class(data_streamer_t), intent(inout) :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), intent(inout) :: coef
     integer, intent(in) :: if_asynch
     integer :: nelb, nelb2, nelv, nelgv,npts,e
 


### PR DESCRIPTION
The cray compiler in lumi complained about the intent of one of the variables. I have modified it such that it does not. 

The variable is not really touched. In the future I will perhaps change the intent to be safer.