### PR TITLE
Docstrings, and "only" for operators

### DIFF
--- a/src/math/operators.f90
+++ b/src/math/operators.f90
@@ -180,7 +180,7 @@ contains
   !! @param vy The y component of the advecting velocity.
   !! @param vz The z component of the advecting velocity.
   !! @param Xh The function space for the fields involved.
-  !! @param coef The SEM coeffients.
+  !! @param coef The SEM coefficients.
   !! @param es Starting element index, defaults to 1.
   !! @param ee Last element index, defaults to mesh size.
   subroutine conv1(du, u, vx, vy, vz, Xh, coef, es, ee)

--- a/src/math/operators.f90
+++ b/src/math/operators.f90
@@ -132,7 +132,7 @@ contains
   !> Othogonalize with regard to vector (1,1,1,1,1,1...,1)^T.
   !! @param x The vector to orthogonolize.
   !! @param n The size of `x`.
-  !! @param glb_n ?
+  !! @param glb_n The global number of elements of `x` across all MPI ranks. Be careful with overflow!
   subroutine ortho(x, n, glb_n)
     integer, intent(in) :: n
     integer, intent(in) :: glb_n

--- a/src/math/operators.f90
+++ b/src/math/operators.f90
@@ -180,7 +180,7 @@ contains
   !! @param vy The y component of the advecting velocity.
   !! @param vz The z component of the advecting velocity.
   !! @param Xh The function space for the fields involved.
-  !! @param coef The coeffients of the (Xh, mesh) pair.
+  !! @param coef The SEM coeffients.
   !! @param es Starting element index, defaults to 1.
   !! @param ee Last element index, defaults to mesh size.
   subroutine conv1(du, u, vx, vy, vz, Xh, coef, es, ee)


### PR DESCRIPTION
* Adds `only` to imports in operators.f90
* Adds docstrings to the operators. I am unsure about one parameter in the `ortho`, please help :-).
* Renamed `c_Xh` to `coef` in `curl`, because all the other operators use `coef`.
 