### PR TITLE
Fix wrapping and expose of Fortran MPI communicator to C/C++ bcknds

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -232,7 +232,8 @@ neko_fortran_SOURCES = \
 	source_terms/source_term_factory.f90\
 	neko.f90
 
-neko_c_SOURCES = common/sighdl.c\
+neko_c_SOURCES = comm/comm_wrapper.c\
+		 common/sighdl.c\
 		 common/cpuid.c\
                  gs/bcknd/device/device_mpi.c\
                  math/bcknd/device/device_mpi_reduce.c
@@ -506,6 +507,7 @@ EXTRA_DIST = \
 	device/opencl/check.h\
 	device/hip/check.h\
 	device/cuda/check.h\
+	comm/comm.h\
 	common/neko_log.h
 
 # Fortran deps. (updated with makedepf90 via target 'depend')

--- a/src/comm/comm.F90.in
+++ b/src/comm/comm.F90.in
@@ -5,6 +5,12 @@ module comm
   !$ use omp_lib
   implicit none
   
+  interface
+     subroutine neko_comm_wrapper_init(fcomm) &
+          bind(c, name='neko_comm_wrapper_init')
+       integer, value :: fcomm
+     end subroutine neko_comm_wrapper_init
+  end interface
   
   !> MPI communicator
   type(MPI_Comm) :: NEKO_COMM
@@ -79,6 +85,9 @@ contains
 
     call MPI_Comm_rank(NEKO_COMM, pe_rank, ierr)
     call MPI_Comm_size(NEKO_COMM, pe_size, ierr)
+
+    ! Setup C/C++ wrapper
+    call neko_comm_wrapper_init(NEKO_COMM%mpi_val)
 
   end subroutine comm_init
 

--- a/src/comm/comm.h
+++ b/src/comm/comm.h
@@ -1,0 +1,16 @@
+#ifndef __COMM_H
+#define __COMM_H
+
+/**
+ * Wrapper for Neko's MPI related data
+ */
+#include <mpi.h>
+
+/**
+ * MPI communicator
+ * @note Same name as for the Fortran equivalent
+ */
+extern MPI_Comm NEKO_COMM;
+
+
+#endif

--- a/src/comm/comm_wrapper.c
+++ b/src/comm/comm_wrapper.c
@@ -1,0 +1,17 @@
+/**
+ * Wrapper for Neko's MPI related data
+ */
+#include <comm/comm.h>
+
+/**
+ * MPI communicator
+ * @note Same name as for the Fortran equivalent
+ */
+MPI_Comm NEKO_COMM;
+
+/**
+ * Setup Neko's communicator for C/C++
+ */
+void neko_comm_wrapper_init(MPI_Fint fcomm) {
+  NEKO_COMM = MPI_Comm_f2c(fcomm);
+}

--- a/src/comm/parmetis_wrapper.c
+++ b/src/comm/parmetis_wrapper.c
@@ -10,6 +10,8 @@
 #include <mpi.h>
 #include <parmetis.h>
 
+#include <comm/comm.h>
+
 
 /*!
   Fortran wrapper for ParMETIS PartGeom
@@ -18,14 +20,12 @@ int ParMETIS_V3_PartGeom_wrapper(idx_t *vtxdist, idx_t *ndims,
 				 real_t *xyz, idx_t *part)
 {
   int rcode;
-  MPI_Comm comm;
-  MPI_Comm_dup(MPI_COMM_WORLD, &comm);
 
   rcode = METIS_ERROR;
 
 #ifdef HAVE_PARMETIS
 
-  rcode = ParMETIS_V3_PartGeom(vtxdist, ndims, xyz, part, &comm);
+  rcode = ParMETIS_V3_PartGeom(vtxdist, ndims, xyz, part, &NEKO_COMM);
 
 #endif
 
@@ -45,8 +45,6 @@ int ParMETIS_V3_PartMeshKway_wrapper(idx_t *elmdist, idx_t *eptr, idx_t *eind,
 {
 
   int rcode;
-  MPI_Comm comm;
-  MPI_Comm_dup(MPI_COMM_WORLD, &comm);
 
   rcode = METIS_ERROR;
 
@@ -54,7 +52,7 @@ int ParMETIS_V3_PartMeshKway_wrapper(idx_t *elmdist, idx_t *eptr, idx_t *eind,
   
   rcode = ParMETIS_V3_PartMeshKway(elmdist, eptr, eind, elmwgt, wgtflag,
 				   numflag, ncon, ncommonnodes, nparts,tpwgts,
-				   ubvec, options, edgecut, part, &comm);
+				   ubvec, options, edgecut, part, &NEKO_COMM);
 #endif
 
   return rcode;

--- a/src/gs/bcknd/device/device_mpi.c
+++ b/src/gs/bcknd/device/device_mpi.c
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2022, The Neko Authors
+ Copyright (c) 2022-2023, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -35,7 +35,6 @@
 /**
  * C wrapper for MPI calls, since passing device pointers does not work in the
  * Fortran MPI interface.
- * @note We use @c MPI_COMM_WORLD which @e should be equal to @c NEKO_COMM.
  */
 
 #include <stdlib.h>
@@ -43,6 +42,8 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
+
+#include <comm/comm.h>
 
 void device_mpi_init_reqs(int n, void **reqs_out) {
   MPI_Request *reqs = malloc(n * sizeof(MPI_Request));
@@ -62,7 +63,7 @@ void device_mpi_isend(void *buf_d, int offset, int nbytes, int rank,
 #else
   int tid = 0;
 #endif
-  MPI_Isend(buf_d+offset, nbytes, MPI_BYTE, rank, tid, MPI_COMM_WORLD, &reqs[i-1]);
+  MPI_Isend(buf_d+offset, nbytes, MPI_BYTE, rank, tid, NEKO_COMM, &reqs[i-1]);
 }
 
 void device_mpi_irecv(void *buf_d, int offset, int nbytes, int rank,
@@ -74,7 +75,7 @@ void device_mpi_irecv(void *buf_d, int offset, int nbytes, int rank,
   int tid = 0;
 #endif
 
-  MPI_Irecv(buf_d+offset, nbytes, MPI_BYTE, rank, tid, MPI_COMM_WORLD, &reqs[i-1]);
+  MPI_Irecv(buf_d+offset, nbytes, MPI_BYTE, rank, tid, NEKO_COMM, &reqs[i-1]);
 }
 
 int device_mpi_test(void *vreqs, int i) {

--- a/src/math/bcknd/device/device_mpi_reduce.c
+++ b/src/math/bcknd/device/device_mpi_reduce.c
@@ -40,6 +40,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <mpi.h>
+#include <comm/comm.h>
 
 #include "device_mpi_op.h"
 
@@ -47,9 +48,9 @@ void device_mpi_allreduce(void *buf_d, void *buf, int count, int nbytes, int op)
 
   if (nbytes == sizeof(float)) {
     if (op == DEVICE_MPI_SUM)
-      MPI_Allreduce(buf_d, buf, count, MPI_FLOAT, MPI_SUM, MPI_COMM_WORLD);
+      MPI_Allreduce(buf_d, buf, count, MPI_FLOAT, MPI_SUM, NEKO_COMM);
     else if (op == DEVICE_MPI_MAX)
-      MPI_Allreduce(buf_d, buf, count, MPI_FLOAT, MPI_MAX, MPI_COMM_WORLD);
+      MPI_Allreduce(buf_d, buf, count, MPI_FLOAT, MPI_MAX, NEKO_COMM);
     else {
       fprintf(stderr, __FILE__ ": Invalid reduction op)\n");
       exit(1);
@@ -57,9 +58,9 @@ void device_mpi_allreduce(void *buf_d, void *buf, int count, int nbytes, int op)
   }
   else if (nbytes == sizeof(double)) {
     if (op == DEVICE_MPI_SUM)
-      MPI_Allreduce(buf_d, buf, count, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+      MPI_Allreduce(buf_d, buf, count, MPI_DOUBLE, MPI_SUM, NEKO_COMM);
     else if (op == DEVICE_MPI_MAX)
-      MPI_Allreduce(buf_d, buf, count, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+      MPI_Allreduce(buf_d, buf, count, MPI_DOUBLE, MPI_MAX, NEKO_COMM);
     else {
       fprintf(stderr, __FILE__ ": Invalid reduction op)\n");
       exit(1);
@@ -76,10 +77,10 @@ void device_mpi_allreduce_inplace(void *buf_d, int count, int nbytes, int op) {
   if (nbytes == sizeof(float)) {
     if (op == DEVICE_MPI_SUM)
       MPI_Allreduce(MPI_IN_PLACE, buf_d, count,
-                    MPI_FLOAT, MPI_SUM, MPI_COMM_WORLD);
+                    MPI_FLOAT, MPI_SUM, NEKO_COMM);
     else if (op == DEVICE_MPI_MAX)
       MPI_Allreduce(MPI_IN_PLACE, buf_d, count,
-                    MPI_FLOAT, MPI_MAX, MPI_COMM_WORLD);
+                    MPI_FLOAT, MPI_MAX, NEKO_COMM);
     else {
       fprintf(stderr, __FILE__ ": Invalid reduction op)\n");
       exit(1);
@@ -88,10 +89,10 @@ void device_mpi_allreduce_inplace(void *buf_d, int count, int nbytes, int op) {
   else if (nbytes == sizeof(double)) {
     if (op == DEVICE_MPI_SUM)
       MPI_Allreduce(MPI_IN_PLACE, buf_d, count,
-                    MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+                    MPI_DOUBLE, MPI_SUM, NEKO_COMM);
     else if (op == DEVICE_MPI_MAX)
       MPI_Allreduce(MPI_IN_PLACE, buf_d, count,
-                    MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+                    MPI_DOUBLE, MPI_MAX, NEKO_COMM);
   }
   else {
     fprintf(stderr, __FILE__ ": Invalid data type)\n");

--- a/src/math/bcknd/device/device_mpi_reduce.h
+++ b/src/math/bcknd/device/device_mpi_reduce.h
@@ -1,7 +1,6 @@
 
 /**
  * C wrapper for MPI calls, until we integrate with NCCL/RCCL
- * @note We use @c MPI_COMM_WORLD which @e should be equal to @c NEKO_COMM.
  */
 
 extern "C" {


### PR DESCRIPTION
Since we can no longer assume `NEKO_COMM` is the same as `MPI_COMM_WORLD`, the Fortran communicator is wrapped into a proper C `MPI_Comm` type, and the C/C++ backends has been changed to use `NEKO_COMM` instead of `MPI_COMM_WORLD`