### PR TITLE
Average fields in two directions

### DIFF
--- a/contrib/average_field_in_space/average_field_in_space.f90
+++ b/contrib/average_field_in_space/average_field_in_space.f90
@@ -2,7 +2,6 @@
 !! Martin Karp 17/02-23
 program average_field_in_space
   use neko
-  use mean_flow
   implicit none
   
   character(len=NEKO_FNAME_LEN) :: inputchar, mesh_fname, field_fname, hom_dir, output_fname
@@ -18,15 +17,23 @@ program average_field_in_space
   type(map_1d_t) :: map_1d
   type(field_t), pointer :: u, avg_u, old_u, el_heights
   type(vector_ptr_t), allocatable :: fields(:)
-  integer :: argc, i, n, lx, j, e, n_levels, dir
+  type(matrix_t) :: avg_matrix
+  type(vector_t) :: volume_per_gll_lvl
+  integer :: argc, i, n, lx, j, e, n_levels, dir, ierr, n_1d
+  logical :: avg_to_1d = .false.
+  real(kind=rp) :: coord
   
   argc = command_argument_count()
 
   if ((argc .lt. 4) .or. (argc .gt. 4)) then
      if (pe_rank .eq. 0) then
-        write(*,*) 'Usage: ./average_field_in_space mesh.nmsh field.fld dir(x, y, z)  outfield.fld' 
-        write(*,*) 'Example command: ./average_field_in_space mesh.nmsh fieldblabla.fld x  outfield.fld'
-        write(*,*) 'Computes the spatial average in x of the field fieldblabla.nek5000 and stores in outfield.fld'
+        write(*,*) 'Usage: ./average_field_in_space mesh.nmsh field.fld dir(x, y, z, xz, xy, yz)  outfield.(fld,csv)' 
+        write(*,*) 'Example command for avg in 1 direction: ./average_field_in_space mesh.nmsh fieldblabla.fld x  outfield.fld'
+        write(*,*) 'Computes the spatial average in 2 directions diretly of the field fieldblabla.nek5000 and stores in out.csv'
+        write(*,*) 'Example command: ./average_field_in_space mesh.nmsh fieldblabla.fld xy  out.csv'
+        write(*,*) 'In out.csv the firsct col are the coords of the gll points'
+        write(*,*) 'In columns 2-n_fields are the averages for all fields in fieldblabla.fld'
+        write(*,*) 'If averaging in 2 directions output must be .csv and for 1 direction .fld'
      end if
      stop
   end if
@@ -94,58 +101,106 @@ program average_field_in_space
   old_u => neko_field_registry%get_field('old_u')
   call neko_field_registry%add_field(dof, 'el_heights')
   el_heights => neko_field_registry%get_field('el_heights')
-  ! 1 corresponds to r, 2 to s, 3 to t
+  ! 1 corresponds to x, 2 to y, 3 to z
   if (trim(hom_dir) .eq. 'x') then
      dir = 1
+     avg_to_1d = .false.
   else if (trim(hom_dir) .eq. 'y') then
      dir = 2
+     avg_to_1d = .false.
   else if (trim(hom_dir) .eq. 'z') then
      dir = 3
+     avg_to_1d = .false.
+  else if (trim(hom_dir) .eq. 'yz') then
+     dir = 1
+     avg_to_1d = .true.
+  else if (trim(hom_dir) .eq. 'xz') then
+     dir = 2
+     avg_to_1d = .true.
+  else if (trim(hom_dir) .eq. 'xy') then
+     dir = 3
+     avg_to_1d = .true.
   else 
      call neko_error('homogenous direction not supported')
   end if
   call map_1d%init(dof, gs_h,  dir, 1e-7_rp)
-
   n_levels = map_1d%n_el_lvls
-
-  do i = 1, msh%nelv
-     !find height in hom-dir
-     !store direction which is hom
-     !set element to height
-     !we assume elements are stacked on eachother...
-     el_dim(1,:) = abs(msh%elements(i)%e%pts(1)%p%x-msh%elements(i)%e%pts(2)%p%x)
-     el_dim(2,:) = abs(msh%elements(i)%e%pts(1)%p%x-msh%elements(i)%e%pts(3)%p%x)
-     el_dim(3,:) = abs(msh%elements(i)%e%pts(1)%p%x-msh%elements(i)%e%pts(5)%p%x)
-     ! 1 corresponds to r, 2 to s, 3 to t
-     el_h = el_dim(map_1d%dir_el(i),dir)
-     el_heights%x(:,:,:,i) = el_h
-  end do
   n = u%dof%size()
-   
-  call copy(u%x,el_heights%x,n)
-  call copy(old_u%x,el_heights%x,n)
-  call copy(avg_u%x,el_heights%x,n)
-  call perform_global_summation(u, avg_u, old_u, n_levels, &
-       map_1d%dir_el,gs_h, coef%mult, msh%nelv, lx)
-  domain_height = u%x(1,1,1,1)
 
+  !allocate array with pointers to all vectors in the file
   allocate(fields(field_data%size()))
-  
   call field_data%get_list(fields,field_data%size())
+  ! Compute average in two direction directly and store in a csv file
+  if (avg_to_1d) then
+     n_1d = n_levels*Xh%lx
+     call avg_matrix%init(n_1d,field_data%size()+1)
+     call volume_per_gll_lvl%init(n_1d)
+     do i = 1, n
+        volume_per_gll_lvl%x(map_1d%pt_lvl(i,1,1,1)) = &
+        volume_per_gll_lvl%x(map_1d%pt_lvl(i,1,1,1)) + coef%B(i,1,1,1)
+     end do
+     call MPI_Allreduce(MPI_IN_PLACE,volume_per_gll_lvl%x, n_1d, &
+        MPI_REAL_PRECISION, MPI_SUM, NEKO_COMM, ierr)
+     !ugly way of getting coordinates, computes average
+     do i = 1, n
+           if (dir .eq. 1) coord = dof%x(i,1,1,1)
+           if (dir .eq. 2) coord = dof%y(i,1,1,1)
+           if (dir .eq. 3) coord = dof%z(i,1,1,1)
+           avg_matrix%x(map_1d%pt_lvl(i,1,1,1),1) = &
+           avg_matrix%x(map_1d%pt_lvl(i,1,1,1),1) + coord*coef%B(i,1,1,1)/volume_per_gll_lvl%x(map_1d%pt_lvl(i,1,1,1))
+     end do
+     do j = 2, field_data%size()+1
+        do i = 1, n
+           avg_matrix%x(map_1d%pt_lvl(i,1,1,1),j) = &
+           avg_matrix%x(map_1d%pt_lvl(i,1,1,1),j) + fields(j-1)%v%x(i)*coef%B(i,1,1,1)/volume_per_gll_lvl%x(map_1d%pt_lvl(i,1,1,1))
+        end do
+     end do 
+     call MPI_Allreduce(MPI_IN_PLACE,avg_matrix%x, (field_data%size()+1)*n_1d, &
+        MPI_REAL_PRECISION, MPI_SUM, NEKO_COMM, ierr)
 
-  do i = 1, field_data%size()
-     call copy(old_u%x,fields(i)%v%x,n)
-     call perform_local_summation(u,old_u, el_heights, domain_height, &
-          map_1d%dir_el, coef, msh%nelv, lx)
-     call copy(old_u%x,u%x,n)
-     call copy(avg_u%x,u%x,n)
+     output_file = file_t(trim(output_fname))
+     call output_file%write(avg_matrix)
+  ! Compute averages in 1 direction and store in a 3d field (lots of redundant data, sorry)
+  ! Should output a 2d field in principle
+  else
+
+
+     do i = 1, msh%nelv
+        !find height in hom-dir
+        !direction in local coords (r,s,t) that is hom is stored in map_1d%dir_el
+        !set element to height
+        !we assume elements are stacked on eachother...
+        el_dim(1,:) = abs(msh%elements(i)%e%pts(1)%p%x-msh%elements(i)%e%pts(2)%p%x)
+        el_dim(2,:) = abs(msh%elements(i)%e%pts(1)%p%x-msh%elements(i)%e%pts(3)%p%x)
+        el_dim(3,:) = abs(msh%elements(i)%e%pts(1)%p%x-msh%elements(i)%e%pts(5)%p%x)
+        ! 1 corresponds to x, 2 to y, 3 to z
+        el_h = el_dim(map_1d%dir_el(i),dir)
+        el_heights%x(:,:,:,i) = el_h
+     end do
+      
+     call copy(u%x,el_heights%x,n)
+     call copy(old_u%x,el_heights%x,n)
+     call copy(avg_u%x,el_heights%x,n)
      call perform_global_summation(u, avg_u, old_u, n_levels, &
           map_1d%dir_el,gs_h, coef%mult, msh%nelv, lx)
-     call copy(fields(i)%v%x,u%x,n)
-  end do 
-  output_file = file_t(trim(output_fname))
-  call output_file%write(field_data)
+     domain_height = u%x(1,1,1,1)
+
+
+     do i = 1, field_data%size()
+        call copy(old_u%x,fields(i)%v%x,n)
+        call perform_local_summation(u,old_u, el_heights, domain_height, &
+             map_1d%dir_el, coef, msh%nelv, lx)
+        call copy(old_u%x,u%x,n)
+        call copy(avg_u%x,u%x,n)
+        call perform_global_summation(u, avg_u, old_u, n_levels, &
+             map_1d%dir_el,gs_h, coef%mult, msh%nelv, lx)
+        call copy(fields(i)%v%x,u%x,n)
+     end do 
+     output_file = file_t(trim(output_fname))
+     call output_file%write(field_data)
+  end if
   if (pe_rank .eq. 0) write(*,*) 'Done'
+
   
   call neko_finalize
 

--- a/contrib/average_field_in_space/average_field_in_space.f90
+++ b/contrib/average_field_in_space/average_field_in_space.f90
@@ -28,9 +28,13 @@ program average_field_in_space
   if ((argc .lt. 4) .or. (argc .gt. 4)) then
      if (pe_rank .eq. 0) then
         write(*,*) 'Usage: ./average_field_in_space mesh.nmsh field.fld dir(x, y, z, xz, xy, yz)  outfield.(fld,csv)' 
+        write(*,*) '----'
         write(*,*) 'Example command for avg in 1 direction: ./average_field_in_space mesh.nmsh fieldblabla.fld x  outfield.fld'
-        write(*,*) 'Computes the spatial average in 2 directions diretly of the field fieldblabla.nek5000 and stores in out.csv'
+        write(*,*) 'Computes spatial average in 1 direction and saves it in outfield.fld'
+        write(*,*) '----'
         write(*,*) 'Example command: ./average_field_in_space mesh.nmsh fieldblabla.fld xy  out.csv'
+        write(*,*) 'Computes the spatial average in 2 directions diretly of the field fieldblabla.nek5000 and stores in out.csv'
+        write(*,*) '----'
         write(*,*) 'In out.csv the firsct col are the coords of the gll points'
         write(*,*) 'In columns 2-n_fields are the averages for all fields in fieldblabla.fld'
         write(*,*) 'If averaging in 2 directions output must be .csv and for 1 direction .fld'

--- a/examples/turb_channel/README.md
+++ b/examples/turb_channel/README.md
@@ -5,3 +5,5 @@ To compute thte spatial and temporal averages of the output fields, mean_fields 
 - average_fields_in_time, averages a fld series in time
 - average_field_in_space, for channelflow we can directly average in xz
 - postprocess_fluid_stats, computes the mean gradients and the reynolds stresses. 
+
+To see the options for each postprocessing script, run it without any command line arguments, for example: ./average_field_in_space

--- a/examples/turb_channel/README.md
+++ b/examples/turb_channel/README.md
@@ -1,3 +1,7 @@
 #Simple turbulent channel case at Re_tau=180
 The channel starts with a slightly perturbed initial condition which becomes turbulent after around 10 time units.
-If one wants to change the mesh and play around, please do so, by generating a new mesh with genmeshbox. 
+If one wants to change the mesh and play around, please do so, by generating a new mesh with genmeshbox.
+To compute thte spatial and temporal averages of the output fields, mean_fields and stats one can use the following contrib scripts:
+- average_fields_in_time, averages a fld series in time
+- average_field_in_space, for channelflow we can directly average in xz
+- postprocess_fluid_stats, computes the mean gradients and the reynolds stresses. 

--- a/src/neko.f90
+++ b/src/neko.f90
@@ -83,6 +83,7 @@ module neko
   use fluid_user_source_term
   use scalar_user_source_term
   use vector
+  use matrix
   use tensor
   use simulation_component
   use probes

--- a/src/sem/map_1d.f90
+++ b/src/sem/map_1d.f90
@@ -9,7 +9,7 @@ module map_1d
   use device
   use comm
   use logger, only: neko_log, LOG_SIZE
-  use utils, only: neko_error
+  use utils, only: neko_error, neko_warning
   use math, only: glmax, glmin, glimax, glimin, relcmp
   use neko_mpi_types
   use, intrinsic :: iso_c_binding
@@ -59,7 +59,9 @@ contains
     call this%free()
 
     if (NEKO_BCKND_DEVICE .eq. 1) then
-       call neko_error('map_1d not yet supported on device')
+        if (pe_rank .eq. 0) then
+           call neko_warning('map_1d does not copy indices to device, but ok if used on cpu')
+        end if
     end if
     
     this%dir = dir
@@ -166,7 +168,9 @@ contains
       end do
     end do
     this%n_el_lvls = glimax(this%el_lvl,nelv)
-    write(*,*) 'number of element levels', this%n_el_lvls
+    if ( pe_rank .eq. 0) then
+       write(*,*) 'Number of element levels', this%n_el_lvls
+    end if
     !Numbers the points in each element based on the element level
     !and its orientation
     do e = 1, nelv


### PR DESCRIPTION
Adds support for computing average in 2 spatial directions directly if there is more than one homogenous direction (for example channel flow).

We also update map_1d so it does not break if compiled with GPU backend, it now gives a warning instead. Still, the mapping is only available on the CPU currently.