### PR TITLE
Addition of new point zone type: Cylinder.

### DIFF
--- a/doc/pages/case-file.md
+++ b/doc/pages/case-file.md
@@ -337,9 +337,15 @@ A more detailed description as well as a  full list of available components and
  their setup is provided in a [separate page of the manual](simcomps.md).
 
 ## Point zones
-Point zones enable the user to select GLL points in the computational domain according to some geometric criterion. Two predefined geometric shapes are selectable from the case file, boxes and spheres.
+Point zones enable the user to select GLL points in the computational domain
+according to some geometric criterion. Two predefined geometric shapes are
+selectable from the case file, boxes and spheres.
 
-A point zone object defined in the case file can be retrieved from the point zone registry, `neko_point_zone_registry`, and can be used to perform any zone-specific operations (e.g. localized source term, probing...). User-specific point zones can also be added manually to the point zone registry from the user file.
+A point zone object defined in the case file can be retrieved from the point
+zone registry, `neko_point_zone_registry`, and can be used to perform any
+zone-specific operations (e.g. localized source term, probing...). User-specific
+point zones can also be added manually to the point zone registry from the user
+file.
 
 A more detailed description as well as a  full list of available components and
  their setup is provided in a [separate page of the manual](point-zones.md).

--- a/doc/pages/point-zones.md
+++ b/doc/pages/point-zones.md
@@ -12,10 +12,10 @@ being applying a localized source term or probing a particular zone of interest.
 
 ## Predefined geometrical shapes
 
-There are two predefined shapes from which to initialize a point zone in the case
-file: boxes and spheres. Each shape is described by its own subtype
-`box_point_zone_t` and `sphere_point_zone_t`, extending the abstract class 
-`point_zone_t`.
+There are three predefined shapes from which to initialize a point zone in the
+case file: boxes, spheres and cylinders. Each shape is described by its own
+subtype `box_point_zone_t`, `sphere_point_zone_t` and `cylinder_point_zone_t`,
+extending the abstract class `point_zone_t`.
 
 ### Box
 
@@ -42,6 +42,22 @@ A sphere is defined by its center and its radius.
         "name": "mysphere",
         "geometry": "sphere",
         "center": [0.0, 0.0, 0.0],
+        "radius": 0.01
+    },
+]
+~~~~~~~~~~~~~~~
+
+### Cylinder
+
+A cylinder is defined by its end points and its radius.
+
+~~~~~~~~~~~~~~~{.json}
+[
+    {
+        "name": "mycylinder",
+        "geometry": "cylinder",
+        "start": [0.0, 0.0, 0.0],
+        "end": [0.0, 0.0, 1.0],
         "radius": 0.01
     },
 ]

--- a/src/.depends
+++ b/src/.depends
@@ -53,7 +53,8 @@ mesh/facet_zone.o : mesh/facet_zone.f90 common/utils.o adt/stack.o adt/tuple.o
 mesh/point_zone.o : mesh/point_zone.f90 device/device.o config/neko_config.o sem/dofmap.o common/utils.o config/num_types.o adt/stack.o 
 mesh/point_zones/sphere_point_zone.o : mesh/point_zones/sphere_point_zone.f90 math/math.o common/json_utils.o config/num_types.o mesh/point_zone.o 
 mesh/point_zones/box_point_zone.o : mesh/point_zones/box_point_zone.f90 math/math.o common/json_utils.o config/num_types.o mesh/point_zone.o 
-mesh/point_zone_factory.o : mesh/point_zone_factory.f90 common/utils.o sem/dofmap.o common/json_utils.o mesh/point_zones/sphere_point_zone.o mesh/point_zones/box_point_zone.o mesh/point_zone.o 
+mesh/point_zones/cylinder_point_zone.o : mesh/point_zones/cylinder_point_zone.f90 math/math.o common/json_utils.o config/num_types.o mesh/point_zone.o 
+mesh/point_zone_factory.o : mesh/point_zone_factory.f90 common/utils.o sem/dofmap.o common/json_utils.o mesh/point_zones/sphere_point_zone.o mesh/point_zones/box_point_zone.o mesh/point_zones/cylinder_point_zone.o mesh/point_zone.o 
 mesh/point_zone_registry.o : mesh/point_zone_registry.f90 common/json_utils.o common/utils.o sem/dofmap.o mesh/point_zone_factory.o mesh/point_zone.o 
 mesh/mesh.o : mesh/mesh.f90 mesh/curve.o adt/uset.o math/math.o mesh/facet_zone.o comm/comm.o common/distdata.o common/datadist.o adt/htable.o adt/tuple.o adt/stack.o common/utils.o mesh/quad.o mesh/hex.o mesh/element.o mesh/point.o config/num_types.o 
 mesh/octree.o : mesh/octree.f90 common/utils.o mesh/point.o config/num_types.o 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -56,6 +56,7 @@ neko_fortran_SOURCES = \
 	mesh/point_zone.f90\
 	mesh/point_zones/sphere_point_zone.f90\
 	mesh/point_zones/box_point_zone.f90\
+	mesh/point_zones/cylinder_point_zone.f90\
 	mesh/point_zone_factory.f90\
 	mesh/point_zone_registry.f90\
 	mesh/mesh.f90\

--- a/src/mesh/point_zone_factory.f90
+++ b/src/mesh/point_zone_factory.f90
@@ -36,6 +36,7 @@ module point_zone_fctry
   use point_zone, only: point_zone_t
   use box_point_zone, only: box_point_zone_t
   use sphere_point_zone, only: sphere_point_zone_t
+  use cylinder_point_zone, only: cylinder_point_zone_t
   use json_module, only: json_file
   use json_utils, only: json_get
   use dofmap, only: dofmap_t
@@ -63,9 +64,11 @@ contains
        allocate(box_point_zone_t::point_zone)
     else if (trim(zone_type) .eq. "sphere") then
        allocate(sphere_point_zone_t::point_zone)
+    else if (trim(zone_type) .eq. "cylinder") then
+       allocate(cylinder_point_zone_t::point_zone)
     else
        call neko_error("Unknown source term "//trim(zone_type)//"! Valid &
-       &source terms are 'box', 'sphere'.")
+         &source terms are 'box', 'sphere', 'cylinder'.")
     end if
 
     call point_zone%init(json, dof%size())

--- a/src/mesh/point_zones/cylinder_point_zone.f90
+++ b/src/mesh/point_zones/cylinder_point_zone.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2019-2021, The Neko Authors
+! Copyright (c) 2024, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without

--- a/src/mesh/point_zones/cylinder_point_zone.f90
+++ b/src/mesh/point_zones/cylinder_point_zone.f90
@@ -1,0 +1,184 @@
+! Copyright (c) 2019-2021, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Implements a cylinder geometry subset.
+module cylinder_point_zone
+  use point_zone, only: point_zone_t
+  use num_types, only: rp
+  use json_utils, only: json_get
+  use json_module, only: json_file
+  use utils, only: neko_error
+  implicit none
+  private
+
+  !> A cylindrical point zone.
+  !! @details As defined here, a cylinder is described by its two end points and
+  !! its radius, specified in the json file
+  !! as e.g. `"start": [<x0>, <y0>, <z0>]",
+  !! "start": [<x1>, <y1>, <z1>]", "radius": <r>`.
+  type, public, extends(point_zone_t) :: cylinder_point_zone_t
+     real(kind=rp), dimension(3) :: p0
+     real(kind=rp), dimension(3) :: p1
+     real(kind=rp) :: radius
+   contains
+     !> Constructor from json object file.
+     procedure, pass(this) :: init => cylinder_point_zone_init_from_json
+     !> Destructor.
+     procedure, pass(this) :: free => cylinder_point_zone_free
+     !> Defines the criterion of selection of a GLL point in the sphere point zone.
+     procedure, pass(this) :: criterion => cylinder_point_zone_criterion
+  end type cylinder_point_zone_t
+
+contains
+
+  !> Constructor from json object file.
+  !! @param json Json object file.
+  !! @param size Size with which to initialize the stack
+  subroutine cylinder_point_zone_init_from_json(this, json, size)
+    class(cylinder_point_zone_t), intent(inout) :: this
+    type(json_file), intent(inout) :: json
+    integer, intent(in) :: size
+
+    character(len=:), allocatable :: name
+    real(kind=rp), dimension(:), allocatable :: p0, p1
+    real(kind=rp) :: radius
+
+    call json_get(json, "name", name)
+    call json_get(json, "start", p0)
+    call json_get(json, "end", p1)
+    call json_get(json, "radius", radius)
+
+    ! Needed to use `shape` because of input name.
+    if (all(shape(p0) .ne. (/3/))) then
+       call neko_error("Cylinder point zone: invalid start point")
+    end if
+
+    if (all(shape(p1) .ne. (/3/))) then
+       call neko_error("Cylinder point zone: invalid end point")
+    end if
+
+    if (radius .lt. 0.0_rp) then
+       call neko_error("Cylinder point zone: invalid radius")
+    end if
+
+    call cylinder_point_zone_init_common(this, size, trim(name), p0, p1, &
+                                         radius)
+
+  end subroutine cylinder_point_zone_init_from_json
+
+  !> Initializes a cylinder point zone from its endpoint coordinates and radius.
+  !! @param size Size of the scratch stack.
+  !! @param name Name of the cylinder point zone.
+  !! @param p0 Coordinates of the first endpoint.
+  !! @param p1 Coordinates of the second endpoint.
+  !! @param radius Sphere radius.
+  subroutine cylinder_point_zone_init_common(this, size, name, p0, p1, radius)
+    class(cylinder_point_zone_t), intent(inout) :: this
+    integer, intent(in), optional :: size
+    character(len=*), intent(in) :: name
+    real(kind=rp), intent(in), dimension(3) :: p0
+    real(kind=rp), intent(in), dimension(3) :: p1
+    real(kind=rp), intent(in) :: radius
+
+    call this%init_base(size, name)
+
+    this%p0 = p0
+    this%p1 = p1
+    this%radius = radius
+
+  end subroutine cylinder_point_zone_init_common
+
+  !> Destructor.
+  subroutine cylinder_point_zone_free(this)
+    class(cylinder_point_zone_t), intent(inout) :: this
+
+    call this%free_base()
+
+    this%p0 = 0.0_rp
+    this%p1 = 0.0_rp
+    this%radius = 0.0_rp
+
+  end subroutine cylinder_point_zone_free
+
+  !> @brief Defines the criterion of selection of a GLL point in the cylinder
+  !! point zone.
+  !! @details A GLL point of coordinates \f$ \vec{X} = (x, y, z) \f$ is
+  !! considered as being inside the cylinder defined by endpoints
+  !! \f$ \vec{p_0} \f$ and \f$ \vec{p_1} \f$ and radius \f$ r \f$ if it
+  !! satisfies the following conditions:
+  !! \f{eqnarray*}{
+  !!   ||\vec{X} - \vec{X_0}|| &\le& r\\
+  !!   0 &\le& t \le 1
+  !! \f}
+  !! where,
+  !! \f{eqnarray*}{
+  !!   t &=& (\vec{X} - \vec{p_0}) \cdot (\vec{p_1} - \vec{p_0})
+  !!         / ||\vec{p_1} - \vec{p_0}|| \\
+  !! \vec{X_0} &=& \vec{p_0} + t \cdot (\vec{p_1} - \vec{p_0})
+  !! \f}
+  !! @param x x-coordinate of the GLL point.
+  !! @param y y-coordinate of the GLL point.
+  !! @param z z-coordinate of the GLL point.
+  !! @param j 1st nonlinear index of the GLL point.
+  !! @param k 2nd nonlinear index of the GLL point.
+  !! @param l 3rd nonlinear index of the GLL point.
+  !! @param e element index of the GLL point.
+  pure function cylinder_point_zone_criterion(this, x, y, z, j, k, l, e) result(is_inside)
+    class(cylinder_point_zone_t), intent(in) :: this
+    real(kind=rp), intent(in) :: x
+    real(kind=rp), intent(in) :: y
+    real(kind=rp), intent(in) :: z
+    integer, intent(in) :: j
+    integer, intent(in) :: k
+    integer, intent(in) :: l
+    integer, intent(in) :: e
+    logical :: is_inside
+
+    real(kind=rp), dimension(3) :: p
+    real(kind=rp), dimension(3) :: line
+    real(kind=rp) :: t
+    real(kind=rp), dimension(3) :: projection
+    real(kind=rp) :: distance
+
+    p = [x, y, z]
+
+    line = this%p1 - this%p0
+    t = dot_product(p - this%p0, line) / norm2(line)
+
+    projection = this%p0 + t * line
+    distance = norm2(projection - p)
+
+    is_inside = t >= 0.0_rp .and. t <= 1.0_rp .and. distance <= this%radius
+
+  end function cylinder_point_zone_criterion
+
+end module cylinder_point_zone


### PR DESCRIPTION
The cylinder point zone is constructed from its end points and radius. This allow the user to define the cylinder in arbitrary orientations and sizes.