### PR TITLE
Fix a segmentation fault.

### DIFF
--- a/src/simulation_components/simulation_component_factory.f90
+++ b/src/simulation_components/simulation_component_factory.f90
@@ -40,6 +40,7 @@ module simulation_component_fctry
   use json_module, only : json_file
   use case, only : case_t
   use json_utils, only : json_get
+  use logger, only : neko_log
   implicit none
   private
 
@@ -59,12 +60,14 @@ contains
 
     if (trim(simcomp_type) .eq. "vorticity") then
        allocate(vorticity_t::simcomp)
-    end if
-    if (trim(simcomp_type) .eq. "lambda2") then
+    else if (trim(simcomp_type) .eq. "lambda2") then
        allocate(lambda2_t::simcomp)
-    end if
-    if (trim(simcomp_type) .eq. "probes") then
+    else if (trim(simcomp_type) .eq. "probes") then
        allocate(probes_t::simcomp)
+    else
+       call neko_log%error("Unknown simulation component type: " &
+                           // trim(simcomp_type))
+       stop
     end if
 
     ! Initialize


### PR DESCRIPTION
When an unknown simulation component is specified we should throw an error and stop rather than segfaulting.