### PR TITLE
Restart fixes

### DIFF
--- a/src/common/time_based_controller.f90
+++ b/src/common/time_based_controller.f90
@@ -66,6 +66,9 @@ module time_based_controller
     !> Increment `nexectutions`.
      procedure, pass(this) :: register_execution => &
        time_based_controller_register_execution
+    !> Set the counter based on a time (for restarts)
+     procedure, pass(this) :: set_counter => &
+       time_based_controller_set_counter
 
   end type time_based_controller_t
 
@@ -172,6 +175,17 @@ contains
 
   end subroutine time_based_controller_register_execution
 
+  !> Set the counter based on a time (for restarts)
+  !! @param t simulation time.
+  subroutine time_based_controller_set_counter(this,t)
+    class(time_based_controller_t), intent(inout) :: this
+    real(kind=rp), intent(in) :: t
+
+    if (this%nsteps .eq. 0) then
+       this%nexecutions = int(t / this%time_interval) + 1
+    end if
+
+  end subroutine time_based_controller_set_counter
 
 
 end module time_based_controller

--- a/src/io/chkp_file.f90
+++ b/src/io/chkp_file.f90
@@ -438,8 +438,7 @@ contains
     end if
     
     call MPI_File_close(fh, ierr)      
-
-    call this%global_interp%free()
+    if (this%mesh2mesh) call this%global_interp%free()
     call this%space_interp%free()
     
   end subroutine chkp_file_read

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -72,7 +72,15 @@ contains
 
     call C%params%get('case.restart_file', restart_file, found)
     if (found .and. len_trim(restart_file) .gt. 0) then
+       ! Restart the case
        call simulation_restart(C, t)
+
+       ! Restart the simulation components
+       if (allocated(neko_simcomps)) then
+         do i=1, size(neko_simcomps)
+            call neko_simcomps(i)%simcomp%restart(t)
+         end do
+       end if
     end if
 
     !> Call stats, samplers and user-init before time loop

--- a/src/simulation_components/simulation_component.f90
+++ b/src/simulation_components/simulation_component.f90
@@ -57,6 +57,9 @@ module simulation_component
      procedure, pass(this) :: init_base => simulation_component_init_base
      !> Destructor for the simulation_component_t (base) class.
      procedure, pass(this) :: free_base => simulation_component_free_base
+     !> Wrapper for calling `set_counter` for the time based controllers.
+     !! Serves as the public interface.
+     procedure, pass(this) :: restart => simulation_component_restart_wrapper
      !> Wrapper for calling `compute_` based on the `compute_controller`.
      !! Serves as the public interface.
      procedure, pass(this) :: compute => simulation_component_compute_wrapper
@@ -155,5 +158,16 @@ contains
     end if
   end subroutine simulation_component_compute_wrapper
 
+  !> Wrapper for calling `set_counter_` based for the controllers.
+  !! Serves as the public interface.
+  !! @param t The time value.
+  subroutine simulation_component_restart_wrapper(this, t)  
+    class(simulation_component_t), intent(inout) :: this
+    real(kind=rp), intent(in) :: t
+
+    call this%compute_controller%set_counter(t)
+    call this%output_controller%set_counter(t)
+
+  end subroutine simulation_component_restart_wrapper
   
 end module simulation_component


### PR DESCRIPTION
Fixes the issue with restarting the simulation components. 

Also removes the error message that one needs gslib to restart the simulation (unless one does mesh2mesh interpolation).