### PR TITLE
Promote coef component to bc_t

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -124,7 +124,7 @@ common/sampler.o : common/sampler.f90 common/time_based_controller.o config/num_
 common/global_interpolation.o : common/global_interpolation.F90 comm/mpi_types.o math/math.o comm/comm.o sem/local_interpolation.o common/utils.o common/log.o mesh/mesh.o sem/dofmap.o sem/space.o config/num_types.o 
 common/profiler.o : common/profiler.F90 common/craypat.o device/hip/roctx.o device/cuda/nvtx.o device/device.o config/neko_config.o 
 common/craypat.o : common/craypat.F90 common/utils.o adt/stack.o 
-bc/bc.o : bc/bc.f90 common/utils.o adt/tuple.o adt/stack.o mesh/facet_zone.o mesh/mesh.o sem/space.o sem/dofmap.o device/device.o config/num_types.o config/neko_config.o 
+bc/bc.o : bc/bc.f90 common/utils.o adt/tuple.o adt/stack.o mesh/facet_zone.o mesh/mesh.o sem/space.o sem/coef.o sem/dofmap.o device/device.o config/num_types.o config/neko_config.o 
 bc/dirichlet.o : bc/dirichlet.f90 bc/bc.o config/num_types.o bc/bcknd/device/device_dirichlet.o 
 bc/neumann.o : bc/neumann.f90 sem/coef.o common/utils.o bc/bc.o config/num_types.o 
 bc/dong_outflow.o : bc/dong_outflow.f90 bc/bcknd/device/device_dong_outflow.o common/utils.o sem/coef.o sem/dofmap.o field/field.o bc/bc.o config/num_types.o device/device.o bc/dirichlet.o config/neko_config.o 

--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -36,6 +36,7 @@ module bc
   use num_types
   use device
   use dofmap, only : dofmap_t
+  use coefs, only : coef_t
   use space, only : space_t
   use mesh, only : mesh_t, NEKO_MSH_MAX_ZLBLS
   use facet_zone, only : facet_zone_t
@@ -54,6 +55,8 @@ module bc
      integer, allocatable :: facet(:)
      !> Map of degrees of freedom
      type(dofmap_t), pointer :: dof
+     !> SEM coefficients
+     type(coef_t), pointer :: coef
      !> The mesh
      type(mesh_t), pointer :: msh
      !> The function space
@@ -185,15 +188,16 @@ contains
 
   !> Constructor
   !! @param dof Map of degrees of freedom.
-  subroutine bc_init(this, dof)
+  subroutine bc_init(this, coef)
     class(bc_t), intent(inout) :: this
-    type(dofmap_t), target, intent(in) :: dof
+    type(coef_t), target, intent(in) :: coef
 
     call bc_free(this)
 
-    this%dof => dof
-    this%Xh => dof%Xh
-    this%msh => dof%msh
+    this%dof => coef%dof
+    this%coef => coef
+    this%Xh => this%dof%Xh
+    this%msh => this%dof%msh
 
     call this%marked_facet%init()
 

--- a/src/bc/dong_outflow.f90
+++ b/src/bc/dong_outflow.f90
@@ -55,7 +55,6 @@ module dong_outflow
      type(field_t), pointer :: u
      type(field_t), pointer :: v
      type(field_t), pointer :: w
-     type(coef_t), pointer :: c_Xh
      real(kind=rp) :: delta
      real(kind=rp) :: uinf
      type(c_ptr) :: normal_x_d
@@ -70,9 +69,8 @@ module dong_outflow
   end type dong_outflow_t
 
 contains
-  subroutine dong_outflow_set_vars(this, c_Xh, u, v, w, uinf, delta)
+  subroutine dong_outflow_set_vars(this, u, v, w, uinf, delta)
     class(dong_outflow_t), intent(inout) :: this
-    type(coef_t), target, intent(in) :: c_Xh
     type(field_t), target, intent(in) :: u, v, w
     real(kind=rp), intent(in) :: uinf
     real(kind=rp), optional, intent(in) :: delta
@@ -92,7 +90,6 @@ contains
     this%uinf = uinf
     this%u => u
     this%v => v
-    this%c_Xh=> c_Xh
     this%w => w
     if ((NEKO_BCKND_DEVICE .eq. 1) .and. (this%msk(0) .gt. 0)) then
        call device_alloc(this%normal_x_d,c_sizeof(dummy)*this%msk(0))
@@ -107,7 +104,7 @@ contains
           facet = this%facet(i)
           idx = nonlinear_index(k,this%Xh%lx, this%Xh%lx,this%Xh%lx)
           normal_xyz = &
-                 this%c_Xh%get_normal(idx(1), idx(2), idx(3), idx(4),facet)
+                 this%coef%get_normal(idx(1), idx(2), idx(3), idx(4),facet)
             temp_x(i) = normal_xyz(1)
             temp_y(i) = normal_xyz(2)
             temp_z(i) = normal_xyz(3)
@@ -141,7 +138,7 @@ contains
        uy = this%v%x(k,1,1,1)
        uz = this%w%x(k,1,1,1)
        idx = nonlinear_index(k,this%Xh%lx, this%Xh%lx,this%Xh%lx)
-       normal_xyz = this%c_Xh%get_normal(idx(1), idx(2), idx(3), idx(4),facet)
+       normal_xyz = this%coef%get_normal(idx(1), idx(2), idx(3), idx(4),facet)
        vn = ux*normal_xyz(1) + uy*normal_xyz(2) + uz*normal_xyz(3)
        S0 = 0.5_rp*(1.0_rp - tanh(vn / (this%uinf * this%delta)))
 

--- a/src/bc/facet_normal.f90
+++ b/src/bc/facet_normal.f90
@@ -50,7 +50,6 @@ module facet_normal
      procedure, pass(this) :: apply_vector => facet_normal_apply_vector
      procedure, pass(this) :: apply_surfvec => facet_normal_apply_surfvec
      procedure, pass(this) :: apply_surfvec_dev => facet_normal_apply_surfvec_dev
-     procedure, pass(this) :: set_coef => facet_normal_set_coef
   end type facet_normal_t
 
 contains
@@ -89,10 +88,7 @@ contains
     integer, intent(in), optional :: tstep
     integer :: i, m, k, idx(4), facet
 
-    if (.not. associated(this%c)) then
-       call neko_error('No coefficients assigned')
-    end if
-    associate(c => this%c)
+    associate(c => this%coef)
       m = this%msk(0)
       do i = 1, m
          k = this%msk(i)
@@ -126,13 +122,6 @@ contains
 
   end subroutine facet_normal_apply_surfvec
 
-  !> Assign coefficients (facet normals etc)
-  subroutine facet_normal_set_coef(this, c)
-    class(facet_normal_t), intent(inout) :: this
-    type(coef_t), target, intent(inout) :: c
-    this%c => c
-  end subroutine facet_normal_set_coef
-
   !> Apply in facet normal direction (vector valued, device version)
   subroutine facet_normal_apply_surfvec_dev(this, x_d, y_d, z_d, &
                                             u_d, v_d, w_d, t, tstep)
@@ -141,10 +130,7 @@ contains
     real(kind=rp), intent(in), optional :: t
     integer, intent(in), optional :: tstep
 
-    if (.not. associated(this%c)) then
-       call neko_error('No coefficients assigned')
-    end if
-    associate(c => this%c)
+    associate(c => this%coef)
       call device_facet_normal_apply_surfvec(this%msk_d, this%facet_d, &
                                              x_d, y_d, z_d, u_d, v_d, w_d, &
                                              c%nx_d, c%ny_d, c%nz_d, c%area_d, &

--- a/src/bc/neumann.f90
+++ b/src/bc/neumann.f90
@@ -46,8 +46,6 @@ module neumann
   !! to the right-hand-side.
   type, public, extends(bc_t) :: neumann_t
      real(kind=rp), private :: flux_
-     !> SEM coeffs.
-     type(coef_t), pointer :: coef
    contains
      procedure, pass(this) :: apply_scalar => neumann_apply_scalar
      procedure, pass(this) :: apply_vector => neumann_apply_vector
@@ -133,13 +131,11 @@ contains
   !> Constructor
   !> @param flux The desired flux.
   !> @param coef The SEM coefficients.
-  subroutine neumann_init_neumann(this, flux, coef)
+  subroutine neumann_init_neumann(this, flux)
     class(neumann_t), intent(inout) :: this
     real(kind=rp), intent(in) :: flux
-    type(coef_t), target, intent(in) :: coef
 
     this%flux_ = flux
-    this%coef => coef
   end subroutine neumann_init_neumann
 
   !> Get the set flux.

--- a/src/bc/non_normal.f90
+++ b/src/bc/non_normal.f90
@@ -55,9 +55,8 @@ module non_normal
 contains
 
   !> Initialize symmetry mask for each axis
-  subroutine non_normal_init_msk(this, c)
+  subroutine non_normal_init_msk(this)
     class(non_normal_t), intent(inout) :: this
-    type(coef_t), intent(in) :: c
     integer :: i, j, k, l
     type(tuple_i4_t), pointer :: bfp(:)
     real(kind=rp) :: sx,sy,sz
@@ -67,11 +66,12 @@ contains
 
     call non_normal_free(this)
 
-    call this%bc_x%init(c%dof)
-    call this%bc_y%init(c%dof)
-    call this%bc_z%init(c%dof)
+    call this%bc_x%init(this%coef)
+    call this%bc_y%init(this%coef)
+    call this%bc_z%init(this%coef)
 
-    associate(nx => c%nx, ny => c%ny, nz => c%nz)
+    associate(c=>this%coef, nx => this%coef%nx, ny => this%coef%ny, &
+              nz => this%coef%nz)
       bfp => this%marked_facet%array()
       do i = 1, this%marked_facet%size()
          bc_facet = bfp(i)

--- a/src/bc/symmetry.f90
+++ b/src/bc/symmetry.f90
@@ -42,6 +42,7 @@ module symmetry
   use utils
   use stack
   use tuple
+  use coefs, only : coef_t
   use, intrinsic :: iso_c_binding, only : c_ptr
   implicit none
   private
@@ -62,9 +63,8 @@ module symmetry
 contains
 
   !> Initialize symmetry mask for each axis
-  subroutine symmetry_init_msk(this, c)
+  subroutine symmetry_init_msk(this)
     class(symmetry_t), intent(inout) :: this
-    type(coef_t), intent(in) :: c
     integer :: i, m, j, l
     type(tuple_i4_t), pointer :: bfp(:)
     real(kind=rp) :: sx,sy,sz
@@ -74,11 +74,12 @@ contains
 
     call symmetry_free(this)
 
-    call this%bc_x%init(c%dof)
-    call this%bc_y%init(c%dof)
-    call this%bc_z%init(c%dof)
+    call this%bc_x%init(this%coef)
+    call this%bc_y%init(this%coef)
+    call this%bc_z%init(this%coef)
 
-    associate(nx => c%nx, ny => c%ny, nz => c%nz)
+    associate(c=>this%coef, nx => this%coef%nx, ny => this%coef%ny, &
+              nz => this%coef%nz)
       bfp => this%marked_facet%array()
       do i = 1, this%marked_facet%size()
          bc_facet = bfp(i)

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -176,21 +176,19 @@ contains
     end associate
 
     ! Initialize velocity surface terms in pressure rhs
-    call this%bc_prs_surface%init(this%dm_Xh)
+    call this%bc_prs_surface%init(this%c_Xh)
     call this%bc_prs_surface%mark_zone(msh%inlet)
     call this%bc_prs_surface%mark_zones_from_list(msh%labeled_zones,&
                                                  'v', this%bc_labels)
     call this%bc_prs_surface%finalize()
-    call this%bc_prs_surface%set_coef(this%c_Xh)
     ! Initialize symmetry surface terms in pressure rhs
-    call this%bc_sym_surface%init(this%dm_Xh)
+    call this%bc_sym_surface%init(this%c_Xh)
     call this%bc_sym_surface%mark_zone(msh%sympln)
     call this%bc_sym_surface%mark_zones_from_list(msh%labeled_zones,&
                                                  'sym', this%bc_labels)
     call this%bc_sym_surface%finalize()
-    call this%bc_sym_surface%set_coef(this%c_Xh)
     ! Initialize dirichlet bcs for velocity residual
-    call this%bc_vel_res_non_normal%init(this%dm_Xh)
+    call this%bc_vel_res_non_normal%init(this%c_Xh)
     call this%bc_vel_res_non_normal%mark_zone(msh%outlet_normal)
     call this%bc_vel_res_non_normal%mark_zones_from_list(msh%labeled_zones,&
                                                          'on', this%bc_labels)
@@ -198,9 +196,9 @@ contains
                                                          'on+dong', &
                                                          this%bc_labels)
     call this%bc_vel_res_non_normal%finalize()
-    call this%bc_vel_res_non_normal%init_msk(this%c_Xh)
+    call this%bc_vel_res_non_normal%init_msk()
 
-    call this%bc_dp%init(this%dm_Xh)
+    call this%bc_dp%init(this%c_Xh)
     call this%bc_dp%mark_zones_from_list(msh%labeled_zones, 'on+dong', &
                                          this%bc_labels)
     call this%bc_dp%mark_zones_from_list(msh%labeled_zones, &
@@ -212,7 +210,7 @@ contains
     !Add 0 prs bcs
     call bc_list_add(this%bclst_dp, this%bc_prs)
 
-    call this%bc_vel_res%init(this%dm_Xh)
+    call this%bc_vel_res%init(this%c_Xh)
     call this%bc_vel_res%mark_zone(msh%inlet)
     call this%bc_vel_res%mark_zone(msh%wall)
     call this%bc_vel_res%mark_zones_from_list(msh%labeled_zones, &
@@ -280,7 +278,7 @@ contains
     integer :: i, n
 
     n = this%u%dof%size()
-    ! Make sure that continuity is maintained (important for interpolation) 
+    ! Make sure that continuity is maintained (important for interpolation)
     ! Do not do this for lagged rhs (derivatives are not necessairly coninous across elements)
     call col2(this%u%x,this%c_Xh%mult,this%u%dof%size())
     call col2(this%v%x,this%c_Xh%mult,this%u%dof%size())
@@ -613,7 +611,7 @@ contains
       ksp_results(4) = this%ksp_vel%solve(Ax, dw, w_res%x, n, &
            c_Xh, this%bclst_dw, gs_Xh)
       call profiler_end_region
-      
+
       call this%proj_u%post_solving(du%x, Ax, c_Xh, &
                                  this%bclst_du, gs_Xh, n, tstep, dt_controller)
       call this%proj_v%post_solving(dv%x, Ax, c_Xh, &

--- a/src/fluid/fluid_scheme.f90
+++ b/src/fluid/fluid_scheme.f90
@@ -284,7 +284,7 @@ contains
     call json_get_or_default(params, &
                             'case.fluid.pressure_solver.projection_hold_steps',&
                             this%pr_projection_activ_step, 5)
-    
+
 
     call json_get_or_default(params, 'case.fluid.freeze', this%freeze, .false.)
 
@@ -325,12 +325,12 @@ contains
 
     call bc_list_init(this%bclst_vel)
 
-    call this%bc_sym%init(this%dm_Xh)
+    call this%bc_sym%init(this%c_Xh)
     call this%bc_sym%mark_zone(msh%sympln)
     call this%bc_sym%mark_zones_from_list(msh%labeled_zones,&
                         'sym', this%bc_labels)
     call this%bc_sym%finalize()
-    call this%bc_sym%init_msk(this%c_Xh)
+    call this%bc_sym%init_msk()
     call bc_list_add(this%bclst_vel, this%bc_sym)
 
     !
@@ -348,7 +348,7 @@ contains
           call neko_error('Invalid inflow condition '//string_val1)
        end if
 
-       call this%bc_inflow%init(this%dm_Xh)
+       call this%bc_inflow%init(this%c_Xh)
        call this%bc_inflow%mark_zone(msh%inlet)
        call this%bc_inflow%mark_zones_from_list(msh%labeled_zones,&
                         'v', this%bc_labels)
@@ -380,7 +380,7 @@ contains
        end if
     end if
 
-    call this%bc_wall%init(this%dm_Xh)
+    call this%bc_wall%init(this%c_Xh)
     call this%bc_wall%mark_zone(msh%wall)
     call this%bc_wall%mark_zones_from_list(msh%labeled_zones,&
                         'w', this%bc_labels)
@@ -393,7 +393,7 @@ contains
        call this%bdry%init(this%dm_Xh, 'bdry')
        this%bdry = 0.0_rp
 
-       call bdry_mask%init(this%dm_Xh)
+       call bdry_mask%init(this%c_Xh)
        call bdry_mask%mark_zone(msh%wall)
        call bdry_mask%mark_zones_from_list(msh%labeled_zones,&
                       'w', this%bc_labels)
@@ -402,7 +402,7 @@ contains
        call bdry_mask%apply_scalar(this%bdry%x, this%dm_Xh%size())
        call bdry_mask%free()
 
-       call bdry_mask%init(this%dm_Xh)
+       call bdry_mask%init(this%c_Xh)
        call bdry_mask%mark_zone(msh%inlet)
        call bdry_mask%mark_zones_from_list(msh%labeled_zones,&
                       'v', this%bc_labels)
@@ -412,7 +412,7 @@ contains
        call bdry_mask%apply_scalar(this%bdry%x, this%dm_Xh%size())
        call bdry_mask%free()
 
-       call bdry_mask%init(this%dm_Xh)
+       call bdry_mask%init(this%c_Xh)
        call bdry_mask%mark_zone(msh%outlet)
        call bdry_mask%mark_zones_from_list(msh%labeled_zones,&
                       'o', this%bc_labels)
@@ -421,7 +421,7 @@ contains
        call bdry_mask%apply_scalar(this%bdry%x, this%dm_Xh%size())
        call bdry_mask%free()
 
-       call bdry_mask%init(this%dm_Xh)
+       call bdry_mask%init(this%c_Xh)
        call bdry_mask%mark_zone(msh%sympln)
        call bdry_mask%mark_zones_from_list(msh%labeled_zones,&
                       'sym', this%bc_labels)
@@ -430,14 +430,14 @@ contains
        call bdry_mask%apply_scalar(this%bdry%x, this%dm_Xh%size())
        call bdry_mask%free()
 
-       call bdry_mask%init(this%dm_Xh)
+       call bdry_mask%init(this%c_Xh)
        call bdry_mask%mark_zone(msh%periodic)
        call bdry_mask%finalize()
        call bdry_mask%set_g(5.0_rp)
        call bdry_mask%apply_scalar(this%bdry%x, this%dm_Xh%size())
        call bdry_mask%free()
 
-       call bdry_mask%init(this%dm_Xh)
+       call bdry_mask%init(this%c_Xh)
        call bdry_mask%mark_zone(msh%outlet_normal)
        call bdry_mask%mark_zones_from_list(msh%labeled_zones,&
                       'on', this%bc_labels)
@@ -550,7 +550,7 @@ contains
     ! Setup pressure boundary conditions
     !
     call bc_list_init(this%bclst_prs)
-    call this%bc_prs%init(this%dm_Xh)
+    call this%bc_prs%init(this%c_Xh)
     call this%bc_prs%mark_zones_from_list(msh%labeled_zones,&
                         'o', this%bc_labels)
     call this%bc_prs%mark_zones_from_list(msh%labeled_zones,&
@@ -566,7 +566,7 @@ contains
     call this%bc_prs%finalize()
     call this%bc_prs%set_g(0.0_rp)
     call bc_list_add(this%bclst_prs, this%bc_prs)
-    call this%bc_dong%init(this%dm_Xh)
+    call this%bc_dong%init(this%c_Xh)
     call this%bc_dong%mark_zones_from_list(msh%labeled_zones,&
                         'o+dong', this%bc_labels)
     call this%bc_dong%mark_zones_from_list(msh%labeled_zones,&
@@ -578,7 +578,7 @@ contains
     call json_get_or_default(params, 'case.fluid.outflow_condition.velocity_scale',&
                              dong_uchar, 1.0_rp)
 
-    call this%bc_dong%set_vars(this%c_Xh, this%u, this%v, this%w,&
+    call this%bc_dong%set_vars(this%u, this%v, this%w,&
          dong_uchar, dong_delta)
 
     call bc_list_add(this%bclst_prs, this%bc_dong)
@@ -740,7 +740,7 @@ contains
           call ip%validate
        end select
     end if
-    
+
     !
     ! Setup checkpoint structure (if everything is fine)
     !

--- a/src/krylov/pc_hsmg.f90
+++ b/src/krylov/pc_hsmg.f90
@@ -207,9 +207,9 @@ contains
             this%dm_crs%size(), 'cg', KSP_MAX_ITER, M = this%pc_crs)
     end if
 
-    call this%bc_crs%init(this%dm_crs)
-    call this%bc_mg%init(this%dm_mg)
-    call this%bc_reg%init(dof)
+    call this%bc_crs%init(this%c_crs)
+    call this%bc_mg%init(this%c_mg)
+    call this%bc_reg%init(coef)
     if (bclst%n .gt. 0) then
        do i = 1, bclst%n
           call this%bc_reg%mark_facets(bclst%bc(i)%bcp%marked_facet)

--- a/src/scalar/scalar_pnpn.f90
+++ b/src/scalar/scalar_pnpn.f90
@@ -178,7 +178,7 @@ contains
 
     ! Initialize dirichlet bcs for scalar residual
     ! todo: look that this works
-    call this%bc_res%init(this%dm_Xh)
+    call this%bc_res%init(this%c_Xh)
     do i = 1, this%n_dir_bcs
        call this%bc_res%mark_facets(this%dir_bcs(i)%marked_facet)
     end do

--- a/src/scalar/scalar_scheme.f90
+++ b/src/scalar/scalar_scheme.f90
@@ -99,7 +99,7 @@ module scalar_scheme
      !> Projection space size.
      integer :: projection_dim
      !< Steps to activate projection for ksp
-     integer :: projection_activ_step   
+     integer :: projection_activ_step
      !> Preconditioner.
      class(pc_t), allocatable :: pc
      !> Dirichlet conditions.
@@ -239,7 +239,7 @@ contains
 !             call this%dir_bcs(j)%mark_zone(zones(i))
 !          else
           this%n_dir_bcs = this%n_dir_bcs + 1
-          call this%dir_bcs(this%n_dir_bcs)%init(this%dm_Xh)
+          call this%dir_bcs(this%n_dir_bcs)%init(this%c_Xh)
           call this%dir_bcs(this%n_dir_bcs)%mark_zone(zones(i))
           read(bc_label(3:), *) dir_value
           call this%dir_bcs(this%n_dir_bcs)%set_g(dir_value)
@@ -248,11 +248,10 @@ contains
 
        if (bc_label(1:2) .eq. 'n=') then
           this%n_neumann_bcs = this%n_neumann_bcs + 1
-          call this%neumann_bcs(this%n_neumann_bcs)%init(this%dm_Xh)
+          call this%neumann_bcs(this%n_neumann_bcs)%init(this%c_Xh)
           call this%neumann_bcs(this%n_neumann_bcs)%mark_zone(zones(i))
           read(bc_label(3:), *) flux_value
-          call this%neumann_bcs(this%n_neumann_bcs)%init_neumann(flux_value,&
-                                                                 this%c_Xh)
+          call this%neumann_bcs(this%n_neumann_bcs)%init_neumann(flux_value)
        end if
 
        !> Check if user bc on this zone
@@ -359,7 +358,7 @@ contains
     ! Setup scalar boundary conditions
     !
     call bc_list_init(this%bclst_dirichlet)
-    call this%user_bc%init(this%dm_Xh)
+    call this%user_bc%init(this%c_Xh)
 
     ! Read boundary types from the case file
     allocate(this%bc_labels(NEKO_MSH_MAX_ZLBLS))


### PR DESCRIPTION
I'm starting the work on a JSON-based interface for boundary conditions, with the final aim to have lists of allocatable bc_t objects in scheme types that are constructed by a factory, following the same pattern as the other objects. Part of this work is to figure out a single constructor interface.

It is pretty clear that coef will be part of that since it is used by many bcs already, and you need that object to do almost any computation. Therefore, as an incrementa step, this changes the bc%init signature to take in a coef object instead of dofmap. The dofmap is then taken for the coef.

Please check a bit extra that the pc_hsmg type is correctly modified, I basically went after the varibale naming there.

