### PR TITLE
Updated cff file to include all authors

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,18 +1,44 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: Neko
+message: 'If you use Neko, please cite it as below.'
+type: software
 authors:
+  - family-names: Alekseenko
+    given-names: Andrey
+  - family-names: Baconnet
+    given-names: Victor
+  - family-names: Chien
+    given-names: Steven
+  - family-names: Du
+    given-names: Shiyu
   - family-names: Jansson
     given-names: Niclas
   - family-names: Karp
     given-names: Martin
+  - family-names: Olsen
+    given-names: Time Felle
   - family-names: Mukha
     given-names: Timofey
+  - family-names: Páll
+    given-names: Szilárd
+  - family-names: Peplinski
+    given-names: Adam
   - family-names: Perez
     given-names: Adalberto
-  - family-names: Baconnet
-    given-names: Victor
   - family-names: Schlatter
     given-names: Philipp
-cff-version: 1.2.0
-message: "If you use Neko, please cite it as below."
+  - family-names: Vincent
+    given-names: Jonathan
+  - family-names: Wahlgren
+    given-names: Jacob
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.6631055
+url: 'https://www.neko.cfd'
+license: BSD-3-Clause
 preferred-citation:
   authors:
     - family-names: Jansson
@@ -25,8 +51,22 @@ preferred-citation:
       given-names: Stefano
     - family-names: Schlatter
       given-names: Philipp
-  title: "Neko: A Modern, Portable, and Scalable Framework for High-Fidelity Computational Fluid Dynamics"
+  title: >-
+    Neko: A Modern, Portable, and Scalable Framework for High-Fidelity
+    Computational Fluid Dynamics
   type: article
-  year: 2021
-  url: https://arxiv.org/abs/2107.01243
-title: "Neko"
+  journal: Computer & Fluids
+  volume: 275
+  year: 2024
+  url: 'https://arxiv.org/abs/2107.01243'
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -58,7 +58,7 @@ preferred-citation:
   journal: Computer & Fluids
   volume: 275
   year: 2024
-  url: 'https://arxiv.org/abs/2107.01243'
+  doi: '10.1016/j.compfluid.2024.106243'
     
     
     


### PR DESCRIPTION
Include all authors with at least one commit in `develop` to the citation file. ref: #1104 and #1188
