### PR TITLE
Add built-in profiler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,10 @@ AC_ARG_ENABLE(device-mpi,
 	      AS_HELP_STRING([--enable-device-mpi],[Enable device aware MPI]),
 	      [enable_device_mpi=${enableval}], [enable_device_mpi=no])
 
+AC_ARG_ENABLE(profiling,
+	      AS_HELP_STRING([--enable-profiling],[Enable profiling support]),
+	      [enable_profiling=${enableval}], [enable_profiling=no])
+
 # Test for a sane fortran environment (^-^)
 AC_LANG(Fortran)
 AC_PROG_FC(,90)
@@ -250,6 +254,13 @@ AX_NVTX
 
 # Checks for ROCTX profiling
 AX_ROCTX
+
+# Cheks for profiling
+if test "x${enable_profiling}" = xyes; then
+   AC_SUBST(enable_profiling, .true.)
+else
+   AC_SUBST(enable_profiling, .false.)
+fi
 
 # JSON-Fortran
 PKG_CHECK_MODULES([JSON_Fortran],[json-fortran >= 7.1.0])

--- a/doc/pages/appendix.md
+++ b/doc/pages/appendix.md
@@ -16,3 +16,23 @@ A number of logging levels are supported.
 - `NEKO_LOG_LEVEL=1`   : Default information mode, adding step informations.
 - `NEKO_LOG_LEVEL=2`   : Verbose mode, logging extra details.
 - `NEKO_LOG_LEVEL=10`  : Debug mode.
+
+## Profiling {#profiling}
+
+Neko can be profiled in a couple of different ways,
+
+- Using the built in profiler (enabled with `--enable-profiling`).
+- Using external profiling tools.
+  - NVIDIA Nsight Systems.
+  - AMD ROCm Profiler.
+  - Craypat.
+
+### Using the built in profiler
+
+The built in profiler can be enabled by configuring Neko with
+`--enable-profiling`. This will enable the profiler and add the necessary flags
+to the build system. The profiler will then use `MPI_Wtime` to measure the time
+spent in a predefined set of regions of the code. The CPU time spent in these
+regions will be accumulated across all MPI ranks and written to a file called
+`profile.log` in the working directory, along with an accumulated number of
+executions for each region.

--- a/doc/pages/installation.md
+++ b/doc/pages/installation.md
@@ -105,6 +105,7 @@ Features are enabled and disabled by passing either `--enable-FEATURE[=arg]` or 
 | `--enable-real=Xp`    | Specify working precision of REAL types:<br>`sp` -- `REAL(kind=4)`<br>`dp` -- `REAL(kind=8)` (default)<br>`qp` -- `REAL(kind=16)`<br> |
 | `--enable-contrib`    | Compile various tools                                                                                                                 |
 | `--enable-device-mpi` | Enable device aware MPI                                                                                                               |
+| `--enable-profiling`  | Enable built in profiling support                                                                                                     |
 
 Optional packages are controlled by passing either `--with-PACKAGE[=ARG]` or `--without-PACKAGE` to `configure`. A list of all supported optional packages are given in the table below.
 

--- a/src/.depends
+++ b/src/.depends
@@ -120,7 +120,8 @@ io/mean_sqr_flow_output.o : io/mean_sqr_flow_output.f90 io/output.o config/num_t
 io/data_streamer.o : io/data_streamer.F90 config/neko_config.o comm/mpi_types.o comm/comm.o device/device.o common/utils.o sem/coef.o field/field.o config/num_types.o 
 common/sampler.o : common/sampler.f90 common/time_based_controller.o config/num_types.o common/profiler.o common/utils.o common/log.o comm/comm.o io/fld_file.o io/output.o 
 common/global_interpolation.o : common/global_interpolation.F90 comm/mpi_types.o math/math.o comm/comm.o sem/local_interpolation.o common/utils.o common/log.o mesh/mesh.o sem/dofmap.o sem/space.o config/num_types.o 
-common/profiler.o : common/profiler.F90 common/craypat.o device/hip/roctx.o device/cuda/nvtx.o device/device.o config/neko_config.o 
+common/profiler.o : common/profiler.F90 common/craypat.o device/hip/roctx.o device/cuda/nvtx.o device/device.o config/neko_config.o common/bcknd/neko_profiler.o
+common/bcknd/neko_profiler.o : common/bcknd/neko_profiler.f90 common/utils.o adt/stack.o comm/comm.o
 common/craypat.o : common/craypat.F90 common/utils.o adt/stack.o 
 bc/bc.o : bc/bc.f90 common/utils.o adt/tuple.o adt/stack.o mesh/facet_zone.o mesh/mesh.o sem/space.o sem/dofmap.o device/device.o config/num_types.o config/neko_config.o 
 bc/dirichlet.o : bc/dirichlet.f90 bc/bc.o config/num_types.o bc/bcknd/device/device_dirichlet.o 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -124,6 +124,7 @@ neko_fortran_SOURCES = \
 	common/sampler.f90\
 	common/global_interpolation.F90\
 	common/profiler.F90\
+	common/bcknd/neko_profiler.f90\
 	common/craypat.F90\
 	bc/bc.f90\
 	bc/dirichlet.f90\

--- a/src/common/bcknd/neko_profiler.f90
+++ b/src/common/bcknd/neko_profiler.f90
@@ -1,0 +1,396 @@
+! Copyright (c) 2022, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Built in profiling tool for neko
+module neko_profiler
+  use utils, only: neko_error
+  use stack, only: stack_i4_t
+  use comm, only: NEKO_COMM, pe_rank, pe_size
+  use mpi_f08, only: mpi_wtime, mpi_ibcast, mpi_waitall
+  use mpi_f08, only: MPI_INTEGER, MPI_DOUBLE, MPI_CHARACTER, &
+    MPI_MAX, MPI_STATUSES_IGNORE, MPI_REQUEST
+  implicit none
+
+  private
+  public :: init_profiler, free_profiler, start_region, end_region
+
+  type :: profiler_region_t
+     !> Region name
+     character(len=80) :: name
+     !> Region ID
+     integer :: id
+     !> List of execution times
+     real(kind=8) :: time
+     !> Number of executions
+     integer :: n = 0
+
+     !> Latest start time
+     real(kind=8) :: start
+     !> Logical value indicating if the region is currently active
+     logical :: active = .false.
+  end type profiler_region_t
+
+  !> List of regions
+  type(profiler_region_t), dimension(:), allocatable :: region_list
+  !> Number of regions
+  integer :: n_regions = 0
+  !> Stack of active regions
+  type(stack_i4_t) :: active_regions
+
+contains
+
+  ! ========================================================================== !
+  ! Definition of the CPU based profiler.
+
+  !> Initialize the profiler
+  subroutine init_profiler()
+
+    if (allocated(region_list)) then
+       call neko_error("Error in profiler: double initialization")
+    end if
+
+    allocate(region_list(0))
+    call active_regions%init(10)
+
+    call start_region("Total Time")
+
+  end subroutine init_profiler
+
+  !> Finalize the profiler
+  !! @note This will deallocate the region list and the stack of active regions
+  subroutine free_profiler(filename)
+    character(len=*), intent(in), optional :: filename
+    integer :: i
+
+    ! Stop the rest of the regions
+    do while (.not. active_regions%is_empty())
+       call end_region()
+    end do
+    call active_regions%free()
+
+    ! Save the profiler log
+    call print_regions(filename)
+
+    deallocate(region_list)
+    n_regions = 0
+
+  end subroutine free_profiler
+
+  ! ========================================================================== !
+  ! Region manipulation
+
+  !> Start a region
+  !! @param name Name of the region
+  !! @param id Optional ID of the region
+  subroutine start_region(name, id)
+    implicit none
+
+    character(len=*), intent(in) :: name
+    integer, intent(in), optional :: id
+    integer :: i_reg, i_stack, j, id_
+    type(profiler_region_t) :: tmp_region
+
+    ! If the profiler is not initialized, return
+    if (.not. allocated(region_list)) return
+
+    if (present(id)) then
+       id_ = id
+    else
+       id_ = 0
+    end if
+
+    do i_reg = 1, n_regions
+       if (region_list(i_reg)%name == trim(name) &
+           .and. region_list(i_reg)%id == id_) then
+
+          if (region_list(i_reg)%active) then
+             call neko_error("Error in profiler: region is already active: " &
+                             // name)
+          end if
+
+          region_list(i_reg)%active = .true.
+          region_list(i_reg)%start = mpi_wtime()
+
+          i_stack = i_reg
+          call active_regions%push(i_stack)
+          return
+       end if
+    end do
+
+    tmp_region%name = trim(name)
+    tmp_region%id = id_
+    tmp_region%active = .true.
+    tmp_region%n = 0
+    tmp_region%start = mpi_wtime()
+    tmp_region%time = 0.0d0
+
+    region_list = [region_list, tmp_region]
+    n_regions = size(region_list)
+
+    call active_regions%push(n_regions)
+
+  end subroutine start_region
+
+  !> End a region
+  !! @param name Name of the region
+  !! @param id Optional ID of the region
+  subroutine end_region(name, id)
+    character(len=*), intent(in), optional :: name
+    integer, intent(in), optional :: id
+    integer :: i, id_, i_stack
+    real(kind=8) :: t
+    type(stack_i4_t) :: tmp_stack
+
+    ! If the profiler is not initialized, return
+    if (.not. allocated(region_list)) return
+
+    if (present(name)) then
+
+       id_ = 0
+       if (present(id)) id_ = id
+
+       do i = 1, n_regions
+          if (region_list(i)%name == trim(name) &
+              .and. region_list(i)%id == id_) then
+             exit
+          end if
+       end do
+
+       i_stack = active_regions%pop()
+       do while (i_stack /= i)
+          call tmp_stack%push(i_stack)
+          i_stack = active_regions%pop()
+       end do
+
+       do while (.not. tmp_stack%is_empty())
+          i_stack = tmp_stack%pop()
+          call active_regions%push(i_stack)
+       end do
+
+    else
+
+       if (active_regions%is_empty()) then
+          call neko_error("Error in profiler: no active region to end")
+       end if
+
+       i = active_regions%pop()
+    end if
+
+
+    if (.not. region_list(i)%active) then
+       call neko_error("Error in profiler: region is not active: " // name)
+    end if
+
+    t = mpi_wtime() - region_list(i)%start
+
+    region_list(i)%time = region_list(i)%time + t
+    region_list(i)%n = region_list(i)%n + 1
+    region_list(i)%active = .false.
+
+  end subroutine end_region
+
+  !> Print the regions to a file, profiler.log
+  subroutine print_regions(filename)
+    character(len=*), intent(in), optional :: filename
+    integer :: i, n, file_id, ierr
+    real(kind=8) :: time
+    character(len=80) :: name
+    character(len=80) :: time_str
+    character(len=80) :: n_str
+
+    ! If the profiler is not initialized, return
+    if (.not. allocated(region_list)) return
+
+    do i = 1, n_regions
+       if (region_list(i)%active) then
+          call neko_error("Error in profiler: region is still active:" &
+                          // region_list(i)%name)
+       end if
+    end do
+
+    if (pe_size .gt. 1) then
+       call synchronize_regions()
+    end if
+    if (pe_rank .ne. 0) return
+
+    if (present(filename)) then
+       open(newunit=file_id, file=filename, status="new", action="write")
+    else
+       open(newunit=file_id, file="profiler.log", status="new", action="write")
+    end if
+
+    write(file_id, *) 'Region, CPU Time [s], Evaluations'
+
+    do i = 1, n_regions
+       name = trim(region_list(i)%name)
+       write (time_str, '(f14.7)') region_list(i)%time
+       write (n_str, '(i14)') region_list(i)%n
+
+       write(file_id, '(a,a1,a,a1,a)') &
+         trim(adjustl(name)), ",", &
+         trim(adjustl(time_str)), ",", &
+         trim(adjustl(n_str))
+    end do
+
+    close(file_id)
+  end subroutine print_regions
+
+  !> Synchronize the regions across all ranks
+  !! This will overwrite the local region list with the global region list
+  !! and is called before printing the regions.
+  subroutine synchronize_regions()
+    integer, parameter :: name_len = 80
+
+    ! Buffers for the region information
+    integer :: buffer_size
+    character(len=name_len), dimension(:,:), allocatable :: buffer_names
+    real(kind=8), dimension(:,:), allocatable :: buffer_times
+    integer, dimension(:,:), allocatable :: buffer_n, buffer_id
+
+    ! Requests for the broadcasts
+    TYPE(MPI_Request), dimension(:), allocatable :: req_names, req_id
+    TYPE(MPI_Request), dimension(:), allocatable :: req_times, req_n
+
+    ! Global list of regions, will overwrite the local list
+    type(profiler_region_t), dimension(:), allocatable :: global_region_list
+    type(profiler_region_t) :: temp_region
+
+    ! Local variables
+    character(len=name_len) :: name
+    real(kind=8) :: time
+    integer :: id, n, i_pe, i_reg, i, ierr
+
+    ! Ensure the buffers are large enough to hold all regions
+    call mpi_allreduce(n_regions, buffer_size, 1, MPI_INTEGER, MPI_MAX, &
+                       NEKO_COMM, ierr)
+
+    ! Allocate the buffers and requests
+    allocate(buffer_names(buffer_size, pe_size))
+    allocate(buffer_times(buffer_size, pe_size))
+    allocate(buffer_id(buffer_size, pe_size))
+    allocate(buffer_n(buffer_size, pe_size))
+
+    allocate(req_names(buffer_size))
+    allocate(req_id(buffer_size))
+    allocate(req_times(buffer_size))
+    allocate(req_n(buffer_size))
+
+    ! Fill the buffers with the local region information
+    do i_reg = 1, buffer_size
+
+       if (i_reg > n_regions) then
+          buffer_names(i_reg, pe_rank + 1) = ""
+          buffer_id(i_reg, pe_rank + 1) = 0
+          buffer_times(i_reg, pe_rank + 1) = 0.0
+          buffer_n(i_reg, pe_rank + 1) = 0
+       else
+          buffer_names(i_reg, pe_rank + 1) = region_list(i_reg)%name
+          buffer_id(i_reg, pe_rank + 1) = region_list(i_reg)%id
+
+          buffer_times(i_reg, pe_rank + 1) = region_list(i_reg)%time
+          buffer_n(i_reg, pe_rank + 1) = region_list(i_reg)%n
+       end if
+
+    end do
+
+    ! Broadcast the information to everyone
+    do i_pe = 0, pe_size - 1
+       do i_reg = 1, buffer_size
+          call mpi_ibcast(buffer_names(i_reg, i_pe + 1), name_len, MPI_CHARACTER, i_pe, &
+                          NEKO_COMM, req_names(i_reg), ierr)
+
+          call mpi_ibcast(buffer_id(i_reg, i_pe + 1), 1, MPI_INTEGER, i_pe, &
+                          NEKO_COMM, req_id(i_reg), ierr)
+
+          call mpi_ibcast(buffer_times(i_reg, i_pe + 1), 1, MPI_DOUBLE, i_pe, &
+                          NEKO_COMM, req_times(i_reg), ierr)
+
+          call mpi_ibcast(buffer_n(i_reg, i_pe + 1), 1, MPI_INTEGER, i_pe, &
+                          NEKO_COMM, req_n(i_reg), ierr)
+       end do
+
+       ! Wait for the broadcasts to finish
+       call mpi_waitall(buffer_size, req_names, MPI_STATUSES_IGNORE, ierr)
+       call mpi_waitall(buffer_size, req_id, MPI_STATUSES_IGNORE, ierr)
+       call mpi_waitall(buffer_size, req_times, MPI_STATUSES_IGNORE, ierr)
+       call mpi_waitall(buffer_size, req_n, MPI_STATUSES_IGNORE, ierr)
+    end do
+
+    ! Build a new list of regions. Every entry must be unique and the same on all
+    ! ranks. Two regions are considered the same if they have the same name and
+    ! the same ID. If a region is not present on a rank, it is added with a time
+    ! of 0.0 and a count of 0.
+
+    ! First, build the global list from the local list
+    allocate(global_region_list(0))
+
+    ! Loop through the global lists and add any newly encountered regions
+    ! to the global list
+    loop_region: do i_reg = 1, buffer_size
+       loop_rank: do i_pe = 1, pe_size
+          name = buffer_names(i_reg, i_pe)
+          id = buffer_id(i_reg, i_pe)
+          time = buffer_times(i_reg, i_pe)
+          n = buffer_n(i_reg, i_pe)
+
+          if (trim(name) == "") cycle loop_rank
+
+          ! Determine if the region is already in the global list
+          do i = 1, size(global_region_list)
+             if (global_region_list(i)%name == name .and. &
+                 global_region_list(i)%id == id) then
+
+                ! Save the time and count
+                global_region_list(i)%time = global_region_list(i)%time + time
+                global_region_list(i)%n = global_region_list(i)%n + n
+
+                cycle loop_rank
+             end if
+          end do
+
+          ! If the region is not in the global list, add it
+          temp_region%name = name
+          temp_region%id = id
+          temp_region%time = time
+          temp_region%n = n
+
+          global_region_list = [global_region_list, temp_region]
+       end do loop_rank
+    end do loop_region
+
+    ! Save the global list
+    region_list = global_region_list
+
+  end subroutine synchronize_regions
+
+
+end module neko_profiler

--- a/src/common/bcknd/neko_profiler.f90
+++ b/src/common/bcknd/neko_profiler.f90
@@ -173,11 +173,11 @@ contains
     ! If the profiler is not initialized, return
     if (.not. allocated(region_list)) return
 
+    id_ = 0
+    if (present(id)) id_ = id
+
+    ! If a name is provided, find the region by name and id
     if (present(name)) then
-
-       id_ = 0
-       if (present(id)) id_ = id
-
        do i = 1, n_regions
           if (region_list(i)%name == trim(name) &
               .and. region_list(i)%id == id_) then
@@ -185,6 +185,7 @@ contains
           end if
        end do
 
+       ! Clean the detected region from the stack
        i_stack = active_regions%pop()
        do while (i_stack /= i)
           call tmp_stack%push(i_stack)
@@ -197,7 +198,7 @@ contains
        end do
 
     else
-
+       ! If no name is provided, end the last region
        if (active_regions%is_empty()) then
           call neko_error("Error in profiler: no active region to end")
        end if
@@ -205,13 +206,12 @@ contains
        i = active_regions%pop()
     end if
 
-
     if (.not. region_list(i)%active) then
        call neko_error("Error in profiler: region is not active: " // name)
     end if
 
+    ! Update the region time and count
     t = mpi_wtime() - region_list(i)%start
-
     region_list(i)%time = region_list(i)%time + t
     region_list(i)%n = region_list(i)%n + 1
     region_list(i)%active = .false.

--- a/src/common/profiler.F90
+++ b/src/common/profiler.F90
@@ -37,6 +37,7 @@ module profiler
   use nvtx
   use roctx
   use craypat
+  use neko_profiler, only: init_profiler, free_profiler, start_region, end_region
   implicit none
 
 contains
@@ -52,6 +53,10 @@ contains
        call craypat_record_start
 #endif
     end if
+
+    if (NEKO_ENABLE_PROFILING) then
+       call init_profiler()
+    end if
   end subroutine profiler_start
 
   !> Stop profiling
@@ -64,6 +69,10 @@ contains
 #ifdef CRAYPAT
        call craypat_record_stop
 #endif
+    end if
+
+    if (NEKO_ENABLE_PROFILING) then
+       call free_profiler()
     end if
   end subroutine profiler_stop
 
@@ -84,10 +93,16 @@ contains
     !   call craypat_region_begin(name)
 #endif
 
+    if (NEKO_ENABLE_PROFILING) then
+       call start_region(name, region_id)
+    end if
   end subroutine profiler_start_region
 
-  !> End the most recently started profiler region
-  subroutine profiler_end_region
+  !> End the most recently started profiler region or the one with the given
+  !! name
+  subroutine profiler_end_region(name, region_id)
+    character(kind=c_char,len=*), optional :: name
+    integer, optional :: region_id
 
 #ifdef HAVE_NVTX
     call nvtxRangePop
@@ -97,6 +112,9 @@ contains
     !   call craypat_region_end
 #endif
 
+    if (NEKO_ENABLE_PROFILING) then
+       call end_region(name, region_id)
+    end if
   end subroutine profiler_end_region
 
 end module profiler

--- a/src/config/neko_config.f90.in
+++ b/src/config/neko_config.f90.in
@@ -47,4 +47,6 @@ module neko_config
 
   integer, parameter :: NEKO_BLK_SIZE = @blk_size@
 
+  logical, parameter :: NEKO_ENABLE_PROFILING = @enable_profiling@
+
 end module neko_config


### PR DESCRIPTION
Addition of a built in profiler which will report the global cpu-time and evaluation count.

The new profiler is disabled by default and can be turned on by setting `--enable-profiling` when configuring Neko.