### PR TITLE
Extend makeneko for several arguments

### DIFF
--- a/makeneko.in
+++ b/makeneko.in
@@ -33,7 +33,7 @@ program usrneko
 end program usrneko
 _ACEOF
 
-$FC $FCFLAGS -I$includedir_pkg -L$libdir $1 usr_driver.f90\
+$FC $FCFLAGS -I$includedir_pkg -L$libdir $@ usr_driver.f90\
     -lneko @LDFLAGS@ @LIBS@ -o neko
 
 rm -f usr_driver.f90


### PR DESCRIPTION
Change  the `makeneko` compile line from `$1` to `$@` to allow for several files to be compiled at once.