### PR TITLE
README with JSON-Fortran

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ To build the project you will need: A Fortran compiler supporting the Fortran-08
 git clone --depth 1 https://github.com/ExtremeFLOW/json-fortran/
 cd json-fortran
 mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=path/to/json-fortran_install -DUSE_GNU_INSTALL_CONVENTION=ON ..
+export JSON_INSTALL=/path/to/json-fortran_install
+cmake -DCMAKE_INSTALL_PREFIX=${JSON_INSTALL} -DUSE_GNU_INSTALL_CONVENTION=ON ..
 make -j4 && make install && cd ../../
-export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:path/to/json-fortran_install/lib/pkgconfig
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/path/to/json-fortran_install/lib/
+export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${JSON_INSTALL}/lib/pkgconfig
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${JSON_INSTALL}/lib/
 ```
 
 A basic CPU version of Neko can then be installed according to the following

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ git clone https://github.com/ExtremeFLOW/neko
 Documentation for Neko is available at https://neko.cfd and most things related to the code, cases, and different features are described there. The documentation is always improving, in large part due to our active users and if something is missing or hard to understand, don't be afraid to create an issue or create a PR. It is a great way to help us improve and also to start getting involved in the project.
 
 ## Building the project
-To build the project you will need: A Fortran compiler supporting the Fortran-08 standard, a working MPI installation, JSON-Fortran, and BLAS/lapack. Optional dependencies are gslib and ParMETIS. We use automake to build the project. These instructions should work in general, but as the project is quickly developing, things might change. While we assume MPI and BLAS are installed, if JSON-Fortran is not already available it can be cloned, installed, and the correct paths set with the following commands (Skip this step if you already have an installation of JSON-Fortran).
+To build the project you will need: A Fortran compiler supporting the Fortran-08 standard, a working MPI installation, JSON-Fortran, and BLAS/lapack. Optional dependencies are gslib and ParMETIS. We use autotools to build the project. These instructions should work in general, but as the project is quickly developing, things might change. While we assume MPI and BLAS are installed, if JSON-Fortran is not already available it can be cloned, installed, and the correct paths set with the following commands (Skip this step if you already have an installation of JSON-Fortran).
 
 ```bash
 export JSON_INSTALL=/path/to/json-fortran_install # Where you want to install json-fortran

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ export JSON_INSTALL=/path/to/json-fortran_install # Where you want to install js
 ```bash
 git clone --depth 1 https://github.com/ExtremeFLOW/json-fortran/
 cmake -S json-fortran -B json-fortran/build -DCMAKE_INSTALL_PREFIX=${JSON_INSTALL} -DUSE_GNU_INSTALL_CONVENTION=ON ..
-cmake --parallel --build json-fortran/build
+cmake --build json-fortran/build
 cmake --install json-fortran/build
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${JSON_INSTALL}/lib/ #On some systems lib should be replaced with lib64
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${JSON_INSTALL}/lib/pkgconfig 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ git clone https://github.com/ExtremeFLOW/neko
 ```
 
 ## Documentation
-Documentation for Neko is available at https://neko.cfd and most things related to the code, cases, and different features are described there. The documentation is always improving, in large part due to our active users and if something is missing or hard to understand, don't be afraid to create an issue or create a PR. It is a great way to help us improve and also to start getting involved in the project.
+Documentation for Neko is available at https://neko.cfd and most things related to the code, cases, and different features are described there. The documentation is always improving, in large part due to our active users and if something is missing or hard to understand, don't be afraid to start a [discussion](https://github.com/ExtremeFLOW/neko/discussions) or create a [Pull request](https://github.com/ExtremeFLOW/neko/pulls). It is a great way to help us improve and also to start getting involved in the project.
 
 ## Building the project
 To build the project you will need: A Fortran compiler supporting the Fortran-08 standard, a working MPI installation, JSON-Fortran, and BLAS/lapack. Optional dependencies are gslib and ParMETIS. We use autotools to build the project. These instructions should work in general, but as the project is quickly developing, things might change. While we assume MPI and BLAS are installed, if JSON-Fortran is not already available it can be cloned, installed, and the correct paths set with the following commands (Skip this step if you already have an installation of JSON-Fortran).

--- a/README.md
+++ b/README.md
@@ -10,17 +10,30 @@ Neko is a portable framework for high-order spectral element flow simulations. W
 git clone https://github.com/ExtremeFLOW/neko
 ```
 
-## Building the project
-To build the project you will need: A Fortran compiler supporting the Fortran-08 standard, a working MPI installation, JSON-Fortran, and BLAS/lapack. Optional dependencies are gslib and ParMETIS. We use automake to build the project. These instructions should work in general, but as the project is quickly developing, things might change.
+## Documentation
+Documentation for Neko is available at https://neko.cfd and most things related to the code, cases, and different features are described there. The documentation is always improving, in large part due to our active users and if something is missing or hard to understand, don't be afraid to create an issue or create a PR. It is a great way for us to help us improve and also to start getting involved in the project.
 
+## Building the project
+To build the project you will need: A Fortran compiler supporting the Fortran-08 standard, a working MPI installation, JSON-Fortran, and BLAS/lapack. Optional dependencies are gslib and ParMETIS. We use automake to build the project. These instructions should work in general, but as the project is quickly developing, things might change. While we assume MPI and BLAS are installed, if JSON-Fortran is not already available it can be cloned, installed, and the correct paths set with the following commands (Skip this step if you already have an installation of JSON-Fortran).
+
+```bash
+git clone --depth 1 https://github.com/ExtremeFLOW/json-fortran/
+cd json-fortran
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=path/to/json-fortran_install -DUSE_GNU_INSTALL_CONVENTION=ON ..
+make -j4 && make install && cd ../../
+export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:path/to/json-fortran_install/lib/pkgconfig
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/path/to/json-fortran_install/lib/
+```
+
+A basic CPU version of Neko can then be installed according to the following
 ```bash
 cd neko
 ./regen.sh
-./configure --prefix=/path/to/neko_install --with-pfunit=/path/to/pFUnit/installed/PFUNIT-VERSION
+./configure --prefix=/path/to/neko_install
 make install
 ```
-
-More detailed installation instructions can be found in the documentation.
+More detailed installation instructions and all the different options (such as how to install Neko for GPUs) can be found in the documentation available at https://neko.cfd. 
 
 ## Running examples
 After the project has been built
@@ -31,19 +44,6 @@ cd examples/tgv
 mpirun -np 4 ./neko tgv.case
 ```
 
-## Testing the Code
-Assuming you configured with pFUnit you should be able to test the code with
-```bash
-make check
-```
-
-## Documentation
-Documentation for Neko is available at https://neko.cfd.
-
-To generate the documentation, you need to have both doxygen and dot (part of the Graphviz package) installed (they will be picked up by configure). Once installed, you should be able to generate the documentation with
-```bash
-make html
-```
 ## Publications using Neko
 * Jansson, N., 2021. *Spectral Element Simulations on the NEC SX-Aurora TSUBASA*. In proc. HPCAsia 2021.
 * Karp, M., Podobas, A., Kenter, T., Jansson, N., Plessl, C., Schlatter, P. and Markidis, S., 2022. *A high-fidelity flow solver for unstructured meshes on field-programmable gate arrays: Design, evaluation, and future challenges*. In proc. HPCAsia 2022.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Documentation for Neko is available at https://neko.cfd and most things related 
 To build the project you will need: A Fortran compiler supporting the Fortran-08 standard, a working MPI installation, JSON-Fortran, and BLAS/lapack. Optional dependencies are gslib and ParMETIS. We use automake to build the project. These instructions should work in general, but as the project is quickly developing, things might change. While we assume MPI and BLAS are installed, if JSON-Fortran is not already available it can be cloned, installed, and the correct paths set with the following commands (Skip this step if you already have an installation of JSON-Fortran).
 
 ```bash
+export JSON_INSTALL=/path/to/json-fortran_install # Where you want to install json-fortran
 git clone --depth 1 https://github.com/ExtremeFLOW/json-fortran/
 cd json-fortran
 mkdir build && cd build
-export JSON_INSTALL=/path/to/json-fortran_install
 cmake -DCMAKE_INSTALL_PREFIX=${JSON_INSTALL} -DUSE_GNU_INSTALL_CONVENTION=ON ..
 make -j4 && make install && cd ../../
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${JSON_INSTALL}/lib64/pkgconfig
@@ -31,7 +31,7 @@ A basic CPU version of Neko can then be installed according to the following
 ```bash
 cd neko
 ./regen.sh
-./configure --prefix=/path/to/neko_install
+./configure --prefix=/path/to/neko_install # Where you want to install neko
 make install
 ```
 More detailed installation instructions and all the different options (such as how to install Neko for GPUs) can be found in the documentation available at https://neko.cfd. 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ git clone https://github.com/ExtremeFLOW/neko
 ```
 
 ## Documentation
-Documentation for Neko is available at https://neko.cfd and most things related to the code, cases, and different features are described there. The documentation is always improving, in large part due to our active users and if something is missing or hard to understand, don't be afraid to create an issue or create a PR. It is a great way for us to help us improve and also to start getting involved in the project.
+Documentation for Neko is available at https://neko.cfd and most things related to the code, cases, and different features are described there. The documentation is always improving, in large part due to our active users and if something is missing or hard to understand, don't be afraid to create an issue or create a PR. It is a great way to help us improve and also to start getting involved in the project.
 
 ## Building the project
 To build the project you will need: A Fortran compiler supporting the Fortran-08 standard, a working MPI installation, JSON-Fortran, and BLAS/lapack. Optional dependencies are gslib and ParMETIS. We use automake to build the project. These instructions should work in general, but as the project is quickly developing, things might change. While we assume MPI and BLAS are installed, if JSON-Fortran is not already available it can be cloned, installed, and the correct paths set with the following commands (Skip this step if you already have an installation of JSON-Fortran).
@@ -43,6 +43,12 @@ cd examples/tgv
 /path/to/neko_install/bin/makeneko tgv.f90
 mpirun -np 4 ./neko tgv.case
 ```
+If there is not a .f90 (user) file in the example, the standard executable `neko` can also be used, for example:
+```bash
+cd examples/hemi
+mpirun -np 4 /path/to/neko_install/bin/neko hemi.case
+```
+only uses built-in functions and does not need a compiled user file. 
 
 ## Publications using Neko
 * Jansson, N., 2021. *Spectral Element Simulations on the NEC SX-Aurora TSUBASA*. In proc. HPCAsia 2021.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ export JSON_INSTALL=/path/to/json-fortran_install # Where you want to install js
 ```bash
 git clone --depth 1 https://github.com/ExtremeFLOW/json-fortran/
 cmake -S json-fortran -B json-fortran/build -DCMAKE_INSTALL_PREFIX=${JSON_INSTALL} -DUSE_GNU_INSTALL_CONVENTION=ON ..
-cmake --build json-fortran/build
+cmake --build json-fortran/build --parallel
 cmake --install json-fortran/build
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${JSON_INSTALL}/lib/ #On some systems lib should be replaced with lib64
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${JSON_INSTALL}/lib/pkgconfig 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Documentation for Neko is available at https://neko.cfd and most things related 
 To build the project you will need: A Fortran compiler supporting the Fortran-08 standard, a working MPI installation, JSON-Fortran, and BLAS/lapack. Optional dependencies are gslib and ParMETIS. We use automake to build the project. These instructions should work in general, but as the project is quickly developing, things might change. While we assume MPI and BLAS are installed, if JSON-Fortran is not already available it can be cloned, installed, and the correct paths set with the following commands (Skip this step if you already have an installation of JSON-Fortran).
 
 ```bash
-export JSON_INSTALL=/path/to/json-fortran_install # To make life easier, lets export a variable where you want to install json-fortran
+export JSON_INSTALL=/path/to/json-fortran_install # Where you want to install json-fortran
 git clone --depth 1 https://github.com/ExtremeFLOW/json-fortran/
 cd json-fortran
 mkdir build && cd build

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ mkdir build && cd build
 export JSON_INSTALL=/path/to/json-fortran_install
 cmake -DCMAKE_INSTALL_PREFIX=${JSON_INSTALL} -DUSE_GNU_INSTALL_CONVENTION=ON ..
 make -j4 && make install && cd ../../
-export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${JSON_INSTALL}/lib/pkgconfig
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${JSON_INSTALL}/lib/
+export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${JSON_INSTALL}/lib64/pkgconfig
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${JSON_INSTALL}/lib64/
 ```
 
 A basic CPU version of Neko can then be installed according to the following

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ To build the project you will need: A Fortran compiler supporting the Fortran-08
 
 ```bash
 export JSON_INSTALL=/path/to/json-fortran_install # Where you want to install json-fortran
+```
+```bash
 git clone --depth 1 https://github.com/ExtremeFLOW/json-fortran/
 cd json-fortran
 mkdir build && cd build

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If there is not a .f90 (user) file in the example, the standard executable `neko
 cd examples/hemi
 mpirun -np 4 /path/to/neko_install/bin/neko hemi.case
 ```
-only uses built-in functions and does not need a compiled user file. 
+only uses built-in functions and does not need a compiled user file. Whether you will need a user file or not depends on what functionality you want and this is also documented in the documentation.
 
 ## Publications using Neko
 * Jansson, N., 2021. *Spectral Element Simulations on the NEC SX-Aurora TSUBASA*. In proc. HPCAsia 2021.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ cd json-fortran
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=${JSON_INSTALL} -DUSE_GNU_INSTALL_CONVENTION=ON ..
 make -j4 && make install && cd ../../
-export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${JSON_INSTALL}/lib64/pkgconfig
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${JSON_INSTALL}/lib64/
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${JSON_INSTALL}/lib/ #On some systems lib should be replaced with lib64
+export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${JSON_INSTALL}/lib/pkgconfig 
+
 ```
 
 A basic CPU version of Neko can then be installed according to the following

--- a/README.md
+++ b/README.md
@@ -21,10 +21,9 @@ export JSON_INSTALL=/path/to/json-fortran_install # Where you want to install js
 ```
 ```bash
 git clone --depth 1 https://github.com/ExtremeFLOW/json-fortran/
-cd json-fortran
-mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=${JSON_INSTALL} -DUSE_GNU_INSTALL_CONVENTION=ON ..
-make -j4 && make install && cd ../../
+cmake -S json-fortran -B json-fortran/build -DCMAKE_INSTALL_PREFIX=${JSON_INSTALL} -DUSE_GNU_INSTALL_CONVENTION=ON ..
+cmake --parallel --build json-fortran/build
+cmake --install json-fortran/build
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${JSON_INSTALL}/lib/ #On some systems lib should be replaced with lib64
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${JSON_INSTALL}/lib/pkgconfig 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Documentation for Neko is available at https://neko.cfd and most things related 
 To build the project you will need: A Fortran compiler supporting the Fortran-08 standard, a working MPI installation, JSON-Fortran, and BLAS/lapack. Optional dependencies are gslib and ParMETIS. We use automake to build the project. These instructions should work in general, but as the project is quickly developing, things might change. While we assume MPI and BLAS are installed, if JSON-Fortran is not already available it can be cloned, installed, and the correct paths set with the following commands (Skip this step if you already have an installation of JSON-Fortran).
 
 ```bash
-export JSON_INSTALL=/path/to/json-fortran_install # Where you want to install json-fortran
+export JSON_INSTALL=/path/to/json-fortran_install # To make life easier, lets export a variable where you want to install json-fortran
 git clone --depth 1 https://github.com/ExtremeFLOW/json-fortran/
 cd json-fortran
 mkdir build && cd build


### PR DESCRIPTION
To make life easier, removed some more advanced options from the readme and added how to compile json-fortran. 

Easier than looking into https://github.com/ExtremeFLOW/neko/blob/develop/.github/workflows/develop.yml for how to compile as I am doing now.

Not perfect, but I think this would be a significant improvement, in particular it's rather easy to copy-paste and get something up and running.