### PR TITLE
Use the global scratch manager for scalar rhs

### DIFF
--- a/src/common/bcknd/cpu/rhs_maker_cpu.f90
+++ b/src/common/bcknd/cpu/rhs_maker_cpu.f90
@@ -96,15 +96,17 @@ contains
 
   end subroutine rhs_maker_ext_cpu
 
-  subroutine scalar_rhs_maker_ext_cpu(temp1, fs_lag, fs_laglag, fs, rho, ext_coeffs, &
-                                n)
-    type(field_t), intent(inout) :: temp1
+  subroutine scalar_rhs_maker_ext_cpu(fs_lag, fs_laglag, fs, rho, ext_coeffs, n)
     type(field_t), intent(inout) :: fs_lag
     type(field_t), intent(inout) :: fs_laglag
     real(kind=rp), intent(inout) :: rho, ext_coeffs(4)
     integer, intent(in) :: n
     real(kind=rp), intent(inout) :: fs(n)
     integer :: i
+    type(field_t), pointer :: temp1
+    integer :: temp_index
+
+    call neko_scratch_registry%request_field(temp1, temp_index)
 
     do i = 1, n
        temp1%x(i,1,1,1) = ext_coeffs(2) * fs_lag%x(i,1,1,1) + &
@@ -120,6 +122,7 @@ contains
        fs(i) = (ext_coeffs(1) * fs(i) + temp1%x(i,1,1,1)) * rho
     end do
 
+    call neko_scratch_registry%relinquish_field(temp_index)
   end subroutine scalar_rhs_maker_ext_cpu
 
   subroutine rhs_maker_bdf_cpu(ulag, vlag, wlag, bfx, bfy, bfz, &
@@ -172,16 +175,19 @@ contains
 
   end subroutine rhs_maker_bdf_cpu
 
-  subroutine scalar_rhs_maker_bdf_cpu(temp1, temp2, s_lag, fs, s, B, rho, dt, &
-       bd, nbd, n)
+  subroutine scalar_rhs_maker_bdf_cpu(s_lag, fs, s, B, rho, dt, bd, nbd, n)
     integer, intent(in) :: n, nbd
-    type(field_t), intent(inout) :: temp1, temp2
     type(field_t), intent(in) :: s
     type(field_series_t), intent(in) :: s_lag
     real(kind=rp), intent(inout) :: fs(n)
     real(kind=rp), intent(in) :: B(n)
     real(kind=rp), intent(in) :: dt, rho, bd(4)
     integer :: i, ilag
+    type(field_t), pointer :: temp1, temp2
+    integer :: temp_indices(2)
+
+    call neko_scratch_registry%request_field(temp1, temp_indices(1))
+    call neko_scratch_registry%request_field(temp2, temp_indices(2))
 
     do i = 1, n
        temp2%x(i,1,1,1) = s%x(i,1,1,1) * B(i) * bd(2)
@@ -201,6 +207,7 @@ contains
        fs(i) = fs(i) + temp2%x(i,1,1,1) * (rho / dt)
     end do
 
+    call neko_scratch_registry%relinquish_field(temp_indices)
   end subroutine scalar_rhs_maker_bdf_cpu
 
 end module rhs_maker_cpu

--- a/src/common/bcknd/device/rhs_maker_device.F90
+++ b/src/common/bcknd/device/rhs_maker_device.F90
@@ -325,9 +325,8 @@ contains
 
   end subroutine rhs_maker_ext_device
 
-  subroutine scalar_rhs_maker_ext_device(temp1, fs_lag, fs_laglag, fs, &
+  subroutine scalar_rhs_maker_ext_device(fs_lag, fs_laglag, fs, &
                            rho, ext_coeffs, n)
-    type(field_t), intent(inout) :: temp1
     type(field_t), intent(inout) :: fs_lag
     type(field_t), intent(inout) :: fs_laglag
     real(kind=rp), intent(inout) :: rho, ext_coeffs(4)
@@ -387,12 +386,10 @@ contains
 
   end subroutine rhs_maker_bdf_device
 
-  subroutine scalar_rhs_maker_bdf_device(temp1, temp2, s_lag, fs, s, B, rho, dt, &
+  subroutine scalar_rhs_maker_bdf_device(s_lag, fs, s, B, rho, dt, &
                                          bd, nbd, n)
     integer, intent(in) :: n, nbd
-    type(field_t), intent(inout) :: temp1
     type(field_t), intent(in) :: s
-    type(field_t), intent(inout) :: temp2
     type(field_series_t), intent(in) :: s_lag
     real(kind=rp), intent(inout) :: fs(n)
     real(kind=rp), intent(in) :: B(n)

--- a/src/common/rhs_maker.f90
+++ b/src/common/rhs_maker.f90
@@ -90,11 +90,10 @@ module rhs_maker
   end interface
 
   abstract interface
-     subroutine scalar_rhs_maker_ext(temp1, fs_lag, fs_laglag, fs, rho, &
+     subroutine scalar_rhs_maker_ext(fs_lag, fs_laglag, fs, rho, &
           ext_coeffs, n)
        import field_t
        import rp
-       type(field_t), intent(inout) :: temp1
        type(field_t), intent(inout) :: fs_lag
        type(field_t), intent(inout) :: fs_laglag
        real(kind=rp), intent(inout) :: rho, ext_coeffs(4)
@@ -119,13 +118,12 @@ module rhs_maker
   end interface
 
   abstract interface
-     subroutine scalar_rhs_maker_bdf(temp1, temp2, s_lag, fs, s, B, rho, dt,&
+     subroutine scalar_rhs_maker_bdf(s_lag, fs, s, B, rho, dt,&
           bd, nbd, n)
        import field_series_t
        import field_t
        import rp
        integer, intent(in) :: n, nbd
-       type(field_t), intent(inout) :: temp1, temp2
        type(field_t), intent(in) :: s
        type(field_series_t), intent(in) :: s_lag
        real(kind=rp), intent(inout) :: fs(n)

--- a/src/scalar/bcknd/cpu/scalar_residual_cpu.f90
+++ b/src/scalar/bcknd/cpu/scalar_residual_cpu.f90
@@ -16,7 +16,7 @@ module scalar_residual_cpu
 contains
 
   !> Compute the residual.
-  !! @param Ax The Helmholz operator.
+  !! @param Ax The Helmholtz operator.
   !! @param s The values of the scalar.
   !! @param s_res The values of the scalar residual.
   !! @param f_xH The right hand side.

--- a/src/scalar/bcknd/cpu/scalar_residual_cpu.f90
+++ b/src/scalar/bcknd/cpu/scalar_residual_cpu.f90
@@ -1,4 +1,4 @@
-!> Residuals in the Pn-Pn formulation (CPU version)
+!> Residuals in the scalar equation (CPU version).
 module scalar_residual_cpu
   use gather_scatter
   use scalar_residual
@@ -6,13 +6,28 @@ module scalar_residual_cpu
   implicit none
   private
 
+  !> Wrapper type for the routine to compute the scalar residual on the CPU.
   type, public, extends(scalar_residual_t) :: scalar_residual_cpu_t
    contains
+     !> Compute the residual.
      procedure, nopass :: compute => scalar_residual_cpu_compute
   end type scalar_residual_cpu_t
 
 contains
 
+  !> Compute the residual.
+  !! @param Ax The Helmholz operator.
+  !! @param s The values of the scalar.
+  !! @param s_res The values of the scalar residual.
+  !! @param f_xH The right hand side.
+  !! @param c_xH The SEM coefficients.
+  !! @param msh The mesh.
+  !! @param Xh The SEM function space.
+  !! @param lambda The thermal conductivity.
+  !! @param rhocp The density multiplied by the specific heat capacity.
+  !! @param bd The coefficeints from the BDF differencing scheme.
+  !! @param dt The timestep.
+  !! @param n The total number of degrees of freedom.
   subroutine scalar_residual_cpu_compute(Ax, s, s_res, f_Xh, c_Xh, msh, Xh, &
       lambda, rhocp, bd, dt, n)
     class(ax_t), intent(in) :: Ax
@@ -32,6 +47,7 @@ contains
     do i = 1, n
        c_Xh%h1(i,1,1,1) = lambda
        ! todo :should not be just rho here.
+       ! Tim M. 2023-12-19: What is this todo?
        c_Xh%h2(i,1,1,1) = rhocp * (bd / dt)
     end do
     c_Xh%ifh2 = .true.

--- a/src/scalar/scalar_pnpn.f90
+++ b/src/scalar/scalar_pnpn.f90
@@ -32,9 +32,11 @@
 !
 !> Modular version of the Classic Nek5000 Pn/Pn formulation for scalars
 module scalar_pnpn
+  use num_types, only: rp
   use scalar_residual_fctry, only : scalar_residual_factory
   use ax_helm_fctry, only: ax_helm_factory
-  use rhs_maker_fctry
+  use rhs_maker_fctry, only : rhs_maker_bdf_t, rhs_maker_ext_t, &
+                              rhs_maker_ext_fctry, rhs_maker_bdf_fctry
   use scalar_scheme, only : scalar_scheme_t
   use dirichlet, only : dirichlet_t
   use field, only : field_t
@@ -43,25 +45,26 @@ module scalar_pnpn
   use mesh, only : mesh_t
   use checkpoint, only : chkp_t
   use coefs, only : coef_t
-  use device
+  use device, only : HOST_TO_DEVICE, device_memcpy
   use gather_scatter, only : gs_t, GS_OP_ADD
   use scalar_residual, only :scalar_residual_t
   use ax_product, only : ax_t
-  use field_series
-  use facet_normal
-  use device_math
-  use device_mathops
-  use scalar_aux
-  use time_scheme_controller
-  use projection
-  use math
-  use logger
-  use advection
-  use profiler
+  use field_series, only: field_series_t
+  use facet_normal, only : facet_normal_t
+  use krylov, only : ksp_monitor_t
+  use device_math, only : device_add2s2, device_col2
+  use scalar_aux, only : scalar_step_info
+  use time_scheme_controller, only : time_scheme_controller_t
+  use projection, only : projection_t
+  use math, only : glsc2, col2, add2s2 
+  use logger, only : neko_log, LOG_SIZE, NEKO_LOG_DEBUG
+  use advection, only : advection_t, advection_factory
+  use profiler, only : profiler_start_region, profiler_end_region
   use json_utils, only: json_get
   use json_module, only : json_file
   use user_intf, only : user_t
   use material_properties, only : material_properties_t
+  use neko_config, only : NEKO_BCKND_DEVICE
   implicit none
   private
 

--- a/src/scalar/scalar_residual.f90
+++ b/src/scalar/scalar_residual.f90
@@ -50,6 +50,19 @@ module scalar_residual
   end type scalar_residual_t
 
   abstract interface
+     !> Interface for computing the residual of a scalar transport equation.
+     !! @param Ax The Helmholz operator.
+     !! @param s The values of the scalar.
+     !! @param s_res The values of the scalar residual.
+     !! @param f_xH The right hand side.
+     !! @param c_xH The SEM coefficients.
+     !! @param msh The mesh.
+     !! @param Xh The SEM function space.
+     !! @param lambda The thermal conductivity.
+     !! @param rhocp The density multiplied by the specific heat capacity.
+     !! @param bd The coefficeints from the BDF differencing scheme.
+     !! @param dt The timestep.
+     !! @param n The total number of degrees of freedom.
      subroutine scalar_residual_interface(Ax, s, s_res, f_Xh, c_Xh, msh, Xh, &
                                           lambda, rhocp, bd, dt, n)
        import field_t

--- a/src/scalar/scalar_residual.f90
+++ b/src/scalar/scalar_residual.f90
@@ -51,7 +51,7 @@ module scalar_residual
 
   abstract interface
      !> Interface for computing the residual of a scalar transport equation.
-     !! @param Ax The Helmholz operator.
+     !! @param Ax The Helmholtz operator.
      !! @param s The values of the scalar.
      !! @param s_res The values of the scalar residual.
      !! @param f_xH The right hand side.

--- a/src/scalar/scalar_scheme.f90
+++ b/src/scalar/scalar_scheme.f90
@@ -131,7 +131,7 @@ module scalar_scheme
      procedure(scalar_scheme_init_intrf), pass(this), deferred :: init
      !> Destructor.
      procedure(scalar_scheme_free_intrf), pass(this), deferred :: free
-     !> Solver for current timestep.
+     !> Solve for the current timestep.
      procedure(scalar_scheme_step_intrf), pass(this), deferred :: step
      !> Restart from a checkpoint.
      procedure(scalar_scheme_restart_intrf), pass(this), deferred :: restart

--- a/src/scalar/scalar_scheme.f90
+++ b/src/scalar/scalar_scheme.f90
@@ -34,30 +34,39 @@
 
 ! todo: module name
 module scalar_scheme
-  use gather_scatter
-  use neko_config
-  use checkpoint
-  use num_types
-  use source_scalar
-  use field
-  use space
-  use dofmap
-  use krylov
-  use coefs
-  use dirichlet
-  use krylov_fctry
-  use precon_fctry
-  use bc
-  use mesh
-  use facet_zone
-  use time_scheme_controller
-  use logger
-  use field_registry
-  use usr_scalar
+  use gather_scatter, only : gs_t
+!  use neko_config
+  use checkpoint, only : chkp_t
+  use num_types, only: rp
+  use source_scalar, only : source_scalar_t, source_scalar_term_pw, &
+                            source_scalar_term, source_scalar_eval_noforce, &
+                            source_scalar_init, source_scalar_set_type, &
+                            source_scalar_set_pw_type, source_scalar_free
+  use field, only : field_t
+  use space, only : space_t
+  use dofmap, only :  dofmap_t
+  use krylov, only : ksp_t
+  use coefs, only : coef_t
+  use dirichlet, only : dirichlet_t
+  use krylov_fctry, only : krylov_solver_factory, krylov_solver_destroy
+  use jacobi, only : jacobi_t
+  use device_jacobi, only : device_jacobi_t
+  use sx_jacobi, only : sx_jacobi_t
+  use hsmg, only : hsmg_t
+  use precon_fctry, only : precon_factory, pc_t, precon_destroy
+  use bc, only : bc_t, bc_list_t, bc_list_free, bc_list_init, &
+                 bc_list_apply_scalar, bc_list_add
+  use mesh, only : mesh_t, NEKO_MSH_MAX_ZLBLS
+  use facet_zone, only : facet_zone_t
+  use time_scheme_controller, only : time_scheme_controller_t
+  use logger, only : neko_log, LOG_SIZE
+  use field_registry, only : neko_field_registry
+  use usr_scalar, only : usr_scalar_t, usr_scalar_bc_eval
   use json_utils, only : json_get, json_get_or_default
   use json_module, only : json_file
   use user_intf, only : user_t
   use material_properties, only : material_properties_t
+  use utils, only : neko_error
   implicit none
 
   type, abstract :: scalar_scheme_t


### PR DESCRIPTION
* Follows what is already done for fluid, and seems to have raised no complaints. For scalars, the residuals subroutines don't use temporaries, only the rhs makers do. Note that on the device, no temporaries are used at all, so there this simply deletes unnecessary arguments. 

* The scalar scheme types now `use ...., only`. 


Also, some improvements to docstrings here and there.