### PR TITLE
HDF5 Support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -255,6 +255,14 @@ AX_NVTX
 # Checks for ROCTX profiling
 AX_ROCTX
 
+# Checks for HDF5
+if (test "x${is_cray}" = xyes || test "x${is_hpe_cray}" = xyes); then
+   AX_CRAY_HDF5_PARALLEL
+else
+   AX_HDF5
+fi
+
+
 # JSON-Fortran
 PKG_CHECK_MODULES([JSON_Fortran],[json-fortran >= 7.1.0])
 LIBS="$JSON_Fortran_LIBS $LIBS"

--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -70,6 +70,7 @@ but also defines several parameters that pertain to the simulation as a whole.
 | `output_checkpoints`       | Whether to output checkpoints, i.e. restart files.                                                    | `true` or `false`                               | `false`       |
 | `checkpoint_control`       | Defines the interpretation of `checkpoint_value` to define the frequency of writing checkpoint files. | `nsamples`, `simulationtime`, `tsteps`, `never` | -             |
 | `checkpoint_value`         | The frequency of sampling in terms of `checkpoint_control`.                                           | Positive real or integer                        | -             |
+| `checkpoint_format`        | The file format of checkpoints                                                                        | `chkp` or `hdf5`                                | `chkp`        |
 | `restart_file`             | checkpoint to use for a restart from previous data                                                    | Strings ending with `.chkp`                     | -             |
 | `timestep`                 | Time-step size                                                                                        | Positive reals                                  | -             |
 | `variable_timestep`        | Whether to use variable dt                                                                            | `true` or `false`                               | `false`       |

--- a/doc/pages/user-guide/installation.md
+++ b/doc/pages/user-guide/installation.md
@@ -126,6 +126,7 @@ Optional packages are controlled by passing either `--with-PACKAGE[=ARG]` or `--
 | `--with-opencl=DIR`             | Compile with OpenCL backend                   |
 | `--with-nvtx=DIR`               | Compile with support for NVTX                 |
 | `--with-roctx=DIR`              | Compile with support for ROCTX                |
+| `--with-hdf5`                   | Compile with support for HDF5                 |
 | `--with-pfunit=DIR`             | Directory for pFUnit (see \subpage testing)   |
 
 @note Accelerators backends are not enabled as a feature in Neko, but rather via optional packages.

--- a/m4/ax_cray.m4
+++ b/m4/ax_cray.m4
@@ -224,3 +224,22 @@ AC_DEFUN([AX_CRAY_ACCEL], [
 	fi
 	AC_SUBST(have_cray_accel)
 ])
+
+
+AC_DEFUN([AX_CRAY_HDF5_PARALLEL],[
+	AC_ARG_WITH([hdf5],[],
+		    [
+		    ], [with_hdf5=no])
+	if test "x${with_hdf5}" != xno; then
+	AC_MSG_CHECKING([Cray HDF5 (parallel) ])
+	if test "${CRAY_HDF5_PARALLEL_VERSION}"; then
+	   AC_MSG_RESULT([yes])
+	   have_cray_hdf5="yes"
+      	   AC_DEFINE(HAVE_HDF5,1,[Define if you have HDF5.])
+	else
+	   AC_MSG_RESULT([no])
+	   have_cray_hdf5="no"
+	fi
+	AC_SUBST(have_cray_hdf5)
+        fi
+])

--- a/m4/ax_hdf5.m4
+++ b/m4/ax_hdf5.m4
@@ -1,0 +1,26 @@
+#
+# ----------------------------------------------------------------------------
+# "THE BEER-WARE LICENSE" (Revision 42):
+# <njansson@kth.se> wrote this file. As long as you retain this notice you
+# can do whatever you want with this stuff. If we meet some day, and you think
+# this stuff is worth it, you can buy me a beer in return Niclas Jansson
+# ----------------------------------------------------------------------------
+#
+
+AC_DEFUN([AX_HDF5],[
+	AC_ARG_WITH([hdf5],
+		    AS_HELP_STRING([--with-hdf5],
+		    [Compile with support for HDF5]),
+		    [with_hdf5=${withval}], [with_hdf5=no])
+                    
+        if test "x${with_hdf5}" != xno; then
+           PKG_CHECK_MODULES([HDF5_Fortran],[hdf5_fortran >= 1.14.0],
+                             have_hdf5=yes, have_hdf5=no)
+	   if test "x${have_hdf5}" = xyes; then 	
+              LIBS="$HDF5_Fortran_LIBS $LIBS"
+              FCFLAGS="$HDF5_Fortran_CFLAGS $FCFLAGS"
+              AC_DEFINE(HAVE_HDF5,[1],
+                     [Define if you have the HDF5 library.])
+           fi
+	fi
+])

--- a/src/.depends
+++ b/src/.depends
@@ -112,7 +112,8 @@ io/stl_file.o : io/stl_file.f90 io/format/stl.o comm/comm.o common/utils.o comm/
 io/nmsh_file.o : io/nmsh_file.f90 common/log.o comm/mpi_types.o common/datadist.o mesh/element.o io/format/nmsh.o adt/tuple.o mesh/point.o common/utils.o mesh/mesh.o comm/comm.o io/generic_file.o 
 io/chkp_file.o : io/chkp_file.f90 common/global_interpolation.o comm/comm.o comm/mpi_types.o sem/interpolation.o math/math.o mesh/mesh.o sem/space.o common/utils.o math/bcknd/device/device_math.o sem/dofmap.o field/field.o config/num_types.o common/checkpoint.o field/field_series.o io/generic_file.o 
 io/csv_file.o : io/csv_file.f90 comm/comm.o common/log.o config/num_types.o common/utils.o io/generic_file.o math/matrix.o math/vector.o 
-io/file.o : io/file.f90 io/csv_file.o io/stl_file.o io/vtk_file.o io/fld_file_data.o io/fld_file.o io/re2_file.o io/rea_file.o io/map_file.o io/chkp_file.o io/nmsh_file.o io/generic_file.o config/num_types.o common/utils.o 
+io/hdf5_file.o : io/hdf5_file.F90 comm/comm.o common/log.o sem/dofmap.o field/field_series.o field/field_list.o field/field.o mesh/mesh.o common/utils.o common/checkpoint.o io/generic_file.o config/num_types.o 
+io/file.o : io/file.f90 io/hdf5_file.o io/csv_file.o io/stl_file.o io/vtk_file.o io/fld_file_data.o io/fld_file.o io/re2_file.o io/rea_file.o io/map_file.o io/chkp_file.o io/nmsh_file.o io/generic_file.o config/num_types.o common/utils.o 
 io/output.o : io/output.f90 io/file.o config/num_types.o 
 io/fluid_output.o : io/fluid_output.f90 io/output.o device/device.o config/neko_config.o field/field_list.o scalar/scalar_scheme.o fluid/fluid_scheme.o config/num_types.o 
 io/fld_file_output.o : io/fld_file_output.f90 io/output.o device/device.o config/neko_config.o field/field_list.o config/num_types.o 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -115,6 +115,7 @@ neko_fortran_SOURCES = \
 	io/nmsh_file.f90\
 	io/chkp_file.f90\
 	io/csv_file.f90\
+	io/hdf5_file.F90\
 	io/file.f90\
 	io/output.f90\
 	io/fluid_output.f90\

--- a/src/case.f90
+++ b/src/case.f90
@@ -402,7 +402,10 @@ contains
     call json_get_or_default(C%params, 'case.output_checkpoints',&
                              logical_val, .true.)
     if (logical_val) then
-       C%f_chkp = chkp_output_t(C%fluid%chkp, path=output_directory)
+       call json_get_or_default(C%params, 'case.checkpoint_format', &
+            string_val, "chkp")
+       C%f_chkp = chkp_output_t(C%fluid%chkp, path=output_directory, &
+            fmt=trim(string_val))
        call json_get_or_default(C%params, 'case.checkpoint_control', &
             string_val, "simulationtime")
        call json_get_or_default(C%params, 'case.checkpoint_value', real_val,&

--- a/src/field/field_series.f90
+++ b/src/field/field_series.f90
@@ -49,6 +49,11 @@ module field_series
      procedure, pass(this) :: size => field_series_size
   end type field_series_t
 
+  !> field_series_ptr_t, To easily obtain a pointer to a field series
+  type, public :: field_series_ptr_t
+     type(field_series_t), pointer :: fs => null()
+  end type field_series_ptr_t
+
 contains
 
   !> Initialize a field series of length @a len for a field @a f

--- a/src/field/field_series.f90
+++ b/src/field/field_series.f90
@@ -51,7 +51,7 @@ module field_series
 
   !> field_series_ptr_t, To easily obtain a pointer to a field series
   type, public :: field_series_ptr_t
-     type(field_series_t), pointer :: fs => null()
+     type(field_series_t), pointer :: ptr => null()
   end type field_series_ptr_t
 
 contains

--- a/src/io/chkp_output.f90
+++ b/src/io/chkp_output.f90
@@ -49,21 +49,30 @@ module chkp_output
 
 contains
 
-  function chkp_output_init(chkp, name, path) result(this)
+  function chkp_output_init(chkp, name, path, fmt) result(this)
     type(chkp_t), intent(in), target :: chkp
     character(len=*), intent(in), optional :: name
     character(len=*), intent(in), optional :: path
+    character(len=*), intent(in), optional :: fmt
     type(chkp_output_t) :: this
     character(len=1024) :: fname
+    character(len=10) :: suffix
+
+    suffix = '.chkp'
+    if (present(fmt)) then
+       if (fmt .eq. 'hdf5') then
+          suffix = '.h5'
+       end if
+    end if
 
     if (present(name) .and. present(path)) then
-       fname = trim(path) // trim(name) // '.chkp'
+       fname = trim(path) // trim(name) // trim(suffix)
     else if (present(name)) then
-       fname = trim(name) // '.chkp'
+       fname = trim(name) // trim(suffix)
     else if (present(path)) then
-       fname = trim(path) // 'fluid.chkp'
+       fname = trim(path) // 'fluid' // trim(suffix)
     else
-       fname = 'fluid.chkp'
+       fname= 'fluid' // trim(suffix)
     end if
 
     call this%init_base(fname)

--- a/src/io/file.f90
+++ b/src/io/file.f90
@@ -45,6 +45,7 @@ module file
   use vtk_file, only : vtk_file_t
   use stl_file, only : stl_file_t
   use csv_file, only : csv_file_t
+  use hdf5_file, only : hdf5_file_t
   implicit none
 
   !> A wrapper around a polymorphic `generic_file_t` that handles its init.
@@ -110,6 +111,8 @@ contains
     else if (suffix .eq. "csv") then
        allocate(csv_file_t::this%file_type)
        this%file_type%serial = .true.
+    else if ((suffix .eq. "hdf5") .or. (suffix .eq. "h5")) then
+       allocate(hdf5_file_t::this%file_type)
     else
        call neko_error('Unknown file format')
     end if

--- a/src/io/hdf5_file.F90
+++ b/src/io/hdf5_file.F90
@@ -1,0 +1,540 @@
+! Copyright (c) 2024, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> HDF5 file format
+module hdf5_file
+  use num_types
+  use generic_file
+  use checkpoint, only : chkp_t
+  use utils
+  use mesh, only : mesh_t
+  use field, only : field_t, field_ptr_t
+  use field_list, only : field_list_t
+  use field_series, only : field_series_t, field_series_ptr_t
+  use dofmap, only : dofmap_t
+  use logger
+  use comm
+  use mpi_f08
+#ifdef HAVE_HDF5
+  use hdf5
+#endif
+  implicit none
+  private
+
+  !> Interface for HDF5 files
+  type, public, extends(generic_file_t) :: hdf5_file_t
+   contains
+     procedure :: read => hdf5_file_read
+     procedure :: write => hdf5_file_write
+  end type hdf5_file_t
+
+contains
+
+#ifdef HAVE_HDF5
+  
+  !> Write data in HDF5 format
+  subroutine hdf5_file_write(this, data, t)
+    class(hdf5_file_t), intent(inout) :: this
+    class(*), target, intent(in) :: data
+    real(kind=rp), intent(in), optional :: t
+    type(mesh_t), pointer :: msh
+    type(dofmap_t), pointer :: dof
+    type(field_ptr_t), allocatable :: fp(:)
+    type(field_series_ptr_t), allocatable :: fsp(:)
+    real(kind=rp), pointer :: dtlag(:)
+    real(kind=rp), pointer :: tlag(:) 
+    integer :: ierr, info, drank, i, j
+    integer(hid_t) :: plist_id, file_id, dset_id, grp_id, attr_id
+    integer(hid_t) :: filespace, memspace
+    integer(hsize_t), dimension(1) :: ddim, dcount, doffset
+    integer :: suffix_pos
+    character(len=5) :: id_str
+    character(len=1024) :: fname
+ 
+    call hdf5_file_determine_data(data, msh, dof, fp, fsp, dtlag, tlag)
+
+    suffix_pos = filename_suffix_pos(this%fname)
+    write(id_str, '(i5.5)') this%counter
+    fname = trim(this%fname(1:suffix_pos-1))//id_str//'.h5'
+       
+    call h5open_f(ierr)
+    call h5pcreate_f(H5P_FILE_ACCESS_F, plist_id, ierr)
+    info = MPI_INFO_NULL%mpi_val
+    call h5pset_fapl_mpio_f(plist_id, NEKO_COMM%mpi_val, info, ierr)
+
+    call h5fcreate_f(fname, H5F_ACC_TRUNC_F, &
+         file_id, ierr, access_prp = plist_id)
+    
+    call h5pcreate_f(H5P_DATASET_XFER_F, plist_id, ierr)
+    call h5pset_dxpl_mpio_f(plist_id, H5FD_MPIO_COLLECTIVE_F, ierr)
+    
+    call h5screate_f(H5S_SCALAR_F, filespace, ierr)
+    ddim = 1
+
+    if (present(t)) then
+       call h5acreate_f(file_id, "Time", H5T_NATIVE_DOUBLE, filespace, attr_id, &
+                        ierr, h5p_default_f, h5p_default_f)
+       call h5awrite_f(attr_id, H5T_NATIVE_DOUBLE, t, ddim, ierr)
+       call h5aclose_f(attr_id, ierr)
+    end if
+
+    if (associated(dof)) then
+       call h5acreate_f(file_id, "Lx", H5T_NATIVE_INTEGER, filespace, attr_id, &
+                        ierr, h5p_default_f, h5p_default_f)
+       call h5awrite_f(attr_id, H5T_NATIVE_INTEGER, dof%Xh%lx, ddim, ierr)
+       call h5aclose_f(attr_id, ierr)
+    end if
+    
+    if (associated(msh)) then
+       call h5gcreate_f(file_id, "Mesh", grp_id, ierr, lcpl_id=h5p_default_f, &
+            gcpl_id=h5p_default_f, gapl_id=h5p_default_f)
+    
+       call h5acreate_f(grp_id, "Elements", H5T_NATIVE_INTEGER, filespace, attr_id, &
+                        ierr, h5p_default_f, h5p_default_f)
+       call h5awrite_f(attr_id, H5T_NATIVE_INTEGER, msh%glb_nelv, ddim, ierr)
+       call h5aclose_f(attr_id, ierr)
+
+       call h5acreate_f(grp_id, "Dimension", H5T_NATIVE_INTEGER, filespace, attr_id, &
+                        ierr, h5p_default_f, h5p_default_f)
+       call h5awrite_f(attr_id, H5T_NATIVE_INTEGER, msh%gdim, ddim, ierr)
+       call h5aclose_f(attr_id, ierr)
+
+       call h5gclose_f(grp_id, ierr)
+    end if
+
+    
+    call h5sclose_f(filespace, ierr)
+    
+    !
+    ! Write restart group (tlag, dtlag)
+    !
+    if (associated(tlag) .and. associated(dtlag)) then    
+       call h5gcreate_f(file_id, "Restart", grp_id, ierr, lcpl_id=h5p_default_f, &
+            gcpl_id=h5p_default_f, gapl_id=h5p_default_f)
+
+       drank = 1
+       ddim = size(tlag)
+       doffset(1) = 0
+       if (pe_rank .eq. 0) then
+          dcount = size(tlag)
+       else
+          dcount = 0
+       end if
+
+       call h5screate_simple_f(drank, ddim, filespace, ierr)
+
+       call h5dcreate_f(grp_id,'tlag', H5T_NATIVE_DOUBLE, &
+                        filespace, dset_id, ierr)
+       call h5dget_space_f(dset_id, filespace, ierr)
+       call h5sselect_hyperslab_f (filespace, H5S_SELECT_SET_F, &
+                                   doffset, dcount, ierr)
+       call h5dwrite_f(dset_id, H5T_NATIVE_DOUBLE, tlag, &
+                          ddim, ierr, xfer_prp = plist_id)
+       call h5dclose_f(dset_id, ierr)
+
+       call h5dcreate_f(grp_id,'dtlag', H5T_NATIVE_DOUBLE, &
+                        filespace, dset_id, ierr)
+       call h5dget_space_f(dset_id, filespace, ierr)
+       call h5sselect_hyperslab_f (filespace, H5S_SELECT_SET_F, &
+                                   doffset, dcount, ierr)
+       call h5dwrite_f(dset_id, H5T_NATIVE_DOUBLE, dtlag, &
+                          ddim, ierr, xfer_prp = plist_id)
+       call h5dclose_f(dset_id, ierr)
+       
+       call h5sclose_f(filespace, ierr)
+       call h5gclose_f(grp_id, ierr)
+       
+    end if
+
+
+    !
+    ! Write fields group
+    ! 
+    if (allocated(fp) .or. allocated(fsp)) then
+       call h5gcreate_f(file_id, "Fields", grp_id, ierr, lcpl_id=h5p_default_f, &
+            gcpl_id=h5p_default_f, gapl_id=h5p_default_f)
+    
+       dcount(1) = int(dof%size(), 8)
+       doffset(1) = int(msh%offset_el, 8) * int((dof%Xh%lx**3),8)
+       ddim =  int(dof%size(), 8)
+       drank = 1
+       call MPI_Allreduce(MPI_IN_PLACE, ddim(1), 1, &
+                          MPI_INTEGER8, MPI_SUM, NEKO_COMM, ierr)
+
+       call h5screate_simple_f(drank, ddim, filespace, ierr)
+       call h5screate_simple_f(drank, dcount, memspace, ierr)
+       
+
+       if (allocated(fp)) then
+          do i = 1, size(fp)
+             call h5dcreate_f(grp_id, fp(i)%ptr%name, H5T_NATIVE_DOUBLE, &
+                              filespace, dset_id, ierr)
+             call h5dget_space_f(dset_id, filespace, ierr)
+             call h5sselect_hyperslab_f(filespace, H5S_SELECT_SET_F, &
+                                        doffset, dcount, ierr)
+             call h5dwrite_f(dset_id, H5T_NATIVE_DOUBLE, &
+                             fp(i)%ptr%x(1,1,1,1), &
+                             ddim, ierr, file_space_id = filespace, &
+                             mem_space_id = memspace, xfer_prp = plist_id)
+             call h5dclose_f(dset_id, ierr)
+          end do
+          deallocate(fp)       
+       end if
+
+       if (allocated(fsp)) then
+          do i = 1, size(fsp)
+             do j = 1, fsp(i)%fs%size()
+                call h5dcreate_f(grp_id, fsp(i)%fs%lf(j)%name, &
+                                 H5T_NATIVE_DOUBLE, filespace, dset_id, ierr)
+                call h5dget_space_f(dset_id, filespace, ierr)
+                call h5sselect_hyperslab_f(filespace, H5S_SELECT_SET_F, &
+                                           doffset, dcount, ierr)
+                call h5dwrite_f(dset_id, H5T_NATIVE_DOUBLE, &
+                                fsp(i)%fs%lf(j)%x(1,1,1,1), &
+                                ddim, ierr, file_space_id = filespace, &
+                                mem_space_id = memspace, xfer_prp = plist_id)
+                call h5dclose_f(dset_id, ierr)
+             end do
+          end do
+          deallocate(fsp)
+       end if
+    
+       call h5gclose_f(grp_id, ierr)
+       call h5sclose_f(filespace, ierr)
+       call h5sclose_f(memspace, ierr)
+    end if
+    
+    call h5pclose_f(plist_id, ierr)
+    call h5fclose_f(file_id, ierr)
+
+    call h5close_f(ierr)
+
+    this%counter = this%counter + 1
+    
+  end subroutine hdf5_file_write
+
+  !> Read data in HDF5 format
+  subroutine hdf5_file_read(this, data)
+    class(hdf5_file_t) :: this
+    class(*), target, intent(inout) :: data
+    integer(hid_t) :: plist_id, file_id, dset_id, grp_id, attr_id
+    integer(hid_t) :: filespace, memspace
+    integer(hsize_t), dimension(1) :: ddim, dcount, doffset
+    integer :: i,j, ierr, info, glb_nelv, gdim, lx, drank
+    type(mesh_t), pointer :: msh
+    type(dofmap_t), pointer :: dof
+    type(field_ptr_t), allocatable :: fp(:)
+    type(field_series_ptr_t), allocatable :: fsp(:)
+    real(kind=rp), pointer :: dtlag(:)
+    real(kind=rp), pointer :: tlag(:) 
+    real(kind=rp) :: t
+
+    call hdf5_file_determine_data(data, msh, dof, fp, fsp, dtlag, tlag)
+
+    call h5open_f(ierr)
+    call h5pcreate_f(H5P_FILE_ACCESS_F, plist_id, ierr)
+    info = MPI_INFO_NULL%mpi_val
+    call h5pset_fapl_mpio_f(plist_id, NEKO_COMM%mpi_val, info, ierr)
+
+    call h5fopen_f(trim(this%fname), H5F_ACC_RDONLY_F, &
+         file_id, ierr, access_prp = plist_id)
+
+    call h5pcreate_f(H5P_DATASET_XFER_F, plist_id, ierr)
+    call h5pset_dxpl_mpio_f(plist_id, H5FD_MPIO_COLLECTIVE_F, ierr)
+
+    ddim = 1 
+    call h5aopen_name_f(file_id, 'Time', attr_id, ierr)
+    call h5aread_f(attr_id, H5T_NATIVE_DOUBLE, t, ddim, ierr)
+    call h5aclose_f(attr_id, ierr)
+
+    select type(data)
+    type is(chkp_t)
+       data%t = t
+    end select
+
+    call h5aopen_name_f(file_id, 'Lx', attr_id, ierr)
+    call h5aread_f(attr_id, H5T_NATIVE_INTEGER, lx, ddim, ierr)
+    call h5aclose_f(attr_id, ierr)
+
+    call h5gopen_f(file_id, 'Mesh', grp_id, ierr, gapl_id=h5p_default_f)
+
+    call h5aopen_name_f(grp_id, 'Elements', attr_id, ierr)
+    call h5aread_f(attr_id, H5T_NATIVE_INTEGER, glb_nelv, ddim, ierr)
+    call h5aclose_f(attr_id, ierr)
+
+    call h5aopen_name_f(grp_id, 'Dimension', attr_id, ierr)
+    call h5aread_f(attr_id, H5T_NATIVE_INTEGER, gdim, ddim, ierr)
+    call h5aclose_f(attr_id, ierr)
+    call h5gclose_f(grp_id, ierr)
+
+
+    if (associated(tlag) .and. associated(dtlag)) then
+       drank = 1
+       ddim = size(tlag)
+       doffset(1) = 0
+       if (pe_rank .eq. 0) then
+          dcount = size(tlag)
+       else
+          dcount = 0
+       end if
+       
+       call h5gopen_f(file_id, 'Restart', grp_id, ierr, gapl_id=h5p_default_f)
+       call h5dopen_f(grp_id, 'tlag', dset_id, ierr)
+       call h5dget_space_f(dset_id, filespace, ierr)
+       call h5sselect_hyperslab_f (filespace, H5S_SELECT_SET_F, &
+                                   doffset, dcount, ierr)
+       call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, tlag, ddim, ierr, xfer_prp=plist_id)
+       call h5dclose_f(dset_id, ierr)
+       call h5sclose_f(filespace, ierr)
+
+       call h5dopen_f(grp_id, 'dtlag', dset_id, ierr)
+       call h5dget_space_f(dset_id, filespace, ierr)
+       call h5sselect_hyperslab_f (filespace, H5S_SELECT_SET_F, &
+                                   doffset, dcount, ierr)
+       call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, dtlag, ddim, ierr, xfer_prp=plist_id)
+       call h5dclose_f(dset_id, ierr)
+       call h5sclose_f(filespace, ierr)
+       
+       call h5gclose_f(grp_id, ierr)
+    end if
+
+   if (allocated(fp) .or. allocated(fsp)) then
+      call h5gopen_f(file_id, 'Fields', grp_id, ierr, gapl_id=h5p_default_f)
+
+       dcount(1) = int(dof%size(), 8)
+       doffset(1) = int(msh%offset_el, 8) * int((dof%Xh%lx**3),8)
+       ddim =  int(dof%size(), 8)
+       drank = 1
+
+       dcount(1) = int(dof%size(), 8)
+       doffset(1) = int(msh%offset_el, 8) * int((dof%Xh%lx**3),8)
+       ddim =  int(dof%size(), 8)
+       drank = 1
+       call MPI_Allreduce(MPI_IN_PLACE, ddim(1), 1, &
+                          MPI_INTEGER8, MPI_SUM, NEKO_COMM, ierr)
+
+       call h5screate_simple_f(drank, dcount, memspace, ierr)
+       
+      if (allocated(fp)) then
+          do i = 1, size(fp)
+             call h5dopen_f(grp_id, fp(i)%ptr%name, dset_id, ierr)
+             call h5dget_space_f(dset_id, filespace, ierr)
+             call h5sselect_hyperslab_f (filespace, H5S_SELECT_SET_F, &
+                  doffset, dcount, ierr)
+             call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, &
+                            fp(i)%ptr%x(1,1,1,1), &
+                            ddim, ierr, file_space_id = filespace, &
+                            mem_space_id = memspace, xfer_prp=plist_id)
+             call h5dclose_f(dset_id, ierr)
+             call h5sclose_f(filespace, ierr)
+          end do
+       end if
+
+       if (allocated(fsp)) then
+          do i = 1, size(fsp)
+             do j = 1, fsp(i)%fs%size()
+                call h5dopen_f(grp_id, fsp(i)%fs%lf(j)%name, dset_id, ierr)
+                call h5dget_space_f(dset_id, filespace, ierr)
+                call h5sselect_hyperslab_f (filespace, H5S_SELECT_SET_F, &
+                                            doffset, dcount, ierr)
+                call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, &
+                               fsp(i)%fs%lf(j)%x(1,1,1,1), &
+                               ddim, ierr, file_space_id = filespace, &
+                               mem_space_id = memspace, xfer_prp=plist_id)
+                call h5dclose_f(dset_id, ierr)
+                call h5sclose_f(filespace, ierr)
+             end do
+          end do
+       end if
+       call h5sclose_f(memspace, ierr)
+       call h5gclose_f(grp_id, ierr)
+    end if
+   
+    call h5pclose_f(plist_id, ierr)
+    call h5fclose_f(file_id, ierr)
+
+    call h5close_f(ierr)
+
+  end subroutine hdf5_file_read
+
+
+  subroutine hdf5_file_determine_data(data, msh, dof, fp, fsp, dtlag, tlag)
+    class(*), target, intent(in) :: data
+    type(mesh_t), pointer, intent(inout) :: msh
+    type(dofmap_t), pointer, intent(inout) :: dof
+    type(field_ptr_t), allocatable, intent(inout) :: fp(:)
+    type(field_series_ptr_t), allocatable, intent(inout) :: fsp(:)
+    real(kind=rp), pointer, intent(inout) :: dtlag(:)
+    real(kind=rp), pointer, intent(inout) :: tlag(:)
+    integer :: i, j, fp_size, fp_cur, fsp_size, fsp_cur
+
+    select type(data)
+    type is (field_t)
+       dof => data%dof
+       msh => data%msh
+       fp_size = 1
+       allocate(fp(fp_size))
+       fp(1)%ptr => data
+
+       nullify(dtlag)
+       nullify(tlag)
+       
+    type is (field_list_t)
+
+       if (data%size() .gt. 0) then
+          allocate(fp(data%size()))
+       
+          dof => data%items(1)%ptr%dof
+          msh => data%items(1)%ptr%msh
+
+          do i = 1, data%size()
+             fp(i)%ptr => data%items(i)%ptr
+          end do
+       else
+          call neko_error('Empty field list')
+       end if
+
+       nullify(dtlag)
+       nullify(tlag)
+       
+    type is(chkp_t)
+
+       if ( .not. associated(data%u) .or. &
+            .not. associated(data%v) .or. &
+            .not. associated(data%w) .or. &
+            .not. associated(data%p) ) then
+          call neko_error('Checkpoint not initialized')
+       end if
+
+       fp_size = 4
+
+       if (associated(data%s)) then
+          fp_size = fp_size + 1
+       end if
+
+       if (associated(data%abx1)) then
+          fp_size = fp_size + 6
+       end if
+
+       if (associated(data%abs1)) then
+          fp_size = fp_size + 2
+       end if
+       
+       allocate(fp(fp_size))
+
+       fsp_size = 0
+       if (associated(data%ulag)) then
+          fsp_size = fsp_size + 3
+       end if
+
+       if (associated(data%slag)) then
+          fsp_size = fsp_size + 1
+       end if
+
+       if (fsp_size .gt. 0) then
+          allocate(fsp(fsp_size))
+          fsp_cur = 1
+       end if
+
+       dof => data%u%dof
+       msh => data%u%msh
+       
+       fp(1)%ptr => data%u
+       fp(2)%ptr => data%v
+       fp(3)%ptr => data%w
+       fp(4)%ptr => data%p
+
+       fp_cur = 5
+       if (associated(data%s)) then
+          fp(fp_cur)%ptr => data%s
+          fp_cur = fp_cur + 1
+       end if
+
+       if (associated(data%abx1)) then
+          fp(fp_cur)%ptr => data%abx1
+          fp(fp_cur+1)%ptr => data%abx2
+          fp(fp_cur+2)%ptr => data%aby1
+          fp(fp_cur+3)%ptr => data%aby2
+          fp(fp_cur+4)%ptr => data%abz1
+          fp(fp_cur+5)%ptr => data%abz2
+          fp_cur = fp_cur + 6
+       end if
+
+       if (associated(data%abs1)) then
+          fp(fp_cur)%ptr => data%abs1
+          fp(fp_cur+1)%ptr => data%abs2
+          fp_cur = fp_cur + 2
+       end if
+
+       if (associated(data%ulag)) then
+          fsp(fsp_cur)%fs => data%ulag
+          fsp(fsp_cur+1)%fs => data%vlag
+          fsp(fsp_cur+2)%fs => data%wlag
+          fsp_cur = fsp_cur + 3
+       end if
+
+       if (associated(data%slag)) then
+          fsp(fsp_cur)%fs => data%slag
+          fsp_cur = fsp_cur + 1
+       end if
+
+       if (associated(data%tlag)) then
+          tlag => data%tlag
+          dtlag => data%dtlag
+       end if       
+       
+    class default
+       call neko_log%error('Invalid data')
+    end select
+    
+  end subroutine hdf5_file_determine_data
+#else
+
+  !> Write data in HDF5 format
+  subroutine hdf5_file_write(this, data, t)
+    class(hdf5_file_t), intent(inout) :: this
+    class(*), target, intent(in) :: data
+    real(kind=rp), intent(in), optional :: t
+    call neko_error('Neko needs to be built with HDF5 support')
+  end subroutine hdf5_file_write
+
+  !> Read data in HDF5 format
+  subroutine hdf5_file_read(this, data)
+    class(hdf5_file_t) :: this
+    class(*), target, intent(inout) :: data
+    call neko_error('Neko needs to be built with HDF5 support')
+  end subroutine hdf5_file_read
+
+
+#endif
+
+end module hdf5_file

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -268,10 +268,20 @@ contains
     type(case_t), intent(inout) :: C
     real(kind=rp), intent(inout) :: t
     type(file_t) :: chkpf
+    character(len=:), allocatable :: chkp_format
     character(len=LOG_SIZE) :: log_buf
+    character(len=10) :: format_str
+    logical :: found
 
+    call C%params%get('case.checkpoint_format', chkp_format, found)   
     call C%fluid%chkp%sync_host()
-    chkpf = file_t('joblimit.chkp')
+    format_str = '.chkp'
+    if (found) then
+       if (chkp_format .eq. 'hdf5') then
+          format_str = '.h5'
+       end if
+    end if
+    chkpf = file_t('joblimit'//trim(format_str))
     call chkpf%write(C%fluid%chkp, t)
     write(log_buf, '(A)') '! saving checkpoint >>>'
     call neko_log%message(log_buf)


### PR DESCRIPTION
This add support for reading/writing (parallel) HDF5 files. The new format has been enabled as an optional format for checkpoints, but the backend can read/write most of our output lists.


