### PR TITLE
Fix field allocation in fld_field_output

### DIFF
--- a/src/io/fld_file_output.f90
+++ b/src/io/fld_file_output.f90
@@ -78,7 +78,7 @@ contains
        deallocate(this%fields%fields)
     end if
 
-    allocate(this%fields%fields(3))
+    allocate(this%fields%fields(nfields))
 
    end subroutine fld_file_output_init
 


### PR DESCRIPTION
`fld_file_output` always allocates 3 fields in the field list instead of using the `nfields` argument. This fixes this bug. Please merge as soon as possible :-).