### PR TITLE
Add helper to extract json array items as json objects

### DIFF
--- a/src/common/json_utils.f90
+++ b/src/common/json_utils.f90
@@ -38,7 +38,7 @@ module json_utils
   implicit none
   private
 
-  public :: json_get, json_get_or_default
+  public :: json_get, json_get_or_default, json_extract_subdict
 
   !> Retrieves a parameter by name or throws an error
   interface json_get
@@ -295,5 +295,25 @@ contains
        call json%add(name, value)
     end if
   end subroutine json_get_or_default_string
+
+  !> Extract `i`th json object from a json array.
+  !! @param core JSON core object.
+  !! @param parent The parent JSON object with the array.
+  !! @param i The index of the object to extract.
+  !! @param subdict JSON object object to be filled with the subdict.
+  subroutine json_extract_subdict(core, parent, i, subdict)
+    type(json_core), intent(inout) :: core
+    type(json_value), pointer, intent(in) :: parent
+    integer, intent(in) :: i
+    type(json_file), intent(inout) :: subdict
+    type(json_value), pointer :: ptr
+    logical :: found
+    character(len=:), allocatable :: buffer
+
+    call core%get_child(parent, i, ptr, found)
+    call core%print_to_string(ptr, buffer)
+    call subdict%load_from_string(buffer)
+
+  end subroutine json_extract_subdict
 
 end module json_utils

--- a/src/common/json_utils.f90
+++ b/src/common/json_utils.f90
@@ -296,21 +296,21 @@ contains
     end if
   end subroutine json_get_or_default_string
 
-  !> Extract `i`th json object from a json array.
+  !> Extract `i`th item from a JSON array as a seprate JSON object.
   !! @param core JSON core object.
   !! @param parent The parent JSON object with the array.
   !! @param i The index of the item to extract.
   !! @param item JSON object object to be filled with the subdict.
-  subroutine json_extract_item(core, parent, i, item)
+  subroutine json_extract_item(core, array, i, item)
     type(json_core), intent(inout) :: core
-    type(json_value), pointer, intent(in) :: parent
+    type(json_value), pointer, intent(in) :: array
     integer, intent(in) :: i
     type(json_file), intent(inout) :: item
     type(json_value), pointer :: ptr
     logical :: found
     character(len=:), allocatable :: buffer
 
-    call core%get_child(parent, i, ptr, found)
+    call core%get_child(array, i, ptr, found)
     call core%print_to_string(ptr, buffer)
     call item%load_from_string(buffer)
 

--- a/src/common/json_utils.f90
+++ b/src/common/json_utils.f90
@@ -296,9 +296,9 @@ contains
     end if
   end subroutine json_get_or_default_string
 
-  !> Extract `i`th item from a JSON array as a seprate JSON object.
+  !> Extract `i`th item from a JSON array as a separate JSON object.
   !! @param core JSON core object.
-  !! @param parent The parent JSON object with the array.
+  !! @param array The JSON object with the array.
   !! @param i The index of the item to extract.
   !! @param item JSON object object to be filled with the subdict.
   subroutine json_extract_item(core, array, i, item)

--- a/src/common/json_utils.f90
+++ b/src/common/json_utils.f90
@@ -300,19 +300,19 @@ contains
   !! @param core JSON core object.
   !! @param parent The parent JSON object with the array.
   !! @param i The index of the item to extract.
-  !! @param subdict JSON object object to be filled with the subdict.
-  subroutine json_extract_item(core, parent, i, subdict)
+  !! @param item JSON object object to be filled with the subdict.
+  subroutine json_extract_item(core, parent, i, item)
     type(json_core), intent(inout) :: core
     type(json_value), pointer, intent(in) :: parent
     integer, intent(in) :: i
-    type(json_file), intent(inout) :: subdict
+    type(json_file), intent(inout) :: item
     type(json_value), pointer :: ptr
     logical :: found
     character(len=:), allocatable :: buffer
 
     call core%get_child(parent, i, ptr, found)
     call core%print_to_string(ptr, buffer)
-    call subdict%load_from_string(buffer)
+    call item%load_from_string(buffer)
 
   end subroutine json_extract_item
 

--- a/src/common/json_utils.f90
+++ b/src/common/json_utils.f90
@@ -38,7 +38,7 @@ module json_utils
   implicit none
   private
 
-  public :: json_get, json_get_or_default, json_extract_subdict
+  public :: json_get, json_get_or_default, json_extract_item
 
   !> Retrieves a parameter by name or throws an error
   interface json_get
@@ -299,9 +299,9 @@ contains
   !> Extract `i`th json object from a json array.
   !! @param core JSON core object.
   !! @param parent The parent JSON object with the array.
-  !! @param i The index of the object to extract.
+  !! @param i The index of the item to extract.
   !! @param subdict JSON object object to be filled with the subdict.
-  subroutine json_extract_subdict(core, parent, i, subdict)
+  subroutine json_extract_item(core, parent, i, subdict)
     type(json_core), intent(inout) :: core
     type(json_value), pointer, intent(in) :: parent
     integer, intent(in) :: i
@@ -314,6 +314,6 @@ contains
     call core%print_to_string(ptr, buffer)
     call subdict%load_from_string(buffer)
 
-  end subroutine json_extract_subdict
+  end subroutine json_extract_item
 
 end module json_utils


### PR DESCRIPTION
Useful for parsing stuff like arrays of source terms, simcomps, etc in the JSON. Not used atm, but soon :-).