### PR TITLE
Fix invalid starting residual for (device) pipecg

### DIFF
--- a/src/krylov/bcknd/device/pipecg_device.F90
+++ b/src/krylov/bcknd/device/pipecg_device.F90
@@ -41,7 +41,8 @@ module pipecg_device
   use gather_scatter, only : gs_t, GS_OP_ADD
   use bc, only : bc_list_t, bc_list_apply
   use math, only : glsc3, rzero, copy
-  use device_math, only : device_rzero, device_copy, device_glsc3
+  use device_math, only : device_rzero, device_copy, &
+       device_glsc3, device_vlsc3
   use device
   use comm
   implicit none
@@ -385,9 +386,9 @@ contains
       tmp1 = 0.0_rp
       tmp2 = 0.0_rp
       tmp3 = 0.0_rp
-      tmp1 = device_glsc3(r_d,coef%mult_d,u_d(u_prev),n)
-      tmp2 = device_glsc3(w_d,coef%mult_d,u_d(u_prev),n)
-      tmp3 = device_glsc3(r_d,coef%mult_d,r_d,n)
+      tmp1 = device_vlsc3(r_d, coef%mult_d, u_d(u_prev), n)
+      tmp2 = device_vlsc3(w_d, coef%mult_d, u_d(u_prev), n)
+      tmp3 = device_vlsc3(r_d, coef%mult_d, r_d, n)
       reduction(1) = tmp1
       reduction(2) = tmp2
       reduction(3) = tmp3
@@ -424,7 +425,7 @@ contains
                                  s_d, u_d(u_prev), u_d(p_cur),&
                                  w_d, z_d, ni_d,&
                                  mi_d, alpha(p_cur), beta(p_cur),&
-                                 coef%mult_d, reduction,n)
+                                 coef%mult_d, reduction, n)
          if (p_cur .eq. DEVICE_PIPECG_P_SPACE) then
             call device_memcpy(alpha, alpha_d, p_cur, &
                                HOST_TO_DEVICE, sync=.false.)

--- a/src/math/bcknd/device/cuda/math.cu
+++ b/src/math/bcknd/device/cuda/math.cu
@@ -372,6 +372,40 @@ extern "C" {
   real * bufred_d = NULL;
 
   /**
+   * Fortran wrapper vlsc3
+   * Compute multiplication sum \f$ dot = u \cdot v \cdot w \f$
+   */
+  real cuda_vlsc3(void *u, void *v, void *w, int *n) {
+        
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
+    const int nb = ((*n) + 1024 - 1)/ 1024;
+    const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;      
+    
+    if ( nb > red_s){
+      red_s = nb;
+      if (bufred != NULL) {
+        CUDA_CHECK(cudaFreeHost(bufred));
+        CUDA_CHECK(cudaFree(bufred_d));        
+      }
+      CUDA_CHECK(cudaMallocHost(&bufred,nb*sizeof(real)));
+      CUDA_CHECK(cudaMalloc(&bufred_d, nb*sizeof(real)));
+    }
+     
+    glsc3_kernel<real><<<nblcks, nthrds, 0, stream>>>
+      ((real *) u, (real *) v, (real *) w, bufred_d, *n);
+    CUDA_CHECK(cudaGetLastError());
+    reduce_kernel<real><<<1, 1024, 0, stream>>> (bufred_d, nb);
+    CUDA_CHECK(cudaGetLastError());
+
+    CUDA_CHECK(cudaMemcpyAsync(bufred, bufred_d, sizeof(real),
+                               cudaMemcpyDeviceToHost, stream));
+    cudaStreamSynchronize(stream);
+
+    return bufred[0];
+  }
+
+  /**
    * Fortran wrapper glsc3
    * Weighted inner product \f$ a^T b c \f$
    */

--- a/src/math/bcknd/device/cuda/math_kernel.h
+++ b/src/math/bcknd/device/cuda/math_kernel.h
@@ -424,7 +424,6 @@ __global__ void reduce_kernel(T * bufred, const int n) {
     bufred[blockIdx.x] = sum;
 }
 
-
 /**
  * Reduction kernel for glsc3
  */

--- a/src/math/bcknd/device/device_math.F90
+++ b/src/math/bcknd/device/device_math.F90
@@ -1229,7 +1229,7 @@ contains
     type(c_ptr) :: u_d, v_d, w_d
     integer :: n
     real(kind=rp) :: res
-
+    res = 0.0_rp
 #ifdef HAVE_HIP
     res = hip_vlsc3(u_d, v_d, w_d, n)
 #elif HAVE_CUDA
@@ -1240,7 +1240,6 @@ contains
 #else
     call neko_error('No device backend configured')
 #endif
-    
   end function device_vlsc3
 
   function device_glsc3(a_d, b_d, c_d, n) result(res)

--- a/src/math/bcknd/device/device_math.F90
+++ b/src/math/bcknd/device/device_math.F90
@@ -272,6 +272,17 @@ module device_math
   end interface
 
   interface
+     real(c_rp) function hip_vlsc3(u_d, v_d, w_d, n) &
+          bind(c, name='hip_vlsc3')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       implicit none
+       type(c_ptr), value :: u_d, v_d, w_d
+       integer(c_int) :: n
+     end function hip_vlsc3
+  end interface
+
+  interface
      real(c_rp) function hip_glsc3(a_d, b_d, c_d, n) &
           bind(c, name='hip_glsc3')
        use, intrinsic :: iso_c_binding
@@ -536,6 +547,17 @@ module device_math
        type(c_ptr), value :: dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d
        integer(c_int) :: n
      end subroutine cuda_vdot3
+  end interface
+
+  interface
+     real(c_rp) function cuda_vlsc3(u_d, v_d, w_d, n) &
+          bind(c, name='cuda_vlsc3')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       implicit none
+       type(c_ptr), value :: u_d, v_d, w_d
+       integer(c_int) :: n
+     end function cuda_vlsc3
   end interface
 
   interface
@@ -882,7 +904,7 @@ module device_math
        device_cadd, device_cfill, device_add2, device_add2s1, device_add2s2, &
        device_addsqr2s2, device_add3s2, device_invcol1, device_invcol2, &
        device_col2, device_col3, device_subcol3, device_sub2, device_sub3, &
-       device_addcol3, device_addcol4, device_vdot3, device_glsc3, &
+       device_addcol3, device_addcol4, device_vdot3, device_vlsc3, device_glsc3, &
        device_glsc3_many, device_add2s2_many, device_glsc2, device_glsum
 
 contains
@@ -1202,6 +1224,24 @@ contains
     call neko_error('No device backend configured')
 #endif
   end subroutine device_vdot3
+
+  function device_vlsc3(u_d, v_d, w_d, n) result(res)
+    type(c_ptr) :: u_d, v_d, w_d
+    integer :: n
+    real(kind=rp) :: res
+
+#ifdef HAVE_HIP
+    res = hip_vlsc3(u_d, v_d, w_d, n)
+#elif HAVE_CUDA
+    res = cuda_vlsc3(u_d, v_d, w_d, n)
+#elif HAVE_OPENCL
+    ! Same kernel as glsc3 (currently no device MPI for OpenCL)
+    res = opencl_glsc3(u_d, v_d, w_d, n)
+#else
+    call neko_error('No device backend configured')
+#endif
+    
+  end function device_vlsc3
 
   function device_glsc3(a_d, b_d, c_d, n) result(res)
     type(c_ptr) :: a_d, b_d, c_d

--- a/src/math/bcknd/device/hip/math.hip
+++ b/src/math/bcknd/device/hip/math.hip
@@ -359,6 +359,44 @@ extern "C" {
   real * bufred_d = NULL;
   
   /**
+   * Fortran wrapper vlsc3
+   * Compute multiplication sum \f$ dot = u \cdot v \cdot w \f$
+   */
+  real hip_vlsc3(void *u, void *v, void *w, int *n) {
+        
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
+    const int nb = ((*n) + 1024 - 1)/ 1024;
+    const hipStream_t stream = (hipStream_t) glb_cmd_queue;
+    
+    if ( nb > red_s){
+      red_s = nb;
+      if (bufred != NULL) {
+        HIP_CHECK(hipHostFree(bufred));
+        HIP_CHECK(hipFree(bufred_d));        
+      }
+      HIP_CHECK(hipHostMalloc(&bufred,nb*sizeof(real),hipHostMallocDefault));
+      HIP_CHECK(hipMalloc(&bufred_d, nb*sizeof(real)));
+    }
+     
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_kernel<real>),
+                       nblcks, nthrds, 0, stream,
+                       (real *) u, (real *) v,
+                       (real *) w, bufred_d, *n);
+    HIP_CHECK(hipGetLastError());
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real>),
+                       1, 1024, 0, stream, bufred_d, nb);
+    HIP_CHECK(hipGetLastError());
+
+    HIP_CHECK(hipMemcpyAsync(bufred, bufred_d, sizeof(real),
+                             hipMemcpyDeviceToHost, stream));
+    hipStreamSynchronize(stream);
+
+    return bufred[0];
+  }
+  
+
+  /**
    * Fortran wrapper glsc3
    * Weighted inner product \f$ a^T b c \f$
    */


### PR DESCRIPTION
Fixed too high starting residual due to double reduction (glsc3 + MPI_Ireduce). The patch introduces vlsc3 for devices.
