### PR TITLE
Cleanup unused variables

### DIFF
--- a/src/bc/neumann.f90
+++ b/src/bc/neumann.f90
@@ -98,7 +98,6 @@ contains
     real(kind=rp), intent(inout),  dimension(n) :: z
     real(kind=rp), intent(in), optional :: t
     integer, intent(in), optional :: tstep
-    integer :: i, m, k
 
     call neko_error("Neumann bc not implemented for vectors")
 

--- a/src/bc/non_normal.f90
+++ b/src/bc/non_normal.f90
@@ -61,7 +61,7 @@ contains
   subroutine non_normal_init(this, coef)
     class(non_normal_t), intent(inout) :: this
     type(coef_t), intent(in) :: coef
-    integer :: i, j, k, l
+    integer :: i, j, l
     type(tuple_i4_t), pointer :: bfp(:)
     real(kind=rp) :: sx,sy,sz
     real(kind=rp), parameter :: TOL = 1d-3

--- a/src/bc/symmetry.f90
+++ b/src/bc/symmetry.f90
@@ -67,7 +67,7 @@ contains
   subroutine symmetry_init(this, coef)
     class(symmetry_t), intent(inout) :: this
     type(coef_t), intent(in) :: coef
-    integer :: i, m, j, l
+    integer :: i, j, l
     type(tuple_i4_t), pointer :: bfp(:)
     real(kind=rp) :: sx,sy,sz
     real(kind=rp), parameter :: TOL = 1d-3
@@ -161,7 +161,6 @@ contains
     real(kind=rp), intent(inout),  dimension(n) :: z
     real(kind=rp), intent(in), optional :: t
     integer, intent(in), optional :: tstep
-    integer :: i, m, k
 
     call this%bc_x%apply_scalar(x,n)
     call this%bc_y%apply_scalar(y,n)

--- a/src/bc/usr_scalar.f90
+++ b/src/bc/usr_scalar.f90
@@ -278,7 +278,7 @@ contains
     real(kind=rp), intent(inout),  dimension(n) :: z
     real(kind=rp), intent(in), optional :: t
     integer, intent(in), optional :: tstep
-    integer :: i, m, k, idx(4), facet
+
   end subroutine usr_scalar_apply_vector
 
   !> No-op vector apply (device version)
@@ -289,11 +289,7 @@ contains
     type(c_ptr) :: z_d
     real(kind=rp), intent(in), optional :: t
     integer, intent(in), optional :: tstep
-    integer :: i, m, k, idx(4), facet
-    integer(c_size_t) :: s
-    real(kind=rp), allocatable :: x(:)
-    real(kind=rp), allocatable :: y(:)
-    real(kind=rp), allocatable :: z(:)
+
   end subroutine usr_scalar_apply_vector_dev
 
   !> Assign user provided eval function

--- a/src/case.f90
+++ b/src/case.f90
@@ -151,7 +151,6 @@ contains
     real(kind=rp) :: stats_start_time, stats_output_val
     integer ::  stats_sampling_interval
     integer :: output_dir_len
-    integer :: n_simcomps
     integer :: precision
 
     !

--- a/src/common/log.f90
+++ b/src/common/log.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2021-2022, The Neko Authors
+! Copyright (c) 2021-2024, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -253,7 +253,7 @@ contains
     use, intrinsic :: iso_c_binding
     character(kind=c_char), dimension(*), intent(in) :: c_msg
     character(len=LOG_SIZE) :: msg
-    integer :: len, i
+    integer :: len
 
     if (pe_rank .eq. 0) then
        len = 0
@@ -275,7 +275,7 @@ contains
     use, intrinsic :: iso_c_binding
     character(kind=c_char), dimension(*), intent(in) :: c_msg
     character(len=LOG_SIZE) :: msg
-    integer :: len, i
+    integer :: len
 
     if (pe_rank .eq. 0) then
        len = 0
@@ -297,7 +297,7 @@ contains
     use, intrinsic :: iso_c_binding
     character(kind=c_char), dimension(*), intent(in) :: c_msg
     character(len=LOG_SIZE) :: msg
-    integer :: len, i
+    integer :: len
 
     if (pe_rank .eq. 0) then
        len = 0
@@ -319,7 +319,7 @@ contains
     use, intrinsic :: iso_c_binding
     character(kind=c_char), dimension(*), intent(in) :: c_msg
     character(len=LOG_SIZE) :: msg
-    integer :: len, i
+    integer :: len
 
     if (pe_rank .eq. 0) then
        len = 0

--- a/src/field/field_list.f90
+++ b/src/field/field_list.f90
@@ -56,7 +56,6 @@ contains
   subroutine field_list_init(this, size)
     class(field_list_t), intent(inout) :: this
     integer, intent(in) :: size
-    integer :: i
 
     call this%free()
 

--- a/src/fluid/flow_ic.f90
+++ b/src/fluid/flow_ic.f90
@@ -67,8 +67,6 @@ contains
     type(gs_t), intent(inout) :: gs
     character(len=*) :: type
     type(json_file), intent(inout) :: params
-    ! Variables for retrieving json parameters
-    logical :: found
     real(kind=rp) :: delta
     real(kind=rp), allocatable :: uinf(:)
     character(len=:), allocatable :: blasius_approximation

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -520,8 +520,6 @@ contains
     type(field_t), pointer :: u_e, v_e, w_e
     ! Indices for tracking temporary fields
     integer :: temp_indices(3)
-    ! Counter
-    integer :: i
 
     if (this%freeze) return
 

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -142,9 +142,6 @@ contains
     type(user_t), intent(in) :: user
     type(material_properties_t), target, intent(inout) :: material_properties
     character(len=15), parameter :: scheme = 'Modular (Pn/Pn)'
-    logical :: found, logical_val
-    integer :: integer_val
-    real(kind=rp) :: real_val
 
     call this%free()
 

--- a/src/fluid/fluid_scheme.f90
+++ b/src/fluid/fluid_scheme.f90
@@ -601,7 +601,6 @@ contains
     logical :: kspp_init
     character(len=*), intent(in) :: scheme
     real(kind=rp) :: real_val
-    real(kind=rp), allocatable :: real_vec(:)
     integer :: integer_val, ierr
     character(len=:), allocatable :: string_val1, string_val2
 

--- a/src/fluid/fluid_source_term.f90
+++ b/src/fluid/fluid_source_term.f90
@@ -94,8 +94,6 @@ contains
     type(json_file) :: source_subdict
     ! Source type
     character(len=:), allocatable :: type
-    ! Dummy source strenth values
-    real(kind=rp) :: values(3)
     logical :: found
     integer :: n_sources, i
 
@@ -198,7 +196,7 @@ contains
     class(fluid_source_term_t), intent(inout) :: this
     real(kind=rp), intent(in) :: t
     integer, intent(in) :: tstep
-    integer :: i, n
+    integer :: i
 
     this%f_x = 0.0_rp
     this%f_y = 0.0_rp

--- a/src/fluid/fluid_volflow.f90
+++ b/src/fluid/fluid_volflow.f90
@@ -105,7 +105,7 @@ contains
     class(fluid_volflow_t), intent(inout) :: this
     type(dofmap_t), intent(inout) :: dm_Xh
     type(json_file), intent(inout) :: params
-    logical average, found
+    logical average
     integer :: direction
     real(kind=rp) :: rate
 
@@ -348,10 +348,9 @@ contains
     class(pc_t), intent(inout) :: pc_prs, pc_vel
     integer, intent(in) :: prs_max_iter, vel_max_iter
     real(kind=rp) :: ifcomp, flow_rate, xsec
-    real(kind=rp) :: current_flow, delta_flow, base_flow, scale
+    real(kind=rp) :: current_flow, delta_flow, scale
     integer :: n, ierr
     type(field_t), pointer :: ta1, ta2, ta3
-    integer :: temp_indices(3)
 
     associate(u_vol => this%u_vol, v_vol => this%v_vol, &
          w_vol => this%w_vol, p_vol => this%p_vol)

--- a/src/io/csv_file.f90
+++ b/src/io/csv_file.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2020-2023, The Neko Authors
+! Copyright (c) 2020-2024, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -67,7 +67,6 @@ contains
     class(*), target, intent(in) :: data
     real(kind=rp), intent(in), optional :: t
 
-    real(kind=rp) :: time
     type(vector_t), pointer :: vec
     type(matrix_t), pointer :: mat
 
@@ -122,8 +121,7 @@ contains
     class(csv_file_t), intent(inout) :: f
     type(vector_t), intent(in) :: data
     real(kind=rp), intent(in), optional :: t
-    character(len=1024) :: fname
-    integer :: suffix_pos, file_unit, i, ierr
+    integer :: file_unit, ierr
 
     open(file=trim(f%fname), position="append", iostat=ierr, newunit=file_unit)
     if (ierr .ne. 0) call neko_error("Error while opening " // trim(f%fname))
@@ -153,7 +151,7 @@ contains
     class(csv_file_t), intent(inout) :: f
     type(matrix_t), intent(in) :: data
     real(kind=rp), intent(in), optional :: t
-    integer :: file_unit, i,j, ierr
+    integer :: file_unit, i, ierr
 
     open(file=trim(f%fname), position="append", iostat=ierr, newunit=file_unit)
     if (ierr .ne. 0) call neko_error("Error while opening " // trim(f%fname))

--- a/src/io/fld_file.f90
+++ b/src/io/fld_file.f90
@@ -85,7 +85,7 @@ contains
     character(len=6) :: id_str
     character(len=1024) :: fname
     character(len=1024) :: start_field
-    integer :: i, ierr, n, j,k,l,el, suffix_pos,tslash_pos
+    integer :: i, ierr, n, suffix_pos, tslash_pos
     integer :: lx, ly, lz, lxyz, gdim, glb_nelv, nelv, offset_el
     integer, allocatable :: idx(:)
     type(MPI_Status) :: status
@@ -492,7 +492,7 @@ contains
     integer, intent(in) :: gdim, lxyz, nelv
     real(kind=rp), intent(in) :: x(lxyz,nelv), y(lxyz,nelv), z(lxyz,nelv)
     integer (kind=MPI_OFFSET_KIND), intent(in) :: byte_offset
-    integer :: i, el, j, ierr, nout
+    integer :: el, j, ierr, nout
     type(MPI_Status) :: status
     real(kind=sp) :: buffer(2*gdim*nelv)
 
@@ -522,7 +522,7 @@ contains
     integer, intent(in) :: lxyz, nelv
     real(kind=rp), intent(in) :: x(lxyz,nelv)
     integer (kind=MPI_OFFSET_KIND), intent(in) :: byte_offset
-    integer :: i, el, j, ierr, nout
+    integer :: el, j, ierr, nout
     type(MPI_Status) :: status
     real(kind=sp) :: buffer(2*nelv)
 
@@ -635,7 +635,7 @@ contains
     character(len=6) :: id_str
     integer (kind=MPI_OFFSET_KIND) :: mpi_offset, byte_offset
     integer :: lx, ly, lz, glb_nelv, counter, lxyz
-    integer :: FLD_DATA_SIZE, n_scalars, n, nd
+    integer :: FLD_DATA_SIZE, n_scalars, n
     real(kind=rp) ::  time
     real(kind=sp) :: temp
     type(linear_dist_t) :: dist
@@ -880,7 +880,7 @@ contains
     integer(kind=MPI_OFFSET_KIND) :: byte_offset
     type(MPI_File) :: fh
     type(MPI_Status) :: status
-    integer :: n, ierr, lxyz, i, j, e
+    integer :: n, ierr, lxyz, i
 
     n = x%n
     lxyz = fld_data%lx*fld_data%ly*fld_data%lz

--- a/src/io/re2_file.f90
+++ b/src/io/re2_file.f90
@@ -224,8 +224,7 @@ contains
     integer :: element_offset
     integer :: re2_data_xy_size
     integer :: re2_data_xyz_size
-    character(len=LOG_SIZE) :: log_buf
-
+ 
     select type(data)
     type is (mesh_t)
        msh => data

--- a/src/krylov/pc_hsmg.f90
+++ b/src/krylov/pc_hsmg.f90
@@ -360,7 +360,7 @@ contains
     real(kind=rp), dimension(n), intent(inout) :: r
     type(c_ptr) :: z_d, r_d
     type(ksp_monitor_t) :: crs_info
-    integer :: i, thrdid, nthrds
+    integer :: thrdid, nthrds
 
     call profiler_start_region('HSMG solve', 8)
     if (NEKO_BCKND_DEVICE .eq. 1) then

--- a/src/les/les_model.f90
+++ b/src/les/les_model.f90
@@ -144,7 +144,7 @@ contains
     class(les_model_t), intent(inout) :: this
     integer :: e, i, j, k
     integer ::  im, ip, jm, jp, km, kp
-    real(kind=rp) :: di, dj, dk, ndim_inv
+    real(kind=rp) :: di, dj, dk
 
 
     do e=1, this%coef%msh%nelv

--- a/src/math/bcknd/cpu/opr_cpu.f90
+++ b/src/math/bcknd/cpu/opr_cpu.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2021-2022, The Neko Authors
+! Copyright (c) 2021-2024, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -527,7 +527,7 @@ contains
     type(field_t), intent(inout) :: lambda2
     type(field_t), intent(in) :: u, v, w
     real(kind=rp) :: grad(coef%Xh%lxyz,3,3)
-    integer :: temp_indices(9), e, i, ind_sort(3)
+    integer :: e, i
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23

--- a/src/math/bcknd/sx/opr_sx.f90
+++ b/src/math/bcknd/sx/opr_sx.f90
@@ -286,10 +286,10 @@ contains
 
   end subroutine opr_sx_cdtp
 
-  subroutine opr_sx_conv1(du,u, vx, vy, vz, Xh, coef, nelv, gdim)
+  subroutine opr_sx_conv1(du,u, vx, vy, vz, Xh, coef, nelv)
     type(space_t), intent(inout) :: Xh
     type(coef_t), intent(inout) :: coef
-    integer, intent(in) :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), intent(inout) ::  du(Xh%lxyz,nelv)
     real(kind=rp), intent(inout), dimension(Xh%lx,Xh%ly,Xh%lz,nelv) ::  u
     real(kind=rp), intent(inout), dimension(Xh%lx,Xh%ly,Xh%lz,nelv) ::  vx
@@ -302,85 +302,85 @@ contains
             coef%drdx, coef%dsdx, coef%dtdx, &
             coef%drdy, coef%dsdy, coef%dtdy, &
             coef%drdz, coef%dsdz, coef%dtdz, &
-            coef%jacinv, nelv, gdim)
+            coef%jacinv, nelv)
     case(13)
        call sx_conv1_lx13(du, u, vx, vy, vz, Xh%dx, Xh%dy, Xh%dz, &
             coef%drdx, coef%dsdx, coef%dtdx, &
             coef%drdy, coef%dsdy, coef%dtdy, &
             coef%drdz, coef%dsdz, coef%dtdz, &
-            coef%jacinv, nelv, gdim)
+            coef%jacinv, nelv)
     case(12)
        call sx_conv1_lx12(du, u, vx, vy, vz, Xh%dx, Xh%dy, Xh%dz, &
             coef%drdx, coef%dsdx, coef%dtdx, &
             coef%drdy, coef%dsdy, coef%dtdy, &
             coef%drdz, coef%dsdz, coef%dtdz, &
-            coef%jacinv, nelv, gdim)
+            coef%jacinv, nelv)
     case(11)
        call sx_conv1_lx11(du, u, vx, vy, vz, Xh%dx, Xh%dy, Xh%dz, &
             coef%drdx, coef%dsdx, coef%dtdx, &
             coef%drdy, coef%dsdy, coef%dtdy, &
             coef%drdz, coef%dsdz, coef%dtdz, &
-            coef%jacinv, nelv, gdim)
+            coef%jacinv, nelv)
     case(10)
        call sx_conv1_lx10(du, u, vx, vy, vz, Xh%dx, Xh%dy, Xh%dz, &
             coef%drdx, coef%dsdx, coef%dtdx, &
             coef%drdy, coef%dsdy, coef%dtdy, &
             coef%drdz, coef%dsdz, coef%dtdz, &
-            coef%jacinv, nelv, gdim)
+            coef%jacinv, nelv)
     case(9)
        call sx_conv1_lx9(du, u, vx, vy, vz, Xh%dx, Xh%dy, Xh%dz, &
             coef%drdx, coef%dsdx, coef%dtdx, &
             coef%drdy, coef%dsdy, coef%dtdy, &
             coef%drdz, coef%dsdz, coef%dtdz, &
-            coef%jacinv, nelv, gdim)
+            coef%jacinv, nelv)
     case(8)
        call sx_conv1_lx8(du, u, vx, vy, vz, Xh%dx, Xh%dy, Xh%dz, &
             coef%drdx, coef%dsdx, coef%dtdx, &
             coef%drdy, coef%dsdy, coef%dtdy, &
             coef%drdz, coef%dsdz, coef%dtdz, &
-            coef%jacinv, nelv, gdim)
+            coef%jacinv, nelv)
     case(7)
        call sx_conv1_lx7(du, u, vx, vy, vz, Xh%dx, Xh%dy, Xh%dz, &
             coef%drdx, coef%dsdx, coef%dtdx, &
             coef%drdy, coef%dsdy, coef%dtdy, &
             coef%drdz, coef%dsdz, coef%dtdz, &
-            coef%jacinv, nelv, gdim)
+            coef%jacinv, nelv)
     case(6)
        call sx_conv1_lx6(du, u, vx, vy, vz, Xh%dx, Xh%dy, Xh%dz, &
             coef%drdx, coef%dsdx, coef%dtdx, &
             coef%drdy, coef%dsdy, coef%dtdy, &
             coef%drdz, coef%dsdz, coef%dtdz, &
-            coef%jacinv, nelv, gdim)
+            coef%jacinv, nelv)
     case(5)
        call sx_conv1_lx5(du, u, vx, vy, vz, Xh%dx, Xh%dy, Xh%dz, &
             coef%drdx, coef%dsdx, coef%dtdx, &
             coef%drdy, coef%dsdy, coef%dtdy, &
             coef%drdz, coef%dsdz, coef%dtdz, &
-            coef%jacinv, nelv, gdim)
+            coef%jacinv, nelv)
     case(4)
        call sx_conv1_lx4(du, u, vx, vy, vz, Xh%dx, Xh%dy, Xh%dz, &
             coef%drdx, coef%dsdx, coef%dtdx, &
             coef%drdy, coef%dsdy, coef%dtdy, &
             coef%drdz, coef%dsdz, coef%dtdz, &
-            coef%jacinv, nelv, gdim)
+            coef%jacinv, nelv)
     case(3)
        call sx_conv1_lx3(du, u, vx, vy, vz, Xh%dx, Xh%dy, Xh%dz, &
             coef%drdx, coef%dsdx, coef%dtdx, &
             coef%drdy, coef%dsdy, coef%dtdy, &
             coef%drdz, coef%dsdz, coef%dtdz, &
-            coef%jacinv, nelv, gdim)
+            coef%jacinv, nelv)
     case(2)
        call sx_conv1_lx2(du, u, vx, vy, vz, Xh%dx, Xh%dy, Xh%dz, &
             coef%drdx, coef%dsdx, coef%dtdx, &
             coef%drdy, coef%dsdy, coef%dtdy, &
             coef%drdz, coef%dsdz, coef%dtdz, &
-            coef%jacinv, nelv, gdim)
+            coef%jacinv, nelv)
     case default
        call sx_conv1_lx(du, u, vx, vy, vz, Xh%dx, Xh%dy, Xh%dz, &
             coef%drdx, coef%dsdx, coef%dtdx, &
             coef%drdy, coef%dsdy, coef%dtdy, &
             coef%drdz, coef%dsdz, coef%dtdz, &
-            coef%jacinv, nelv, gdim, Xh%lx)
+            coef%jacinv, nelv, Xh%lx)
     end select
 
   end subroutine opr_sx_conv1
@@ -432,11 +432,11 @@ contains
 
   end subroutine opr_sx_curl
 
-  function opr_sx_cfl(dt, u, v, w, Xh, coef, nelv, gdim) result(cfl)
+  function opr_sx_cfl(dt, u, v, w, Xh, coef, nelv) result(cfl)
     type(space_t) :: Xh
     type(coef_t) :: coef
-    integer :: nelv, gdim
-    real(kind=rp) :: dt
+    integer, intent(in) :: nelv
+    real(kind=rp), intent(in) :: dt
     real(kind=rp), dimension(Xh%lx,Xh%ly,Xh%lz,nelv) ::  u, v, w
     real(kind=rp) :: cfl
 
@@ -447,98 +447,98 @@ contains
            coef%drdy, coef%dsdy, coef%dtdy, &
            coef%drdz, coef%dsdz, coef%dtdz, &
            Xh%dr_inv, Xh%ds_inv, Xh%dt_inv, &
-           coef%jacinv, nelv, gdim)
+           coef%jacinv, nelv)
     case (13)
        cfl = sx_cfl_lx13(dt, u, v, w, &
            coef%drdx, coef%dsdx, coef%dtdx, &
            coef%drdy, coef%dsdy, coef%dtdy, &
            coef%drdz, coef%dsdz, coef%dtdz, &
            Xh%dr_inv, Xh%ds_inv, Xh%dt_inv, &
-           coef%jacinv, nelv, gdim)
+           coef%jacinv, nelv)
     case (12)
        cfl = sx_cfl_lx12(dt, u, v, w, &
            coef%drdx, coef%dsdx, coef%dtdx, &
            coef%drdy, coef%dsdy, coef%dtdy, &
            coef%drdz, coef%dsdz, coef%dtdz, &
            Xh%dr_inv, Xh%ds_inv, Xh%dt_inv, &
-           coef%jacinv, nelv, gdim)
+           coef%jacinv, nelv)
     case (11)
        cfl = sx_cfl_lx11(dt, u, v, w, &
            coef%drdx, coef%dsdx, coef%dtdx, &
            coef%drdy, coef%dsdy, coef%dtdy, &
            coef%drdz, coef%dsdz, coef%dtdz, &
            Xh%dr_inv, Xh%ds_inv, Xh%dt_inv, &
-           coef%jacinv, nelv, gdim)
+           coef%jacinv, nelv)
     case (10)
        cfl = sx_cfl_lx10(dt, u, v, w, &
            coef%drdx, coef%dsdx, coef%dtdx, &
            coef%drdy, coef%dsdy, coef%dtdy, &
            coef%drdz, coef%dsdz, coef%dtdz, &
            Xh%dr_inv, Xh%ds_inv, Xh%dt_inv, &
-           coef%jacinv, nelv, gdim)
+           coef%jacinv, nelv)
     case (9)
        cfl = sx_cfl_lx9(dt, u, v, w, &
            coef%drdx, coef%dsdx, coef%dtdx, &
            coef%drdy, coef%dsdy, coef%dtdy, &
            coef%drdz, coef%dsdz, coef%dtdz, &
            Xh%dr_inv, Xh%ds_inv, Xh%dt_inv, &
-           coef%jacinv, nelv, gdim)
+           coef%jacinv, nelv)
     case (8)
        cfl = sx_cfl_lx8(dt, u, v, w, &
            coef%drdx, coef%dsdx, coef%dtdx, &
            coef%drdy, coef%dsdy, coef%dtdy, &
            coef%drdz, coef%dsdz, coef%dtdz, &
            Xh%dr_inv, Xh%ds_inv, Xh%dt_inv, &
-           coef%jacinv, nelv, gdim)
+           coef%jacinv, nelv)
     case (7)
        cfl = sx_cfl_lx7(dt, u, v, w, &
            coef%drdx, coef%dsdx, coef%dtdx, &
            coef%drdy, coef%dsdy, coef%dtdy, &
            coef%drdz, coef%dsdz, coef%dtdz, &
            Xh%dr_inv, Xh%ds_inv, Xh%dt_inv, &
-           coef%jacinv, nelv, gdim)
+           coef%jacinv, nelv)
     case (6)
        cfl = sx_cfl_lx6(dt, u, v, w, &
            coef%drdx, coef%dsdx, coef%dtdx, &
            coef%drdy, coef%dsdy, coef%dtdy, &
            coef%drdz, coef%dsdz, coef%dtdz, &
            Xh%dr_inv, Xh%ds_inv, Xh%dt_inv, &
-           coef%jacinv, nelv, gdim)
+           coef%jacinv, nelv)
     case (5)
        cfl = sx_cfl_lx5(dt, u, v, w, &
            coef%drdx, coef%dsdx, coef%dtdx, &
            coef%drdy, coef%dsdy, coef%dtdy, &
            coef%drdz, coef%dsdz, coef%dtdz, &
            Xh%dr_inv, Xh%ds_inv, Xh%dt_inv, &
-           coef%jacinv, nelv, gdim)
+           coef%jacinv, nelv)
     case (4)
        cfl = sx_cfl_lx4(dt, u, v, w, &
            coef%drdx, coef%dsdx, coef%dtdx, &
            coef%drdy, coef%dsdy, coef%dtdy, &
            coef%drdz, coef%dsdz, coef%dtdz, &
            Xh%dr_inv, Xh%ds_inv, Xh%dt_inv, &
-           coef%jacinv, nelv, gdim)
+           coef%jacinv, nelv)
     case (3)
        cfl = sx_cfl_lx3(dt, u, v, w, &
            coef%drdx, coef%dsdx, coef%dtdx, &
            coef%drdy, coef%dsdy, coef%dtdy, &
            coef%drdz, coef%dsdz, coef%dtdz, &
            Xh%dr_inv, Xh%ds_inv, Xh%dt_inv, &
-           coef%jacinv, nelv, gdim)
+           coef%jacinv, nelv)
     case (2)
        cfl = sx_cfl_lx2(dt, u, v, w, &
            coef%drdx, coef%dsdx, coef%dtdx, &
            coef%drdy, coef%dsdy, coef%dtdy, &
            coef%drdz, coef%dsdz, coef%dtdz, &
            Xh%dr_inv, Xh%ds_inv, Xh%dt_inv, &
-           coef%jacinv, nelv, gdim)
+           coef%jacinv, nelv)
     case default
        cfl = sx_cfl_lx(dt, u, v, w, &
            coef%drdx, coef%dsdx, coef%dtdx, &
            coef%drdy, coef%dsdy, coef%dtdy, &
            coef%drdz, coef%dsdz, coef%dtdz, &
            Xh%dr_inv, Xh%ds_inv, Xh%dt_inv, &
-           coef%jacinv, nelv, gdim, Xh%lx)
+           coef%jacinv, nelv, Xh%lx)
     end select
 
   end function opr_sx_cfl

--- a/src/math/bcknd/sx/sx_cfl.f90
+++ b/src/math/bcknd/sx/sx_cfl.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2022, The Neko Authors
+! Copyright (c) 2022-2024, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -45,8 +45,8 @@ contains
 
   function sx_cfl_lx(dt, u, v, w, drdx, dsdx, dtdx, drdy, dsdy, dtdy, &
        drdz, dsdz, dtdz, dr_inv, ds_inv, dt_inv, &
-       jacinv,nelv, gdim, lx) result(cfl)
-    integer :: nelv, gdim, lx
+       jacinv, nelv, lx) result(cfl)
+    integer, intent(in) :: nelv, lx
     real(kind=rp), intent(in) :: dt
     real(kind=rp), dimension(lx,lx,lx,nelv) ::  u, v, w
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -89,9 +89,9 @@ contains
 
   function sx_cfl_lx14(dt, u, v, w, drdx, dsdx, dtdx, drdy, dsdy, dtdy, &
        drdz, dsdz, dtdz, dr_inv, ds_inv, dt_inv, &
-       jacinv,nelv, gdim) result(cfl)
+       jacinv, nelv) result(cfl)
     integer, parameter :: lx =14
-    integer :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), intent(in) :: dt
     real(kind=rp), dimension(lx,lx,lx,nelv) ::  u, v, w
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -134,9 +134,9 @@ contains
 
   function sx_cfl_lx13(dt, u, v, w, drdx, dsdx, dtdx, drdy, dsdy, dtdy, &
        drdz, dsdz, dtdz, dr_inv, ds_inv, dt_inv, &
-       jacinv,nelv, gdim) result(cfl)
+       jacinv, nelv) result(cfl)
     integer, parameter :: lx = 13
-    integer :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), intent(in) :: dt
     real(kind=rp), dimension(lx,lx,lx,nelv) ::  u, v, w
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -179,9 +179,9 @@ contains
 
   function sx_cfl_lx12(dt, u, v, w, drdx, dsdx, dtdx, drdy, dsdy, dtdy, &
        drdz, dsdz, dtdz, dr_inv, ds_inv, dt_inv, &
-       jacinv,nelv, gdim) result(cfl)
+       jacinv, nelv) result(cfl)
     integer, parameter :: lx = 12
-    integer :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), intent(in) :: dt
     real(kind=rp), dimension(lx,lx,lx,nelv) ::  u, v, w
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -224,9 +224,9 @@ contains
 
   function sx_cfl_lx11(dt, u, v, w, drdx, dsdx, dtdx, drdy, dsdy, dtdy, &
        drdz, dsdz, dtdz, dr_inv, ds_inv, dt_inv, &
-       jacinv,nelv, gdim) result(cfl)
+       jacinv, nelv) result(cfl)
     integer, parameter :: lx = 11
-    integer :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), intent(in) :: dt
     real(kind=rp), dimension(lx,lx,lx,nelv) ::  u, v, w
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -269,9 +269,9 @@ contains
 
   function sx_cfl_lx10(dt, u, v, w, drdx, dsdx, dtdx, drdy, dsdy, dtdy, &
        drdz, dsdz, dtdz, dr_inv, ds_inv, dt_inv, &
-       jacinv,nelv, gdim) result(cfl)
+       jacinv, nelv) result(cfl)
     integer, parameter :: lx = 10
-    integer :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), intent(in) :: dt
     real(kind=rp), dimension(lx,lx,lx,nelv) ::  u, v, w
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -314,9 +314,9 @@ contains
 
   function sx_cfl_lx9(dt, u, v, w, drdx, dsdx, dtdx, drdy, dsdy, dtdy, &
        drdz, dsdz, dtdz, dr_inv, ds_inv, dt_inv, &
-       jacinv,nelv, gdim) result(cfl)
+       jacinv, nelv) result(cfl)
     integer, parameter :: lx = 9
-    integer :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), intent(in) :: dt
     real(kind=rp), dimension(lx,lx,lx,nelv) ::  u, v, w
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -359,9 +359,9 @@ contains
 
   function sx_cfl_lx8(dt, u, v, w, drdx, dsdx, dtdx, drdy, dsdy, dtdy, &
        drdz, dsdz, dtdz, dr_inv, ds_inv, dt_inv, &
-       jacinv,nelv, gdim) result(cfl)
+       jacinv, nelv) result(cfl)
     integer, parameter :: lx = 8
-    integer :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), intent(in) :: dt
     real(kind=rp), dimension(lx,lx,lx,nelv) ::  u, v, w
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -404,9 +404,9 @@ contains
 
   function sx_cfl_lx7(dt, u, v, w, drdx, dsdx, dtdx, drdy, dsdy, dtdy, &
        drdz, dsdz, dtdz, dr_inv, ds_inv, dt_inv, &
-       jacinv,nelv, gdim) result(cfl)
+       jacinv, nelv) result(cfl)
     integer, parameter :: lx = 7
-    integer :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), intent(in) :: dt
     real(kind=rp), dimension(lx,lx,lx,nelv) ::  u, v, w
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -449,9 +449,9 @@ contains
 
   function sx_cfl_lx6(dt, u, v, w, drdx, dsdx, dtdx, drdy, dsdy, dtdy, &
        drdz, dsdz, dtdz, dr_inv, ds_inv, dt_inv, &
-       jacinv,nelv, gdim) result(cfl)
+       jacinv, nelv) result(cfl)
     integer, parameter :: lx = 6
-    integer :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), intent(in) :: dt
     real(kind=rp), dimension(lx,lx,lx,nelv) ::  u, v, w
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -494,9 +494,9 @@ contains
 
   function sx_cfl_lx5(dt, u, v, w, drdx, dsdx, dtdx, drdy, dsdy, dtdy, &
        drdz, dsdz, dtdz, dr_inv, ds_inv, dt_inv, &
-       jacinv,nelv, gdim) result(cfl)
+       jacinv, nelv) result(cfl)
     integer, parameter :: lx = 5
-    integer :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), intent(in) :: dt
     real(kind=rp), dimension(lx,lx,lx,nelv) ::  u, v, w
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -539,9 +539,9 @@ contains
 
   function sx_cfl_lx4(dt, u, v, w, drdx, dsdx, dtdx, drdy, dsdy, dtdy, &
        drdz, dsdz, dtdz, dr_inv, ds_inv, dt_inv, &
-       jacinv,nelv, gdim) result(cfl)
+       jacinv, nelv) result(cfl)
     integer, parameter :: lx = 4
-    integer :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), intent(in) :: dt
     real(kind=rp), dimension(lx,lx,lx,nelv) ::  u, v, w
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -584,9 +584,9 @@ contains
 
   function sx_cfl_lx3(dt, u, v, w, drdx, dsdx, dtdx, drdy, dsdy, dtdy, &
        drdz, dsdz, dtdz, dr_inv, ds_inv, dt_inv, &
-       jacinv,nelv, gdim) result(cfl)
+       jacinv, nelv) result(cfl)
     integer, parameter :: lx = 3
-    integer :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), intent(in) :: dt
     real(kind=rp), dimension(lx,lx,lx,nelv) ::  u, v, w
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -629,9 +629,9 @@ contains
 
   function sx_cfl_lx2(dt, u, v, w, drdx, dsdx, dtdx, drdy, dsdy, dtdy, &
        drdz, dsdz, dtdz, dr_inv, ds_inv, dt_inv, &
-       jacinv,nelv, gdim) result(cfl)
+       jacinv, nelv) result(cfl)
     integer, parameter :: lx = 2
-    integer :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), intent(in) :: dt
     real(kind=rp), dimension(lx,lx,lx,nelv) ::  u, v, w
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx

--- a/src/math/bcknd/sx/sx_conv1.f90
+++ b/src/math/bcknd/sx/sx_conv1.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2021, The Neko Authors
+! Copyright (c) 2021-2024, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -45,8 +45,8 @@ contains
 
   subroutine sx_conv1_lx(du, u, vx, vy, vz, dx, dy, dz, &
        drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, &
-       jacinv, nelv, gdim, lx)
-    integer, intent(in) :: nelv, gdim, lx
+       jacinv, nelv, lx)
+    integer, intent(in) :: nelv, lx
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(inout) ::  du
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) ::  u, vx, vy, vz
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -120,9 +120,9 @@ contains
 
   subroutine sx_conv1_lx14(du, u, vx, vy, vz, dx, dy, dz, &
        drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, &
-       jacinv, nelv, gdim)
+       jacinv, nelv)
     integer, parameter :: lx = 14
-    integer, intent(in) :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(inout) ::  du
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) ::  u, vx, vy, vz
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -196,9 +196,9 @@ contains
 
   subroutine sx_conv1_lx13(du, u, vx, vy, vz, dx, dy, dz, &
        drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, &
-       jacinv, nelv, gdim)
+       jacinv, nelv)
     integer, parameter :: lx = 13
-    integer, intent(in) :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(inout) ::  du
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) ::  u, vx, vy, vz
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -272,9 +272,9 @@ contains
 
   subroutine sx_conv1_lx12(du, u, vx, vy, vz, dx, dy, dz, &
        drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, &
-       jacinv, nelv, gdim)
+       jacinv, nelv)
     integer, parameter :: lx = 12
-    integer, intent(in) :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(inout) ::  du
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) ::  u, vx, vy, vz
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -348,9 +348,9 @@ contains
 
   subroutine sx_conv1_lx11(du, u, vx, vy, vz, dx, dy, dz, &
        drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, &
-       jacinv, nelv, gdim)
+       jacinv, nelv)
     integer, parameter :: lx = 11
-    integer, intent(in) :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(inout) ::  du
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) ::  u, vx, vy, vz
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -424,9 +424,9 @@ contains
 
   subroutine sx_conv1_lx10(du, u, vx, vy, vz, dx, dy, dz, &
        drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, &
-       jacinv, nelv, gdim)
+       jacinv, nelv)
     integer, parameter :: lx = 10
-    integer, intent(in) :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(inout) ::  du
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) ::  u, vx, vy, vz
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -500,9 +500,9 @@ contains
 
   subroutine sx_conv1_lx9(du, u, vx, vy, vz, dx, dy, dz, &
        drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, &
-       jacinv, nelv, gdim)
+       jacinv, nelv)
     integer, parameter :: lx = 9
-    integer, intent(in) :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(inout) ::  du
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) ::  u, vx, vy, vz
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -576,9 +576,9 @@ contains
 
   subroutine sx_conv1_lx8(du, u, vx, vy, vz, dx, dy, dz, &
        drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, &
-       jacinv, nelv, gdim)
+       jacinv, nelv)
     integer, parameter :: lx = 8
-    integer, intent(in) :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(inout) ::  du
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) ::  u, vx, vy, vz
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -652,9 +652,9 @@ contains
 
   subroutine sx_conv1_lx7(du, u, vx, vy, vz, dx, dy, dz, &
        drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, &
-       jacinv, nelv, gdim)
+       jacinv, nelv)
     integer, parameter :: lx = 7
-    integer, intent(in) :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(inout) ::  du
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) ::  u, vx, vy, vz
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -728,9 +728,9 @@ contains
 
   subroutine sx_conv1_lx6(du, u, vx, vy, vz, dx, dy, dz, &
        drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, &
-       jacinv, nelv, gdim)
+       jacinv, nelv)
     integer, parameter :: lx = 6
-    integer, intent(in) :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(inout) ::  du
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) ::  u, vx, vy, vz
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -804,9 +804,9 @@ contains
 
   subroutine sx_conv1_lx5(du, u, vx, vy, vz, dx, dy, dz, &
        drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, &
-       jacinv, nelv, gdim)
+       jacinv, nelv)
     integer, parameter :: lx = 5
-    integer, intent(in) :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(inout) ::  du
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) ::  u, vx, vy, vz
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -880,9 +880,9 @@ contains
 
   subroutine sx_conv1_lx4(du, u, vx, vy, vz, dx, dy, dz, &
        drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, &
-       jacinv, nelv, gdim)
+       jacinv, nelv)
     integer, parameter :: lx = 4
-    integer, intent(in) :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(inout) ::  du
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) ::  u, vx, vy, vz
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -956,9 +956,9 @@ contains
 
   subroutine sx_conv1_lx3(du, u, vx, vy, vz, dx, dy, dz, &
        drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, &
-       jacinv, nelv, gdim)
+       jacinv, nelv)
     integer, parameter :: lx = 3
-    integer, intent(in) :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(inout) ::  du
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) ::  u, vx, vy, vz
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx
@@ -1032,9 +1032,9 @@ contains
 
   subroutine sx_conv1_lx2(du, u, vx, vy, vz, dx, dy, dz, &
        drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, &
-       jacinv, nelv, gdim)
+       jacinv, nelv)
     integer, parameter :: lx = 2
-    integer, intent(in) :: nelv, gdim
+    integer, intent(in) :: nelv
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(inout) ::  du
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) ::  u, vx, vy, vz
     real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: drdx, dsdx, dtdx

--- a/src/math/bcknd/sx/sx_lambda2.f90
+++ b/src/math/bcknd/sx/sx_lambda2.f90
@@ -52,7 +52,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -232,7 +231,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -412,7 +410,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -592,7 +589,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -772,7 +768,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -952,7 +947,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -1132,7 +1126,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -1312,7 +1305,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -1492,7 +1484,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -1672,7 +1663,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -1852,7 +1842,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -2032,7 +2021,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -2212,7 +2200,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -2392,7 +2379,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -2572,7 +2558,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -2752,7 +2737,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -2932,7 +2916,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23
@@ -3112,7 +3095,6 @@ contains
     real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cB
     real(kind=rp), dimension(lx,lx,lx), intent(in) :: w3
     real(kind=rp) :: grad(lx*lx*lx,3,3)
-    integer :: temp_indices(9), ind_sort(3)
     real(kind=rp) :: eigen(3), B, C, D, q, r, theta, l2
     real(kind=rp) :: s11, s22, s33, s12, s13, s23, o12, o13, o23
     real(kind=rp) :: a11, a22, a33, a12, a13, a23

--- a/src/math/bcknd/xsmm/ax_helm_xsmm.F90
+++ b/src/math/bcknd/xsmm/ax_helm_xsmm.F90
@@ -84,7 +84,7 @@ contains
     type(coef_t), intent(inout) :: coef
     real(kind=rp), intent(inout) :: w(Xh%lx, Xh%ly, Xh%lz, msh%nelv)
     real(kind=rp), intent(inout) :: u(Xh%lx, Xh%ly, Xh%lz, msh%nelv)
-
+#ifdef HAVE_LIBXSMM
     real(kind=rp) :: dudr(Xh%lx,Xh%ly,Xh%lz)
     real(kind=rp) :: duds(Xh%lx,Xh%ly,Xh%lz)
     real(kind=rp) :: dudt(Xh%lx,Xh%ly,Xh%lz)
@@ -95,7 +95,6 @@ contains
     real(kind=rp) :: tm2(Xh%lx,Xh%ly,Xh%lz)
     real(kind=rp) :: tm3(Xh%lx,Xh%ly,Xh%lz)
     integer :: e, k, lxy, lxz, lyz, lxyz
-#ifdef HAVE_LIBXSMM
     type(libxsmm_dmmfunction), save :: ax_helm_xmm1
     type(libxsmm_dmmfunction), save :: ax_helm_xmm2
     type(libxsmm_dmmfunction), save :: ax_helm_xmm3

--- a/src/math/bcknd/xsmm/opr_xsmm.F90
+++ b/src/math/bcknd/xsmm/opr_xsmm.F90
@@ -88,11 +88,11 @@ contains
     type(coef_t), intent(in), target :: coef
     real(kind=rp), dimension(coef%Xh%lx,coef%Xh%ly,coef%Xh%lz,coef%msh%nelv), intent(inout) ::  du
     real(kind=rp), dimension(coef%Xh%lx,coef%Xh%ly,coef%Xh%lz,coef%msh%nelv), intent(in) ::  u, dr, ds, dt
+#ifdef HAVE_LIBXSMM
     real(kind=rp) :: drst(coef%Xh%lx,coef%Xh%ly,coef%Xh%lz)
     type(space_t), pointer :: Xh
     type(mesh_t), pointer :: msh
     integer :: e, k, lxy, lyz, lxyz
-#ifdef HAVE_LIBXSMM
     type(libxsmm_dmmfunction), save :: dudxyz_xmm1
     type(libxsmm_dmmfunction), save :: dudxyz_xmm2
     type(libxsmm_dmmfunction), save :: dudxyz_xmm3
@@ -142,6 +142,7 @@ contains
     real(kind=rp), dimension(coef%Xh%lxyz,coef%msh%nelv), intent(inout) :: uy
     real(kind=rp), dimension(coef%Xh%lxyz,coef%msh%nelv), intent(inout) :: uz
     real(kind=rp), dimension(coef%Xh%lxyz,coef%msh%nelv), intent(in) :: u
+#ifdef HAVE_LIBXSMM
     real(kind=rp) :: ur(coef%Xh%lxyz)
     real(kind=rp) :: us(coef%Xh%lxyz)
     real(kind=rp) :: ut(coef%Xh%lxyz)
@@ -150,7 +151,7 @@ contains
     integer :: e, i, N
     N = coef%Xh%lx - 1
 
-#ifdef HAVE_LIBXSMM
+
     if ((.not. lgrad_xsmm_init) .or. &
          (init_size .gt. 0 .and. init_size .ne. N)) then
        call libxsmm_dispatch(lgrad_xmm1, (N+1), (N+1)**2, (N+1), &
@@ -162,7 +163,7 @@ contains
        lgrad_xsmm_init = .true.
        init_size = N
     end if
-#endif
+
 
     do e=1,coef%msh%nelv
        if(coef%msh%gdim .eq. 3) then
@@ -190,6 +191,7 @@ contains
           end do
        endif
     end do
+#endif
   end subroutine opr_xsmm_opgrad
 
   subroutine local_grad3_xsmm(ur, us, ut, u, n, D, Dt)
@@ -200,11 +202,12 @@ contains
     real(kind=rp), intent(in) :: u(0:n, 0:n, 0:n)
     real(kind=rp), intent(in) :: D(0:n, 0:n)
     real(kind=rp), intent(in) :: Dt(0:n, 0:n)
+#ifdef HAVE_LIBXSMM
     integer :: m1, m2, k
 
     m1 = n + 1
     m2 = m1*m1
-#ifdef HAVE_LIBXSMM
+
     call libxsmm_mmcall(lgrad_xmm1, D, u, ur)
     do k=0,n
        call libxsmm_mmcall(lgrad_xmm2, u(0,0,k), Dt, us(0,0,k))
@@ -221,7 +224,7 @@ contains
     real(kind=rp), intent(in) :: u(0:n, 0:n)
     real(kind=rp), intent(in) :: D(0:n, 0:n)
     real(kind=rp), intent(in) :: Dt(0:n, 0:n)
-    integer :: m1, m2, k
+    integer :: m1
 
     m1 = n + 1
 
@@ -237,13 +240,14 @@ contains
     real(kind=rp), dimension(coef%Xh%lxyz,coef%msh%nelv), intent(in) :: dr
     real(kind=rp), dimension(coef%Xh%lxyz,coef%msh%nelv), intent(in) :: ds
     real(kind=rp), dimension(coef%Xh%lxyz,coef%msh%nelv), intent(in) :: dt
+#ifdef HAVE_LIBXSMM
     real(kind=rp) :: wx(coef%Xh%lxyz)
     real(kind=rp) :: ta1(coef%Xh%lxyz)
     real(kind=rp) :: ta2(coef%Xh%lxyz)
     real(kind=rp) :: ta3(coef%Xh%lxyz)
     integer :: e, i1, i2, n1, n2, iz
     type(space_t), pointer :: Xh
-#ifdef HAVE_LIBXSMM
+
     type(libxsmm_dmmfunction), save :: cdtp_xmm1
     type(libxsmm_dmmfunction), save :: cdtp_xmm2
     type(libxsmm_dmmfunction), save :: cdtp_xmm3
@@ -293,10 +297,11 @@ contains
     real(kind=rp), intent(inout), dimension(Xh%lx,Xh%ly,Xh%lz,nelv) ::  vx
     real(kind=rp), intent(inout), dimension(Xh%lx,Xh%ly,Xh%lz,nelv) ::  vy
     real(kind=rp), intent(inout), dimension(Xh%lx,Xh%ly,Xh%lz,nelv) ::  vz
+#ifdef HAVE_LIBXSMM
     !   Store the inverse jacobian to speed this operation up
     real(kind=rp), dimension(Xh%lx,Xh%ly,Xh%lz) :: dudr, duds, dudt
     integer :: ie, iz, i
-#ifdef HAVE_LIBXSMM
+
     type(libxsmm_dmmfunction), save :: conv1_xmm1
     type(libxsmm_dmmfunction), save :: conv1_xmm2
     type(libxsmm_dmmfunction), save :: conv1_xmm3

--- a/src/math/operators.f90
+++ b/src/math/operators.f90
@@ -137,16 +137,12 @@ contains
   !! @param uz Will store the z component of the gradient.
   !! @param u The values of the field.
   !! @param coef The SEM coefficients.
-  !! @param es Starting element index, optional, defaults to 1.
-  !! @param ee Ending element index, optional, defaults to `nelv`.
-  subroutine grad(ux, uy, uz, u, coef, es, ee)
+  subroutine grad(ux, uy, uz, u, coef)
     type(coef_t), intent(in) :: coef
     real(kind=rp), dimension(coef%Xh%lxyz,coef%msh%nelv), intent(inout) :: ux
     real(kind=rp), dimension(coef%Xh%lxyz,coef%msh%nelv), intent(inout) :: uy
     real(kind=rp), dimension(coef%Xh%lxyz,coef%msh%nelv), intent(inout) :: uz
     real(kind=rp), dimension(coef%Xh%lxyz,coef%msh%nelv), intent(in) :: u
-    integer, optional :: es, ee
-    integer :: eblk_start, eblk_end
 
     call dudxyz(ux, u, coef%drdx, coef%dsdx, coef%dtdx, coef)
     call dudxyz(uy, u, coef%drdy, coef%dsdy, coef%dtdy, coef)
@@ -278,7 +274,7 @@ contains
       end if
 
       if (NEKO_BCKND_SX .eq. 1) then
-         call opr_sx_conv1(du, u, vx, vy, vz, Xh, coef, nelv, gdim)
+         call opr_sx_conv1(du, u, vx, vy, vz, Xh, coef, nelv)
       else if (NEKO_BCKND_XSMM .eq. 1) then
          call opr_xsmm_conv1(du, u, vx, vy, vz, Xh, coef, nelv, gdim)
       else if (NEKO_BCKND_DEVICE .eq. 1) then
@@ -342,7 +338,7 @@ contains
     integer :: ierr
 
     if (NEKO_BCKND_SX .eq. 1) then
-       cfl = opr_sx_cfl(dt, u, v, w, Xh, coef, nelv, gdim)
+       cfl = opr_sx_cfl(dt, u, v, w, Xh, coef, nelv)
     else if (NEKO_BCKND_DEVICE .eq. 1) then
        cfl = opr_device_cfl(dt, u, v, w, Xh, coef, nelv, gdim)
     else

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -467,7 +467,7 @@ contains
     class(element_t), pointer :: ep
     type(tuple_i4_t) :: e
     type(tuple4_i4_t) :: f
-    integer :: p_local_idx, res
+    integer :: p_local_idx
     integer :: el, id
     integer :: i, j, k, ierr, el_glb_idx, n_sides, n_nodes, src, dst
 
@@ -1400,7 +1400,7 @@ contains
     integer, value :: el
     type(point_t), target, intent(inout) :: p1, p2, p3, p4
     class(element_t), pointer :: ep
-    integer :: p(4), el_glb_idx, i, p_local_idx
+    integer :: p(4), el_glb_idx
     type(tuple_i4_t) :: e
 
     ! Connectivity invalidated if a new element is added
@@ -1436,7 +1436,7 @@ contains
     integer, value :: el
     type(point_t), target, intent(inout) :: p1, p2, p3, p4, p5, p6, p7, p8
     class(element_t), pointer :: ep
-    integer :: p(8), el_glb_idx, i, p_local_idx
+    integer :: p(8), el_glb_idx
     type(tuple4_i4_t) :: f
     type(tuple_i4_t) :: e
 
@@ -1678,7 +1678,6 @@ contains
     type(point_t), pointer :: pi
     type(tuple4_i4_t) :: t
     type(tuple_i4_t) :: t2
-    integer :: i
 
     select type(ele => this%elements(e)%e)
     type is(hex_t)

--- a/src/qoi/drag_torque.f90
+++ b/src/qoi/drag_torque.f90
@@ -112,7 +112,6 @@ contains
     real(kind=rp) :: torqvy = 0.0_rp
     real(kind=rp) :: torqvz = 0.0_rp
     real(kind=rp) :: dragx, dragy, dragz
-    real(kind=rp) :: torqx, torqy, torqz
     integer :: ie, ifc, mem, ierr
     dragx = 0.0
     dragy = 0.0
@@ -228,8 +227,8 @@ contains
     real(kind=rp), intent(in) :: pm1 (Xh%lx,xh%ly,Xh%lz,coef%msh%nelv)
     real(kind=rp), intent(in) :: visc
     integer, intent(in) :: f,e
-    integer :: pf,l, k, i, j1, j2
-    real(kind=rp) ::    n1,n2,n3, j, a, r1, r2, r3, v, dgtq_i(3,4)
+    integer :: pf, i, j1, j2
+    real(kind=rp) ::    n1,n2,n3, a, v, dgtq_i(3,4)
     integer :: skpdat(6,6), NX, NY, NZ
     integer :: js1
     integer :: jf1
@@ -237,7 +236,7 @@ contains
     integer :: js2
     integer :: jf2
     integer :: jskip2
-    real(kind=rp) :: s11_, s21_, s31_, s12_, s22_, s32_, s13_, s23_, s33_
+    real(kind=rp) :: s11_, s12_, s22_, s13_, s23_, s33_
 
 
     NX = Xh%lx

--- a/src/scalar/scalar_pnpn.f90
+++ b/src/scalar/scalar_pnpn.f90
@@ -141,9 +141,6 @@ contains
     type(material_properties_t), intent(inout) :: material_properties
     integer :: i
     character(len=15), parameter :: scheme = 'Modular (Pn/Pn)'
-    ! Variables for retrieving json parameters
-    logical :: found, logical_val
-    integer :: integer_val
 
     call this%free()
 

--- a/src/sem/cpr.f90
+++ b/src/sem/cpr.f90
@@ -147,7 +147,6 @@ contains
     real(kind=rp) :: L(0:cpr%Xh%lx-1)
     real(kind=rp) :: delta(cpr%Xh%lx)
     integer :: i, kj, j, j2, kk
-    character(len=LOG_SIZE) :: log_buf
 
     associate(Xh => cpr%Xh, v=> cpr%v, vt => cpr%vt, &
          vinv => cpr%vinv, vinvt => cpr%vinvt, w => cpr%w)
@@ -224,8 +223,7 @@ contains
     real(kind=rp) :: w1(cpr%Xh%lx,cpr%Xh%lx,cpr%Xh%lx)
     real(kind=rp) :: specmat(cpr%Xh%lx,cpr%Xh%lx)
     real(kind=rp) :: specmatt(cpr%Xh%lx,cpr%Xh%lx)
-    integer :: i, j, k, e, nxyz, nelv
-    character(len=LOG_SIZE) :: log_buf
+    integer :: k, e, nxyz, nelv
     character(len=4) :: space
 
     ! define some constants
@@ -277,8 +275,8 @@ contains
     real(kind=rp) :: fz(cpr%Xh%lx, cpr%Xh%lx)
     real(kind=rp) :: l2norm, oldl2norm, targeterr
     integer :: isort(cpr%Xh%lx, cpr%Xh%lx, cpr%Xh%lx)
-    integer :: i, j, k, e, nxyz, nelv
-    integer :: kut, kutx, kuty, kutz, nx
+    integer :: i, k, e, nxyz, nelv
+    integer :: kut, nx
     character(len=LOG_SIZE) :: log_buf
 
     ! define some constants
@@ -381,9 +379,7 @@ contains
     real(kind=rp), intent(inout) :: vsort(nxyz)
     real(kind=rp), intent(inout) :: v(nxyz)
     integer, intent(inout) :: isort(nxyz)
-    real(kind=rp) :: wrksort(nxyz)
-    integer :: wrkisort(nxyz)
-    integer :: i, j, k
+    integer :: i
 
     ! copy absolute values to sort by magnitude
     do i =1, nxyz
@@ -531,7 +527,7 @@ contains
     type(coef_t), intent(in) :: coef
     real(kind=rp) :: elemdata(coef%Xh%lx, coef%Xh%lx, coef%Xh%lx)
     real(kind=rp) :: vole, suma, l2e
-    integer i, e, eg, nxyz
+    integer i, e, nxyz
     character(len=4) :: space
 
     ! Get the volume of the element

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -60,7 +60,7 @@ contains
     real(kind=rp) :: t, cfl
     real(kind=dp) :: start_time_org, start_time, end_time
     character(len=LOG_SIZE) :: log_buf
-    integer :: tstep, i
+    integer :: tstep
     character(len=:), allocatable :: restart_file
     logical :: output_at_end, found
     ! for variable_tsteping

--- a/src/simulation_components/probes.F90
+++ b/src/simulation_components/probes.F90
@@ -433,7 +433,7 @@ contains
     real(kind=rp), dimension(:,:), intent(in) :: new_points
 
     real(kind=rp), dimension(:,:), allocatable :: temp
-    integer :: n_old, n_new, n_global
+    integer :: n_old, n_new
 
     ! Get the current number of points
     n_old = this%n_local_probes


### PR DESCRIPTION
Fix jwd2006i-i warnings (fj) for never referenced variables

Note: we still have unused dummy arguments (jwd2008i-i) 
