### PR TITLE
Fix Vreman model nut computation and improve destructors

### DIFF
--- a/src/les/bcknd/cpu/vreman_cpu.f90
+++ b/src/les/bcknd/cpu/vreman_cpu.f90
@@ -128,7 +128,7 @@ contains
           ! alpha_ij alpha_ij
           aijaij = beta11 + beta22 + beta33
 
-          nut%x(i,:,:,e) = c*delta%x(i,1,1,1) * sqrt(b_beta/(aijaij + NEKO_EPS))
+          nut%x(i,1,1,e) = c*delta%x(i,1,1,e) * sqrt(b_beta/(aijaij + NEKO_EPS))
        end do
     end do
 

--- a/src/les/vreman.f90
+++ b/src/les/vreman.f90
@@ -94,6 +94,8 @@ contains
     real(kind=rp) :: c
     character(len=*), intent(in) :: nut_name
 
+    call this%free()
+
     call this%init_base(dofmap, coef, nut_name)
     this%c = c
 

--- a/src/simulation_components/les_simcomp.f90
+++ b/src/simulation_components/les_simcomp.f90
@@ -83,6 +83,11 @@ contains
   subroutine les_simcomp_free(this)
     class(les_simcomp_t), intent(inout) :: this
     call this%free_base()
+
+    if (allocated(this%les_model)) then
+      call this%les_model%free()
+      deallocate(this%les_model)
+    end if
   end subroutine les_simcomp_free
 
   !> Compute the les_simcomp field.

--- a/src/simulation_components/les_simcomp.f90
+++ b/src/simulation_components/les_simcomp.f90
@@ -70,6 +70,8 @@ contains
     class(case_t), intent(inout), target :: case
     character(len=:), allocatable :: name
 
+    call this%free()
+
     call json_get(json, "model", name)
 
     call this%init_base(json, case)


### PR DESCRIPTION
* Fixes a bug in how nut is computed, indexing was incorrect.
* deallocates les_model in the les_simcomp in the destructor.
* Calls "free" in the beginning of constructors in vreman and les simcomp as per convention.