### PR TITLE
Slight update to field_dirichlet bcs

### DIFF
--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -148,23 +148,24 @@ Periodic boundary conditions are *always* defined inside the mesh file.
 The value of the keyword is an array of strings, with the following possible
 values:
 
-* Standard boundary conditions 
+* Standard boundary conditions
   * `w`, a no-slip wall.
   * `v`, a velocity Dirichlet boundary.
   * `sym`, a symmetry boundary.
-  * `o`, outlet boundary. 
+  * `o`, outlet boundary.
   * `on`, Dirichlet for the boundary-parallel velocity and homogeneous Neumann for
    the wall-normal. The wall-parallel velocity is defined by the initial
-   condition. 
+   condition.
 
 * Advanced boundary conditions
-  * `d_vel_u`, `d_vel_v`, `d_vel_w` (or a combination of them, separated by a `"/"`), a 
-  Dirichlet boundary for more complex velocity profiles. This boundary condition uses a 
-  [more advanced user interface](#user-file_field-dirichlet-update). 
-  * `d_pres`, a boundary for specified non-uniform pressure profiles, similar in 
-  essence to `d_vel_u`,`d_vel_v` and `d_vel_w`. Can be combined with other 
-  complex Dirichlet coonditions by specifying e.g.: `"d_vel_u/d_vel_v/d_pres"`.
-  * `o+dong`, outlet boundary using the Dong condition. 
+  * `d_vel_u`, `d_vel_v`, `d_vel_w` (or a combination of them, separated by a
+  `"/"`), a Dirichlet boundary for more complex velocity profiles. This boundary
+  condition uses a [more advanced user
+  interface](#user-file_field-dirichlet-update).
+  * `d_pres`, a boundary for specified non-uniform pressure profiles, similar in
+  essence to `d_vel_u`,`d_vel_v` and `d_vel_w`. Can be combined with other
+  complex Dirichlet conditions by specifying e.g.: `"d_vel_u/d_vel_v/d_pres"`.
+  * `o+dong`, outlet boundary using the Dong condition.
   * `on+dong`, an `on` boundary using the Dong condition, ensuring that the
    wall-normal velocity is directed outwards.
 
@@ -474,7 +475,7 @@ of using source terms for the scalar can be found in the `scalar_mms` example.
 ## Statistics
 
 This object adds the collection of statistics for the fluid fields. For
-additional details on the workflow, see the 
+additional details on the workflow, see the
 [corresponding page](@ref statistics-guide) in the user manual.
 
 | Name                | Description                                                          | Admissible values | Default value |

--- a/src/bc/field_dirichlet.f90
+++ b/src/bc/field_dirichlet.f90
@@ -119,7 +119,7 @@ contains
 
     call this%field_bc%init(this%dof, bc_name)
     call this%field_list%init(1)
-    call this%field_list%assign(1, this%field_bc)
+    call this%field_list%assign_to_field(1, this%field_bc)
 
   end subroutine field_dirichlet_init
 

--- a/src/bc/field_dirichlet_vector.f90
+++ b/src/bc/field_dirichlet_vector.f90
@@ -35,7 +35,7 @@ module field_dirichlet_vector
   use num_types, only: rp
   use coefs, only: coef_t
   use dirichlet, only: dirichlet_t
-  use bc, only: bc_list_t, bc_t
+  use bc, only: bc_list_t, bc_t, bc_list_free
   use device, only: c_ptr, c_size_t
   use utils, only: split_string
   use field, only : field_t
@@ -43,17 +43,28 @@ module field_dirichlet_vector
   use math, only: masked_copy
   use device_math, only: device_masked_copy
   use dofmap, only : dofmap_t
-  use field_dirichlet, only: field_dirichlet_t
+  use field_dirichlet, only: field_dirichlet_t, field_dirichlet_update
   use utils, only: neko_error
+  use field_list, only : field_list_t
   implicit none
   private
 
   !> Extension of the user defined dirichlet condition `field_dirichlet`
   ! for the application on a vector field.
   type, public, extends(bc_t) :: field_dirichlet_vector_t
-     type(field_dirichlet_t) :: field_dirichlet_u
-     type(field_dirichlet_t) :: field_dirichlet_v
-     type(field_dirichlet_t) :: field_dirichlet_w
+     ! The bc for the first compoent.
+     type(field_dirichlet_t) :: bc_u
+     ! The bc for the second compoent.
+     type(field_dirichlet_t) :: bc_v
+     ! The bc for the third compoent.
+     type(field_dirichlet_t) :: bc_w
+     !> A field list to store the bcs for passing to various subroutines.
+     type(field_list_t) :: field_list
+     !> A bc list to store the bcs for passing to various subroutines.
+     type(bc_list_t) :: bc_list
+     !> Function pointer to the user routine performing the update of the values
+     !! of the boundary fields.
+     procedure(field_dirichlet_update), nopass, pointer :: update => null()
    contains
      !> Initializes this%field_bc.
      procedure, pass(this) :: init_field => field_dirichlet_vector_init
@@ -87,9 +98,17 @@ contains
   subroutine field_dirichlet_vector_free(this)
     class(field_dirichlet_vector_t), target, intent(inout) :: this
 
-    call this%field_dirichlet_u%free()
-    call this%field_dirichlet_v%free()
-    call this%field_dirichlet_w%free()
+    call this%bc_u%free()
+    call this%bc_v%free()
+    call this%bc_w%free()
+
+    call this%field_list%free()
+    call bc_list_free(this%bc_list)
+
+    if (associated(this%update)) then
+       nullify(this%update)
+    end if
+
 
   end subroutine field_dirichlet_vector_free
 
@@ -142,17 +161,17 @@ contains
     integer, intent(in), optional :: tstep
 
     if (present(t) .and. present(tstep)) then
-       call this%field_dirichlet_u%apply_scalar(x, n, t, tstep)
-       call this%field_dirichlet_v%apply_scalar(y, n, t, tstep)
-       call this%field_dirichlet_w%apply_scalar(z, n, t, tstep)
+       call this%bc_u%apply_scalar(x, n, t, tstep)
+       call this%bc_v%apply_scalar(y, n, t, tstep)
+       call this%bc_w%apply_scalar(z, n, t, tstep)
     else if (present(t)) then
-       call this%field_dirichlet_u%apply_scalar(x, n, t=t)
-       call this%field_dirichlet_v%apply_scalar(y, n, t=t)
-       call this%field_dirichlet_w%apply_scalar(z, n, t=t)
+       call this%bc_u%apply_scalar(x, n, t=t)
+       call this%bc_v%apply_scalar(y, n, t=t)
+       call this%bc_w%apply_scalar(z, n, t=t)
     else if (present(tstep)) then
-       call this%field_dirichlet_u%apply_scalar(x, n, tstep=tstep)
-       call this%field_dirichlet_v%apply_scalar(y, n, tstep=tstep)
-       call this%field_dirichlet_w%apply_scalar(z, n, tstep=tstep)
+       call this%bc_u%apply_scalar(x, n, tstep=tstep)
+       call this%bc_v%apply_scalar(y, n, tstep=tstep)
+       call this%bc_w%apply_scalar(z, n, tstep=tstep)
     end if
 
   end subroutine field_dirichlet_vector_apply_vector
@@ -172,17 +191,17 @@ contains
     integer, intent(in), optional :: tstep
 
     if (present(t) .and. present(tstep)) then
-       call this%field_dirichlet_u%apply_scalar_dev(x_d, t, tstep)
-       call this%field_dirichlet_v%apply_scalar_dev(y_d, t, tstep)
-       call this%field_dirichlet_w%apply_scalar_dev(z_d, t, tstep)
+       call this%bc_u%apply_scalar_dev(x_d, t, tstep)
+       call this%bc_v%apply_scalar_dev(y_d, t, tstep)
+       call this%bc_w%apply_scalar_dev(z_d, t, tstep)
     else if (present(t)) then
-       call this%field_dirichlet_u%apply_scalar_dev(x_d, t=t)
-       call this%field_dirichlet_v%apply_scalar_dev(y_d, t=t)
-       call this%field_dirichlet_w%apply_scalar_dev(z_d, t=t)
+       call this%bc_u%apply_scalar_dev(x_d, t=t)
+       call this%bc_v%apply_scalar_dev(y_d, t=t)
+       call this%bc_w%apply_scalar_dev(z_d, t=t)
     else if (present(tstep)) then
-       call this%field_dirichlet_u%apply_scalar_dev(x_d, tstep=tstep)
-       call this%field_dirichlet_v%apply_scalar_dev(y_d, tstep=tstep)
-       call this%field_dirichlet_w%apply_scalar_dev(z_d, tstep=tstep)
+       call this%bc_u%apply_scalar_dev(x_d, tstep=tstep)
+       call this%bc_v%apply_scalar_dev(y_d, tstep=tstep)
+       call this%bc_w%apply_scalar_dev(z_d, tstep=tstep)
     end if
 
    end subroutine field_dirichlet_vector_apply_vector_dev

--- a/src/field/field_list.f90
+++ b/src/field/field_list.f90
@@ -122,7 +122,9 @@ contains
     if (allocated(this%items)) then
        n_fields = this%size()
        do i=1, n_fields
-          call this%items(i)%ptr%free()
+          if (associated(this%items(i)%ptr)) then
+             call this%items(i)%ptr%free()
+          end if
           nullify(this%items(i)%ptr)
        end do
        deallocate(this%items)

--- a/src/field/field_list.f90
+++ b/src/field/field_list.f90
@@ -5,6 +5,7 @@ module field_list
   use space, only : space_t
   use dofmap, only : dofmap_t
   use mesh, only : mesh_t
+  use utils, only : neko_error
   implicit none
   private
 
@@ -18,8 +19,11 @@ module field_list
      procedure, pass(this) :: free => field_list_free
      !> Append a field to the list.
      procedure, pass(this) :: append => field_list_append
+     generic :: get => get_by_index, get_by_name
      !> Get an item pointer by array index
-     procedure, pass(this) :: get => field_list_get
+     procedure, pass(this) :: get_by_index => field_list_get_by_index
+     !> Get an item pointer by field name
+     procedure, pass(this) :: get_by_name => field_list_get_by_name
      !> Point item at given index.
      generic :: assign => assign_to_ptr, assign_to_field_ptr
      procedure, pass(this) :: assign_to_ptr => field_list_assign_to_ptr
@@ -42,6 +46,8 @@ module field_list
      procedure, pass(this) :: msh => field_list_msh
      !> Check wether the dofmap is internal for an item in the list.
      procedure, pass(this) :: internal_dofmap => field_list_internal_dofmap
+     !> Get the name for an item in the list.
+     procedure, pass(this) :: name => field_list_name
   end type field_list_t
 
 contains
@@ -66,12 +72,30 @@ contains
 
   !> Get an item pointer by array index
   !! @param i The index of the item.
-  function field_list_get(this, i) result(f)
+  function field_list_get_by_index(this, i) result(f)
     class(field_list_t), intent(inout) :: this
     type(field_t), pointer :: f
-    integer :: i
+    integer, intent(in) :: i
     f => this%items(i)%ptr
-  end function field_list_get
+  end function field_list_get_by_index
+
+  !> Get an item pointer by array index
+  !! @param i The index of the item.
+  function field_list_get_by_name(this, name) result(f)
+    class(field_list_t), intent(inout) :: this
+    type(field_t), pointer :: f
+    character(len=*), intent(in) :: name
+    integer :: i
+
+    do i=1, this%size()
+      if (this%name(i) .eq. trim(name)) then
+         f => this%items(i)%ptr
+         return
+      end if
+    end do
+
+    call neko_error("No field with name " // trim(name) // " found in list")
+  end function field_list_get_by_name
 
   !> Append a field to the list.
   !! @param f The field to append.
@@ -206,6 +230,16 @@ contains
 
     result = this%items(i)%ptr%internal_dofmap
   end function field_list_internal_dofmap
+
+  !> Get the name for an item in the list.
+  !! @param i The index of the item.
+  function field_list_name(this, i) result(result)
+    class(field_list_t), target, intent(in) :: this
+    integer, intent(in) :: i
+    character(len=80) :: result
+
+    result = this%items(i)%ptr%name
+  end function field_list_name
 
 
 end module field_list

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -590,9 +590,9 @@ contains
 
       !> We assume that no change of boundary conditions
       !! occurs between elements. I.e. we do not apply gsop here like in Nek5000
-      !> Apply dirichlet
-      call this%dirichlet_update_(this%field_dirichlet_fields, &
-           this%field_dirichlet_bcs, this%c_Xh, t, tstep, "fluid")
+      !> Apply the user dirichlet boundary condition
+      call this%user_bc_vel%update(this%user_bc_vel%field_list, &
+              this%user_bc_vel%bc_list, this%c_Xh, t, tstep, "fluid")
 
       call this%bc_apply_vel(t, tstep)
       call this%bc_apply_prs(t, tstep)

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -591,8 +591,8 @@ contains
       !> We assume that no change of boundary conditions
       !! occurs between elements. I.e. we do not apply gsop here like in Nek5000
       !> Apply the user dirichlet boundary condition
-      call this%user_bc_vel%update(this%user_bc_vel%field_list, &
-              this%user_bc_vel%bc_list, this%c_Xh, t, tstep, "fluid")
+      call this%user_field_bc_vel%update(this%user_field_bc_vel%field_list, &
+              this%user_field_bc_vel%bc_list, this%c_Xh, t, tstep, "fluid")
 
       call this%bc_apply_vel(t, tstep)
       call this%bc_apply_prs(t, tstep)

--- a/src/fluid/fluid_scheme.f90
+++ b/src/fluid/fluid_scheme.f90
@@ -109,8 +109,8 @@ module fluid_scheme
      class(bc_t), allocatable :: bc_inflow !< Dirichlet inflow for velocity
 
      ! Attributes for field dirichlet BCs
-     type(field_dirichlet_vector_t) :: user_bc_vel   !< User-computed Dirichlet velocity condition
-     type(field_dirichlet_t) :: user_bc_prs   !< User-computed Dirichlet pressure condition
+     type(field_dirichlet_vector_t) :: user_field_bc_vel   !< User-computed Dirichlet velocity condition
+     type(field_dirichlet_t) :: user_field_bc_prs   !< User-computed Dirichlet pressure condition
      type(dirichlet_t) :: bc_prs               !< Dirichlet pressure condition
      type(dong_outflow_t) :: bc_dong           !< Dong outflow condition
      type(symmetry_t) :: bc_sym                !< Symmetry plane for velocity
@@ -392,73 +392,73 @@ contains
     call bc_list_add(this%bclst_vel, this%bc_wall)
 
     ! Setup field dirichlet bc for u-velocity
-    call this%user_bc_vel%bc_u%init_base(this%c_Xh)
-    call this%user_bc_vel%bc_u%mark_zones_from_list(msh%labeled_zones,&
+    call this%user_field_bc_vel%bc_u%init_base(this%c_Xh)
+    call this%user_field_bc_vel%bc_u%mark_zones_from_list(msh%labeled_zones,&
                         'd_vel_u', this%bc_labels)
-    call this%user_bc_vel%bc_u%finalize()
+    call this%user_field_bc_vel%bc_u%finalize()
 
-    call MPI_Allreduce(this%user_bc_vel%bc_u%msk(0), integer_val, 1, &
+    call MPI_Allreduce(this%user_field_bc_vel%bc_u%msk(0), integer_val, 1, &
          MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
-    if (integer_val .gt. 0)  call this%user_bc_vel%bc_u%init_field('d_vel_u')
+    if (integer_val .gt. 0)  call this%user_field_bc_vel%bc_u%init_field('d_vel_u')
 
     ! Setup field dirichlet bc for v-velocity
-    call this%user_bc_vel%bc_v%init_base(this%c_Xh)
-    call this%user_bc_vel%bc_v%mark_zones_from_list(msh%labeled_zones,&
+    call this%user_field_bc_vel%bc_v%init_base(this%c_Xh)
+    call this%user_field_bc_vel%bc_v%mark_zones_from_list(msh%labeled_zones,&
                         'd_vel_v', this%bc_labels)
-    call this%user_bc_vel%bc_v%finalize()
+    call this%user_field_bc_vel%bc_v%finalize()
 
-    call MPI_Allreduce(this%user_bc_vel%bc_v%msk(0), integer_val, 1, &
+    call MPI_Allreduce(this%user_field_bc_vel%bc_v%msk(0), integer_val, 1, &
          MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
-    if (integer_val .gt. 0)  call this%user_bc_vel%bc_v%init_field('d_vel_v')
+    if (integer_val .gt. 0)  call this%user_field_bc_vel%bc_v%init_field('d_vel_v')
 
     ! Setup field dirichlet bc for w-velocity
-    call this%user_bc_vel%bc_w%init_base(this%c_Xh)
-    call this%user_bc_vel%bc_w%mark_zones_from_list(msh%labeled_zones,&
+    call this%user_field_bc_vel%bc_w%init_base(this%c_Xh)
+    call this%user_field_bc_vel%bc_w%mark_zones_from_list(msh%labeled_zones,&
                         'd_vel_w', this%bc_labels)
-    call this%user_bc_vel%bc_w%finalize()
+    call this%user_field_bc_vel%bc_w%finalize()
 
-    call MPI_Allreduce(this%user_bc_vel%bc_w%msk(0), integer_val, 1, &
+    call MPI_Allreduce(this%user_field_bc_vel%bc_w%msk(0), integer_val, 1, &
          MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
-    if (integer_val .gt. 0)  call this%user_bc_vel%bc_w%init_field('d_vel_w')
+    if (integer_val .gt. 0)  call this%user_field_bc_vel%bc_w%init_field('d_vel_w')
 
     ! Setup our global field dirichlet bc
-    call this%user_bc_vel%init_base(this%c_Xh)
-    call this%user_bc_vel%mark_zones_from_list(msh%labeled_zones,&
+    call this%user_field_bc_vel%init_base(this%c_Xh)
+    call this%user_field_bc_vel%mark_zones_from_list(msh%labeled_zones,&
                         'd_vel_u', this%bc_labels)
-    call this%user_bc_vel%mark_zones_from_list(msh%labeled_zones,&
+    call this%user_field_bc_vel%mark_zones_from_list(msh%labeled_zones,&
                         'd_vel_v', this%bc_labels)
-    call this%user_bc_vel%mark_zones_from_list(msh%labeled_zones,&
+    call this%user_field_bc_vel%mark_zones_from_list(msh%labeled_zones,&
                         'd_vel_w', this%bc_labels)
-    call this%user_bc_vel%finalize()
+    call this%user_field_bc_vel%finalize()
 
     ! Add the field bc to velocity bcs
-    call bc_list_add(this%bclst_vel, this%user_bc_vel)
+    call bc_list_add(this%bclst_vel, this%user_field_bc_vel)
 
     !
     ! Associate our field dirichlet update to the user one.
     !
-    this%user_bc_vel%update => user%user_dirichlet_update
+    this%user_field_bc_vel%update => user%user_dirichlet_update
 
     !
     ! Initialize field list and bc list for user_dirichlet_update
     !
 
     ! Note, some of these are potentially not initialized !
-    call this%user_bc_vel%field_list%init(4)
-    call this%user_bc_vel%field_list%assign_to_field(1, &
-            this%user_bc_vel%bc_u%field_bc)
-    call this%user_bc_vel%field_list%assign_to_field(2, &
-            this%user_bc_vel%bc_v%field_bc)
-    call this%user_bc_vel%field_list%assign_to_field(3, &
-            this%user_bc_vel%bc_w%field_bc)
-    call this%user_bc_vel%field_list%assign_to_field(4, &
-            this%user_bc_prs%field_bc)
+    call this%user_field_bc_vel%field_list%init(4)
+    call this%user_field_bc_vel%field_list%assign_to_field(1, &
+            this%user_field_bc_vel%bc_u%field_bc)
+    call this%user_field_bc_vel%field_list%assign_to_field(2, &
+            this%user_field_bc_vel%bc_v%field_bc)
+    call this%user_field_bc_vel%field_list%assign_to_field(3, &
+            this%user_field_bc_vel%bc_w%field_bc)
+    call this%user_field_bc_vel%field_list%assign_to_field(4, &
+            this%user_field_bc_prs%field_bc)
 
-    call bc_list_init(this%user_bc_vel%bc_list, size=4)
+    call bc_list_init(this%user_field_bc_vel%bc_list, size=4)
     ! Note, bc_list_add only adds if the bc is not empty
-    call bc_list_add(this%user_bc_vel%bc_list, this%user_bc_vel%bc_u)
-    call bc_list_add(this%user_bc_vel%bc_list, this%user_bc_vel%bc_v)
-    call bc_list_add(this%user_bc_vel%bc_list, this%user_bc_vel%bc_w)
+    call bc_list_add(this%user_field_bc_vel%bc_list, this%user_field_bc_vel%bc_u)
+    call bc_list_add(this%user_field_bc_vel%bc_list, this%user_field_bc_vel%bc_v)
+    call bc_list_add(this%user_field_bc_vel%bc_list, this%user_field_bc_vel%bc_w)
 
     !
     ! Check if we need to output boundaries
@@ -634,16 +634,16 @@ contains
                         'on', this%bc_labels)
 
     ! Field dirichlet pressure bc
-    call this%user_bc_prs%init_base(this%c_Xh)
-    call this%user_bc_prs%mark_zones_from_list(msh%labeled_zones,&
+    call this%user_field_bc_prs%init_base(this%c_Xh)
+    call this%user_field_bc_prs%mark_zones_from_list(msh%labeled_zones,&
                         'd_pres', this%bc_labels)
-    call this%user_bc_prs%finalize()
-    call MPI_Allreduce(this%user_bc_prs%msk(0), integer_val, 1, &
+    call this%user_field_bc_prs%finalize()
+    call MPI_Allreduce(this%user_field_bc_prs%msk(0), integer_val, 1, &
          MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
 
-    if (integer_val .gt. 0)  call this%user_bc_prs%init_field('d_pres')
-    call bc_list_add(this%bclst_prs, this%user_bc_prs)
-    call bc_list_add(this%user_bc_vel%bc_list, this%user_bc_prs)
+    if (integer_val .gt. 0)  call this%user_field_bc_prs%init_field('d_pres')
+    call bc_list_add(this%bclst_prs, this%user_field_bc_prs)
+    call bc_list_add(this%user_field_bc_vel%bc_list, this%user_field_bc_prs)
 
     if (msh%outlet%size .gt. 0) then
        call this%bc_prs%mark_zone(msh%outlet)
@@ -721,12 +721,12 @@ contains
     !
     ! Free everything related to field_dirichlet BCs
     !
-    call this%user_bc_prs%field_bc%free()
-    call this%user_bc_prs%free()
-    call this%user_bc_vel%bc_u%field_bc%free()
-    call this%user_bc_vel%bc_v%field_bc%free()
-    call this%user_bc_vel%bc_w%field_bc%free()
-    call this%user_bc_vel%free()
+    call this%user_field_bc_prs%field_bc%free()
+    call this%user_field_bc_prs%free()
+    call this%user_field_bc_vel%bc_u%field_bc%free()
+    call this%user_field_bc_vel%bc_v%field_bc%free()
+    call this%user_field_bc_vel%bc_w%field_bc%free()
+    call this%user_field_bc_vel%free()
 
     call this%Xh%free()
 

--- a/src/fluid/fluid_scheme.f90
+++ b/src/fluid/fluid_scheme.f90
@@ -445,10 +445,14 @@ contains
 
     ! Note, some of these are potentially not initialized !
     call this%user_bc_vel%field_list%init(4)
-    call this%user_bc_vel%field_list%assign(1, this%user_bc_vel%bc_u%field_bc)
-    call this%user_bc_vel%field_list%assign(2, this%user_bc_vel%bc_v%field_bc)
-    call this%user_bc_vel%field_list%assign(3, this%user_bc_vel%bc_w%field_bc)
-    call this%user_bc_vel%field_list%assign(4, this%user_bc_prs%field_bc)
+    call this%user_bc_vel%field_list%assign_to_field(1, &
+            this%user_bc_vel%bc_u%field_bc)
+    call this%user_bc_vel%field_list%assign_to_field(2, &
+            this%user_bc_vel%bc_v%field_bc)
+    call this%user_bc_vel%field_list%assign_to_field(3, &
+            this%user_bc_vel%bc_w%field_bc)
+    call this%user_bc_vel%field_list%assign_to_field(4, &
+            this%user_bc_prs%field_bc)
 
     call bc_list_init(this%user_bc_vel%bc_list, size=4)
     ! Note, bc_list_add only adds if the bc is not empty

--- a/src/fluid/fluid_scheme.f90
+++ b/src/fluid/fluid_scheme.f90
@@ -109,13 +109,8 @@ module fluid_scheme
      class(bc_t), allocatable :: bc_inflow !< Dirichlet inflow for velocity
 
      ! Attributes for field dirichlet BCs
-     type(field_dirichlet_vector_t) :: bc_field_vel   !< Field Dirichlet velocity condition
-     type(field_dirichlet_t) :: bc_field_prs   !< Field Dirichlet pressure condition
-     procedure(field_dirichlet_update), nopass, pointer :: dirichlet_update_ &
-          => null() !< Pointer to user_dirichlet_update to be called in fluid_scheme_step
-     type(bc_list_t) :: field_dirichlet_bcs       !< List of BC objects to pass to user_dirichlet_update
-     type(field_list_t) :: field_dirichlet_fields !< List of fields to pass to user_dirichlet_update
-
+     type(field_dirichlet_vector_t) :: user_bc_vel   !< User-computed Dirichlet velocity condition
+     type(field_dirichlet_t) :: user_bc_prs   !< User-computed Dirichlet pressure condition
      type(dirichlet_t) :: bc_prs               !< Dirichlet pressure condition
      type(dong_outflow_t) :: bc_dong           !< Dong outflow condition
      type(symmetry_t) :: bc_sym                !< Symmetry plane for velocity
@@ -397,71 +392,69 @@ contains
     call bc_list_add(this%bclst_vel, this%bc_wall)
 
     ! Setup field dirichlet bc for u-velocity
-    call this%bc_field_vel%field_dirichlet_u%init_base(this%c_Xh)
-    call this%bc_field_vel%field_dirichlet_u%mark_zones_from_list(msh%labeled_zones,&
+    call this%user_bc_vel%bc_u%init_base(this%c_Xh)
+    call this%user_bc_vel%bc_u%mark_zones_from_list(msh%labeled_zones,&
                         'd_vel_u', this%bc_labels)
-    call this%bc_field_vel%field_dirichlet_u%finalize()
+    call this%user_bc_vel%bc_u%finalize()
 
-    call MPI_Allreduce(this%bc_field_vel%field_dirichlet_u%msk(0), integer_val, 1, &
+    call MPI_Allreduce(this%user_bc_vel%bc_u%msk(0), integer_val, 1, &
          MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
-    if (integer_val .gt. 0)  call this%bc_field_vel%field_dirichlet_u%init_field('d_vel_u')
+    if (integer_val .gt. 0)  call this%user_bc_vel%bc_u%init_field('d_vel_u')
 
     ! Setup field dirichlet bc for v-velocity
-    call this%bc_field_vel%field_dirichlet_v%init_base(this%c_Xh)
-    call this%bc_field_vel%field_dirichlet_v%mark_zones_from_list(msh%labeled_zones,&
+    call this%user_bc_vel%bc_v%init_base(this%c_Xh)
+    call this%user_bc_vel%bc_v%mark_zones_from_list(msh%labeled_zones,&
                         'd_vel_v', this%bc_labels)
-    call this%bc_field_vel%field_dirichlet_v%finalize()
+    call this%user_bc_vel%bc_v%finalize()
 
-    call MPI_Allreduce(this%bc_field_vel%field_dirichlet_v%msk(0), integer_val, 1, &
+    call MPI_Allreduce(this%user_bc_vel%bc_v%msk(0), integer_val, 1, &
          MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
-    if (integer_val .gt. 0)  call this%bc_field_vel%field_dirichlet_v%init_field('d_vel_v')
+    if (integer_val .gt. 0)  call this%user_bc_vel%bc_v%init_field('d_vel_v')
 
     ! Setup field dirichlet bc for w-velocity
-    call this%bc_field_vel%field_dirichlet_w%init_base(this%c_Xh)
-    call this%bc_field_vel%field_dirichlet_w%mark_zones_from_list(msh%labeled_zones,&
+    call this%user_bc_vel%bc_w%init_base(this%c_Xh)
+    call this%user_bc_vel%bc_w%mark_zones_from_list(msh%labeled_zones,&
                         'd_vel_w', this%bc_labels)
-    call this%bc_field_vel%field_dirichlet_w%finalize()
+    call this%user_bc_vel%bc_w%finalize()
 
-    call MPI_Allreduce(this%bc_field_vel%field_dirichlet_w%msk(0), integer_val, 1, &
+    call MPI_Allreduce(this%user_bc_vel%bc_w%msk(0), integer_val, 1, &
          MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
-    if (integer_val .gt. 0)  call this%bc_field_vel%field_dirichlet_w%init_field('d_vel_w')
+    if (integer_val .gt. 0)  call this%user_bc_vel%bc_w%init_field('d_vel_w')
 
     ! Setup our global field dirichlet bc
-    call this%bc_field_vel%init_base(this%c_Xh)
-    call this%bc_field_vel%mark_zones_from_list(msh%labeled_zones,&
+    call this%user_bc_vel%init_base(this%c_Xh)
+    call this%user_bc_vel%mark_zones_from_list(msh%labeled_zones,&
                         'd_vel_u', this%bc_labels)
-    call this%bc_field_vel%mark_zones_from_list(msh%labeled_zones,&
+    call this%user_bc_vel%mark_zones_from_list(msh%labeled_zones,&
                         'd_vel_v', this%bc_labels)
-    call this%bc_field_vel%mark_zones_from_list(msh%labeled_zones,&
+    call this%user_bc_vel%mark_zones_from_list(msh%labeled_zones,&
                         'd_vel_w', this%bc_labels)
-    call this%bc_field_vel%finalize()
+    call this%user_bc_vel%finalize()
 
     ! Add the field bc to velocity bcs
-    call bc_list_add(this%bclst_vel, this%bc_field_vel)
+    call bc_list_add(this%bclst_vel, this%user_bc_vel)
 
     !
     ! Associate our field dirichlet update to the user one.
     !
-    this%dirichlet_update_ => user%user_dirichlet_update
+    this%user_bc_vel%update => user%user_dirichlet_update
 
     !
     ! Initialize field list and bc list for user_dirichlet_update
     !
-    allocate(this%field_dirichlet_fields%items(4))
 
-    this%field_dirichlet_fields%items(1)%ptr => &
-         this%bc_field_vel%field_dirichlet_u%field_bc
-    this%field_dirichlet_fields%items(2)%ptr => &
-         this%bc_field_vel%field_dirichlet_v%field_bc
-    this%field_dirichlet_fields%items(3)%ptr => &
-         this%bc_field_vel%field_dirichlet_w%field_bc
-    this%field_dirichlet_fields%items(4)%ptr => &
-         this%bc_field_prs%field_bc
+    ! Note, some of these are potentially not initialized !
+    call this%user_bc_vel%field_list%init(4)
+    call this%user_bc_vel%field_list%assign(1, this%user_bc_vel%bc_u%field_bc)
+    call this%user_bc_vel%field_list%assign(2, this%user_bc_vel%bc_v%field_bc)
+    call this%user_bc_vel%field_list%assign(3, this%user_bc_vel%bc_w%field_bc)
+    call this%user_bc_vel%field_list%assign(4, this%user_bc_prs%field_bc)
 
-    call bc_list_init(this%field_dirichlet_bcs, size=4)
-    call bc_list_add(this%field_dirichlet_bcs, this%bc_field_vel%field_dirichlet_u)
-    call bc_list_add(this%field_dirichlet_bcs, this%bc_field_vel%field_dirichlet_v)
-    call bc_list_add(this%field_dirichlet_bcs, this%bc_field_vel%field_dirichlet_w)
+    call bc_list_init(this%user_bc_vel%bc_list, size=4)
+    ! Note, bc_list_add only adds if the bc is not empty
+    call bc_list_add(this%user_bc_vel%bc_list, this%user_bc_vel%bc_u)
+    call bc_list_add(this%user_bc_vel%bc_list, this%user_bc_vel%bc_v)
+    call bc_list_add(this%user_bc_vel%bc_list, this%user_bc_vel%bc_w)
 
     !
     ! Check if we need to output boundaries
@@ -637,16 +630,16 @@ contains
                         'on', this%bc_labels)
 
     ! Field dirichlet pressure bc
-    call this%bc_field_prs%init_base(this%c_Xh)
-    call this%bc_field_prs%mark_zones_from_list(msh%labeled_zones,&
+    call this%user_bc_prs%init_base(this%c_Xh)
+    call this%user_bc_prs%mark_zones_from_list(msh%labeled_zones,&
                         'd_pres', this%bc_labels)
-    call this%bc_field_prs%finalize()
-    call MPI_Allreduce(this%bc_field_prs%msk(0), integer_val, 1, &
+    call this%user_bc_prs%finalize()
+    call MPI_Allreduce(this%user_bc_prs%msk(0), integer_val, 1, &
          MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
 
-    if (integer_val .gt. 0)  call this%bc_field_prs%init_field('d_pres')
-    call bc_list_add(this%bclst_prs, this%bc_field_prs)
-    call bc_list_add(this%field_dirichlet_bcs, this%bc_field_prs)
+    if (integer_val .gt. 0)  call this%user_bc_prs%init_field('d_pres')
+    call bc_list_add(this%bclst_prs, this%user_bc_prs)
+    call bc_list_add(this%user_bc_vel%bc_list, this%user_bc_prs)
 
     if (msh%outlet%size .gt. 0) then
        call this%bc_prs%mark_zone(msh%outlet)
@@ -724,18 +717,12 @@ contains
     !
     ! Free everything related to field_dirichlet BCs
     !
-    call this%bc_field_prs%field_bc%free()
-    call this%bc_field_prs%free()
-    call this%bc_field_vel%field_dirichlet_u%field_bc%free()
-    call this%bc_field_vel%field_dirichlet_v%field_bc%free()
-    call this%bc_field_vel%field_dirichlet_w%field_bc%free()
-    call this%bc_field_vel%free()
-
-    call this%field_dirichlet_fields%free()
-    call bc_list_free(this%field_dirichlet_bcs)
-    if (associated(this%dirichlet_update_)) then
-       this%dirichlet_update_ => null()
-    end if
+    call this%user_bc_prs%field_bc%free()
+    call this%user_bc_prs%free()
+    call this%user_bc_vel%bc_u%field_bc%free()
+    call this%user_bc_vel%bc_v%field_bc%free()
+    call this%user_bc_vel%bc_w%field_bc%free()
+    call this%user_bc_vel%free()
 
     call this%Xh%free()
 

--- a/src/neko.f90
+++ b/src/neko.f90
@@ -100,6 +100,8 @@ module neko
   use box_point_zone, only: box_point_zone_t
   use sphere_point_zone, only: sphere_point_zone_t
   use point_zone_registry, only: neko_point_zone_registry
+  use field_dirichlet, only : field_dirichlet_t
+  use field_dirichlet_vector, only : field_dirichlet_vector_t
   use, intrinsic :: iso_fortran_env
   !$ use omp_lib
   implicit none

--- a/src/scalar/scalar_pnpn.f90
+++ b/src/scalar/scalar_pnpn.f90
@@ -348,7 +348,7 @@ contains
       !> Apply Dirichlet boundary conditions
       !! We assume that no change of boundary conditions
       !! occurs between elements. i.e. we do not apply gsop here like in Nek5000
-      call this%dirichlet_update_(this%field_dirichlet_fields, &
+      call this%field_dir_bc%update(this%field_dir_bc%field_list, &
            this%field_dirichlet_bcs, this%c_Xh, t, tstep, "scalar")
       call bc_list_apply_scalar(this%bclst_dirichlet, this%s%x, this%dm_Xh%size())
 

--- a/src/scalar/scalar_scheme.f90
+++ b/src/scalar/scalar_scheme.f90
@@ -109,13 +109,8 @@ module scalar_scheme
      type(dirichlet_t) :: dir_bcs(NEKO_MSH_MAX_ZLBLS)
      !> Field Dirichlet conditions.
      type(field_dirichlet_t) :: field_dir_bc
-     !> Pointer to user_dirichlet_update to be called in fluid_scheme_step
-     procedure(field_dirichlet_update), nopass, pointer :: dirichlet_update_ &
-          => null()
      !> List of BC objects to pass to user_dirichlet_update
      type(bc_list_t) :: field_dirichlet_bcs
-     !< List of fields to pass to user_dirichlet_update
-     type(field_list_t) :: field_dirichlet_fields
      !> Neumann conditions.
      type(neumann_t) :: neumann_bcs(NEKO_MSH_MAX_ZLBLS)
      !> User Dirichlet conditions.
@@ -421,14 +416,7 @@ contains
     !
     ! Associate our field dirichlet update to the user one.
     !
-    this%dirichlet_update_ => user%user_dirichlet_update
-
-    !
-    ! Initialize field list and bc list for user_dirichlet_update
-    !
-    allocate(this%field_dirichlet_fields%items(1))
-    this%field_dirichlet_fields%items(1)%ptr => &
-         this%field_dir_bc%field_bc
+    this%field_dir_bc%update => user%user_dirichlet_update
 
     call bc_list_init(this%field_dirichlet_bcs, size=1)
     call bc_list_add(this%field_dirichlet_bcs, this%field_dir_bc)
@@ -479,13 +467,8 @@ contains
     call this%slag%free()
 
     ! Free everything related to field dirichlet BCs
-    call this%field_dirichlet_fields%free()
     call bc_list_free(this%field_dirichlet_bcs)
-    call this%field_dir_bc%field_bc%free()
     call this%field_dir_bc%free()
-    if (associated(this%dirichlet_update_)) then
-       this%dirichlet_update_ => null()
-    end if
 
   end subroutine scalar_scheme_free
 


### PR DESCRIPTION
My main goal here is to reduce the number of additional components in the scheme types necessary to add the user field_dirichlet bcs. Currently we need the bc itself, a field list for the dummy fields in the bc,  a bc_list to store the field_dirichlet bcs themselves, and an update procedure pointer to the user routine.

To trim this down, I put most of these things inside the field_dirichlet types themselves. The only extra thing still in the scalar_scheme is the bc_list. I did not quite dare to add a bc_list to a type to store.. a pointer to itself. However, for the field_dirichlet_vector I could store the bc_list, it just contains the 3 field_dirichlet_bcs that are stored as components inside field_dirichlet_vector.

For the fluid, I use the lists in velocity field_dirichlet to also store the field and bc for the pressure. I also use it to store the `update` pointer.

Also adds some extra routines to the field_list wrapper.

As a note, the way things are handled for the field_dirichlet_vector is a bit scary, because we always add the dummy fields for u,v,w,p, *even when they are not initialized* due to the fact that the bc for them is not asked for in the case file.  So, if you point to those uninitialized fields in the user routine, things will crash.  I have not addressed this here. 