### PR TITLE
Feature/variable dt

### DIFF
--- a/doc/pages/case-file.md
+++ b/doc/pages/case-file.md
@@ -71,8 +71,8 @@ but also defines several parameters that pertain to the simulation as a whole.
 | `checkpoint_control` | Defines the interpretation of `checkpoint_value` to define the frequency of writing checkpoint files. | `nsamples`, `simulationtime`, `tsteps`, `never` | -             |
 | `checkpoint_value`   | The frequency of sampling in terms of `checkpoint_control`.                                           | Positive real or integer                        | -             |
 | `restart_file`       | checkpoint to use for a restart from previous data                                                    | Strings ending with `.chkp`                     | -             |
-| `constant_cfl`       | Desired CFL number                                                                                    | Positive real | - |
-| `cfl_max_update_frequency` | Minimum interval between two time-step-updating step in terms of time steps                     | Integer | `1` |
+| `constant_cfl`       | The desired CFL number                                                                                    | Positive real | - |
+| `cfl_max_update_frequency` | The minimum interval between two time-step-updating steps in terms of time steps                     | Integer | `1` |
 | `time_step`          | Time-step size if `constant_cfl` is not specified; maximum time-step size if `constant_cfl` is specified.                                             | Positive reals                                  | -             |
 | `end_time`           | Final time at which the simulation is stopped.                                                        | Positive reals                                  | -             |
 | `job_timelimit`      | The maximum wall clock duration of the simulation.                                                    | String formatted as HH:MM:SS                    | No limit      |

--- a/doc/pages/case-file.md
+++ b/doc/pages/case-file.md
@@ -71,7 +71,11 @@ but also defines several parameters that pertain to the simulation as a whole.
 | `checkpoint_control` | Defines the interpretation of `checkpoint_value` to define the frequency of writing checkpoint files. | `nsamples`, `simulationtime`, `tsteps`, `never` | -             |
 | `checkpoint_value`   | The frequency of sampling in terms of `checkpoint_control`.                                           | Positive real or integer                        | -             |
 | `restart_file`       | checkpoint to use for a restart from previous data                                                    | Strings ending with `.chkp`                     | -             |
-| `time_step`          | Time-step size.                                                                                       | Positive reals                                  | -             |
+| `constant_cfl`       | Desired CFL number                                                                                    | Positive real
+                          | -             |
+| `cfl_max_update_frequency` | Minimum interval between two time-step-updating step in terms of time steps                     | Integer
+                          | -             | `1`
+| `time_step`          | Time-step size if `constant_cfl` is not specified; maximum time-step size if `constant_cfl` is specified.                                             | Positive reals                                  | -             |
 | `end_time`           | Final time at which the simulation is stopped.                                                        | Positive reals                                  | -             |
 | `job_timelimit`      | The maximum wall clock duration of the simulation.                                                    | String formatted as HH:MM:SS                    | No limit      |
 

--- a/doc/pages/case-file.md
+++ b/doc/pages/case-file.md
@@ -71,10 +71,8 @@ but also defines several parameters that pertain to the simulation as a whole.
 | `checkpoint_control` | Defines the interpretation of `checkpoint_value` to define the frequency of writing checkpoint files. | `nsamples`, `simulationtime`, `tsteps`, `never` | -             |
 | `checkpoint_value`   | The frequency of sampling in terms of `checkpoint_control`.                                           | Positive real or integer                        | -             |
 | `restart_file`       | checkpoint to use for a restart from previous data                                                    | Strings ending with `.chkp`                     | -             |
-| `constant_cfl`       | Desired CFL number                                                                                    | Positive real
-                          | -             |
-| `cfl_max_update_frequency` | Minimum interval between two time-step-updating step in terms of time steps                     | Integer
-                          | `1`           |
+| `constant_cfl`       | Desired CFL number                                                                                    | Positive real | - |
+| `cfl_max_update_frequency` | Minimum interval between two time-step-updating step in terms of time steps                     | Integer | `1` |
 | `time_step`          | Time-step size if `constant_cfl` is not specified; maximum time-step size if `constant_cfl` is specified.                                             | Positive reals                                  | -             |
 | `end_time`           | Final time at which the simulation is stopped.                                                        | Positive reals                                  | -             |
 | `job_timelimit`      | The maximum wall clock duration of the simulation.                                                    | String formatted as HH:MM:SS                    | No limit      |

--- a/doc/pages/case-file.md
+++ b/doc/pages/case-file.md
@@ -74,7 +74,7 @@ but also defines several parameters that pertain to the simulation as a whole.
 | `constant_cfl`       | Desired CFL number                                                                                    | Positive real
                           | -             |
 | `cfl_max_update_frequency` | Minimum interval between two time-step-updating step in terms of time steps                     | Integer
-                          | -             | `1`
+                          | `1`           |
 | `time_step`          | Time-step size if `constant_cfl` is not specified; maximum time-step size if `constant_cfl` is specified.                                             | Positive reals                                  | -             |
 | `end_time`           | Final time at which the simulation is stopped.                                                        | Positive reals                                  | -             |
 | `job_timelimit`      | The maximum wall clock duration of the simulation.                                                    | String formatted as HH:MM:SS                    | No limit      |

--- a/src/.depends
+++ b/src/.depends
@@ -156,6 +156,7 @@ time_schemes/ext_time_scheme.o : time_schemes/ext_time_scheme.f90 common/utils.o
 time_schemes/ab_time_scheme.o : time_schemes/ab_time_scheme.f90 common/utils.o math/math.o time_schemes/time_scheme.o config/num_types.o config/neko_config.o 
 time_schemes/time_scheme_controller.o : time_schemes/time_scheme_controller.f90 device/device.o time_schemes/ab_time_scheme.o time_schemes/ext_time_scheme.o time_schemes/bdf_time_scheme.o config/num_types.o config/neko_config.o 
 common/time_based_controller.o : common/time_based_controller.f90 common/utils.o config/num_types.o 
+common/time_step_controller.o : common/time_step_controller.f90 case.o
 common/stats_quant.o : common/stats_quant.f90 config/num_types.o 
 common/statistics.o : common/statistics.f90 comm/comm.o common/log.o common/stats_quant.o config/num_types.o 
 common/rhs_maker.o : common/rhs_maker.f90 field/field.o field/field_series.o config/num_types.o 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -159,7 +159,6 @@ neko_fortran_SOURCES = \
 	time_schemes/ab_time_scheme.f90\
 	time_schemes/time_scheme_controller.f90\
 	common/time_based_controller.f90\
-	common/time_step_controller.f90\
 	common/stats_quant.f90\
 	common/statistics.f90\
 	common/rhs_maker.f90\
@@ -190,6 +189,7 @@ neko_fortran_SOURCES = \
 	fluid/bcknd/device/pnpn_res_device.F90\
 	fluid/fluid_user_source_term.f90\
 	fluid/fluid_source_term.f90\
+	common/time_step_controller.f90\
 	simulation.f90\
 	math/ax_helm_fctry.f90\
 	math/bcknd/cpu/ax_helm.f90\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -159,6 +159,7 @@ neko_fortran_SOURCES = \
 	time_schemes/ab_time_scheme.f90\
 	time_schemes/time_scheme_controller.f90\
 	common/time_based_controller.f90\
+	common/time_step_controller.f90\
 	common/stats_quant.f90\
 	common/statistics.f90\
 	common/rhs_maker.f90\

--- a/src/common/time_step_controller.f90
+++ b/src/common/time_step_controller.f90
@@ -32,7 +32,6 @@
 !
 !> Implements type time_step_controller.
 module time_step_controller
-  use num_types, only : rp
   use case
   use json_utils, only : json_get_or_default
   implicit none

--- a/src/common/time_step_controller.f90
+++ b/src/common/time_step_controller.f90
@@ -1,0 +1,144 @@
+! Copyright (c) 2022, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Implements type time_step_controller.
+module time_step_controller
+  use num_types, only : rp
+  use case
+  use json_utils, only : json_get_or_default
+  implicit none
+  private
+
+  !> Provides a tool to set time step dt
+  type, public :: time_step_controller_t
+     !> Components recording time stepping info
+     logical :: if_variable_dt = .false.
+     logical :: if_restart = .false.
+     real(kind=rp) :: set_cfl = 0.0_rp
+     real(kind=rp) :: max_dt = 0.0_rp
+     integer :: max_update_frequency = 1
+   contains
+     !> Initialize object.
+     procedure, pass(this) :: init => time_step_controller_init
+     !> Set time stepping
+     procedure, pass(this) :: set_dt => time_step_controller_set_dt
+
+  end type time_step_controller_t
+
+contains
+
+  !> Constructor
+  !! @param order order of the interpolation
+  subroutine time_step_controller_init(this, C)
+    class(time_step_controller_t), intent(inout) :: this
+    type(case_t), intent(inout) :: C
+    logical :: found
+    character(len=:), allocatable :: restart_file
+
+    call C%params%get('case.timestep', this%max_dt, found)
+    call C%params%get('case.constant_cfl', this%set_cfl, this%if_variable_dt)
+    call C%params%get('case.restart_file', restart_file, this%if_restart)
+    call json_get_or_default(C%params, 'case.cfl_max_update_frequency',&
+                                    this%max_update_frequency, 1)
+
+  end subroutine time_step_controller_init
+
+  !> Set new dt based on cfl if requested
+  !! @param C case type.
+  !! @param cfl courant number of current iteration.
+  !! @param cfl_avrg average Courant number.
+  !! @param dt_last_change time step since last dt change.
+  !! @param tstep the current time step.
+  !! @Algorithm: 
+  !! 1. If the simulation is not a restarted one,
+  !! set the first time step such that cfl is the set one;
+  !! 2. If the simulation is a restarted one,
+  !! set the first time step from the restart file.
+  !! 3. During time-stepping, adjust dt when cfl_avrg is offset by 20%.
+  subroutine time_step_controller_set_dt(this, C, cfl, cfl_avrg, dt_last_change, tstep)
+    implicit none
+    class(time_step_controller_t), intent(inout) :: this
+    type(case_t), intent(inout) :: C
+    real(kind=rp), intent(in) :: cfl
+    real(kind=rp), intent(inout) :: cfl_avrg
+    integer, intent(inout) :: dt_last_change
+    real(kind=rp) :: dt_old, scaling_factor
+    character(len=LOG_SIZE) :: log_buf    
+    real(kind=rp) :: alpha = 0.5_rp !coefficient of running average
+    integer, intent(in):: tstep
+
+    if (this%if_variable_dt .eqv. .true.) then
+       if ((tstep .eq. 1) .and. .not. this%if_restart) then
+          ! set the first dt for desired cfl
+          C%dt = min(this%set_cfl/cfl*C%dt, this%max_dt)
+       else if ((tstep .eq. 1) .and. this%if_restart) then
+          C%dt = C%dtlag(1)
+       else
+          ! Calculate the average of cfl over the desired interval
+          cfl_avrg = alpha * cfl + (1-alpha) * cfl_avrg
+
+          if (abs(cfl_avrg - this%set_cfl) .ge. 0.2*this%set_cfl .and. &
+             dt_last_change .ge. this%max_update_frequency) then
+
+             if (this%set_cfl/cfl .ge. 1) then 
+                scaling_factor = min(1.2_rp, this%set_cfl/cfl) 
+             else
+                scaling_factor = max(0.8_rp, this%set_cfl/cfl) 
+             end if
+
+             dt_old = C%dt
+             C%dt = scaling_factor * dt_old
+             C%dt = min(C%dt, this%max_dt)
+
+             write(log_buf, '(A,E15.7,1x,A,E15.7)') 'Avrg CFL:', cfl_avrg, &
+                         'set_cfl:', this%set_cfl
+             call neko_log%message(log_buf)
+
+             write(log_buf, '(A,E15.7,1x,A,E15.7)') 'old dt:', dt_old, &
+                         'new dt:', C%dt
+             call neko_log%message(log_buf)
+
+             dt_last_change = 0
+
+          else
+             dt_last_change = dt_last_change + 1
+          end if
+       end if
+
+    end if
+
+  end subroutine time_step_controller_set_dt
+
+
+
+
+end module time_step_controller

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -58,8 +58,6 @@ module fluid_pnpn
   type, public, extends(fluid_scheme_t) :: fluid_pnpn_t
      type(field_t) :: p_res, u_res, v_res, w_res
 
-     type(field_series_t) :: ulag, vlag, wlag
-
      type(field_t) :: dp, du, dv, dw
 
      class(ax_t), allocatable :: Ax
@@ -174,10 +172,6 @@ contains
       call this%dv%init(dm_Xh, 'dv')
       call this%dw%init(dm_Xh, 'dw')
       call this%dp%init(dm_Xh, 'dp')
-
-      call this%ulag%init(this%u, 2)
-      call this%vlag%init(this%v, 2)
-      call this%wlag%init(this%w, 2)
 
     end associate
 
@@ -459,10 +453,6 @@ contains
     end if
 
     call this%vol_flow%free()
-
-    call this%ulag%free()
-    call this%vlag%free()
-    call this%wlag%free()
 
   end subroutine fluid_pnpn_free
 

--- a/src/fluid/fluid_scheme.f90
+++ b/src/fluid/fluid_scheme.f90
@@ -71,6 +71,7 @@ module fluid_scheme
   use user_intf, only : user_t
   use utils, only : neko_warning, neko_error
   use material_properties, only : material_properties_t
+  use field_series
   implicit none
 
   !> Base type of all fluid formulations
@@ -79,6 +80,7 @@ module fluid_scheme
      type(field_t), pointer :: v => null() !< y-component of Velocity
      type(field_t), pointer :: w => null() !< z-component of Velocity
      type(field_t), pointer :: p => null() !< Pressure
+     type(field_series_t) :: ulag, vlag, wlag !< fluid field (lag)
      type(space_t) :: Xh        !< Function space \f$ X_h \f$
      type(dofmap_t) :: dm_Xh    !< Dofmap associated with \f$ X_h \f$
      type(gs_t) :: gs_Xh        !< Gather-scatter associated with \f$ X_h \f$
@@ -526,6 +528,12 @@ contains
     this%w => neko_field_registry%get_field('w')
     this%p => neko_field_registry%get_field('p')
 
+    !! lag fields
+    call this%ulag%init(this%u, 2)
+    call this%vlag%init(this%v, 2)
+    call this%wlag%init(this%w, 2)
+
+
     !
     ! Setup pressure boundary conditions
     !
@@ -656,6 +664,11 @@ contains
     nullify(this%v)
     nullify(this%w)
     nullify(this%p)
+
+    call this%ulag%free()
+    call this%vlag%free()
+    call this%wlag%free()
+
 
     if (associated(this%f_x)) then
        call this%f_x%free()

--- a/src/scalar/scalar_pnpn.f90
+++ b/src/scalar/scalar_pnpn.f90
@@ -75,9 +75,6 @@ module scalar_pnpn
      !> The residual of the transport equation.
      type(field_t) :: s_res
 
-     !> Lag arrays, i.e. solutions at previous timesteps.
-     type(field_series_t) :: slag
-
      !> Solution increment.
      type(field_t) :: ds
 
@@ -168,8 +165,6 @@ contains
       call this%abx2%init(dm_Xh, "abx2")
 
       call this%ds%init(dm_Xh, 'ds')
-
-      call this%slag%init(this%s, 2)
 
     end associate
 
@@ -273,9 +268,6 @@ contains
     if (allocated(this%makebdf)) then
        deallocate(this%makebdf)
     end if
-
-
-    call this%slag%free()
 
   end subroutine scalar_pnpn_free
 

--- a/src/scalar/scalar_scheme.f90
+++ b/src/scalar/scalar_scheme.f90
@@ -63,6 +63,7 @@ module scalar_scheme
   use material_properties, only : material_properties_t
   use utils, only : neko_error
   use scalar_source_term, only : scalar_source_term_t
+  use field_series
   implicit none
 
   !> Base type for a scalar advection-diffusion solver.
@@ -75,6 +76,8 @@ module scalar_scheme
      type(field_t), pointer :: w
      !> The scalar.
      type(field_t), pointer :: s
+     !> Lag arrays, i.e. solutions at previous timesteps.
+     type(field_series_t) :: slag
      !> Function space \f$ X_h \f$.
      type(space_t), pointer :: Xh
      !> Dofmap associated with \f$ X_h \f$.
@@ -309,6 +312,8 @@ contains
     call neko_field_registry%add_field(this%dm_Xh, 's')
     this%s => neko_field_registry%get_field('s')
 
+    call this%slag%init(this%s, 2)
+
     this%gs_Xh => gs_Xh
     this%c_Xh => c_Xh
 
@@ -391,6 +396,8 @@ contains
     call this%source_term%free()
 
     call bc_list_free(this%bclst)
+
+    call this%slag%free()
 
   end subroutine scalar_scheme_free
 

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -282,7 +282,7 @@ contains
   !> Set new dt based on cfl if requested
   !! @param dt current time step
   !! @param params json case file
-  !! @param cfl courant number of current iteration
+  !! @param cfl Courant number of current iteration.
   !! @param cfl_avrg average courant number
   !! @param dt_last_change time step since last dt change
   subroutine simulation_setdt(dt, params, cfl, cfl_avrg, dt_last_change, tstep)

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -284,7 +284,7 @@ contains
   !! @param params json case file
   !! @param cfl Courant number of current iteration.
   !! @param cfl_avrg Average courant number.
-  !! @param dt_last_change time step since last dt change
+  !! @param dt_last_change Time step since last dt change.
   subroutine simulation_setdt(dt, params, cfl, cfl_avrg, dt_last_change, tstep)
     implicit none
     real(kind=rp), intent(inout) :: dt

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -309,9 +309,9 @@ contains
           dt_last_change .ge. min_update_frequency) then
 
           if (set_cfl/cfl .ge. 1) then 
-             scaling_factor = min(1.2, set_cfl/cfl) 
+             scaling_factor = min(1.2_rp, set_cfl/cfl) 
           else
-             scaling_factor = max(0.8, set_cfl/cfl) 
+             scaling_factor = max(0.8_rp, set_cfl/cfl) 
           end if
 
           dt_old = dt

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -150,8 +150,6 @@ contains
        call neko_simcomps%compute(t, tstep)
 
        call C%q%eval(t, C%dt, tstep)
-       !> Sample is called after fluid step. Therefore, C%ulag(1) has 
-       !! u for the last time step
        call C%s%sample(t, tstep)
 
        ! Update material properties

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -122,7 +122,6 @@ contains
 
        write(log_buf, '(A,E15.7,1x,A,E15.7)') 'CFL:', cfl, 'dt:', C%dt
        call neko_log%message(log_buf)
-       
        call simulation_settime(t, C%dt, C%ext_bdf, C%tlag, C%dtlag, tstep)
 
        call neko_log%section('Fluid')

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -102,15 +102,16 @@ contains
     call neko_log%newline()
 
     call profiler_start
-
+    cfl = C%fluid%compute_cfl(C%dt)
     start_time_org = MPI_WTIME()
 
     do while (t .lt. C%end_time .and. (.not. jobctrl_time_limit()))
        call profiler_start_region('Time-Step')
        tstep = tstep + 1
        start_time = MPI_WTIME()
-       if (tstep .eq. 1) cfl = C%fluid%compute_cfl(C%dt)
-       if (dt_last_change .eq. 0) cfl_avrg = cfl
+       if (dt_last_change .eq. 0) then
+          cfl_avrg = cfl
+       end
        call simulation_setdt(C%dt, C%params, cfl, cfl_avrg, dt_last_change, tstep)
        !calculate the cfl after the possibly varied dt
        cfl = C%fluid%compute_cfl(C%dt)

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -281,7 +281,7 @@ contains
 
   end subroutine simulation_joblimit_chkp
 
-    !> Set new dt based on cfl if requested
+  !> Set new dt based on cfl if requested
   !! @param dt current time step
   !! @param params json case file
   !! @param cfl courant number of current iteration

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -46,6 +46,7 @@ module simulation
   use math, only : col2
   use simcomp_executor, only : neko_simcomps
   use json_utils, only : json_get_or_default
+  use time_step_controller
   implicit none
   private
 
@@ -63,18 +64,19 @@ contains
     integer :: tstep, i
     character(len=:), allocatable :: restart_file
     logical :: output_at_end, found
-    ! for variable_time_steping
+    ! for variable_tsteping
     integer :: dt_last_change = 0
     real(kind=rp) :: cfl_avrg = 0_rp
     real(kind=rp) :: set_cfl
+    type(time_step_controller_t) :: dt_controller
 
     t = 0d0
     tstep = 0
     call neko_log%section('Starting simulation')
     write(log_buf,'(A, E15.7,A,E15.7,A)') 'T  : [', 0d0,',',C%end_time,')'
     call neko_log%message(log_buf)
-    call C%params%get('case.constant_cfl', set_cfl, found)
-    if (.not. found) then
+    call dt_controller%init(C)
+    if (.not. dt_controller%if_variable_dt) then
        write(log_buf,'(A, E15.7)') 'dt :  ', C%dt
        call neko_log%message(log_buf)
     else
@@ -112,7 +114,7 @@ contains
        if (dt_last_change .eq. 0) then
           cfl_avrg = cfl
        end if
-       call simulation_setdt(C%dt, C%params, cfl, cfl_avrg, dt_last_change, tstep)
+       call dt_controller%set_dt(C, cfl, cfl_avrg, dt_last_change, tstep)
        !calculate the cfl after the possibly varied dt
        cfl = C%fluid%compute_cfl(C%dt)
 
@@ -279,72 +281,6 @@ contains
 
   end subroutine simulation_joblimit_chkp
 
-  !> Set new dt based on cfl if requested
-  !! @param dt current time step
-  !! @param params json case file
-  !! @param cfl Courant number of current iteration.
-  !! @param cfl_avrg Average courant number.
-  !! @param dt_last_change Time step since last dt change.
-  subroutine simulation_setdt(dt, params, cfl, cfl_avrg, dt_last_change, tstep)
-    implicit none
-    real(kind=rp), intent(inout) :: dt
-    type(json_file), intent(inout) :: params
-    real(kind=rp), intent(in) :: cfl
-    real(kind=rp), intent(inout) :: cfl_avrg
-    integer, intent(inout) :: dt_last_change
-    real(kind=rp) :: set_cfl, dt_old, scaling_factor, max_dt
-    integer :: min_update_frequency
-    character(len=LOG_SIZE) :: log_buf    
-    logical :: found
-    real(kind=rp) :: alpha = 0.5_rp !coefficient of running average
-    integer, intent(in):: tstep
-
-    call params%get('case.timestep', max_dt, found)
-    call params%get('case.constant_cfl', set_cfl, found)
-
-    if (found .eqv. .true.) then
-       if (tstep .eq. 1) then ! set the first dt for desired cfl
-          dt = min(set_cfl/cfl*dt, max_dt)
-       else
-         call json_get_or_default(params, 'case.cfl_min_update_frequency',&
-                                    min_update_frequency, 1)
-
-         ! Calculate the average of cfl over the desired interval
-         cfl_avrg = alpha * cfl + (1-alpha) * cfl_avrg
-
-         if (abs(cfl_avrg - set_cfl) .ge. 0.2*set_cfl .and. &
-            dt_last_change .ge. min_update_frequency) then
-
-            if (set_cfl/cfl .ge. 1) then 
-               scaling_factor = min(1.2_rp, set_cfl/cfl) 
-            else
-               scaling_factor = max(0.8_rp, set_cfl/cfl) 
-            end if
-
-            dt_old = dt
-            dt = scaling_factor * dt_old
-            dt = min(dt, max_dt)
-
-            write(log_buf, '(A,E15.7,1x,A,E15.7)') 'Avrg CFL:', cfl_avrg, &
-                        'set_cfl:', set_cfl
-            call neko_log%message(log_buf)
-
-            write(log_buf, '(A,E15.7,1x,A,E15.7)') 'old dt:', dt_old, &
-                        'new dt:', dt
-            call neko_log%message(log_buf)
-
-            dt_last_change = 0
-
-         else
-            dt_last_change = dt_last_change + 1
-         end if
-       end if
-
-    end if
-
-  end subroutine simulation_setdt
-
-
-
 end module simulation
+
 

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -111,7 +111,7 @@ contains
        start_time = MPI_WTIME()
        if (dt_last_change .eq. 0) then
           cfl_avrg = cfl
-       end
+       end if
        call simulation_setdt(C%dt, C%params, cfl, cfl_avrg, dt_last_change, tstep)
        !calculate the cfl after the possibly varied dt
        cfl = C%fluid%compute_cfl(C%dt)

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -283,7 +283,7 @@ contains
   !! @param dt current time step
   !! @param params json case file
   !! @param cfl Courant number of current iteration.
-  !! @param cfl_avrg average courant number
+  !! @param cfl_avrg Average courant number.
   !! @param dt_last_change time step since last dt change
   subroutine simulation_setdt(dt, params, cfl, cfl_avrg, dt_last_change, tstep)
     implicit none

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -78,7 +78,7 @@ contains
        write(log_buf,'(A, E15.7)') 'dt :  ', C%dt
        call neko_log%message(log_buf)
     else
-       write(log_buf,'(A, E15.7)') 'cfl :  ', set_cfl
+       write(log_buf,'(A, E15.7)') 'CFL :  ', set_cfl
        call neko_log%message(log_buf)
     end if
 


### PR DESCRIPTION
This PR is re-issued following PR #1013. The branch in PR #1013 is too old and hence full of conflicts. This branch is built on most up-to-date develop-branch. In this branch, two things are modified:

1. variable time stepping uses a running average instead of an arithmetic average (to cope with sudden explosion of the cfl number)
2. lag fields are promoted to _scheme type (not just for pnpn)

Special acknowledge to @adperezm for setting up the architecture in PR#1013.