### PR TITLE
Generic fld_output, global output_control and simcomp file output

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -108,7 +108,7 @@ io/csv_file.o : io/csv_file.f90 comm/comm.o common/log.o config/num_types.o comm
 io/file.o : io/file.f90 io/csv_file.o io/stl_file.o io/vtk_file.o io/fld_file_data.o io/fld_file.o io/re2_file.o io/rea_file.o io/map_file.o io/chkp_file.o io/nmsh_file.o io/generic_file.o config/num_types.o common/utils.o 
 io/output.o : io/output.f90 io/file.o config/num_types.o 
 io/fluid_output.o : io/fluid_output.f90 io/output.o device/device.o config/neko_config.o field/field_list.o scalar/scalar_scheme.o fluid/fluid_scheme.o config/num_types.o 
-io/fld_output.o : io/fld_output.f90 io/output.o device/device.o config/neko_config.o field/field_list.o config/num_types.o 
+io/fld_file_output.o : io/fld_file_output.f90 io/output.o device/device.o config/neko_config.o field/field_list.o config/num_types.o 
 io/chkp_output.o : io/chkp_output.f90 config/num_types.o io/output.o common/checkpoint.o 
 io/mean_flow_output.o : io/mean_flow_output.f90 io/output.o device/device.o config/num_types.o fluid/mean_flow.o 
 io/fluid_stats_output.o : io/fluid_stats_output.f90 io/output.o device/device.o config/num_types.o config/neko_config.o fluid/fluid_stats.o 
@@ -231,7 +231,7 @@ scalar/bcknd/sx/scalar_residual_sx.o : scalar/bcknd/sx/scalar_residual_sx.f90 ma
 scalar/source_scalar.o : scalar/source_scalar.f90 math/bcknd/device/device_math.o device/device.o common/utils.o sem/dofmap.o config/num_types.o config/neko_config.o 
 simulation_components/simulation_component.o : simulation_components/simulation_component.f90 common/json_utils.o common/time_based_controller.o case.o config/num_types.o 
 simulation_components/simcomp_executor.o : simulation_components/simcomp_executor.f90 case.o common/json_utils.o simulation_components/simulation_component_factory.o simulation_components/simulation_component.o config/num_types.o 
-simulation_components/vorticity.o : simulation_components/vorticity.f90 io/fld_output.o case.o math/operators.o field/field.o field/field_registry.o simulation_components/simulation_component.o config/num_types.o 
+simulation_components/vorticity.o : simulation_components/vorticity.f90 common/json_utils.o io/fld_file_output.o case.o math/operators.o field/field.o field/field_registry.o simulation_components/simulation_component.o config/num_types.o 
 simulation_components/lambda2.o : simulation_components/lambda2.f90 device/device.o case.o math/operators.o field/field.o field/field_registry.o simulation_components/simulation_component.o config/num_types.o 
 simulation_components/simulation_component_factory.o : simulation_components/simulation_component_factory.f90 common/log.o common/json_utils.o case.o simulation_components/probes.o simulation_components/lambda2.o simulation_components/vorticity.o simulation_components/simulation_component.o 
 source_terms/source_term.o : source_terms/source_term.f90 field/field_list.o sem/coef.o config/num_types.o config/neko_config.o 

--- a/src/.depends
+++ b/src/.depends
@@ -105,9 +105,10 @@ io/stl_file.o : io/stl_file.f90 io/format/stl.o comm/comm.o comm/mpi_types.o mes
 io/nmsh_file.o : io/nmsh_file.f90 common/log.o comm/mpi_types.o common/datadist.o mesh/element.o io/format/nmsh.o adt/tuple.o mesh/point.o common/utils.o mesh/mesh.o comm/comm.o io/generic_file.o 
 io/chkp_file.o : io/chkp_file.f90 common/global_interpolation.o comm/comm.o comm/mpi_types.o sem/interpolation.o math/math.o mesh/mesh.o sem/space.o common/utils.o math/bcknd/device/device_math.o sem/dofmap.o field/field.o config/num_types.o common/checkpoint.o field/field_series.o io/generic_file.o 
 io/csv_file.o : io/csv_file.f90 comm/comm.o common/log.o config/num_types.o common/utils.o io/generic_file.o math/matrix.o math/vector.o 
-io/file.o : io/file.f90 io/csv_file.o io/stl_file.o io/vtk_file.o io/fld_file_data.o io/fld_file.o io/re2_file.o io/rea_file.o io/map_file.o io/chkp_file.o io/nmsh_file.o io/generic_file.o common/utils.o 
+io/file.o : io/file.f90 io/csv_file.o io/stl_file.o io/vtk_file.o io/fld_file_data.o io/fld_file.o io/re2_file.o io/rea_file.o io/map_file.o io/chkp_file.o io/nmsh_file.o io/generic_file.o config/num_types.o common/utils.o 
 io/output.o : io/output.f90 io/file.o config/num_types.o 
-io/fluid_output.o : io/fluid_output.f90 io/output.o device/device.o config/neko_config.o field/field_list.o scalar/scalar_scheme.o fluid/fluid_scheme.o 
+io/fluid_output.o : io/fluid_output.f90 io/output.o device/device.o config/neko_config.o field/field_list.o scalar/scalar_scheme.o fluid/fluid_scheme.o config/num_types.o 
+io/fld_output.o : io/fld_output.f90 io/output.o device/device.o config/neko_config.o field/field_list.o config/num_types.o 
 io/chkp_output.o : io/chkp_output.f90 config/num_types.o io/output.o common/checkpoint.o 
 io/mean_flow_output.o : io/mean_flow_output.f90 io/output.o device/device.o config/num_types.o fluid/mean_flow.o 
 io/fluid_stats_output.o : io/fluid_stats_output.f90 io/output.o device/device.o config/num_types.o config/neko_config.o fluid/fluid_stats.o 
@@ -230,7 +231,7 @@ scalar/bcknd/sx/scalar_residual_sx.o : scalar/bcknd/sx/scalar_residual_sx.f90 ma
 scalar/source_scalar.o : scalar/source_scalar.f90 math/bcknd/device/device_math.o device/device.o common/utils.o sem/dofmap.o config/num_types.o config/neko_config.o 
 simulation_components/simulation_component.o : simulation_components/simulation_component.f90 common/json_utils.o common/time_based_controller.o case.o config/num_types.o 
 simulation_components/simcomp_executor.o : simulation_components/simcomp_executor.f90 case.o common/json_utils.o simulation_components/simulation_component_factory.o simulation_components/simulation_component.o config/num_types.o 
-simulation_components/vorticity.o : simulation_components/vorticity.f90 case.o math/operators.o field/field.o field/field_registry.o simulation_components/simulation_component.o config/num_types.o 
+simulation_components/vorticity.o : simulation_components/vorticity.f90 io/fld_output.o case.o math/operators.o field/field.o field/field_registry.o simulation_components/simulation_component.o config/num_types.o 
 simulation_components/lambda2.o : simulation_components/lambda2.f90 device/device.o case.o math/operators.o field/field.o field/field_registry.o simulation_components/simulation_component.o config/num_types.o 
 simulation_components/simulation_component_factory.o : simulation_components/simulation_component_factory.f90 common/log.o common/json_utils.o case.o simulation_components/probes.o simulation_components/lambda2.o simulation_components/vorticity.o simulation_components/simulation_component.o 
 source_terms/source_term.o : source_terms/source_term.f90 field/field_list.o sem/coef.o config/num_types.o config/neko_config.o 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -111,7 +111,7 @@ neko_fortran_SOURCES = \
 	io/file.f90\
 	io/output.f90\
 	io/fluid_output.f90\
-	io/fld_output.f90\
+	io/fld_file_output.f90\
 	io/chkp_output.f90\
 	io/mean_flow_output.f90\
 	io/fluid_stats_output.f90\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -111,6 +111,7 @@ neko_fortran_SOURCES = \
 	io/file.f90\
 	io/output.f90\
 	io/fluid_output.f90\
+	io/fld_output.f90\
 	io/chkp_output.f90\
 	io/mean_flow_output.f90\
 	io/fluid_stats_output.f90\

--- a/src/case.f90
+++ b/src/case.f90
@@ -397,6 +397,8 @@ contains
        call C%s%add(C%f_out, real_val, 'nsamples')
     else if (trim(string_val) .eq. 'never') then
        ! Fix a dummy 0.0 output_value
+       call json_get_or_default(C%params, 'case.fluid.output_value', real_val, &
+                                0.0_rp)
        call C%s%add(C%f_out, 0.0_rp, string_val)
     else
        call json_get(C%params, 'case.fluid.output_value', real_val)

--- a/src/common/time_based_controller.f90
+++ b/src/common/time_based_controller.f90
@@ -57,6 +57,11 @@ module time_based_controller
      integer :: nexecutions = 0
      !> Whether to never output.
      logical :: never = .false.
+     !> Control mode defining the meaning of `control_value`.
+     !> Can be `simulationtime`, `tsteps`, `nsamples` or `never`.
+     character(len=:), allocatable :: control_mode
+     !> Defines the frequency of writes.
+     real(kind=rp) :: control_value
 
    contains
      !> Constructor.
@@ -90,6 +95,8 @@ contains
     real(kind=rp), intent(in) :: control_value
 
     this%end_time = end_time
+    this%control_mode = control_mode
+    this%control_value = control_value
 
     if (trim(control_mode) .eq. 'simulationtime') then
        this%time_interval = control_value

--- a/src/io/chkp_output.f90
+++ b/src/io/chkp_output.f90
@@ -66,7 +66,7 @@ contains
        fname = 'fluid.chkp'
     end if
 
-    call output_init(this, fname)
+    call this%init_base(fname)
     this%chkp => chkp
   end function chkp_output_init
 

--- a/src/io/file.f90
+++ b/src/io/file.f90
@@ -207,7 +207,7 @@ contains
   !! @param precision Precision as defined in `num_types`.
   subroutine file_set_precision(this, precision)
     class(file_t), intent(inout) :: this
-    integer, intent(inout) :: precision
+    integer, intent(in) :: precision
 
     character(len=80) :: suffix
 

--- a/src/io/file.f90
+++ b/src/io/file.f90
@@ -32,20 +32,26 @@
 !
 !> Module for file I/O operations.
 module file
-  use utils
-  use generic_file
-  use nmsh_file
-  use chkp_file
-  use map_file
-  use rea_file
-  use re2_file
-  use fld_file
-  use fld_file_data
-  use vtk_file
-  use stl_file
-  use csv_file
+  use utils, only : neko_error, neko_warning, filename_suffix
+  use num_types, only : rp
+  use generic_file, only : generic_file_t
+  use nmsh_file, only : nmsh_file_t
+  use chkp_file, only : chkp_file_t
+  use map_file, only : map_file_t
+  use rea_file, only : rea_file_t
+  use re2_file, only : re2_file_t
+  use fld_file, only : fld_file_t
+  use fld_file_data, only : fld_file_data_t
+  use vtk_file, only : vtk_file_t
+  use stl_file, only : stl_file_t
+  use csv_file, only : csv_file_t
   implicit none
 
+  !> A wrapper around a polymorphic `generic_file_t` that handles its init.
+  !! This is essentially a factory for `generic_file_t` descendants additionally
+  !! handling special CSV file parameters (header and precision).
+  !! @remark We could perhaps make a more typical design, with just a factory
+  !! subroutine, like for most other polymorphic types.
   type file_t
      class(generic_file_t), allocatable :: file_type
    contains

--- a/src/io/file.f90
+++ b/src/io/file.f90
@@ -50,8 +50,6 @@ module file
   !> A wrapper around a polymorphic `generic_file_t` that handles its init.
   !! This is essentially a factory for `generic_file_t` descendants additionally
   !! handling special CSV file parameters (header and precision).
-  !! @remark We could perhaps make a more typical design, with just a factory
-  !! subroutine, like for most other polymorphic types.
   type file_t
      class(generic_file_t), allocatable :: file_type
    contains

--- a/src/io/fld_file.f90
+++ b/src/io/fld_file.f90
@@ -381,7 +381,7 @@ contains
     end do
 
 
-    !> Include metadata with bounding boxes (Just copying from nek5000) 
+    !> Include metadata with bounding boxes (Just copying from nek5000)
     if (write_mesh) then
        !The offset is: mpioff + element_off*2(min max value)*4(single precision)*gdim(dimensions)
        byte_offset = int(mpi_offset,i8) + &
@@ -450,7 +450,7 @@ contains
                        int(2, i8) * &
                        int(MPI_REAL_SIZE, i8)
        end if
-       
+
        byte_offset = int(mpi_offset,i8) + &
                      int(offset_el, i8) * &
                      int(2, i8) * &
@@ -461,7 +461,7 @@ contains
                      int(2, i8) * &
                      int(MPI_REAL_SIZE, i8)
     end do
-    
+
 
     call MPI_File_sync(fh, ierr)
     call MPI_File_close(fh, ierr)
@@ -510,12 +510,12 @@ contains
 
      ! write out data
      nout = 2*gdim*nelv
-  
+
      call MPI_File_write_at_all(fh, byte_offset, buffer, nout, &
             MPI_REAL, status, ierr)
 
   end subroutine fld_file_write_metadata_vector
-  
+
   subroutine fld_file_write_metadata_scalar(this, fh, byte_offset, x, lxyz, nelv)
     class(fld_file_t), intent(inout) :: this
     type(MPI_File), intent(inout) :: fh
@@ -535,7 +535,7 @@ contains
 
      ! write out data
      nout = 2*nelv
-  
+
      call MPI_File_write_at_all(fh, byte_offset, buffer, nout, &
             MPI_REAL, status, ierr)
 
@@ -967,7 +967,7 @@ contains
 
   subroutine fld_file_set_precision(this, precision)
     class(fld_file_t) :: this
-    integer, intent(inout) :: precision
+    integer, intent(in) :: precision
 
     if (precision .eq. dp) then
        this%dp_precision = .true.

--- a/src/io/fld_file_output.f90
+++ b/src/io/fld_file_output.f90
@@ -30,8 +30,8 @@
 ! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 ! POSSIBILITY OF SUCH DAMAGE.
 !
-!> Implements `fld_output_t`.
-module fld_output
+!> Implements `fld_file_output_t`.
+module fld_file_output
   use num_types, only : rp
   use field_list, only : field_list_t
   use neko_config, only : NEKO_BCKND_DEVICE
@@ -41,15 +41,15 @@ module fld_output
   private
 
   !> A simple output saving a list of fields to a .fld file.
-  type, public, extends(output_t) :: fld_output_t
+  type, public, extends(output_t) :: fld_file_output_t
      ! The list of fields to save.
      type(field_list_t) :: fields
    contains
      ! Constructor.
-     procedure, pass(this) :: init => fld_output_init
+     procedure, pass(this) :: init => fld_file_output_init
      ! Writes the data.
-     procedure, pass(this) :: sample => fld_output_sample
-  end type fld_output_t
+     procedure, pass(this) :: sample => fld_file_output_sample
+  end type fld_file_output_t
 
 contains
 
@@ -58,8 +58,8 @@ contains
   !! @param name The base name of the files.
   !! @param name The number of field pointers to preallocate in the field list.
   !! @param path Optional path to the write folder.
-  subroutine fld_output_init(this, precision, name, nfields, path)
-    class(fld_output_t), intent (inout) :: this
+  subroutine fld_file_output_init(this, precision, name, nfields, path)
+    class(fld_file_output_t), intent (inout) :: this
     integer, intent(in) :: precision
     character(len=*), intent(in) :: name
     character(len=*), intent(in), optional :: path
@@ -80,12 +80,12 @@ contains
 
     allocate(this%fields%fields(3))
 
-   end subroutine fld_output_init
+   end subroutine fld_file_output_init
 
   !> Writes the data.
   !! @param t The time value.
-  subroutine fld_output_sample(this, t)
-    class(fld_output_t), intent(inout) :: this
+  subroutine fld_file_output_sample(this, t)
+    class(fld_file_output_t), intent(inout) :: this
     real(kind=rp), intent(in) :: t
     integer :: i
 
@@ -102,6 +102,6 @@ contains
 
     call this%file_%write(this%fields, t)
 
-  end subroutine fld_output_sample
+  end subroutine fld_file_output_sample
 
-end module fld_output
+end module fld_file_output

--- a/src/io/fld_output.f90
+++ b/src/io/fld_output.f90
@@ -1,0 +1,107 @@
+! Copyright (c) 2020-2023, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Implements `fld_output_t`.
+module fld_output
+  use num_types, only : rp
+  use field_list, only : field_list_t
+  use neko_config, only : NEKO_BCKND_DEVICE
+  use device, only : device_memcpy, DEVICE_TO_HOST
+  use output, only : output_t
+  implicit none
+  private
+
+  !> A simple output saving a list of fields to a .fld file.
+  type, public, extends(output_t) :: fld_output_t
+     ! The list of fields to save.
+     type(field_list_t) :: fields
+   contains
+     ! Constructor.
+     procedure, pass(this) :: init => fld_output_init
+     ! Writes the data.
+     procedure, pass(this) :: sample => fld_output_sample
+  end type fld_output_t
+
+contains
+
+  !> Constructor.
+  !! @param precision the precison of the reals in the file.
+  !! @param name The base name of the files.
+  !! @param name The number of field pointers to preallocate in the field list.
+  !! @param path Optional path to the write folder.
+  subroutine fld_output_init(this, precision, name, nfields, path)
+    class(fld_output_t), intent (inout) :: this
+    integer, intent(in) :: precision
+    character(len=*), intent(in) :: name
+    character(len=*), intent(in), optional :: path
+    integer, intent(in) :: nfields
+    character(len=1024) :: fname
+
+    if (present(path)) then
+       fname = trim(path) // trim(name) // '.fld'
+    else
+       fname = trim(name) // '.fld'
+    end if
+
+    call this%init_base(fname, precision)
+
+    if (allocated(this%fields%fields)) then
+       deallocate(this%fields%fields)
+    end if
+
+    allocate(this%fields%fields(3))
+
+   end subroutine fld_output_init
+
+  !> Writes the data.
+  !! @param t The time value.
+  subroutine fld_output_sample(this, t)
+    class(fld_output_t), intent(inout) :: this
+    real(kind=rp), intent(in) :: t
+    integer :: i
+
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       associate(fields => this%fields%fields)
+         do i = 1, size(fields)
+            call device_memcpy(fields(i)%f%x, fields(i)%f%x_d, &
+                 fields(i)%f%dof%size(), DEVICE_TO_HOST, &
+                 sync=(i .eq. size(fields))) ! Sync on the last field
+         end do
+       end associate
+
+    end if
+
+    call this%file_%write(this%fields, t)
+
+  end subroutine fld_output_sample
+
+end module fld_output

--- a/src/io/fluid_output.f90
+++ b/src/io/fluid_output.f90
@@ -32,12 +32,13 @@
 !
 !> Defines an output for a fluid
 module fluid_output
+  use num_types, only : rp
   use fluid_scheme, only : fluid_scheme_t
   use scalar_scheme, only : scalar_scheme_t
   use field_list, only : field_list_t
   use neko_config
   use device
-  use output
+  use output, only : output_t
   implicit none
 
   !> Fluid output
@@ -72,7 +73,7 @@ contains
        fname = 'field.fld'
     end if
 
-    call output_init(this, fname, precision)
+    call this%init_base(fname, precision)
 
     if (allocated(this%fluid%fields)) then
        deallocate(this%fluid%fields)

--- a/src/io/fluid_stats_output.f90
+++ b/src/io/fluid_stats_output.f90
@@ -71,7 +71,7 @@ contains
        fname = 'stats.fld'
     end if
 
-    call output_init(this, fname)
+    call this%init_base(fname)
     this%stats => stats
     this%T_begin = T_begin
   end function fluid_stats_output_init

--- a/src/io/mean_flow_output.f90
+++ b/src/io/mean_flow_output.f90
@@ -70,7 +70,7 @@ contains
        fname = 'mean_field.fld'
     end if
 
-    call output_init(this, fname)
+    call this%init_base(fname)
     this%mf => mf
     this%T_begin = T_begin
   end function mean_flow_output_init

--- a/src/io/mean_sqr_flow_output.f90
+++ b/src/io/mean_sqr_flow_output.f90
@@ -69,7 +69,7 @@ contains
        fname = 'mean_sqr_field.fld'
     end if
 
-    call output_init(this, fname)
+    call this%init_base(fname)
     this%msqrf => msqrf
     this%T_begin = T_begin
   end function mean_sqr_flow_output_init

--- a/src/io/output.f90
+++ b/src/io/output.f90
@@ -35,12 +35,13 @@ module output
   use num_types, only : rp
   use file, only : file_t
   implicit none
+  private
 
   !> Abstract type defining an output type
   type, public, abstract :: output_t
      type(file_t) :: file_
    contains
-     procedure, pass(this) :: init => output_init
+     procedure, pass(this) :: init_base => output_init
      procedure, pass(this) :: set_counter => output_set_counter
      procedure, pass(this) :: set_start_counter => output_set_start_counter
      procedure(output_sample), pass(this), deferred :: sample
@@ -64,7 +65,7 @@ contains
   subroutine output_init(this, fname, precision)
     class(output_t), intent(inout) :: this
     character(len=*), intent(inout) :: fname
-    integer, intent(inout), optional :: precision
+    integer, intent(in), optional :: precision
 
     if (present(precision)) then
        this%file_ = file_t(fname, precision=precision)

--- a/src/simulation_components/simulation_component.f90
+++ b/src/simulation_components/simulation_component.f90
@@ -132,6 +132,14 @@ contains
     call json_get_or_default(json, "output_value", output_value, &
                              compute_value)
 
+
+    if (output_control == "global") then
+       call json_get(this%case%params, 'case.fluid.output_control', &
+                     output_control)
+       call json_get(this%case%params, 'case.fluid.output_value', &
+                     output_value)
+    end if
+
     call json_get(json, "order", order)
     this%order = order
 

--- a/src/simulation_components/vorticity.f90
+++ b/src/simulation_components/vorticity.f90
@@ -41,7 +41,7 @@ module vorticity
   use field, only : field_t
   use operators, only : curl
   use case, only : case_t
-  use fld_output, only : fld_output_t
+  use fld_file_output, only : fld_file_output_t
   use json_utils, only : json_get, json_get_or_default
   implicit none
   private
@@ -69,7 +69,7 @@ module vorticity
      type(field_t) :: temp2
 
      !> Output writer.
-     type(fld_output_t), private :: output
+     type(fld_file_output_t), private :: output
 
    contains
      !> Constructor from json, wrapping the actual constructor.
@@ -117,7 +117,7 @@ contains
     class(vorticity_t), intent(inout) :: this
     character(len=*), intent(in), optional :: filename
     integer, intent(in), optional :: precision
-    type(fld_output_t) :: output
+    type(fld_file_output_t) :: output
 
     this%u => neko_field_registry%get_field_by_name("u")
     this%v => neko_field_registry%get_field_by_name("v")


### PR DESCRIPTION
This PR introduces:

- `output_control: "global"` for simcomps, which syncs `output_control` and `output_value` with the fluid. Useful to control output of multiple thing by a single set of parameters.
- `fld_output_t`, which is much luck `fluid_output` but does not add the fluid fields to the output. Can be used to output any number of arrays to a new fld.
- Working on outputing simcomp fields to files. What I have now is that if you don't specify `output_filename`, the field (e.g. vorticity) gets added to the `fluid_output` in the case. Otherwise, a new fld file is created. Opinions welcome.
- A small refactor to the `output_t` constructor, so that one can use `init` in descendents as is now standard.

When working on this I realized that e.g. the probes simcom just manages its own output, without adding an `output` to the `sampler`. I'm not sure what is best and how things will go forwards, so here I focused on making it easier to use the `sampler` by adding `fld_output_t`.