### PR TITLE
Restart fixes - second round

### DIFF
--- a/src/bc/blasius.f90
+++ b/src/bc/blasius.f90
@@ -196,8 +196,8 @@ contains
             end select
          end do
 
-         call device_memcpy(bla_x, blax_d, m, HOST_TO_DEVICE, sync=.true.)
-         call device_memcpy(bla_y, blay_d, m, HOST_TO_DEVICE, sync=.true.)
+         call device_memcpy(bla_x, blax_d, m, HOST_TO_DEVICE, sync=.false.)
+         call device_memcpy(bla_y, blay_d, m, HOST_TO_DEVICE, sync=.false.)
          call device_memcpy(bla_z, blaz_d, m, HOST_TO_DEVICE, sync=.true.)
 
          deallocate(bla_x, bla_y, bla_z)

--- a/src/bc/blasius.f90
+++ b/src/bc/blasius.f90
@@ -196,9 +196,9 @@ contains
             end select
          end do
 
-         call device_memcpy(bla_x, blax_d, m, HOST_TO_DEVICE, sync=.false.)
-         call device_memcpy(bla_y, blay_d, m, HOST_TO_DEVICE, sync=.false.)
-         call device_memcpy(bla_z, blaz_d, m, HOST_TO_DEVICE, sync=.false.)
+         call device_memcpy(bla_x, blax_d, m, HOST_TO_DEVICE, sync=.true.)
+         call device_memcpy(bla_y, blay_d, m, HOST_TO_DEVICE, sync=.true.)
+         call device_memcpy(bla_z, blaz_d, m, HOST_TO_DEVICE, sync=.true.)
 
          deallocate(bla_x, bla_y, bla_z)
       end if

--- a/src/bc/dong_outflow.f90
+++ b/src/bc/dong_outflow.f90
@@ -113,9 +113,9 @@ contains
             temp_z(i) = normal_xyz(3)
          end do
          call device_memcpy(temp_x, this%normal_x_d, m, &
-                            HOST_TO_DEVICE, sync=.true.)
+                            HOST_TO_DEVICE, sync=.false.)
          call device_memcpy(temp_y, this%normal_y_d, m, &
-                            HOST_TO_DEVICE, sync=.true.)
+                            HOST_TO_DEVICE, sync=.false.)
          call device_memcpy(temp_z, this%normal_z_d, m, &
                             HOST_TO_DEVICE, sync=.true.)
          deallocate( temp_x, temp_y, temp_z)

--- a/src/bc/dong_outflow.f90
+++ b/src/bc/dong_outflow.f90
@@ -113,11 +113,11 @@ contains
             temp_z(i) = normal_xyz(3)
          end do
          call device_memcpy(temp_x, this%normal_x_d, m, &
-                            HOST_TO_DEVICE, sync=.false.)
+                            HOST_TO_DEVICE, sync=.true.)
          call device_memcpy(temp_y, this%normal_y_d, m, &
-                            HOST_TO_DEVICE, sync=.false.)
+                            HOST_TO_DEVICE, sync=.true.)
          call device_memcpy(temp_z, this%normal_z_d, m, &
-                            HOST_TO_DEVICE, sync=.false.)
+                            HOST_TO_DEVICE, sync=.true.)
          deallocate( temp_x, temp_y, temp_z)
       end if
 

--- a/src/bc/usr_inflow.f90
+++ b/src/bc/usr_inflow.f90
@@ -291,9 +291,9 @@ contains
          end associate
  
         
-         call device_memcpy(x, usr_x_d, m, HOST_TO_DEVICE, sync=.false.)
-         call device_memcpy(y, usr_y_d, m, HOST_TO_DEVICE, sync=.false.)
-         call device_memcpy(z, usr_z_d, m, HOST_TO_DEVICE, sync=.false.)
+         call device_memcpy(x, usr_x_d, m, HOST_TO_DEVICE, sync=.true.)
+         call device_memcpy(y, usr_y_d, m, HOST_TO_DEVICE, sync=.true.)
+         call device_memcpy(z, usr_z_d, m, HOST_TO_DEVICE, sync=.true.)
 
          deallocate(x, y, z)
       end if

--- a/src/bc/usr_inflow.f90
+++ b/src/bc/usr_inflow.f90
@@ -290,8 +290,8 @@ contains
            end do
          end associate
         
-         call device_memcpy(x, usr_x_d, m, HOST_TO_DEVICE, sync=.true.)
-         call device_memcpy(y, usr_y_d, m, HOST_TO_DEVICE, sync=.true.)
+         call device_memcpy(x, usr_x_d, m, HOST_TO_DEVICE, sync=.false.)
+         call device_memcpy(y, usr_y_d, m, HOST_TO_DEVICE, sync=.false.)
          call device_memcpy(z, usr_z_d, m, HOST_TO_DEVICE, sync=.true.)
 
          deallocate(x, y, z)

--- a/src/bc/usr_scalar.f90
+++ b/src/bc/usr_scalar.f90
@@ -256,7 +256,7 @@ contains
          end do
  
         
-         call device_memcpy(x, this%usr_x_d, m, HOST_TO_DEVICE, sync=.false.)
+         call device_memcpy(x, this%usr_x_d, m, HOST_TO_DEVICE, sync=.true.)
 
          deallocate(x)
       end if

--- a/src/common/checkpoint.f90
+++ b/src/common/checkpoint.f90
@@ -240,6 +240,15 @@ contains
          if (associated(this%s)) then
             call device_memcpy(this%s%x, this%s%x_d, this%s%dof%size(), &
                                HOST_TO_DEVICE, sync=.false.)
+
+            call device_memcpy(this%slag%lf(1)%x, this%slag%lf(1)%x_d, &
+                               this%s%dof%size(), HOST_TO_DEVICE, sync=.false.)
+            call device_memcpy(this%slag%lf(2)%x, this%slag%lf(2)%x_d, &
+                               this%s%dof%size(), HOST_TO_DEVICE, sync=.false.)
+            call device_memcpy(this%abs1%x, this%abs1%x_d, &
+                               w%dof%size(), HOST_TO_DEVICE, sync=.false.)
+            call device_memcpy(this%abs2%x, this%abs2%x_d, &
+                               w%dof%size(), HOST_TO_DEVICE, sync=.false.)
          end if
        end associate
     end if

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -286,6 +286,7 @@ contains
 
     n = this%u%dof%size()
     ! Make sure that continuity is maintained (important for interpolation) 
+    ! Do not do this for lagged rhs (derivatives are not necessairly coninous across elements)
     call col2(this%u%x,this%c_Xh%mult,this%u%dof%size())
     call col2(this%v%x,this%c_Xh%mult,this%u%dof%size())
     call col2(this%w%x,this%c_Xh%mult,this%u%dof%size())
@@ -295,13 +296,6 @@ contains
        call col2(this%vlag%lf(i)%x,this%c_Xh%mult,this%u%dof%size())
        call col2(this%wlag%lf(i)%x,this%c_Xh%mult,this%u%dof%size())
     end do
-
-    call col2(this%abx1%x,this%c_Xh%mult,this%abx1%dof%size())
-    call col2(this%abx2%x,this%c_Xh%mult,this%abx2%dof%size())
-    call col2(this%aby1%x,this%c_Xh%mult,this%aby1%dof%size())
-    call col2(this%aby2%x,this%c_Xh%mult,this%aby2%dof%size())
-    call col2(this%abz1%x,this%c_Xh%mult,this%abz1%dof%size())
-    call col2(this%abz2%x,this%c_Xh%mult,this%abz2%dof%size())
 
     
     if (NEKO_BCKND_DEVICE .eq. 1) then
@@ -346,7 +340,6 @@ contains
    end if
 
 
-
     call this%gs_Xh%op(this%u,GS_OP_ADD)
     call this%gs_Xh%op(this%v,GS_OP_ADD)
     call this%gs_Xh%op(this%w,GS_OP_ADD)
@@ -357,12 +350,6 @@ contains
        call this%gs_Xh%op(this%vlag%lf(i),GS_OP_ADD)
        call this%gs_Xh%op(this%wlag%lf(i),GS_OP_ADD)
     end do
-    call this%gs_Xh%op(this%abx1,GS_OP_ADD)
-    call this%gs_Xh%op(this%abx2,GS_OP_ADD)
-    call this%gs_Xh%op(this%aby1,GS_OP_ADD)
-    call this%gs_Xh%op(this%aby2,GS_OP_ADD)
-    call this%gs_Xh%op(this%abz1,GS_OP_ADD)
-    call this%gs_Xh%op(this%abz2,GS_OP_ADD)
 
     !! If we would decide to only restart from lagged fields instead of asving abx1, aby1 etc.
     !! Observe that one also needs to recompute the focing at the old time steps

--- a/src/scalar/scalar_pnpn.f90
+++ b/src/scalar/scalar_pnpn.f90
@@ -219,8 +219,6 @@ contains
     n = this%s%dof%size()
 
     call col2(this%s%x, this%c_Xh%mult, n) 
-    call col2(this%abx1%x, this%c_Xh%mult, n) 
-    call col2(this%abx2%x, this%c_Xh%mult, n) 
     call col2(this%slag%lf(1)%x, this%c_Xh%mult, n) 
     call col2(this%slag%lf(2)%x, this%c_Xh%mult, n) 
     if (NEKO_BCKND_DEVICE .eq. 1) then
@@ -239,10 +237,6 @@ contains
     call this%gs_Xh%op(this%s,GS_OP_ADD)
     call this%gs_Xh%op(this%slag%lf(1),GS_OP_ADD)
     call this%gs_Xh%op(this%slag%lf(2),GS_OP_ADD)
-    call this%gs_Xh%op(this%abx1,GS_OP_ADD)
-    call this%gs_Xh%op(this%abx2,GS_OP_ADD)
-
-
 
   end subroutine scalar_pnpn_restart
 
@@ -315,18 +309,6 @@ contains
          ksp_maxiter => this%ksp_maxiter, &
          msh => this%msh, res => this%res, &
          makeext => this%makeext, makebdf => this%makebdf)
-
-      if (neko_log%level_ .ge. NEKO_LOG_DEBUG) then
-         write(log_buf,'(A,A,E15.7,A,E15.7,A,E15.7)') 'Scalar debug',&
-              ' l2norm s', glsc2(this%s%x,this%s%x,n),&
-              ' slag1', glsc2(this%slag%lf(1)%x,this%slag%lf(1)%x,n),&
-              ' slag2', glsc2(this%slag%lf(2)%x,this%slag%lf(2)%x,n)
-         call neko_log%message(log_buf)
-         write(log_buf,'(A,A,E15.7,A,E15.7)') 'Scalar debug2',&
-              ' l2norm abx1', glsc2(this%abx1%x,this%abx1%x,n),&
-              ' abx2', glsc2(this%abx2%x,this%abx2%x,n)
-         call neko_log%message(log_buf)
-      end if
       
       ! Evaluate the source term and scale with the mass matrix.
       call f_Xh%eval(t)


### PR DESCRIPTION
Further fixes of the restarts... Also found a data race for using the device for user bcs due to the asynchronous memcpy.

I anticipate that both Adalberto and Siavash should observe more similar results now. 

We should perhaps go further with regards to async memcpy and try to limit async to things that happen in the iterative solvers to avoid things like this. 