### PR TITLE
Fix heading

### DIFF
--- a/doc/pages/case-file.md
+++ b/doc/pages/case-file.md
@@ -54,7 +54,7 @@ The three following options are possible.
 4. `never`, then `_value` is ignored and output is never performed.
 
 
-## The `case` object 
+## The case object 
 
 This object is mostly used as a high-level container for all the other objects,
 but also defines several parameters that pertain to the simulation as a whole.


### PR DESCRIPTION
This removes the invalid rendering of `case`, that on some combinations of browsers etc renders as <tt>case</tt>