### PR TITLE
Change strain rate to include the 1/2 factor

### DIFF
--- a/src/math/operators.f90
+++ b/src/math/operators.f90
@@ -358,9 +358,9 @@ contains
        call device_cmult(s13_d, 0.5_rp, nelv*lxyz)
        call device_cmult(s23_d, 0.5_rp, nelv*lxyz)
     else
-       call cmult(s12_d, 0.5_rp, nelv*lxyz)
-       call cmult(s13_d, 0.5_rp, nelv*lxyz)
-       call cmult(s23_d, 0.5_rp, nelv*lxyz)
+       call cmult(s12, 0.5_rp, nelv*lxyz)
+       call cmult(s13, 0.5_rp, nelv*lxyz)
+       call cmult(s23, 0.5_rp, nelv*lxyz)
     endif
 
   end subroutine strain_rate

--- a/src/math/operators.f90
+++ b/src/math/operators.f90
@@ -56,7 +56,7 @@ module operators
 
   public :: dudxyz, opgrad, ortho, cdtp, conv1, curl, cfl,&
             lambda2op, strain_rate
-  
+
 contains
 
   !> Compute derivative of a scalar field along a single direction.
@@ -286,7 +286,7 @@ contains
 
   end function cfl
 
-  !> Compute double the strain rate tensor, i.e du_i/dx_j + du_j/dx_i
+  !> Compute the strain rate tensor, i.e 0.5 * du_i/dx_j + du_j/dx_i
   !! @param s11 Will hold the 1,1 component of the strain rate tensor.
   !! @param s22 Will hold the 2,2 component of the strain rate tensor.
   !! @param s33 Will hold the 3,3 component of the strain rate tensor.
@@ -354,13 +354,13 @@ contains
     call dudxyz (s33, w%x, coef%drdz, coef%dsdz, coef%dtdz, coef)
 
     if (NEKO_BCKND_DEVICE .eq. 1) then
-       call device_cmult(s11_d, 2.0_rp, nelv*lxyz)
-       call device_cmult(s22_d, 2.0_rp, nelv*lxyz)
-       call device_cmult(s33_d, 2.0_rp, nelv*lxyz)
+       call device_cmult(s12_d, 0.5_rp, nelv*lxyz)
+       call device_cmult(s13_d, 0.5_rp, nelv*lxyz)
+       call device_cmult(s23_d, 0.5_rp, nelv*lxyz)
     else
-       call cmult(s11, 2.0_rp, nelv*lxyz)
-       call cmult(s22, 2.0_rp, nelv*lxyz)
-       call cmult(s33, 2.0_rp, nelv*lxyz)
+       call cmult(s12_d, 0.5_rp, nelv*lxyz)
+       call cmult(s13_d, 0.5_rp, nelv*lxyz)
+       call cmult(s23_d, 0.5_rp, nelv*lxyz)
     endif
 
   end subroutine strain_rate

--- a/src/qoi/drag_torque.f90
+++ b/src/qoi/drag_torque.f90
@@ -99,13 +99,13 @@ contains
     type(field_t), intent(inout) :: p
     real(kind=rp), intent(in) :: visc, center(3)
     real(kind=rp) :: dgtq(3,4)
-    real(kind=rp) :: dragpx = 0.0_rp ! pressure 
+    real(kind=rp) :: dragpx = 0.0_rp ! pressure
     real(kind=rp) :: dragpy = 0.0_rp
     real(kind=rp) :: dragpz = 0.0_rp
     real(kind=rp) :: dragvx = 0.0_rp ! viscous
     real(kind=rp) :: dragvy = 0.0_rp
     real(kind=rp) :: dragvz = 0.0_rp
-    real(kind=rp) :: torqpx = 0.0_rp ! pressure 
+    real(kind=rp) :: torqpx = 0.0_rp ! pressure
     real(kind=rp) :: torqpy = 0.0_rp
     real(kind=rp) :: torqpz = 0.0_rp
     real(kind=rp) :: torqvx = 0.0_rp ! viscous
@@ -135,7 +135,7 @@ contains
                                 s11, s22, s33, s12, s13, s23,&
                                 p%x,visc,ifc,ie, coef, coef%Xh)
 
-         dragpx = dragpx + dgtq(1,1)  ! pressure 
+         dragpx = dragpx + dgtq(1,1)  ! pressure
          dragpy = dragpy + dgtq(2,1)
          dragpz = dragpz + dgtq(3,1)
 
@@ -143,7 +143,7 @@ contains
          dragvy = dragvy + dgtq(2,2)
          dragvz = dragvz + dgtq(3,2)
 
-         torqpx = torqpx + dgtq(1,3)  ! pressure 
+         torqpx = torqpx + dgtq(1,3)  ! pressure
          torqpy = torqpy + dgtq(2,3)
          torqpz = torqpz + dgtq(3,3)
 
@@ -180,18 +180,18 @@ contains
       call MPI_Allreduce(MPI_IN_PLACE,torqvz, 1, &
          MPI_REAL_PRECISION, MPI_SUM, NEKO_COMM, ierr)
 
-      dgtq(1,1) = dragpx  ! pressure 
+      dgtq(1,1) = dragpx  ! pressure
       dgtq(2,1) = dragpy
       dgtq(3,1) = dragpz
-               
+
       dgtq(1,2) = dragvx  ! viscous
       dgtq(2,2) = dragvy
       dgtq(3,2) = dragvz
-               
-      dgtq(1,3) = torqpx  ! pressure 
+
+      dgtq(1,3) = torqpx  ! pressure
       dgtq(2,3) = torqpy
       dgtq(3,3) = torqpz
-               
+
       dgtq(1,4) = torqvx  ! viscous
       dgtq(2,4) = torqvy
       dgtq(3,4) = torqvz
@@ -212,7 +212,7 @@ contains
   subroutine drag_torque_facet(dgtq,xm0,ym0,zm0, center,&
                                s11, s22, s33, s12, s13, s23,&
                                pm1,visc,f,e, coef, Xh)
-    type(coef_t), intent(in) :: coef 
+    type(coef_t), intent(in) :: coef
     type(space_t), intent(in) :: Xh
     real(kind=rp), intent(out) :: dgtq(3,4)
     real(kind=rp), intent(in) :: center(3)
@@ -231,11 +231,11 @@ contains
     integer :: pf,l, k, i, j1, j2
     real(kind=rp) ::    n1,n2,n3, j, a, r1, r2, r3, v, dgtq_i(3,4)
     integer :: skpdat(6,6), NX, NY, NZ
-    integer :: js1   
-    integer :: jf1   
+    integer :: js1
+    integer :: jf1
     integer :: jskip1
-    integer :: js2   
-    integer :: jf2   
+    integer :: js2
+    integer :: jf2
     integer :: jskip2
     real(kind=rp) :: s11_, s21_, s31_, s12_, s22_, s32_, s13_, s23_, s33_
 
@@ -328,39 +328,39 @@ contains
   !! @param n2, normal vector y
   !! @param n3, normal vector z
   !! @param v, the viscosity
-  subroutine drag_torque_pt(dgtq,x,y,z, center, s11, s22, s33, s12, s13, s23,&
-                            p,n1, n2, n3,v)
+  subroutine drag_torque_pt(dgtq, x, y, z, center, s11, s22, s33, s12, s13, s23,&
+                            p, n1, n2, n3, v)
     real(kind=rp), intent(inout) :: dgtq(3,4)
-    real(kind=rp), intent(in) :: x 
+    real(kind=rp), intent(in) :: x
     real(kind=rp), intent(in) :: y
     real(kind=rp), intent(in) :: z
     real(kind=rp), intent(in) :: p
     real(kind=rp), intent(in) :: v
     real(kind=rp), intent(in) :: n1, n2, n3, center(3)
     real(kind=rp), intent(in) :: s11, s12, s22, s13, s23, s33
-    real(kind=rp) ::  s21, s31, s32, r1, r2, r3 
+    real(kind=rp) ::  s21, s31, s32, r1, r2, r3
     call rzero(dgtq,12)
     s21 = s12
     s32 = s23
     s31 = s13
     !pressure drag
-    dgtq(1,1) = p*n1  
+    dgtq(1,1) = p*n1
     dgtq(2,1) = p*n2
     dgtq(3,1) = p*n3
     ! viscous drag
-    dgtq(1,2) = -v*(s11*n1 + s12*n2 + s13*n3)
-    dgtq(2,2) = -v*(s21*n1 + s22*n2 + s23*n3)
-    dgtq(3,2) = -v*(s31*n1 + s32*n2 + s33*n3)
+    dgtq(1,2) = -2*v*(s11*n1 + s12*n2 + s13*n3)
+    dgtq(2,2) = -2*v*(s21*n1 + s22*n2 + s23*n3)
+    dgtq(3,2) = -2*v*(s31*n1 + s32*n2 + s33*n3)
     r1 = x-center(1)
     r2 = y-center(2)
     r3 = z-center(3)
     !pressure torque
-    dgtq(1,3) = (r2*dgtq(3,1)-r3*dgtq(2,1)) 
+    dgtq(1,3) = (r2*dgtq(3,1)-r3*dgtq(2,1))
     dgtq(2,3) = (r3*dgtq(1,1)-r1*dgtq(3,1))
     dgtq(3,3) = (r1*dgtq(2,1)-r2*dgtq(1,1))
     !viscous torque
     dgtq(1,4) = (r2*dgtq(3,2)-r3*dgtq(2,2))
-    dgtq(2,4) = (r3*dgtq(1,2)-r1*dgtq(3,2)) 
+    dgtq(2,4) = (r3*dgtq(1,2)-r1*dgtq(3,2))
     dgtq(3,4) = (r1*dgtq(2,2)-r2*dgtq(1,2))
   end subroutine drag_torque_pt
 


### PR DESCRIPTION
This changes the strain_rate operator to actually return the strain rate instead of its double (which I think I copied from Nek5000). The x2 convention is easy to forget about and now caused some issues with the implemention of models for the stress formulation branch.

On develop, the operator is not used.

