### PR TITLE
Manually set vec and mat to null in `csv_file_write`

### DIFF
--- a/src/io/csv_file.f90
+++ b/src/io/csv_file.f90
@@ -68,11 +68,11 @@ contains
     real(kind=rp), intent(in), optional :: t
 
     real(kind=rp) :: time
-    type(vector_t), pointer :: vec => null()
-    type(matrix_t), pointer :: mat => null()
+    type(vector_t), pointer :: vec
+    type(matrix_t), pointer :: mat
 
-    if (associated(vec)) vec => null()
-    if (associated(mat)) mat => null()
+    nullify(vec)
+    nullify(mat)
 
     select type(data)
     type is (vector_t)
@@ -180,8 +180,11 @@ contains
   subroutine csv_file_read(this, data)
     class(csv_file_t) :: this
     class(*), target, intent(inout) :: data
-    type(vector_t), pointer :: vec => null()
-    type(matrix_t), pointer :: mat => null()
+    type(vector_t), pointer :: vec
+    type(matrix_t), pointer :: mat
+
+    nullify(vec)
+    nullify(mat)
 
     select type(data)
     type is (vector_t)

--- a/src/io/csv_file.f90
+++ b/src/io/csv_file.f90
@@ -71,6 +71,9 @@ contains
     type(vector_t), pointer :: vec => null()
     type(matrix_t), pointer :: mat => null()
 
+    if (associated(vec)) vec => null()
+    if (associated(mat)) mat => null()
+
     select type(data)
     type is (vector_t)
        if (.not. allocated(data%x)) then


### PR DESCRIPTION
Fixes #1079 

See https://github.com/ExtremeFLOW/neko/issues/1079#issuecomment-1864994418 for the full explanation.

In summary, it seems that declaring pointers as:

```.f90
    type(vector_t), pointer :: vec => null()
    type(matrix_t), pointer :: mat => null()
```

Does not properly set the pointers to `null()`. I have found a workaround, to manually set `vec` and `mat` to `null`:

```.f90
    type(vector_t), pointer :: vec
    type(matrix_t), pointer :: mat

    nullify(vec)
    nullify(mat)
```