### PR TITLE
Reduce the risk of memory issues in mark zones from list

### DIFF
--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -321,9 +321,8 @@ contains
     do i = 1, NEKO_MSH_MAX_ZLBLS
        !Check if several bcs are defined for this zone
        !bcs are seperated by /, but we could use something else
-       split_key = split_string(trim(bc_labels(i)),'/')
-       do l = 1, size(split_key)
-          if (trim(split_key(l)) .eq. trim(bc_key)) then
+       if (index(trim(bc_labels(i)), '/') .eq. 0) then
+          if (trim(bc_key) .eq. trim(bc_labels(i))) then
              call bc_mark_zone(this, bc_zones(i))
              ! Loop across all faces in the mesh
              do j = 1,this%msh%nelv
@@ -334,7 +333,22 @@ contains
                 end do
              end do
           end if
-       end do
+       else
+          split_key = split_string(trim(bc_labels(i)),'/')
+          do l = 1, size(split_key)
+             if (trim(split_key(l)) .eq. trim(bc_key)) then
+                call bc_mark_zone(this, bc_zones(i))
+                ! Loop across all faces in the mesh
+                do j = 1,this%msh%nelv
+                   do k = 1, 2 * this%msh%gdim
+                      if (this%msh%facet_type(k,j) .eq. -i) then
+                         this%msh%facet_type(k,j) = msh_bc_type
+                      end if
+                   end do
+                end do
+             end if
+          end do
+       end if
     end do
   end subroutine bc_mark_zones_from_list
 


### PR DESCRIPTION
This is a hotfix to prevent some of the observed memory issues observed in mark zones from list, most likely caused by `split_string`

The intent is to remove this as soon as the bcs are overhauled 
