### PR TITLE
Refactor and extend field_list

### DIFF
--- a/src/common/structs.f90
+++ b/src/common/structs.f90
@@ -12,7 +12,7 @@ module structs
 
   !> Pointer to array
   type, public :: array_ptr_t
-     real(kind=rp), pointer :: x(:)
+     real(kind=rp), pointer :: ptr(:)
   end type array_ptr_t
 end module structs
 

--- a/src/field/field.f90
+++ b/src/field/field.f90
@@ -76,7 +76,7 @@ module field
 
   !> field_ptr_t, To easily obtain a pointer to a field
   type, public ::  field_ptr_t
-     type(field_t), pointer :: f => null()
+     type(field_t), pointer :: ptr => null()
   end type field_ptr_t
 
 contains

--- a/src/field/field_list.f90
+++ b/src/field/field_list.f90
@@ -1,19 +1,63 @@
 module field_list
   use field, only : field_ptr_t, field_t
+  use iso_c_binding, only : c_ptr
   implicit none
   private
 
   !> field_list_t, To be able to group fields together
   type, public :: field_list_t
-     type(field_ptr_t), allocatable :: fields(:)
+     type(field_ptr_t), allocatable :: items(:)
    contains
+     !> Constructor. Allocates array and pointers.
+     procedure, pass(this) :: init => field_list_init
+     !> Destructor.
+     procedure, pass(this) :: free => field_list_free
      !> Append a field to the list.
      procedure, pass(this) :: append => field_list_append
-     !> Destructor
-     procedure, pass(this) :: free => field_list_free
+     !> Get an item pointer by array index
+     procedure, pass(this) :: get => field_list_get
+     !> Point item at given index.
+     generic :: set => set_to_ptr, set_to_field_ptr
+     procedure, pass(this) :: set_to_ptr => field_list_set_to_ptr
+     procedure, pass(this) :: set_to_field_ptr => field_list_set_to_field_ptr
+     procedure, pass(this) :: set_to_field => field_list_set_to_field
+
+     !> Get device pointer for a given index
+     procedure, pass(this) :: x_d => field_list_x_d
+
+     !> Get number of items in the list.
+     procedure, pass(this) :: size => field_list_size
   end type field_list_t
 
 contains
+  !> Constructor. Just allocates the array.
+  !! @param size The size of the list to preallocate
+  subroutine field_list_init(this, size)
+    class(field_list_t), intent(inout) :: this
+    integer, intent(in) :: size
+    integer :: i
+
+    call this%free()
+
+    allocate(this%items(size))
+  end subroutine field_list_init
+
+  !> Get number of items in the list.
+  pure function field_list_size(this) result(n)
+    class(field_list_t), intent(in) :: this
+    integer :: n
+    n = size(this%items)
+  end function field_list_size
+
+  !> Get an item pointer by array index
+  !! @param i The index of the item.
+  function field_list_get(this, i) result(f)
+    class(field_list_t), intent(inout) :: this
+    type(field_t), pointer :: f
+    integer :: i
+    f = this%items(i)%ptr
+  end function field_list_get
+
   !> Append a field to the list.
   !! @param f The field to append.
   subroutine field_list_append(this, f)
@@ -22,12 +66,12 @@ contains
     type(field_ptr_t), allocatable :: tmp(:)
     integer :: len
 
-    len = size(this%fields)
+    len = size(this%items)
 
     allocate(tmp(len+1))
-    tmp(1:len) = this%fields
-    call move_alloc(tmp, this%fields)
-    this%fields(len+1)%f => f
+    tmp(1:len) = this%items
+    call move_alloc(tmp, this%items)
+    this%items(len+1)%ptr => f
 
   end subroutine field_list_append
 
@@ -36,16 +80,58 @@ contains
     class(field_list_t), intent(inout) :: this
     integer :: i, n_fields
 
-    if (allocated(this%fields)) then
-       n_fields = size(this%fields)
+    if (allocated(this%items)) then
+       n_fields = this%size()
        do i=1, n_fields
-          call this%fields(i)%f%free()
-          nullify(this%fields(i)%f)
+          call this%items(i)%ptr%free()
+          nullify(this%items(i)%ptr)
        end do
-       deallocate(this%fields)
+       deallocate(this%items)
     end if
 
   end subroutine field_list_free
+
+  !> Get device pointer for a given index
+  !! @param i The index of the item.
+  function field_list_x_d(this, i) result(ptr)
+    class(field_list_t), intent(inout) :: this
+    type(c_ptr), pointer :: ptr
+    integer :: i
+    ptr = this%items(i)%ptr%x_d
+  end function field_list_x_d
+
+  !> Point item at a given index.
+  !! @param i The index of the item.
+  !! @param ptr A field pointer to point the item to.
+  subroutine field_list_set_to_ptr(this, i, ptr)
+    class(field_list_t), intent(inout) :: this
+    integer, intent(in) :: i
+    type(field_t), pointer, intent(in) :: ptr
+
+    this%items(i)%ptr => ptr
+  end subroutine field_list_set_to_ptr
+
+  !> Point item at a given index.
+  !! @param i The index of the item.
+  !! @param ptr An encapsulated field pointer to point the item to.
+  subroutine field_list_set_to_field_ptr(this, i, ptr)
+    class(field_list_t), intent(inout) :: this
+    integer, intent(in) :: i
+    type(field_ptr_t), intent(in) :: ptr
+
+    this%items(i)%ptr => ptr%ptr
+  end subroutine field_list_set_to_field_ptr
+
+  !> Point item at a given index.
+  !! @param i The index of the item.
+  !! @param field A field to point the item to.
+  subroutine field_list_set_to_field(this, i, fld)
+    class(field_list_t), intent(inout) :: this
+    integer, intent(in) :: i
+    type(field_t), target, intent(in) :: fld
+
+    this%items(i)%ptr => fld
+  end subroutine field_list_set_to_field
 
 
 

--- a/src/field/scratch_registry.f90
+++ b/src/field/scratch_registry.f90
@@ -99,7 +99,7 @@ contains
     if (present(size)) then
        allocate (this%fields(size))
        do i= 1, size
-          allocate(this%fields(i)%f)
+          allocate(this%fields(i)%ptr)
        end do
        allocate (this%inuse(size))
     else
@@ -125,8 +125,8 @@ contains
 
     if (allocated(this%fields)) then
        do i=1, this%nfields
-          call this%fields(i)%f%free()
-          deallocate(this%fields(i)%f)
+          call this%fields(i)%ptr%free()
+          deallocate(this%fields(i)%ptr)
        end do
 
        deallocate(this%fields)
@@ -182,7 +182,7 @@ contains
     temp(1:this%nfields) = this%fields(1:this%nfields)
 
     do i=this%nfields +1, size(temp)
-       allocate(temp(i)%f)
+       allocate(temp(i)%ptr)
     enddo
 
     call move_alloc(temp, this%fields)
@@ -208,11 +208,11 @@ contains
          if (this%inuse(index) .eqv. .false.) then
             write (name, "(A3,I0.3)") "wrk", index
 
-            if (.not. allocated(this%fields(index)%f%x)) then
-               call this%fields(index)%f%init(this%dof, trim(name))
+            if (.not. allocated(this%fields(index)%ptr%x)) then
+               call this%fields(index)%ptr%init(this%dof, trim(name))
                nfields = nfields + 1
             end if
-            f => this%fields(index)%f
+            f => this%fields(index)%ptr
             this%inuse(index) = .true.
             this%nfields_inuse = this%nfields_inuse + 1
             return
@@ -225,8 +225,8 @@ contains
       nfields_inuse = nfields_inuse + 1
       this%inuse(nfields) = .true.
       write (name, "(A3,I0.3)") "wrk", index
-      call this%fields(nfields)%f%init(this%dof, trim(name))
-      f => this%fields(nfields)%f
+      call this%fields(nfields)%ptr%init(this%dof, trim(name))
+      f => this%fields(nfields)%ptr
 
     end associate
   end subroutine request_field

--- a/src/fluid/fluid_source_term.f90
+++ b/src/fluid/fluid_source_term.f90
@@ -108,10 +108,10 @@ contains
 
     if (json%valid_path('case.fluid.source_terms')) then
        ! We package the fields for the source term to operate on in a field list.
-       allocate(rhs_fields%fields(3))
-       rhs_fields%fields(1)%f => f_x
-       rhs_fields%fields(2)%f => f_y
-       rhs_fields%fields(3)%f => f_z
+       call rhs_fields%init(3)
+       call rhs_fields%set(1, f_x)
+       call rhs_fields%set(2, f_y)
+       call rhs_fields%set(3, f_z)
 
        call json%get_core(core)
        call json%get('case.fluid.source_terms', source_object, found)

--- a/src/fluid/fluid_stats.f90
+++ b/src/fluid/fluid_stats.f90
@@ -227,49 +227,49 @@ contains
     call this%e13%init(this%stats_work, 'e13')
     call this%e23%init(this%stats_work, 'e23')
 
-    allocate(this%stat_fields%fields(this%n_stats))
+    allocate(this%stat_fields%items(this%n_stats))
 
-    this%stat_fields%fields(1)%f => this%pp%mf
-    this%stat_fields%fields(2)%f => this%uu%mf
-    this%stat_fields%fields(3)%f => this%vv%mf
-    this%stat_fields%fields(4)%f => this%ww%mf
-    this%stat_fields%fields(5)%f => this%uv%mf
-    this%stat_fields%fields(6)%f => this%uw%mf
-    this%stat_fields%fields(7)%f => this%vw%mf
-    this%stat_fields%fields(8)%f => this%uuu%mf !< <uuu>
-    this%stat_fields%fields(9)%f => this%vvv%mf !< <vvv>
-    this%stat_fields%fields(10)%f => this%www%mf !< <www>
-    this%stat_fields%fields(11)%f => this%uuv%mf !< <uuv>
-    this%stat_fields%fields(12)%f => this%uuw%mf !< <uuw>
-    this%stat_fields%fields(13)%f => this%uvv%mf !< <uvv>
-    this%stat_fields%fields(14)%f => this%uvw%mf !< <uvv>
-    this%stat_fields%fields(15)%f => this%vvw%mf !< <vvw>
-    this%stat_fields%fields(16)%f => this%uww%mf !< <uww>
-    this%stat_fields%fields(17)%f => this%vww%mf !< <vww>
-    this%stat_fields%fields(18)%f => this%uuuu%mf !< <uuuu>
-    this%stat_fields%fields(19)%f => this%vvvv%mf !< <vvvv>
-    this%stat_fields%fields(20)%f => this%wwww%mf !< <wwww>
-    this%stat_fields%fields(21)%f => this%ppp%mf
-    this%stat_fields%fields(22)%f => this%pppp%mf
-    this%stat_fields%fields(23)%f => this%pu%mf
-    this%stat_fields%fields(24)%f => this%pv%mf
-    this%stat_fields%fields(25)%f => this%pw%mf
+    this%stat_fields%items(1)%ptr => this%pp%mf
+    this%stat_fields%items(2)%ptr => this%uu%mf
+    this%stat_fields%items(3)%ptr => this%vv%mf
+    this%stat_fields%items(4)%ptr => this%ww%mf
+    this%stat_fields%items(5)%ptr => this%uv%mf
+    this%stat_fields%items(6)%ptr => this%uw%mf
+    this%stat_fields%items(7)%ptr => this%vw%mf
+    this%stat_fields%items(8)%ptr => this%uuu%mf !< <uuu>
+    this%stat_fields%items(9)%ptr => this%vvv%mf !< <vvv>
+    this%stat_fields%items(10)%ptr => this%www%mf !< <www>
+    this%stat_fields%items(11)%ptr => this%uuv%mf !< <uuv>
+    this%stat_fields%items(12)%ptr => this%uuw%mf !< <uuw>
+    this%stat_fields%items(13)%ptr => this%uvv%mf !< <uvv>
+    this%stat_fields%items(14)%ptr => this%uvw%mf !< <uvv>
+    this%stat_fields%items(15)%ptr => this%vvw%mf !< <vvw>
+    this%stat_fields%items(16)%ptr => this%uww%mf !< <uww>
+    this%stat_fields%items(17)%ptr => this%vww%mf !< <vww>
+    this%stat_fields%items(18)%ptr => this%uuuu%mf !< <uuuu>
+    this%stat_fields%items(19)%ptr => this%vvvv%mf !< <vvvv>
+    this%stat_fields%items(20)%ptr => this%wwww%mf !< <wwww>
+    this%stat_fields%items(21)%ptr => this%ppp%mf
+    this%stat_fields%items(22)%ptr => this%pppp%mf
+    this%stat_fields%items(23)%ptr => this%pu%mf
+    this%stat_fields%items(24)%ptr => this%pv%mf
+    this%stat_fields%items(25)%ptr => this%pw%mf
 
-    this%stat_fields%fields(26)%f => this%pdudx%mf
-    this%stat_fields%fields(27)%f => this%pdudy%mf
-    this%stat_fields%fields(28)%f => this%pdudz%mf
-    this%stat_fields%fields(29)%f => this%pdvdx%mf
-    this%stat_fields%fields(30)%f => this%pdvdy%mf
-    this%stat_fields%fields(31)%f => this%pdvdz%mf
-    this%stat_fields%fields(32)%f => this%pdwdx%mf
-    this%stat_fields%fields(33)%f => this%pdwdy%mf
-    this%stat_fields%fields(34)%f => this%pdwdz%mf
-    this%stat_fields%fields(35)%f => this%e11%mf
-    this%stat_fields%fields(36)%f => this%e22%mf
-    this%stat_fields%fields(37)%f => this%e33%mf
-    this%stat_fields%fields(38)%f => this%e12%mf
-    this%stat_fields%fields(39)%f => this%e13%mf
-    this%stat_fields%fields(40)%f => this%e23%mf
+    this%stat_fields%items(26)%ptr => this%pdudx%mf
+    this%stat_fields%items(27)%ptr => this%pdudy%mf
+    this%stat_fields%items(28)%ptr => this%pdudz%mf
+    this%stat_fields%items(29)%ptr => this%pdvdx%mf
+    this%stat_fields%items(30)%ptr => this%pdvdy%mf
+    this%stat_fields%items(31)%ptr => this%pdvdz%mf
+    this%stat_fields%items(32)%ptr => this%pdwdx%mf
+    this%stat_fields%items(33)%ptr => this%pdwdy%mf
+    this%stat_fields%items(34)%ptr => this%pdwdz%mf
+    this%stat_fields%items(35)%ptr => this%e11%mf
+    this%stat_fields%items(36)%ptr => this%e22%mf
+    this%stat_fields%items(37)%ptr => this%e33%mf
+    this%stat_fields%items(38)%ptr => this%e12%mf
+    this%stat_fields%items(39)%ptr => this%e13%mf
+    this%stat_fields%items(40)%ptr => this%e23%mf
 
 
   end subroutine fluid_stats_init
@@ -648,35 +648,35 @@ contains
     integer :: n
 
     if (present(mean)) then
-       n = mean%fields(1)%f%dof%size()
-       call copy(mean%fields(1)%f%x,this%u_mean%x,n)
-       call copy(mean%fields(2)%f%x,this%v_mean%x,n)
-       call copy(mean%fields(3)%f%x,this%w_mean%x,n)
-       call copy(mean%fields(4)%f%x,this%p_mean%x,n)
+       n = mean%items(1)%ptr%dof%size()
+       call copy(mean%items(1)%ptr%x,this%u_mean%x,n)
+       call copy(mean%items(2)%ptr%x,this%v_mean%x,n)
+       call copy(mean%items(3)%ptr%x,this%w_mean%x,n)
+       call copy(mean%items(4)%ptr%x,this%p_mean%x,n)
     end if
 
     if (present(reynolds)) then
-       n = reynolds%fields(1)%f%dof%size()
-       call copy(reynolds%fields(1)%f%x,this%pp%mf%x,n)
-       call subcol3(reynolds%fields(1)%f%x,this%p_mean%x,this%p_mean%x,n)
+       n = reynolds%items(1)%ptr%dof%size()
+       call copy(reynolds%items(1)%ptr%x,this%pp%mf%x,n)
+       call subcol3(reynolds%items(1)%ptr%x,this%p_mean%x,this%p_mean%x,n)
 
-       call copy(reynolds%fields(2)%f%x,this%uu%mf%x,n)
-       call subcol3(reynolds%fields(2)%f%x,this%u_mean%x,this%u_mean%x,n)
+       call copy(reynolds%items(2)%ptr%x,this%uu%mf%x,n)
+       call subcol3(reynolds%items(2)%ptr%x,this%u_mean%x,this%u_mean%x,n)
 
-       call copy(reynolds%fields(3)%f%x,this%vv%mf%x,n)
-       call subcol3(reynolds%fields(3)%f%x,this%v_mean%x,this%v_mean%x,n)
+       call copy(reynolds%items(3)%ptr%x,this%vv%mf%x,n)
+       call subcol3(reynolds%items(3)%ptr%x,this%v_mean%x,this%v_mean%x,n)
 
-       call copy(reynolds%fields(4)%f%x,this%ww%mf%x,n)
-       call subcol3(reynolds%fields(4)%f%x,this%w_mean%x,this%w_mean%x,n)
+       call copy(reynolds%items(4)%ptr%x,this%ww%mf%x,n)
+       call subcol3(reynolds%items(4)%ptr%x,this%w_mean%x,this%w_mean%x,n)
 
-       call copy(reynolds%fields(5)%f%x,this%uv%mf%x,n)
-       call subcol3(reynolds%fields(5)%f%x,this%u_mean%x,this%v_mean%x,n)
+       call copy(reynolds%items(5)%ptr%x,this%uv%mf%x,n)
+       call subcol3(reynolds%items(5)%ptr%x,this%u_mean%x,this%v_mean%x,n)
 
-       call copy(reynolds%fields(6)%f%x,this%uw%mf%x,n)
-       call subcol3(reynolds%fields(6)%f%x,this%u_mean%x,this%w_mean%x,n)
+       call copy(reynolds%items(6)%ptr%x,this%uw%mf%x,n)
+       call subcol3(reynolds%items(6)%ptr%x,this%u_mean%x,this%w_mean%x,n)
 
-       call copy(reynolds%fields(7)%f%x,this%vw%mf%x,n)
-       call subcol3(reynolds%fields(7)%f%x,this%v_mean%x,this%w_mean%x,n)
+       call copy(reynolds%items(7)%ptr%x,this%vw%mf%x,n)
+       call subcol3(reynolds%items(7)%ptr%x,this%v_mean%x,this%w_mean%x,n)
     end if
     if (present(pressure_skewness)) then
 
@@ -695,7 +695,7 @@ contains
 
     if (present(mean_vel_grad)) then
        !Compute gradient of mean flow
-       n = mean_vel_grad%fields(1)%f%dof%size()
+       n = mean_vel_grad%items(1)%ptr%dof%size()
        if (NEKO_BCKND_DEVICE .eq. 1) then
           call device_memcpy(this%u_mean%x, this%u_mean%x_d, n, &
                              HOST_TO_DEVICE, sync=.false.)
@@ -728,20 +728,20 @@ contains
           call device_memcpy(this%dwdz%x, this%dwdz%x_d, n, &
                              DEVICE_TO_HOST, sync=.true.)
        else
-          call opgrad(this%dudx%x,this%dudy%x, this%dudz%x,this%u_mean%x,this%coef)
-          call opgrad(this%dvdx%x,this%dvdy%x, this%dvdz%x,this%v_mean%x,this%coef)
-          call opgrad(this%dwdx%x,this%dwdy%x, this%dwdz%x,this%w_mean%x,this%coef)
+          call opgrad(this%dudx%x,this%dudy%x, this%dudz%x, this%u_mean%x,this%coef)
+          call opgrad(this%dvdx%x,this%dvdy%x, this%dvdz%x, this%v_mean%x,this%coef)
+          call opgrad(this%dwdx%x,this%dwdy%x, this%dwdz%x, this%w_mean%x,this%coef)
        end if
        call invers2(this%stats_work%x, this%coef%B,n)
-       call col3(mean_vel_grad%fields(1)%f%x, this%dudx%x,this%stats_work%x, n)
-       call col3(mean_vel_grad%fields(2)%f%x, this%dudy%x,this%stats_work%x, n)
-       call col3(mean_vel_grad%fields(3)%f%x, this%dudz%x,this%stats_work%x, n)
-       call col3(mean_vel_grad%fields(4)%f%x, this%dvdx%x,this%stats_work%x, n)
-       call col3(mean_vel_grad%fields(5)%f%x, this%dvdy%x,this%stats_work%x, n)
-       call col3(mean_vel_grad%fields(6)%f%x, this%dvdz%x,this%stats_work%x, n)
-       call col3(mean_vel_grad%fields(7)%f%x, this%dwdx%x,this%stats_work%x, n)
-       call col3(mean_vel_grad%fields(8)%f%x, this%dwdy%x,this%stats_work%x, n)
-       call col3(mean_vel_grad%fields(9)%f%x, this%dwdz%x,this%stats_work%x, n)
+       call col3(mean_vel_grad%items(1)%ptr%x, this%dudx%x, this%stats_work%x, n)
+       call col3(mean_vel_grad%items(2)%ptr%x, this%dudy%x, this%stats_work%x, n)
+       call col3(mean_vel_grad%items(3)%ptr%x, this%dudz%x, this%stats_work%x, n)
+       call col3(mean_vel_grad%items(4)%ptr%x, this%dvdx%x, this%stats_work%x, n)
+       call col3(mean_vel_grad%items(5)%ptr%x, this%dvdy%x, this%stats_work%x, n)
+       call col3(mean_vel_grad%items(6)%ptr%x, this%dvdz%x, this%stats_work%x, n)
+       call col3(mean_vel_grad%items(7)%ptr%x, this%dwdx%x, this%stats_work%x, n)
+       call col3(mean_vel_grad%items(8)%ptr%x, this%dwdy%x, this%stats_work%x, n)
+       call col3(mean_vel_grad%items(9)%ptr%x, this%dwdz%x, this%stats_work%x, n)
 
     end if
 

--- a/src/fluid/fluid_user_source_term.f90
+++ b/src/fluid/fluid_user_source_term.f90
@@ -160,7 +160,7 @@ contains
     call this%free()
     call this%init_base(fields, coef, 0.0_rp, huge(0.0_rp))
 
-    this%dm => fields%fields(1)%f%dof
+    this%dm => fields%items(1)%ptr%dof
 
     allocate(this%u(this%dm%Xh%lx, this%dm%Xh%ly, this%dm%Xh%lz, &
              this%dm%msh%nelv))
@@ -224,16 +224,16 @@ contains
     integer :: n
 
     call this%compute_vector_(this, t)
-    n = this%fields%fields(1)%f%dof%size()
+    n = this%fields%items(1)%ptr%dof%size()
 
     if (NEKO_BCKND_DEVICE .eq. 1) then
-       call device_add2(this%fields%fields(1)%f%x_d, this%u_d, n)
-       call device_add2(this%fields%fields(2)%f%x_d, this%v_d, n)
-       call device_add2(this%fields%fields(3)%f%x_d, this%w_d, n)
+       call device_add2(this%fields%x_d(1), this%u_d, n)
+       call device_add2(this%fields%x_d(2), this%v_d, n)
+       call device_add2(this%fields%x_d(3), this%w_d, n)
     else
-       call add2(this%fields%fields(1)%f%x, this%u, n)
-       call add2(this%fields%fields(2)%f%x, this%v, n)
-       call add2(this%fields%fields(3)%f%x, this%w, n)
+       call add2(this%fields%items(1)%ptr%x, this%u, n)
+       call add2(this%fields%items(2)%ptr%x, this%v, n)
+       call add2(this%fields%items(3)%ptr%x, this%w, n)
     end if
 
   end subroutine fluid_user_source_term_compute

--- a/src/io/fld_file.f90
+++ b/src/io/fld_file.f90
@@ -112,27 +112,27 @@ contains
 
     select type(data)
     type is (fld_file_data_t)
-       if (data%x%n .gt. 0) x%x => data%x%x
-       if (data%y%n .gt. 0) y%x => data%y%x
-       if (data%z%n .gt. 0) z%x => data%z%x
+       if (data%x%n .gt. 0) x%ptr => data%x%x
+       if (data%y%n .gt. 0) y%ptr => data%y%x
+       if (data%z%n .gt. 0) z%ptr => data%z%x
        if (data%u%n .gt. 0) then
-          u%x => data%u%x
+          u%ptr => data%u%x
           write_velocity = .true.
        end if
-       if (data%v%n .gt. 0) v%x => data%v%x
-       if (data%w%n .gt. 0) w%x => data%w%x
+       if (data%v%n .gt. 0) v%ptr => data%v%x
+       if (data%w%n .gt. 0) w%ptr => data%w%x
        if (data%p%n .gt. 0) then
-          p%x => data%p%x
+          p%ptr => data%p%x
           write_pressure = .true.
        end if
        if (data%t%n .gt. 0) then
           write_temperature = .true.
-          tem%x => data%t%x
+          tem%ptr => data%t%x
        end if
        n_scalar_fields = data%n_scalars
        allocate(scalar_fields(n_scalar_fields))
        do i = 1, n_scalar_fields
-          scalar_fields(i)%x => data%s(i)%x
+          scalar_fields(i)%ptr => data%s(i)%x
        end do
        nelv = data%nelv
        lx = data%lx
@@ -147,43 +147,43 @@ contains
           idx(i) = data%idx(i)
        end do
     type is (field_t)
-       p%x => data%x(:,1,1,1)
+       p%ptr => data%x(:,1,1,1)
        dof => data%dof
        write_pressure = .true.
        write_velocity = .false.
     type is (field_list_t)
-       select case (size(data%fields))
+       select case (data%size())
        case (1)
-          p%x => data%fields(1)%f%x(:,1,1,1)
+          p%ptr => data%items(1)%ptr%x(:,1,1,1)
           write_pressure = .true.
           write_velocity = .false.
        case (2)
-          p%x => data%fields(1)%f%x(:,1,1,1)
-          tem%x => data%fields(2)%f%x(:,1,1,1)
+          p%ptr => data%items(1)%ptr%x(:,1,1,1)
+          tem%ptr => data%items(2)%ptr%x(:,1,1,1)
           write_pressure = .true.
           write_temperature = .true.
        case (3)
-          u%x => data%fields(1)%f%x(:,1,1,1)
-          v%x => data%fields(2)%f%x(:,1,1,1)
-          w%x => data%fields(3)%f%x(:,1,1,1)
+          u%ptr => data%items(1)%ptr%x(:,1,1,1)
+          v%ptr => data%items(2)%ptr%x(:,1,1,1)
+          w%ptr => data%items(3)%ptr%x(:,1,1,1)
           write_velocity = .true.
        case (4)
-          p%x => data%fields(1)%f%x(:,1,1,1)
-          u%x => data%fields(2)%f%x(:,1,1,1)
-          v%x => data%fields(3)%f%x(:,1,1,1)
-          w%x => data%fields(4)%f%x(:,1,1,1)
+          p%ptr => data%items(1)%ptr%x(:,1,1,1)
+          u%ptr => data%items(2)%ptr%x(:,1,1,1)
+          v%ptr => data%items(3)%ptr%x(:,1,1,1)
+          w%ptr => data%items(4)%ptr%x(:,1,1,1)
           write_pressure = .true.
           write_velocity = .true.
        case (5:99)
-          p%x => data%fields(1)%f%x(:,1,1,1)
-          u%x => data%fields(2)%f%x(:,1,1,1)
-          v%x => data%fields(3)%f%x(:,1,1,1)
-          w%x => data%fields(4)%f%x(:,1,1,1)
-          tem%x => data%fields(5)%f%x(:,1,1,1)
-          n_scalar_fields = size(data%fields) - 5
+          p%ptr => data%items(1)%ptr%x(:,1,1,1)
+          u%ptr => data%items(2)%ptr%x(:,1,1,1)
+          v%ptr => data%items(3)%ptr%x(:,1,1,1)
+          w%ptr => data%items(4)%ptr%x(:,1,1,1)
+          tem%ptr => data%items(5)%ptr%x(:,1,1,1)
+          n_scalar_fields = data%size() - 5
           allocate(scalar_fields(n_scalar_fields))
           do i = 1,n_scalar_fields
-             scalar_fields(i)%x => data%fields(i+5)%f%x(:,1,1,1)
+             scalar_fields(i)%ptr => data%items(i+5)%ptr%x(:,1,1,1)
           end do
           write_pressure = .true.
           write_velocity = .true.
@@ -191,21 +191,21 @@ contains
        case default
           call neko_error('This many fields not supported yet, fld_file')
        end select
-       dof => data%fields(1)%f%dof
+       dof => data%items(1)%ptr%dof
 
     type is (mean_flow_t)
-       u%x => data%u%mf%x(:,1,1,1)
-       v%x => data%v%mf%x(:,1,1,1)
-       w%x => data%w%mf%x(:,1,1,1)
-       p%x => data%p%mf%x(:,1,1,1)
+       u%ptr => data%u%mf%x(:,1,1,1)
+       v%ptr => data%v%mf%x(:,1,1,1)
+       w%ptr => data%w%mf%x(:,1,1,1)
+       p%ptr => data%p%mf%x(:,1,1,1)
        dof => data%u%mf%dof
        write_pressure = .true.
        write_velocity = .true.
     type is (mean_sqr_flow_t)
-       u%x => data%uu%mf%x(:,1,1,1)
-       v%x => data%vv%mf%x(:,1,1,1)
-       w%x => data%ww%mf%x(:,1,1,1)
-       p%x => data%pp%mf%x(:,1,1,1)
+       u%ptr => data%uu%mf%x(:,1,1,1)
+       v%ptr => data%vv%mf%x(:,1,1,1)
+       w%ptr => data%ww%mf%x(:,1,1,1)
+       p%ptr => data%pp%mf%x(:,1,1,1)
        dof => data%pp%mf%dof
        write_pressure = .true.
        write_velocity = .true.
@@ -214,9 +214,9 @@ contains
     end select
     ! Fix things for pointers that do not exist in all data types...
     if (associated(dof)) then
-       x%x => dof%x(:,1,1,1)
-       y%x => dof%y(:,1,1,1)
-       z%x => dof%z(:,1,1,1)
+       x%ptr => dof%x(:,1,1,1)
+       y%ptr => dof%y(:,1,1,1)
+       z%ptr => dof%z(:,1,1,1)
        msh => dof%msh
        Xh => dof%Xh
     end if
@@ -324,7 +324,7 @@ contains
             (int(gdim*lxyz, i8) * &
             int(FLD_DATA_SIZE, i8))
 
-       call fld_file_write_vector_field(this, fh, byte_offset, x%x, y%x, z%x, n,  gdim, lxyz, nelv)
+       call fld_file_write_vector_field(this, fh, byte_offset, x%ptr, y%ptr, z%ptr, n,  gdim, lxyz, nelv)
        mpi_offset = mpi_offset + int(glb_nelv, i8) * &
             (int(gdim *lxyz, i8) * &
             int(FLD_DATA_SIZE, i8))
@@ -334,7 +334,7 @@ contains
        byte_offset = mpi_offset + int(offset_el, i8) * &
             (int(gdim * (lxyz), i8) * &
             int(FLD_DATA_SIZE, i8))
-       call fld_file_write_vector_field(this, fh, byte_offset, u%x, v%x, w%x, n, gdim, lxyz, nelv)
+       call fld_file_write_vector_field(this, fh, byte_offset, u%ptr, v%ptr, w%ptr, n, gdim, lxyz, nelv)
 
        mpi_offset = mpi_offset + int(glb_nelv, i8) * &
             (int(gdim * (lxyz), i8) * &
@@ -346,7 +346,7 @@ contains
        byte_offset = mpi_offset + int(offset_el, i8) * &
             (int((lxyz), i8) * &
             int(FLD_DATA_SIZE, i8))
-       call fld_file_write_field(this, fh, byte_offset, p%x, n)
+       call fld_file_write_field(this, fh, byte_offset, p%ptr, n)
        mpi_offset = mpi_offset + int(glb_nelv, i8) * &
             (int((lxyz), i8) * &
             int(FLD_DATA_SIZE, i8))
@@ -356,7 +356,7 @@ contains
        byte_offset = mpi_offset + int(offset_el, i8) * &
             (int((lxyz), i8) * &
             int(FLD_DATA_SIZE, i8))
-       call fld_file_write_field(this, fh, byte_offset, tem%x, n)
+       call fld_file_write_field(this, fh, byte_offset, tem%ptr, n)
        mpi_offset = mpi_offset + int(glb_nelv, i8) * &
             (int((lxyz), i8) * &
             int(FLD_DATA_SIZE, i8))
@@ -374,7 +374,7 @@ contains
        byte_offset = int(mpi_offset,i8) + int(offset_el, i8) * &
             (int((lxyz), i8) * &
             int(FLD_DATA_SIZE, i8))
-       call fld_file_write_field(this, fh, byte_offset, scalar_fields(i)%x, n)
+       call fld_file_write_field(this, fh, byte_offset, scalar_fields(i)%ptr, n)
        mpi_offset = int(mpi_offset,i8) + int(glb_nelv, i8) * &
             (int(lxyz, i8) * &
             int(FLD_DATA_SIZE, i8))
@@ -389,7 +389,7 @@ contains
                      int(2, i8) * &
                      int(MPI_REAL_SIZE, i8) * &
                      int(gdim, i8)
-       call fld_file_write_metadata_vector(this, fh, byte_offset, x%x, y%x, z%x, gdim, lxyz, nelv)
+       call fld_file_write_metadata_vector(this, fh, byte_offset, x%ptr, y%ptr, z%ptr, gdim, lxyz, nelv)
        mpi_offset = int(mpi_offset,i8) + &
                      int(glb_nelv, i8) * &
                      int(2, i8) * &
@@ -403,7 +403,7 @@ contains
                      int(2, i8) * &
                      int(MPI_REAL_SIZE, i8) * &
                      int(gdim, i8)
-       call fld_file_write_metadata_vector(this, fh, byte_offset, u%x, v%x, w%x, gdim, lxyz, nelv)
+       call fld_file_write_metadata_vector(this, fh, byte_offset, u%ptr, v%ptr, w%ptr, gdim, lxyz, nelv)
        mpi_offset = int(mpi_offset,i8) + &
                      int(glb_nelv, i8) * &
                      int(2, i8) * &
@@ -417,7 +417,7 @@ contains
                      int(offset_el, i8) * &
                      int(2, i8) * &
                      int(MPI_REAL_SIZE, i8)
-       call fld_file_write_metadata_scalar(this, fh, byte_offset, p%x, lxyz, nelv)
+       call fld_file_write_metadata_scalar(this, fh, byte_offset, p%ptr, lxyz, nelv)
        mpi_offset = int(mpi_offset,i8) + &
                      int(glb_nelv, i8) * &
                      int(2, i8) * &
@@ -430,7 +430,7 @@ contains
                      int(offset_el, i8) * &
                      int(2, i8) * &
                      int(MPI_REAL_SIZE, i8)
-       call fld_file_write_metadata_scalar(this, fh, byte_offset, tem%x, lxyz, nelv)
+       call fld_file_write_metadata_scalar(this, fh, byte_offset, tem%ptr, lxyz, nelv)
        mpi_offset = int(mpi_offset,i8) + &
                      int(glb_nelv, i8) * &
                      int(2, i8) * &
@@ -455,7 +455,7 @@ contains
                      int(offset_el, i8) * &
                      int(2, i8) * &
                      int(MPI_REAL_SIZE, i8)
-       call fld_file_write_metadata_scalar(this, fh, byte_offset, scalar_fields(i)%x, lxyz, nelv)
+       call fld_file_write_metadata_scalar(this, fh, byte_offset, scalar_fields(i)%ptr, lxyz, nelv)
        mpi_offset = int(mpi_offset,i8) + &
                      int(glb_nelv, i8) * &
                      int(2, i8) * &

--- a/src/io/fld_file_data.f90
+++ b/src/io/fld_file_data.f90
@@ -78,27 +78,27 @@ contains
     type(vector_ptr_t), intent(inout) :: ptr_list(n)
     i = 1
     if(this%u%n .gt. 0) then
-       ptr_list(i)%v => this%u
+       ptr_list(i)%ptr => this%u
        i = i + 1
     end if
     if(this%v%n .gt. 0) then
-       ptr_list(i)%v => this%v
+       ptr_list(i)%ptr => this%v
        i = i + 1
     end if
     if(this%w%n .gt. 0) then
-       ptr_list(i)%v => this%w
+       ptr_list(i)%ptr => this%w
        i = i + 1
     end if
     if(this%p%n .gt. 0) then
-       ptr_list(i)%v => this%p
+       ptr_list(i)%ptr => this%p
        i = i + 1
     end if
     if(this%t%n .gt. 0) then
-       ptr_list(i)%v => this%t
+       ptr_list(i)%ptr => this%t
        i = i + 1
     end if
     do j = 1, this%n_scalars
-       ptr_list(i)%v => this%s(j)
+       ptr_list(i)%ptr => this%s(j)
        i = i +1
     end do
 

--- a/src/io/fld_file_output.f90
+++ b/src/io/fld_file_output.f90
@@ -74,11 +74,7 @@ contains
 
     call this%init_base(fname, precision)
 
-    if (allocated(this%fields%fields)) then
-       deallocate(this%fields%fields)
-    end if
-
-    allocate(this%fields%fields(nfields))
+    call this%fields%init(nfields)
 
    end subroutine fld_file_output_init
 
@@ -90,10 +86,10 @@ contains
     integer :: i
 
     if (NEKO_BCKND_DEVICE .eq. 1) then
-       associate(fields => this%fields%fields)
+       associate(fields => this%fields%items)
          do i = 1, size(fields)
-            call device_memcpy(fields(i)%f%x, fields(i)%f%x_d, &
-                 fields(i)%f%dof%size(), DEVICE_TO_HOST, &
+            call device_memcpy(fields(i)%ptr%x, fields(i)%ptr%x_d, &
+                 fields(i)%ptr%dof%size(), DEVICE_TO_HOST, &
                  sync=(i .eq. size(fields))) ! Sync on the last field
          end do
        end associate

--- a/src/io/fluid_output.f90
+++ b/src/io/fluid_output.f90
@@ -75,23 +75,19 @@ contains
 
     call this%init_base(fname, precision)
 
-    if (allocated(this%fluid%fields)) then
-       deallocate(this%fluid%fields)
-    end if
-
     if (present(scalar)) then
-       allocate(this%fluid%fields(5))
+       call this%fluid%init(5)
     else
-       allocate(this%fluid%fields(4))
+       call this%fluid%init(4)
     end if
 
-    this%fluid%fields(1)%f => fluid%p
-    this%fluid%fields(2)%f => fluid%u
-    this%fluid%fields(3)%f => fluid%v
-    this%fluid%fields(4)%f => fluid%w
+    call this%fluid%set(1, fluid%p)
+    call this%fluid%set(2, fluid%u)
+    call this%fluid%set(3, fluid%v)
+    call this%fluid%set(4, fluid%w)
 
     if (present(scalar)) then
-       this%fluid%fields(5)%f => scalar%s
+       call this%fluid%set(5, scalar%s)
     end if
 
   end function fluid_output_init
@@ -104,10 +100,10 @@ contains
 
     if (NEKO_BCKND_DEVICE .eq. 1) then
 
-       associate(fields => this%fluid%fields)
+       associate(fields => this%fluid%items)
          do i = 1, size(fields)
-            call device_memcpy(fields(i)%f%x, fields(i)%f%x_d, &
-                 fields(i)%f%dof%size(), DEVICE_TO_HOST, &
+            call device_memcpy(fields(i)%ptr%x, fields(i)%ptr%x_d, &
+                 fields(i)%ptr%dof%size(), DEVICE_TO_HOST, &
                  sync=(i .eq. size(fields))) ! Sync on the last field
          end do
        end associate

--- a/src/io/fluid_stats_output.f90
+++ b/src/io/fluid_stats_output.f90
@@ -81,13 +81,13 @@ contains
     class(fluid_stats_output_t), intent(inout) :: this
     real(kind=rp), intent(in) :: t
     integer :: i
-    associate (out_fields => this%stats%stat_fields%fields)
+    associate (out_fields => this%stats%stat_fields%items)
       if (t .ge. this%T_begin) then
          call this%stats%make_strong_grad()
          if ( NEKO_BCKND_DEVICE .eq. 1) then
             do i = 1, size(out_fields)
-               call device_memcpy(out_fields(i)%f%x, out_fields(i)%f%x_d,&
-                  out_fields(i)%f%dof%size(), DEVICE_TO_HOST, &
+               call device_memcpy(out_fields(i)%ptr%x, out_fields(i)%ptr%x_d,&
+                  out_fields(i)%ptr%dof%size(), DEVICE_TO_HOST, &
                   sync=(i .eq. size(out_fields))) ! Sync on last field
             end do
          end if

--- a/src/math/vector.f90
+++ b/src/math/vector.f90
@@ -56,7 +56,7 @@ module vector
   end type vector_t
 
   type, public :: vector_ptr_t
-     type(vector_t), pointer :: v
+     type(vector_t), pointer :: ptr
   end type vector_ptr_t
 
 contains

--- a/src/scalar/scalar_source_term.f90
+++ b/src/scalar/scalar_source_term.f90
@@ -102,8 +102,8 @@ contains
 
     if (json%valid_path('case.scalar.source_terms')) then
        ! We package the fields for the source term to operate on in a field list.
-       allocate(rhs_fields%fields(1))
-       rhs_fields%fields(1)%f => f
+       call rhs_fields%init(1)
+       call rhs_fields%set(1, f)
 
        call json%get_core(core)
        call json%get('case.scalar.source_terms', source_object, found)

--- a/src/scalar/scalar_user_source_term.f90
+++ b/src/scalar/scalar_user_source_term.f90
@@ -148,7 +148,7 @@ contains
     call this%free()
     call this%init_base(fields, coef, 0.0_rp, huge(0.0_rp))
 
-    this%dm => fields%fields(1)%f%dof
+    this%dm => fields%items(1)%ptr%dof
 
     allocate(this%s(this%dm%Xh%lx, this%dm%Xh%ly, this%dm%Xh%lz, &
              this%dm%msh%nelv))
@@ -200,12 +200,12 @@ contains
     integer :: n
 
     call this%compute_vector_(this, t)
-    n = this%fields%fields(1)%f%dof%size()
+    n = this%fields%items(1)%ptr%dof%size()
 
     if (NEKO_BCKND_DEVICE .eq. 1) then
-       call device_add2(this%fields%fields(1)%f%x_d, this%s_d, n)
+       call device_add2(this%fields%x_d(1), this%s_d, n)
     else
-       call add2(this%fields%fields(1)%f%x, this%s, n)
+       call add2(this%fields%items(1)%ptr%x, this%s, n)
     end if
 
   end subroutine scalar_user_source_term_compute

--- a/src/sem/spectral_error_indicator.f90
+++ b/src/sem/spectral_error_indicator.f90
@@ -669,16 +669,16 @@ contains
   !! @param uu field to add to the list
   !! @param vv field to add to the list
   !! @param ww field to add to the list
-  subroutine list_init3(list,uu,vv,ww)
+  subroutine list_init3(list, uu, vv, ww)
     type(field_list_t), intent(inout) :: list
     type(field_t) , target:: uu
     type(field_t) , target:: vv
     type(field_t) , target:: ww
     !> Initialize field lists
-    allocate(list%fields(3))
-    list%fields(1)%f => uu
-    list%fields(2)%f => vv
-    list%fields(3)%f => ww
+    call list%init(3)
+    call list%set(1, uu)
+    call list%set(2, vv)
+    call list%set(3, ww)
   end subroutine list_init3
 
 
@@ -686,8 +686,7 @@ contains
   !! @param list list to deallocate
   subroutine list_final3(list)
     type(field_list_t), intent(inout) :: list
-    !> Deallocate field lists
-    deallocate(list%fields)
+    call list%free
   end subroutine list_final3
 
 

--- a/src/simulation_components/field_writer.f90
+++ b/src/simulation_components/field_writer.f90
@@ -125,8 +125,7 @@ contains
        end if
        do i=1, size(fields)
           fieldi = trim(fields(i))
-          this%output%fields%fields(i)%f => &
-            neko_field_registry%get_field(fieldi)
+          call this%output%fields%set(i, neko_field_registry%get_field(fieldi))
        end do
 
        call this%case%s%add(this%output, &

--- a/src/simulation_components/probes.F90
+++ b/src/simulation_components/probes.F90
@@ -123,10 +123,11 @@ contains
     call json_get(json, 'points_file', points_file)
     call json_get(json, 'output_file', output_file)
 
-    allocate(this%sampled_fields%fields(this%n_fields))
+    call this%sampled_fields%init(this%n_fields)
     do i = 1, this%n_fields
-       this%sampled_fields%fields(i)%f => neko_field_registry%get_field(&
-                                          trim(this%which_fields(i)))
+
+       call this%sampled_fields%set(i, neko_field_registry%get_field(&
+                                    trim(this%which_fields(i))))
     end do
     !> This is distributed as to make it similar to parallel file
     !! formats latera
@@ -226,9 +227,7 @@ contains
        deallocate(this%out_vals_trsp)
     end if
 
-    if (allocated(this%sampled_fields%fields)) then
-       deallocate(this%sampled_fields%fields)
-    end if
+    call this%sampled_fields%free()
 
     if (allocated(this%n_local_probes_tot)) then
        deallocate(this%n_local_probes_tot)
@@ -327,7 +326,7 @@ contains
 
     do i = 1,this%n_fields
        call this%global_interp%evaluate(this%out_values(:,i), &
-                                        this%sampled_fields%fields(i)%f%x)
+                                        this%sampled_fields%items(i)%ptr%x)
     end do
 
     if (NEKO_BCKND_DEVICE .eq. 1) then

--- a/src/source_terms/bcknd/cpu/boussinesq_source_term_cpu.f90
+++ b/src/source_terms/bcknd/cpu/boussinesq_source_term_cpu.f90
@@ -57,12 +57,12 @@ contains
     real(kind=rp), intent(in) :: beta
     integer :: n_fields, i, n
 
-    n_fields = size(fields%fields)
-    n = fields%fields(1)%f%dof%size()
+    n_fields = fields%size()
+    n = fields%items(1)%ptr%dof%size()
 
     do i=1, n_fields
-       call add2s2(fields%fields(i)%f%x, s%x, g(i)*beta, n)
-       call cadd(fields%fields(i)%f%x, -g(i)*beta*ref_value, n)
+       call add2s2(fields%items(i)%ptr%x, s%x, g(i)*beta, n)
+       call cadd(fields%items(i)%ptr%x, -g(i)*beta*ref_value, n)
     end do
   end subroutine boussinesq_source_term_compute_cpu
 

--- a/src/source_terms/bcknd/cpu/brinkman_source_term_cpu.f90
+++ b/src/source_terms/bcknd/cpu/brinkman_source_term_cpu.f90
@@ -53,15 +53,15 @@ contains
     type(field_t), pointer :: u, v, w
     integer :: n
 
-    n = fields%fields(1)%f%dof%size()
+    n = fields%items(1)%ptr%dof%size()
 
     u => neko_field_registry%get_field('u')
     v => neko_field_registry%get_field('v')
     w => neko_field_registry%get_field('w')
 
-    call subcol3(fields%fields(1)%f%x, u%x, brinkman%x, n)
-    call subcol3(fields%fields(2)%f%x, v%x, brinkman%x, n)
-    call subcol3(fields%fields(3)%f%x, w%x, brinkman%x, n)
+    call subcol3(fields%items(1)%ptr%x, u%x, brinkman%x, n)
+    call subcol3(fields%items(2)%ptr%x, v%x, brinkman%x, n)
+    call subcol3(fields%items(3)%ptr%x, w%x, brinkman%x, n)
 
   end subroutine brinkman_source_term_compute_cpu
 

--- a/src/source_terms/bcknd/cpu/const_source_term_cpu.f90
+++ b/src/source_terms/bcknd/cpu/const_source_term_cpu.f90
@@ -50,11 +50,11 @@ contains
     real(kind=rp), intent(in) :: values(:)
     integer :: n_fields, i, n
 
-    n_fields = size(fields%fields)
-    n = fields%fields(1)%f%dof%size()
+    n_fields = fields%size()
+    n = fields%items(1)%ptr%dof%size()
 
     do i=1, n_fields
-       call cadd(fields%fields(i)%f%x, values(i), n)
+       call cadd(fields%items(i)%ptr%x, values(i), n)
     end do
   end subroutine const_source_term_compute_cpu
 

--- a/src/source_terms/bcknd/device/boussinesq_source_term_device.f90
+++ b/src/source_terms/bcknd/device/boussinesq_source_term_device.f90
@@ -58,12 +58,12 @@ contains
     real(kind=rp), intent(in) :: beta
     integer :: n_fields, i, n
 
-    n_fields = size(fields%fields)
-    n = fields%fields(1)%f%dof%size()
+    n_fields = fields%size()
+    n = fields%items(1)%ptr%dof%size()
 
     do i=1, n_fields
-       call device_add2s2(fields%fields(i)%f%x_d, s%x_d, g(i)*beta, n)
-       call device_cadd(fields%fields(i)%f%x_d, -g(i)*beta*ref_value, n)
+       call device_add2s2(fields%x_d(i), s%x_d, g(i)*beta, n)
+       call device_cadd(fields%x_d(i), -g(i)*beta*ref_value, n)
     end do
   end subroutine boussinesq_source_term_compute_device
 

--- a/src/source_terms/bcknd/device/brinkman_source_term_device.f90
+++ b/src/source_terms/bcknd/device/brinkman_source_term_device.f90
@@ -53,15 +53,15 @@ contains
     integer :: n
     type(field_t), pointer :: u, v, w
 
-    n = fields%fields(1)%f%dof%size()
+    n = fields%items(1)%ptr%dof%size()
 
     u => neko_field_registry%get_field('u')
     v => neko_field_registry%get_field('v')
     w => neko_field_registry%get_field('w')
 
-    call device_subcol3(fields%fields(1)%f%x_d, u%x_d, brinkman%x_d, n)
-    call device_subcol3(fields%fields(2)%f%x_d, v%x_d, brinkman%x_d, n)
-    call device_subcol3(fields%fields(3)%f%x_d, w%x_d, brinkman%x_d, n)
+    call device_subcol3(fields%x_d(1), u%x_d, brinkman%x_d, n)
+    call device_subcol3(fields%x_d(2), v%x_d, brinkman%x_d, n)
+    call device_subcol3(fields%x_d(3), w%x_d, brinkman%x_d, n)
 
   end subroutine brinkman_source_term_compute_device
 

--- a/src/source_terms/bcknd/device/const_source_term_device.f90
+++ b/src/source_terms/bcknd/device/const_source_term_device.f90
@@ -50,11 +50,11 @@ contains
     real(kind=rp), intent(in) :: values(:)
     integer :: n_fields, i, n
 
-    n_fields = size(fields%fields)
-    n = fields%fields(1)%f%dof%size()
+    n_fields = fields%size()
+    n = fields%items(1)%ptr%dof%size()
 
     do i=1, n_fields
-       call device_cadd(fields%fields(i)%f%x_d, values(i), n)
+       call device_cadd(fields%x_d(i), values(i), n)
     end do
   end subroutine const_source_term_compute_device
 

--- a/src/source_terms/boussinesq_source_term.f90
+++ b/src/source_terms/boussinesq_source_term.f90
@@ -92,7 +92,7 @@ contains
     real(kind=rp), allocatable :: g(:)
     real(kind=rp) :: beta
 
-    if (.not. size(fields%fields) == 3) then
+    if (.not. fields%size() == 3) then
        call neko_error("Boussinesq term expects 3 fields to work on.")
     end if
 
@@ -139,7 +139,7 @@ contains
     call this%init_base(fields, coef, start_time, end_time)
 
     if (.not. neko_field_registry%field_exists(scalar_name)) then
-       call neko_field_registry%add_field(this%fields%fields(1)%f%dof, "s")
+       call neko_field_registry%add_field(this%fields%items(1)%ptr%dof, "s")
     end if
     this%s => neko_field_registry%get_field("s")
 
@@ -165,8 +165,8 @@ contains
     integer, intent(in) :: tstep
     integer :: n_fields, i, n
 
-    n_fields = size(this%fields%fields)
-    n = this%fields%fields(1)%f%dof%size()
+    n_fields = this%fields%size()
+    n = this%fields%items(1)%ptr%dof%size()
 
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call boussinesq_source_term_compute_device(this%fields, this%s,&

--- a/src/source_terms/const_source_term.f90
+++ b/src/source_terms/const_source_term.f90
@@ -104,7 +104,7 @@ contains
     call this%free()
     call this%init_base(fields, coef, start_time, end_time)
 
-    if (size(values) .ne. size(fields%fields)) then
+    if (size(values) .ne. fields%size()) then
        call neko_error("Number of fields and values inconsistent.")
     end if
 
@@ -127,8 +127,9 @@ contains
     integer, intent(in) :: tstep
     integer :: n_fields, i, n
 
-    n_fields = size(this%fields%fields)
-    n = this%fields%fields(1)%f%dof%size()
+    n_fields = this%fields%size()
+
+    n = this%fields%items(1)%ptr%dof%size()
 
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call const_source_term_compute_device(this%fields, this%values)

--- a/src/source_terms/source_term.f90
+++ b/src/source_terms/source_term.f90
@@ -128,13 +128,14 @@ contains
     this%coef => coef
     this%start_time = start_time
     this%end_time = end_time
-    n_fields = size(fields%fields)
-    allocate(this%fields%fields(n_fields))
+    n_fields = fields%size()
+
+    call this%fields%init(n_fields)
 
     ! A lot of attribute nesting here due to Fortran needing wrapper types
     ! but this is just pointer assignement for the fields.
     do i=1, n_fields
-       this%fields%fields(i)%f => fields%fields(i)%f
+       call this%fields%set(i, fields%get(i))
     end do
   end subroutine source_term_init_base
 


### PR DESCRIPTION
Here, I start implementing a convention for helper types.
- `_list_t` types have its component called `items`
- `_ptr_t` types have its component called `ptr`

I add a lot of convenience subroutines for the `field_list_t`, so that one can avoid expressions like `this%fields%items(i)%ptr%x_d` etc as much as possible. I would say quite a lot of code looks more elegant now. I will add a routine to return `x` for an item as well, I just need to look up how to return allocatable arrays in a good way (maybe it is trivial).

The next step will be to add a similar list type for vector_ptr_t and array_ptr_t.