### PR TITLE
Fix ROCm detection on Cray EX platforms for none HPE provided modules

### DIFF
--- a/m4/ax_cray.m4
+++ b/m4/ax_cray.m4
@@ -195,6 +195,12 @@ AC_DEFUN([AX_CRAY_ROCM],[
 	    hip_bcknd="1"
 	  else
 	    AC_MSG_RESULT([no])
+            if test "${ROCM_PATH}"; then
+              AX_HIP
+            else
+              AC_MSG_ERROR([Cray ROCm Toolkit not found])
+              have_hip="no"
+            fi
             AC_MSG_ERROR([Cray ROCm Toolkit not found])
 	    have_hip="no"
 	  fi

--- a/m4/ax_cray.m4
+++ b/m4/ax_cray.m4
@@ -201,8 +201,6 @@ AC_DEFUN([AX_CRAY_ROCM],[
               AC_MSG_ERROR([Cray ROCm Toolkit not found])
               have_hip="no"
             fi
-            AC_MSG_ERROR([Cray ROCm Toolkit not found])
-	    have_hip="no"
 	  fi
 	fi
 	AC_SUBST(hip_bcknd)


### PR DESCRIPTION
This fixes an issue with detecting ROCm on CRAY EX platforms when using the wrappers (CC,ftn) but a none HPE provided rocm module
