### PR TITLE
Fix privacy and imports in krylov solvers

### DIFF
--- a/src/fluid/bcknd/cpu/pnpn_res_cpu.f90
+++ b/src/fluid/bcknd/cpu/pnpn_res_cpu.f90
@@ -1,13 +1,16 @@
 !> Residuals in the Pn-Pn formulation (CPU version)
 module pnpn_res_cpu
-  use gather_scatter
+  use gather_scatter, only : gs_t, GS_OP_ADD
   use operators
-  use field
-  use ax_product
-  use coefs
-  use facet_normal
+  use field, only : field_t
+  use ax_product, only : ax_t
+  use coefs, only : coef_t
+  use facet_normal, only : facet_normal_t
   use pnpn_residual, only : pnpn_prs_res_t, pnpn_vel_res_t
   use scratch_registry, only: neko_scratch_registry
+  use mesh, only : mesh_t
+  use num_types, only : rp
+  use space, only : space_t
   implicit none
   private
   

--- a/src/fluid/bcknd/device/pnpn_res_device.F90
+++ b/src/fluid/bcknd/device/pnpn_res_device.F90
@@ -31,12 +31,15 @@
 ! POSSIBILITY OF SUCH DAMAGE.
 !
 module pnpn_res_device
-  use gather_scatter
+  use gather_scatter, only : gs_t, GS_OP_ADD
   use operators
-  use field
-  use ax_product
-  use coefs
-  use facet_normal
+  use field, only : field_t
+  use ax_product, only : ax_t
+  use coefs, only : coef_t
+  use facet_normal, only : facet_normal_t
+  use mesh, only : mesh_t
+  use num_types, only : rp, c_rp
+  use space, only : space_t
   use device_math
   use device_mathops
   use pnpn_residual, only : pnpn_prs_res_t, pnpn_vel_res_t

--- a/src/fluid/bcknd/sx/pnpn_res_sx.f90
+++ b/src/fluid/bcknd/sx/pnpn_res_sx.f90
@@ -1,13 +1,16 @@
-!> Residuals in the Pn-Pn formulation (CPU version)
+!> Residuals in the Pn-Pn formulation (SX version)
 module pnpn_res_sx
-  use gather_scatter
+  use gather_scatter, only : gs_t, GS_OP_ADD
   use operators
-  use field
-  use ax_product
-  use coefs
-  use facet_normal
+  use field, only : field_t
+  use ax_product, only : ax_t
+  use coefs, only : coef_t
+  use facet_normal, only : facet_normal_t
   use pnpn_residual, only : pnpn_prs_res_t, pnpn_vel_res_t    
   use scratch_registry, only: neko_scratch_registry
+  use mesh, only : mesh_t
+  use num_types, only : rp
+  use space, only : space_t
   implicit none
   private
   

--- a/src/fluid/fluid_volflow.f90
+++ b/src/fluid/fluid_volflow.f90
@@ -61,7 +61,7 @@ module fluid_volflow
   use operators
   use num_types
   use mathops    
-  use krylov
+  use krylov, only : ksp_t, ksp_monitor_t
   use precon
   use dofmap
   use field
@@ -72,9 +72,13 @@ module fluid_volflow
   use neko_config
   use device_math
   use device_mathops
+  use gather_scatter, only : gs_t, GS_OP_ADD
   use json_module, only : json_file
   use json_utils, only: json_get
   use scratch_registry, only : scratch_registry_t
+  use bc, only : bc_list_t, bc_list_apply, bc_list_apply_vector, &
+                 bc_list_apply_scalar
+  use ax_product, only : ax_t
   implicit none
   private
   

--- a/src/krylov/bcknd/cpu/bicgstab.f90
+++ b/src/krylov/bcknd/cpu/bicgstab.f90
@@ -32,8 +32,17 @@
 !
 !> Defines various Bi-Conjugate Gradient Stabilized methods
 module bicgstab
-  use krylov
-  use math
+  use num_types, only: rp
+  use krylov, only : ksp_t, ksp_monitor_t, KSP_MAX_ITER
+  use precon,  only : pc_t
+  use ax_product, only : ax_t
+  use field, only : field_t
+  use coefs, only : coef_t
+  use gather_scatter, only : gs_t, GS_OP_ADD
+  use bc, only : bc_list_t, bc_list_apply
+  use math, only : glsc3, rzero, copy, NEKO_EPS, add2s2, x_update, &
+                   p_update
+  use utils, only : neko_error
   implicit none
   private
 

--- a/src/krylov/bcknd/cpu/cacg.f90
+++ b/src/krylov/bcknd/cpu/cacg.f90
@@ -32,8 +32,16 @@
 !
 !> Defines a communication avoiding Conjugate Gradient method
 module cacg
-  use krylov
-  use math
+  use num_types, only: rp
+  use krylov, only : ksp_t, ksp_monitor_t, KSP_MAX_ITER
+  use precon,  only : pc_t
+  use ax_product, only : ax_t
+  use field, only : field_t
+  use coefs, only : coef_t
+  use gather_scatter, only : gs_t, GS_OP_ADD
+  use bc, only : bc_list_t, bc_list_apply, bc_list_apply_scalar
+  use math, only : glsc3, rzero, copy, x_update
+  use utils, only : neko_warning
   use comm
   use mxm_wrapper
   implicit none

--- a/src/krylov/bcknd/cpu/cg.f90
+++ b/src/krylov/bcknd/cpu/cg.f90
@@ -32,8 +32,15 @@
 !
 !> Defines various Conjugate Gradient methods
 module cg
-  use krylov
-  use math
+  use num_types, only: rp
+  use krylov, only : ksp_t, ksp_monitor_t, KSP_MAX_ITER
+  use precon,  only : pc_t
+  use ax_product, only : ax_t
+  use field, only : field_t
+  use coefs, only : coef_t
+  use gather_scatter, only : gs_t, GS_OP_ADD
+  use bc, only : bc_list_t, bc_list_apply
+  use math, only : glsc3, rzero, copy
   use comm
   implicit none
   private

--- a/src/krylov/bcknd/cpu/gmres.f90
+++ b/src/krylov/bcknd/cpu/gmres.f90
@@ -32,8 +32,15 @@
 !
 !> Defines various GMRES methods
 module gmres
-  use krylov
-  use math
+  use krylov, only : ksp_t, ksp_monitor_t
+  use precon,  only : pc_t
+  use ax_product, only : ax_t
+  use num_types, only: rp
+  use field, only : field_t
+  use coefs, only : coef_t
+  use gather_scatter, only : gs_t, GS_OP_ADD
+  use bc, only : bc_list_t, bc_list_apply
+  use math, only : glsc3, rzero, rone, copy, sub2, cmult2
   use comm
   implicit none
   private

--- a/src/krylov/bcknd/cpu/pipecg.f90
+++ b/src/krylov/bcknd/cpu/pipecg.f90
@@ -32,8 +32,15 @@
 !
 !> Defines a pipelined Conjugate Gradient methods
 module pipecg
-  use krylov
-  use math
+  use krylov, only : ksp_t, ksp_monitor_t, KSP_MAX_ITER
+  use precon,  only : pc_t
+  use ax_product, only : ax_t
+  use num_types, only: rp
+  use field, only : field_t
+  use coefs, only : coef_t
+  use gather_scatter, only : gs_t, GS_OP_ADD
+  use bc, only : bc_list_t, bc_list_apply
+  use math, only : glsc3, rzero, copy
   use comm
   implicit none
   private
@@ -52,8 +59,11 @@ module pipecg
      real(kind=rp), allocatable :: mi(:)
      real(kind=rp), allocatable :: ni(:)
    contains
+     !> Constructor.
      procedure, pass(this) :: init => pipecg_init
+     !> Destructor.
      procedure, pass(this) :: free => pipecg_free
+     !> Solve the linear system.
      procedure, pass(this) :: solve => pipecg_solve
   end type pipecg_t
   

--- a/src/krylov/bcknd/device/cg_device.f90
+++ b/src/krylov/bcknd/device/cg_device.f90
@@ -32,9 +32,17 @@
 !
 !> Defines various Conjugate Gradient methods for accelerators
 module cg_device
-  use krylov
+  use num_types, only: rp
+  use krylov, only : ksp_t, ksp_monitor_t, KSP_MAX_ITER
+  use precon,  only : pc_t
+  use ax_product, only : ax_t
+  use field, only : field_t
+  use coefs, only : coef_t
+  use gather_scatter, only : gs_t, GS_OP_ADD
+  use bc, only : bc_list_t, bc_list_apply
   use device  
-  use device_math
+  use device_math, only : device_rzero, device_copy, device_glsc3, &
+                          device_add2s2, device_add2s1
   implicit none
 
   !> Device based preconditioned conjugate gradient method

--- a/src/krylov/bcknd/device/gmres_device.F90
+++ b/src/krylov/bcknd/device/gmres_device.F90
@@ -32,9 +32,20 @@
 !
 !> Defines various GMRES methods
 module gmres_device
-  use krylov
-  use math
-  use device_math
+  use krylov, only : ksp_t, ksp_monitor_t
+  use precon,  only : pc_t
+  use ax_product, only : ax_t
+  use num_types, only: rp, c_rp
+  use field, only : field_t
+  use coefs, only : coef_t
+  use gather_scatter, only : gs_t, GS_OP_ADD
+  use bc, only : bc_list_t, bc_list_apply
+  use device_identity, only : device_ident_t
+  use math, only : rone, rzero
+  use device_math, only : device_rzero, device_copy, device_glsc3, &
+                          device_add2s2, device_add2s1, device_rone, &
+                          device_cmult2, device_add2s2_many, device_glsc3_many,&
+                          device_sub2
   use device
   use comm
   use, intrinsic :: iso_c_binding

--- a/src/krylov/bcknd/device/pipecg_device.F90
+++ b/src/krylov/bcknd/device/pipecg_device.F90
@@ -32,10 +32,16 @@
 !
 !> Defines a pipelined Conjugate Gradient methods
 module pipecg_device
-  use krylov
-  use math
-  use num_types
-  use device_math
+  use krylov, only : ksp_t, ksp_monitor_t, KSP_MAX_ITER
+  use precon,  only : pc_t
+  use ax_product, only : ax_t
+  use num_types, only: rp, c_rp
+  use field, only : field_t
+  use coefs, only : coef_t
+  use gather_scatter, only : gs_t, GS_OP_ADD
+  use bc, only : bc_list_t, bc_list_apply
+  use math, only : glsc3, rzero, copy
+  use device_math, only : device_rzero, device_copy, device_glsc3
   use device
   use comm
   implicit none

--- a/src/krylov/bcknd/sx/cg_sx.f90
+++ b/src/krylov/bcknd/sx/cg_sx.f90
@@ -32,7 +32,15 @@
 !
 !> Defines various Conjugate Gradient methods
 module cg_sx
-  use krylov
+  use num_types, only: rp
+  use krylov, only : ksp_t, ksp_monitor_t, KSP_MAX_ITER
+  use precon,  only : pc_t
+  use ax_product, only : ax_t
+  use field, only : field_t
+  use coefs, only : coef_t
+  use gather_scatter, only : gs_t, GS_OP_ADD
+  use bc, only : bc_list_t, bc_list_apply
+  use math, only : glsc3, rzero, copy
   use math
   implicit none
   private

--- a/src/krylov/bcknd/sx/cg_sx.f90
+++ b/src/krylov/bcknd/sx/cg_sx.f90
@@ -40,7 +40,7 @@ module cg_sx
   use coefs, only : coef_t
   use gather_scatter, only : gs_t, GS_OP_ADD
   use bc, only : bc_list_t, bc_list_apply
-  use math, only : glsc3, rzero, copy
+  use math, only : glsc3, rzero, copy, add2s1
   implicit none
   private
 

--- a/src/krylov/bcknd/sx/cg_sx.f90
+++ b/src/krylov/bcknd/sx/cg_sx.f90
@@ -41,7 +41,6 @@ module cg_sx
   use gather_scatter, only : gs_t, GS_OP_ADD
   use bc, only : bc_list_t, bc_list_apply
   use math, only : glsc3, rzero, copy
-  use math
   implicit none
   private
 

--- a/src/krylov/bcknd/sx/gmres_sx.f90
+++ b/src/krylov/bcknd/sx/gmres_sx.f90
@@ -32,8 +32,15 @@
 !
 !> Defines various GMRES methods
 module gmres_sx
-  use krylov
-  use math
+  use krylov, only : ksp_t, ksp_monitor_t
+  use precon,  only : pc_t
+  use ax_product, only : ax_t
+  use num_types, only: rp
+  use field, only : field_t
+  use coefs, only : coef_t
+  use gather_scatter, only : gs_t, GS_OP_ADD
+  use bc, only : bc_list_t, bc_list_apply
+  use math, only : glsc3, rzero, rone, copy, cmult2, col2, col3, add2s2
   use comm
   implicit none
   private

--- a/src/krylov/bcknd/sx/pipecg_sx.f90
+++ b/src/krylov/bcknd/sx/pipecg_sx.f90
@@ -32,8 +32,15 @@
 !
 !> Defines a pipelined Conjugate Gradient methods SX-Aurora backend
 module pipecg_sx
-  use krylov
-  use math
+  use krylov, only : ksp_t, ksp_monitor_t, KSP_MAX_ITER
+  use precon,  only : pc_t
+  use ax_product, only : ax_t
+  use num_types, only: rp
+  use field, only : field_t
+  use coefs, only : coef_t
+  use gather_scatter, only : gs_t, GS_OP_ADD
+  use bc, only : bc_list_t, bc_list_apply
+  use math, only : glsc3, rzero, copy
   use comm
   implicit none
   private

--- a/src/krylov/krylov_fctry.f90
+++ b/src/krylov/krylov_fctry.f90
@@ -43,7 +43,8 @@ module krylov_fctry
   use gmres_sx, only : sx_gmres_t
   use gmres_device, only : gmres_device_t
   use num_Types, only : rp
-  use krylov, only : ksp_t, ksp_monitor_t, pc_t
+  use krylov, only : ksp_t, ksp_monitor_t
+  use precon, only : pc_t
   use utils, only : neko_error
   use neko_config
   implicit none

--- a/src/krylov/precon.f90
+++ b/src/krylov/precon.f90
@@ -34,6 +34,7 @@
 module precon
   use num_types, only : rp
   implicit none
+  private
   
   !> Defines a canonical Krylov preconditioner
   type, public, abstract :: pc_t

--- a/src/math/ax.f90
+++ b/src/math/ax.f90
@@ -32,15 +32,16 @@
 !
 !> Defines a Matrix-vector product
 module ax_product
-  use num_types
-  use coefs
-  use space
-  use field
-  use mesh
+  use num_types, only : rp
+  use coefs, only : coef_t
+  use space, only : space_t
+  use field, only : field_t
+  use mesh, only : mesh_t
   implicit none
+  private
 
   !> Base type for a matrix-vector product providing \f$ Ax \f$
-  type, abstract :: ax_t
+  type, public, abstract :: ax_t
    contains
      procedure(ax_compute), nopass, deferred :: compute
   end type ax_t

--- a/src/math/ax.f90
+++ b/src/math/ax.f90
@@ -47,11 +47,11 @@ module ax_product
 
   !> Abstract interface for computing\f$ Ax \f$ inside a Krylov method
   !!
-  !! @param w vector of size @a (lx,ly,lz,nelv)
-  !! @param z vector of size @a (lx,ly,lz,nelv)
-  !! @param coef Coefficients
-  !! @param msh mesh
-  !! @param Xh function space \f$ X_h \f$
+  !! @param w Vector of size @a (lx,ly,lz,nelv).
+  !! @param u Vector of size @a (lx,ly,lz,nelv).
+  !! @param coef Coefficients.
+  !! @param msh Mesh.
+  !! @param Xh Function space \f$ X_h \f$.
   abstract interface
   subroutine ax_compute(w, u, coef, msh, Xh)
        import space_t

--- a/src/math/ax_helm_fctry.f90
+++ b/src/math/ax_helm_fctry.f90
@@ -44,7 +44,7 @@ module ax_helm_fctry
 
 contains
 
-  !> Factory routine for the a Helmholz problem matrix-vector product.
+  !> Factory routine for the a Helmholtz problem matrix-vector product.
   !! The selection is based on the compute backend.
   !! @param Ax The matrix-vector product type to be allocated.
   subroutine ax_helm_factory(Ax)

--- a/src/math/ax_helm_fctry.f90
+++ b/src/math/ax_helm_fctry.f90
@@ -44,6 +44,9 @@ module ax_helm_fctry
 
 contains
 
+  !> Factory routine for the a Helmholz problem matrix-vector product.
+  !! The selection is based on the compute backend.
+  !! @param Ax The matrix-vector product type to be allocated.
   subroutine ax_helm_factory(Ax)
     class(ax_t), allocatable, intent(inout) :: Ax
     

--- a/src/math/bcknd/cpu/ax_helm.f90
+++ b/src/math/bcknd/cpu/ax_helm.f90
@@ -111,7 +111,7 @@ contains
  
   end subroutine ax_helm_compute
 
-  !> Generic CPU kernel for the Helmholz matrix-vector product.
+  !> Generic CPU kernel for the Helmholtz matrix-vector product.
   subroutine ax_helm_lx(w, u, Dx, Dy, Dz, Dxt, Dyt, Dzt, &
        h1, G11, G22, G33, G12, G13, G23, n, lx)
     integer, intent(in) :: n, lx

--- a/src/math/bcknd/cpu/ax_helm.f90
+++ b/src/math/bcknd/cpu/ax_helm.f90
@@ -36,13 +36,23 @@ module ax_helm
   implicit none
   private 
 
+  !> CPU matrix-vector product for a Helmholz problem.
   type, public, extends(ax_t) :: ax_helm_t
    contains
+     !> Compute the product.
      procedure, nopass :: compute => ax_helm_compute
   end type ax_helm_t
 
 contains 
 
+  !> Compute the product.
+  !! @param w Vector of size @a (lx,ly,lz,nelv).
+  !! @param u Vector of size @a (lx,ly,lz,nelv).
+  !! @param coef Coefficients.
+  !! @param msh Mesh.
+  !! @param Xh Function space \f$ X_h \f$.
+  !! @note Since this is a performance-crtical routine, it is implemented in
+  !! several kernels corresponding to different polynmial orders.
   subroutine ax_helm_compute(w, u, coef, msh, Xh)
     type(mesh_t), intent(inout) :: msh
     type(space_t), intent(inout) :: Xh
@@ -101,6 +111,7 @@ contains
  
   end subroutine ax_helm_compute
 
+  !> Generic CPU kernel for the Helmholz matrix-vector product.
   subroutine ax_helm_lx(w, u, Dx, Dy, Dz, Dxt, Dyt, Dzt, &
        h1, G11, G22, G33, G12, G13, G23, n, lx)
     integer, intent(in) :: n, lx

--- a/src/math/bcknd/cpu/ax_helm.f90
+++ b/src/math/bcknd/cpu/ax_helm.f90
@@ -36,7 +36,7 @@ module ax_helm
   implicit none
   private 
 
-  !> CPU matrix-vector product for a Helmholz problem.
+  !> CPU matrix-vector product for a Helmholtz problem.
   type, public, extends(ax_t) :: ax_helm_t
    contains
      !> Compute the product.

--- a/src/math/bcknd/cpu/ax_helm.f90
+++ b/src/math/bcknd/cpu/ax_helm.f90
@@ -31,7 +31,12 @@
 ! POSSIBILITY OF SUCH DAMAGE.
 !
 module ax_helm
-  use ax_product
+  use ax_product, only : ax_t
+  use num_types, only : rp
+  use coefs, only : coef_t
+  use space, only : space_t
+  use field, only : field_t
+  use mesh, only : mesh_t
   use math, only : addcol4
   implicit none
   private 

--- a/src/math/bcknd/device/ax_helm_device.F90
+++ b/src/math/bcknd/device/ax_helm_device.F90
@@ -31,7 +31,12 @@
 ! POSSIBILITY OF SUCH DAMAGE.
 !
 module ax_helm_device
-  use ax_product
+  use ax_product, only : ax_t
+  use num_types, only : rp
+  use coefs, only : coef_t
+  use space, only : space_t
+  use field, only : field_t
+  use mesh, only : mesh_t
   use device_math, only : device_addcol4
   use device, only : device_get_ptr
   use num_types, only : rp

--- a/src/math/bcknd/sx/ax_helm_sx.f90
+++ b/src/math/bcknd/sx/ax_helm_sx.f90
@@ -31,7 +31,12 @@
 ! POSSIBILITY OF SUCH DAMAGE.
 !
 module ax_helm_sx
-  use ax_product
+  use ax_product, only : ax_t
+  use num_types, only : rp
+  use coefs, only : coef_t
+  use space, only : space_t
+  use field, only : field_t
+  use mesh, only : mesh_t
   use math, only : addcol4
   implicit none
   private

--- a/src/math/bcknd/xsmm/ax_helm_xsmm.F90
+++ b/src/math/bcknd/xsmm/ax_helm_xsmm.F90
@@ -58,7 +58,12 @@
 ! not be used for advertising or product endorsement purposes.
 !
 module ax_helm_xsmm
-  use ax_product
+  use ax_product, only : ax_t
+  use num_types, only : rp
+  use coefs, only : coef_t
+  use space, only : space_t
+  use field, only : field_t
+  use mesh, only : mesh_t
   use mxm_wrapper
   use num_types
 #ifdef HAVE_LIBXSMM


### PR DESCRIPTION
This mostly fixed use statements in Krylov solver types, making the use `only`. Also adds `private` at module scope in some places. A little bit of docstrings. No functionality is changed.

