### PR TITLE
Fix bc_label loop in scalar_scheme_t

### DIFF
--- a/src/scalar/scalar_scheme.f90
+++ b/src/scalar/scalar_scheme.f90
@@ -198,13 +198,13 @@ contains
   subroutine scalar_scheme_add_bcs(this, zones, bc_labels)
     class(scalar_scheme_t), intent(inout) :: this
     type(facet_zone_t), intent(inout) :: zones(NEKO_MSH_MAX_ZLBLS)
-    character(len=20), intent(in) :: bc_labels(NEKO_MSH_MAX_ZLBLS)
+    character(len=20), intent(in) :: bc_labels(:)
     character(len=20) :: bc_label
     integer :: i, j, bc_idx
     real(kind=rp) :: dir_value
     logical :: bc_exists
 
-    do i = 1, NEKO_MSH_MAX_ZLBLS
+    do i = 1, size(bc_labels)
        bc_label = trim(bc_labels(i))
        if (bc_label(1:1) .eq. 'd') then
           bc_exists = .false.


### PR DESCRIPTION
There is an issue with how we parse bc_labels, which seems to so far simply gone undetected. By default, the size of the bc_labels array is `NEKO_MSH_MAX_ZLBLS`. However, when we pass bc_labels to the `json_get`, the array gets reallocated to the size as found in the case file. So, all the loops that parse bc_labels and iterate up to `NEKO_MSH_MAX_ZLBLS` are going through garbage.  Now, most of these loops search for an exact string comparison, which will essentially never happen.

But for the scalar, we search for the *first element*  of the label to be "d" (or "n", once Neumann is merged), and *that* can actually randomly be there for a garbage bc_label item, which will of course crash everything. Therefore, I fix the bc_labels to be an assumed shape array and iterate up to its size.

This will fix things in practice, but in principle we should do the same everywhere we loop through the bc_labels, and throw error if json_get reallocates to a size, which is larger than the `NEKO_MSH_MAX_ZLBLS`.

Question: why do we have limit on the bc_labels size at all?
