### PR TITLE
Move finalize and map in point zone factory

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -51,8 +51,8 @@ adt/stack.o : adt/stack.f90 adt/tuple.o math/math.o common/structs.o mesh/point.
 adt/tuple.o : adt/tuple.f90 config/num_types.o math/math.o 
 mesh/facet_zone.o : mesh/facet_zone.f90 common/utils.o adt/stack.o adt/tuple.o 
 mesh/point_zone.o : mesh/point_zone.f90 device/device.o config/neko_config.o sem/dofmap.o common/utils.o config/num_types.o adt/stack.o 
-mesh/point_zones/sphere_point_zone.o : mesh/point_zones/sphere_point_zone.f90 math/math.o common/json_utils.o sem/dofmap.o config/num_types.o mesh/point_zone.o 
-mesh/point_zones/box_point_zone.o : mesh/point_zones/box_point_zone.f90 math/math.o common/json_utils.o sem/dofmap.o config/num_types.o mesh/point_zone.o 
+mesh/point_zones/sphere_point_zone.o : mesh/point_zones/sphere_point_zone.f90 math/math.o common/json_utils.o config/num_types.o mesh/point_zone.o 
+mesh/point_zones/box_point_zone.o : mesh/point_zones/box_point_zone.f90 math/math.o common/json_utils.o config/num_types.o mesh/point_zone.o 
 mesh/point_zone_factory.o : mesh/point_zone_factory.f90 common/utils.o sem/dofmap.o common/json_utils.o mesh/point_zones/sphere_point_zone.o mesh/point_zones/box_point_zone.o mesh/point_zone.o 
 mesh/point_zone_registry.o : mesh/point_zone_registry.f90 common/json_utils.o common/utils.o sem/dofmap.o mesh/point_zone_factory.o mesh/point_zone.o 
 mesh/mesh.o : mesh/mesh.f90 mesh/curve.o adt/uset.o math/math.o mesh/facet_zone.o comm/comm.o common/distdata.o common/datadist.o adt/htable.o adt/tuple.o adt/stack.o common/utils.o mesh/quad.o mesh/hex.o mesh/element.o mesh/point.o config/num_types.o 

--- a/src/mesh/point_zone.f90
+++ b/src/mesh/point_zone.f90
@@ -110,14 +110,13 @@ module point_zone
   abstract interface
      !> The common constructor using a JSON object.
      !! @param json Json object for the point zone.
-     !! @param dof Dofmap of all GLL points from which to map the point zone.
-     subroutine point_zone_init(this, json, dof)
+     subroutine point_zone_init(this, json, size)
        import :: point_zone_t
        import :: json_file
        import :: dofmap_t
        class(point_zone_t), intent(inout) :: this
        type(json_file), intent(inout) :: json
-       type(dofmap_t), intent(inout) :: dof
+       integer, intent(in) :: size
      end subroutine point_zone_init
   end interface
 

--- a/src/mesh/point_zone.f90
+++ b/src/mesh/point_zone.f90
@@ -110,6 +110,7 @@ module point_zone
   abstract interface
      !> The common constructor using a JSON object.
      !! @param json Json object for the point zone.
+     !! @param size Size with which to initialize the stack
      subroutine point_zone_init(this, json, size)
        import :: point_zone_t
        import :: json_file

--- a/src/mesh/point_zone_factory.f90
+++ b/src/mesh/point_zone_factory.f90
@@ -68,7 +68,10 @@ module point_zone_fctry
               &source terms are 'box', 'sphere'.")
       end if
 
-      call point_zone%init(json, dof)
+      call point_zone%init(json, dof%size())
+
+      call point_zone%map(dof)
+      call point_zone%finalize()
 
     end subroutine point_zone_factory
 

--- a/src/mesh/point_zones/box_point_zone.f90
+++ b/src/mesh/point_zones/box_point_zone.f90
@@ -64,7 +64,7 @@ contains
 
   !> Constructor from json object file.
   !! @param json Json object file.
-  !! @param dof Dofmap from which to map the zone.
+  !! @param size Size with which to initialize the stack
   subroutine box_point_zone_init_from_json(this, json, size)
     class(box_point_zone_t), intent(inout) :: this
     type(json_file), intent(inout) :: json

--- a/src/mesh/point_zones/box_point_zone.f90
+++ b/src/mesh/point_zones/box_point_zone.f90
@@ -34,7 +34,6 @@
 module box_point_zone
   use point_zone, only: point_zone_t
   use num_types, only: rp
-  use dofmap, only: dofmap_t
   use json_utils, only: json_get
   use json_module, only: json_file
   use math, only: abscmp
@@ -66,10 +65,10 @@ contains
   !> Constructor from json object file.
   !! @param json Json object file.
   !! @param dof Dofmap from which to map the zone.
-  subroutine box_point_zone_init_from_json(this, json, dof)
+  subroutine box_point_zone_init_from_json(this, json, size)
     class(box_point_zone_t), intent(inout) :: this
     type(json_file), intent(inout) :: json
-    type(dofmap_t), intent(inout) :: dof
+    integer, intent(in) :: size
 
     character(len=:), allocatable :: str_read
     real(kind=rp), allocatable :: values(:)
@@ -86,12 +85,8 @@ contains
     zmax = values(2)
     call json_get(json, "name", str_read)
 
-    call box_point_zone_init_common(this, dof%size(), trim(str_read), xmin, &
+    call box_point_zone_init_common(this, size, trim(str_read), xmin, &
          xmax, ymin, ymax, zmin, zmax)
-
-    call this%map(dof)
-
-    call this%finalize()
 
   end subroutine box_point_zone_init_from_json
 

--- a/src/mesh/point_zones/sphere_point_zone.f90
+++ b/src/mesh/point_zones/sphere_point_zone.f90
@@ -34,7 +34,6 @@
 module sphere_point_zone
   use point_zone, only: point_zone_t
   use num_types, only: rp
-  use dofmap, only: dofmap_t
   use json_utils, only: json_get
   use json_module, only: json_file
   use math, only: abscmp
@@ -64,10 +63,10 @@ contains
   !> Constructor from json object file.
   !! @param json Json object file.
   !! @param dof Dofmap from which to map the zone.
-  subroutine sphere_point_zone_init_from_json(this, json, dof)
+  subroutine sphere_point_zone_init_from_json(this, json, size)
     class(sphere_point_zone_t), intent(inout) :: this
     type(json_file), intent(inout) :: json
-    type(dofmap_t), intent(inout) :: dof
+    integer, intent(in) :: size
 
     character(len=:), allocatable :: str_read
     real(kind=rp), allocatable :: values(:)
@@ -82,12 +81,8 @@ contains
     radius = value
     call json_get(json, "name", str_read)
 
-    call sphere_point_zone_init_common(this, dof%size(), trim(str_read), x0, &
+    call sphere_point_zone_init_common(this, size, trim(str_read), x0, &
          y0, z0, radius)
-
-    call this%map(dof)
-
-    call this%finalize()
 
   end subroutine sphere_point_zone_init_from_json
   

--- a/src/mesh/point_zones/sphere_point_zone.f90
+++ b/src/mesh/point_zones/sphere_point_zone.f90
@@ -62,7 +62,7 @@ contains
 
   !> Constructor from json object file.
   !! @param json Json object file.
-  !! @param dof Dofmap from which to map the zone.
+  !! @param size Size with which to initialize the stack
   subroutine sphere_point_zone_init_from_json(this, json, size)
     class(sphere_point_zone_t), intent(inout) :: this
     type(json_file), intent(inout) :: json


### PR DESCRIPTION
I think it makes more sense like this, so that `map` and `finalize` are called separately and **only** in point zone factory. That way it will also be easier to change the workflow if necessary.