### PR TITLE
Fix periodic

### DIFF
--- a/examples/scalar_mms/README.md
+++ b/examples/scalar_mms/README.md
@@ -20,7 +20,7 @@ example more interesting later. An additional purpose is to provide a test case
 for scalar source terms.
 
 The advecting velocity is set to 1 in $x$. The source term $\hat f$ is easily
-obtained as $ \rho c_p u \cdot \cos(x) - \lambda \sin(x)$.
+obtained as $\rho c_p u \cdot \cos(x) - \lambda \sin(x)$.
 Here, we set $\rho = c_p =u = 1$, and $\lambda = 0.01$.
 
 

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -1400,11 +1400,6 @@ contains
     ep => this%elements(el)%e
     el_glb_idx = el + this%offset_el
 
-    do i = 1, NEKO_QUAD_NPTS
-       p_local_idx = this%get_local(this%points(p(i)))
-       call this%point_neigh(p_local_idx)%push(el_glb_idx)
-    end do
-
     select type(ep)
     type is (quad_t)
        call ep%init(el_glb_idx, &

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -375,16 +375,16 @@ contains
     call this%outlet_normal%free()
     call this%sympln%free()
     call this%periodic%free()
+    this%lconn = .false.
+    this%lnumr = .false.
+    this%ldist = .false.
+    this%lgenc = .true.
 
   end subroutine mesh_free
 
   subroutine mesh_finalize(this)
     class(mesh_t), target, intent(inout) :: this
     integer :: i
-    class(element_t), pointer :: ep
-    type(tuple_i4_t) :: e
-    type(tuple4_i4_t) :: f
-    integer :: p_local_idx, res
     
     call mesh_generate_flags(this)
     call mesh_generate_conn(this)
@@ -605,6 +605,7 @@ contains
     !
     ! Find all external (between PEs) boundaries
     !
+    print *, pe_size
     if (pe_size .gt. 1) then
 
        call mesh_generate_external_point_conn(this)

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -1877,7 +1877,7 @@ contains
     integer :: local_id
 
     if (this%htf%get(f, local_id) .gt. 0) then
-       call neko_error('Invalid global id (local facet) ' // f)
+       call neko_error('Invalid global id (local facet)')
     end if
 
   end function mesh_get_local_facet

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -605,7 +605,6 @@ contains
     !
     ! Find all external (between PEs) boundaries
     !
-    print *, pe_size
     if (pe_size .gt. 1) then
 
        call mesh_generate_external_point_conn(this)

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -1411,10 +1411,6 @@ contains
             this%points(p(1)), this%points(p(2)), &
             this%points(p(3)), this%points(p(4)))
 
-       do i = 1, NEKO_QUAD_NEDS
-          call ep%facet_id(e, i)
-          call this%add_edge(e)
-       end do
 
     class default
        call neko_error('Invalid element type')

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -420,12 +420,11 @@ contains
              end do
 
              do i = 1, NEKO_QUAD_NEDS
-                call ep%edge_id(e, i)
+                call ep%facet_id(e, i)
                 call this%add_edge(e)
              end do
           end select
        end do
-
     end if
 
 
@@ -1788,6 +1787,7 @@ contains
                 call neko_error('Multiple matches when creating periodic ids')
              else if (match .eq. 0) then
                 call neko_error('Cannot find matching periodic point')
+             end if
           end do
        end select
     type is(quad_t)

--- a/tests/field/field_parallel.pf
+++ b/tests/field/field_parallel.pf
@@ -73,6 +73,7 @@ contains
     
     call msh%add_element(2, p(2), p(5), p(6), p(4), &
          p(8), p(11), p(12), p(9))
+    call msh%generate_conn()
     
   end subroutine test_field_gen_msh
   
@@ -88,6 +89,8 @@ contains
 
     call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
 
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
     call test_field_gen_msh(msh)
     call Xh%init(GLL, lx, lx, lx)
     

--- a/tests/mean_field/mean_field_parallel.pf
+++ b/tests/mean_field/mean_field_parallel.pf
@@ -73,6 +73,7 @@ contains
     
     call msh%add_element(2, p(2), p(5), p(6), p(4), &
          p(8), p(11), p(12), p(9))
+    call msh%generate_conn()
     
   end subroutine test_mean_field_gen_msh
   
@@ -87,6 +88,8 @@ contains
     integer :: ierr
 
     call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
 
     call test_mean_field_gen_msh(msh)
     call Xh%init(GLL, lx, lx, lx)

--- a/tests/mean_sqr_field/mean_sqr_field_parallel.pf
+++ b/tests/mean_sqr_field/mean_sqr_field_parallel.pf
@@ -74,6 +74,7 @@ contains
     
     call msh%add_element(2, p(2), p(5), p(6), p(4), &
          p(8), p(11), p(12), p(9))
+    call msh%generate_conn()
     
   end subroutine test_mean_sqr_field_gen_msh
   
@@ -89,6 +90,8 @@ contains
 
     call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
 
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
     call test_mean_sqr_field_gen_msh(msh)
     call Xh%init(GLL, lx, lx, lx)
     

--- a/tests/scratch_registry/test_scratch_registry.pf
+++ b/tests/scratch_registry/test_scratch_registry.pf
@@ -3,11 +3,11 @@ module test_scratch_registry
   use field
   use point
   use space
-  use comm
   use mesh
   use dofmap
   use math
   use scratch_registry
+  use comm, only : NEKO_COMM, pe_rank, pe_size
   use num_types
   implicit none
 
@@ -42,10 +42,11 @@ contains
     p(12) = point_t(2d0, 1d0, 1d0)
     call p(12)%set_id(12)
     
-    call comm_init
     call msh%init(3, 1)
     call msh%add_element(1, p(1), p(2), p(4), p(3), &
          p(7), p(8), p(9), p(10))
+    pe_rank = 1
+    pe_size = 1
     call msh%generate_conn()
     
   end subroutine test_scratch_registry_gen_msh

--- a/tests/scratch_registry/test_scratch_registry.pf
+++ b/tests/scratch_registry/test_scratch_registry.pf
@@ -3,6 +3,7 @@ module test_scratch_registry
   use field
   use point
   use space
+  use comm
   use mesh
   use dofmap
   use math
@@ -40,10 +41,12 @@ contains
     call p(11)%set_id(11)
     p(12) = point_t(2d0, 1d0, 1d0)
     call p(12)%set_id(12)
-  
+    
+    call comm_init
     call msh%init(3, 1)
     call msh%add_element(1, p(1), p(2), p(4), p(3), &
          p(7), p(8), p(9), p(10))
+    call msh%generate_conn()
     
   end subroutine test_scratch_registry_gen_msh
   
@@ -57,6 +60,7 @@ contains
     integer :: ierr
 
     call test_scratch_registry_gen_msh(msh)
+  
     call Xh%init(GLL, lx, lx, lx)
     dm = dofmap_t(msh, Xh)
     


### PR DESCRIPTION
Seems like there was an issue that the facets belonging to a periodic facet could be changed by a neighboring element, but then not added to the table correctly when generating connectivity. 

This PR changes this. For future developments, we should note though that if the entire side is not periodic but a mesh would change from periodic to some other BC along a boundary, this is not necessarily well defined if the element it changes on is not guaranteed to be on the same rank.