### PR TITLE
Add CUDA vector version for device ax_helm

### DIFF
--- a/src/fluid/bcknd/device/pnpn_res_device.F90
+++ b/src/fluid/bcknd/device/pnpn_res_device.F90
@@ -352,9 +352,8 @@ contains
     call device_cfill(c_Xh%h2_d, rho * (bd / dt), n)
     c_Xh%ifh2 = .true.
 
-    call Ax%compute(u_res%x, u%x, c_Xh, msh, Xh)
-    call Ax%compute(v_res%x, v%x, c_Xh, msh, Xh)
-    call Ax%compute(w_res%x, w%x, c_Xh, msh, Xh)
+    call Ax%compute_vector(u_res%x, v_res%x, w_res%x, &
+                           u%x, v%x, w%x, c_Xh, msh, Xh)
 
     call neko_scratch_registry%request_field(ta1, temp_indices(1))
     call neko_scratch_registry%request_field(ta2, temp_indices(2))

--- a/src/math/ax.f90
+++ b/src/math/ax.f90
@@ -82,7 +82,7 @@ module ax_product
   !! @param Xh Function space \f$ X_h \f$.
   abstract interface
      subroutine ax_compute_vector(this, au, av, aw, u, v, w, coef, msh, Xh)
-        import space_t
+       import space_t
        import mesh_t
        import coef_t
        import ax_t

--- a/src/math/bcknd/device/ax_helm_device.F90
+++ b/src/math/bcknd/device/ax_helm_device.F90
@@ -46,6 +46,7 @@ module ax_helm_device
   type, public, extends(ax_helm_t) :: ax_helm_device_t
    contains
      procedure, nopass :: compute => ax_helm_device_compute
+     procedure, pass(this) :: compute_vector => ax_helm_device_compute_vector
   end type ax_helm_device_t
 
 #ifdef HAVE_HIP
@@ -75,6 +76,21 @@ module ax_helm_device
        type(c_ptr), value :: h1_d, g11_d, g22_d, g33_d, g12_d, g13_d, g23_d
        integer(c_int) :: nel, lx
      end subroutine cuda_ax_helm
+  end interface
+
+  interface
+     subroutine cuda_ax_helm_vector(au_d, av_d, aw_d, u_d, v_d, w_d, &
+          dx_d, dy_d, dz_d, dxt_d, dyt_d, dzt_d,&
+          h1_d, g11_d, g22_d, g33_d, g12_d, g13_d, g23_d, nelv, lx) &
+          bind(c, name='cuda_ax_helm_vector')
+       use, intrinsic :: iso_c_binding
+       type(c_ptr), value :: au_d, av_d, aw_d
+       type(c_ptr), value :: u_d, v_d, w_d
+       type(c_ptr), value :: dx_d, dy_d, dz_d
+       type(c_ptr), value :: dxt_d, dyt_d, dzt_d
+       type(c_ptr), value :: h1_d, g11_d, g22_d, g33_d, g12_d, g13_d, g23_d
+       integer(c_int) :: nel, lx
+     end subroutine cuda_ax_helm_vector
   end interface
 #elif HAVE_OPENCL
   interface
@@ -130,6 +146,77 @@ contains
     end if
 
   end subroutine ax_helm_device_compute
+
+  subroutine ax_helm_device_compute_vector(this, au, av, aw, &
+                                           u, v, w, coef, msh, Xh)
+    class(ax_helm_device_t), intent(in) :: this
+    type(space_t), intent(inout) :: Xh
+    type(mesh_t), intent(inout) :: msh
+    type(coef_t), intent(inout) :: coef
+    real(kind=rp), intent(inout) :: au(Xh%lx, Xh%ly, Xh%lz, msh%nelv)
+    real(kind=rp), intent(inout) :: av(Xh%lx, Xh%ly, Xh%lz, msh%nelv)
+    real(kind=rp), intent(inout) :: aw(Xh%lx, Xh%ly, Xh%lz, msh%nelv)
+    real(kind=rp), intent(inout) :: u(Xh%lx, Xh%ly, Xh%lz, msh%nelv)
+    real(kind=rp), intent(inout) :: v(Xh%lx, Xh%ly, Xh%lz, msh%nelv)
+    real(kind=rp), intent(inout) :: w(Xh%lx, Xh%ly, Xh%lz, msh%nelv)
+    type(c_ptr) :: u_d, v_d, w_d
+    type(c_ptr) :: au_d, av_d, aw_d
+
+    u_d = device_get_ptr(u)
+    v_d = device_get_ptr(v)
+    w_d = device_get_ptr(w)
+
+    au_d = device_get_ptr(au)
+    av_d = device_get_ptr(av)
+    aw_d = device_get_ptr(aw)
+
+#ifdef HAVE_HIP
+    call hip_ax_helm(au_d, u_d, Xh%dx_d, Xh%dy_d, Xh%dz_d, &
+         Xh%dxt_d, Xh%dyt_d, Xh%dzt_d, coef%h1_d, &
+         coef%G11_d, coef%G22_d, coef%G33_d, &
+         coef%G12_d, coef%G13_d, coef%G23_d, &
+         msh%nelv, Xh%lx)
+    call hip_ax_helm(av_d, v_d, Xh%dx_d, Xh%dy_d, Xh%dz_d, &
+         Xh%dxt_d, Xh%dyt_d, Xh%dzt_d, coef%h1_d, &
+         coef%G11_d, coef%G22_d, coef%G33_d, &
+         coef%G12_d, coef%G13_d, coef%G23_d, &
+         msh%nelv, Xh%lx)
+    call hip_ax_helm(aw_d, w_d, Xh%dx_d, Xh%dy_d, Xh%dz_d, &
+         Xh%dxt_d, Xh%dyt_d, Xh%dzt_d, coef%h1_d, &
+         coef%G11_d, coef%G22_d, coef%G33_d, &
+         coef%G12_d, coef%G13_d, coef%G23_d, &
+         msh%nelv, Xh%lx)
+#elif HAVE_CUDA
+    call cuda_ax_helm_vector(au_d, av_d, aw_d, u_d, v_d, w_d, &
+         Xh%dx_d, Xh%dy_d, Xh%dz_d, Xh%dxt_d, Xh%dyt_d, Xh%dzt_d, coef%h1_d, &
+         coef%G11_d, coef%G22_d, coef%G33_d, &
+         coef%G12_d, coef%G13_d, coef%G23_d, &
+         msh%nelv, Xh%lx)
+#elif HAVE_OPENCL
+    call opencl_ax_helm(au_d, u_d, Xh%dx_d, Xh%dy_d, Xh%dz_d, &
+         Xh%dxt_d, Xh%dyt_d, Xh%dzt_d, coef%h1_d, &
+         coef%G11_d, coef%G22_d, coef%G33_d, &
+         coef%G12_d, coef%G13_d, coef%G23_d, &
+         msh%nelv, Xh%lx)
+    call opencl_ax_helm(av_d, v_d, Xh%dx_d, Xh%dy_d, Xh%dz_d, &
+         Xh%dxt_d, Xh%dyt_d, Xh%dzt_d, coef%h1_d, &
+         coef%G11_d, coef%G22_d, coef%G33_d, &
+         coef%G12_d, coef%G13_d, coef%G23_d, &
+         msh%nelv, Xh%lx)
+    call opencl_ax_helm(aw_d, w_d, Xh%dx_d, Xh%dy_d, Xh%dz_d, &
+         Xh%dxt_d, Xh%dyt_d, Xh%dzt_d, coef%h1_d, &
+         coef%G11_d, coef%G22_d, coef%G33_d, &
+         coef%G12_d, coef%G13_d, coef%G23_d, &
+         msh%nelv, Xh%lx)
+#endif
+
+    if (coef%ifh2) then
+       call device_addcol4(au_d ,coef%h2_d, coef%B_d, u_d, coef%dof%size())
+       call device_addcol4(av_d ,coef%h2_d, coef%B_d, v_d, coef%dof%size())
+       call device_addcol4(aw_d ,coef%h2_d, coef%B_d, w_d, coef%dof%size())
+    end if
+    
+  end subroutine ax_helm_device_compute_vector
 
 end module ax_helm_device
 

--- a/src/math/bcknd/device/cuda/ax_helm.cu
+++ b/src/math/bcknd/device/cuda/ax_helm.cu
@@ -177,6 +177,76 @@ extern "C" {
       } 
     }
   } 
+
+  /** 
+   * Fortran wrapper for device CUDA Ax vector version
+   */
+  void cuda_ax_helm_vector(void *au, void *av, void *aw,
+                           void *u, void *v, void *w,
+                           void *dx, void *dy, void *dz,
+                           void *dxt, void *dyt, void *dzt,
+                           void *h1, void *g11, void *g22,
+                           void *g33, void *g12, void *g13,
+                           void *g23, int *nelv, int *lx) {
+
+    const dim3 nthrds((*lx), (*lx), 1);
+    const dim3 nblcks((*nelv), 1, 1);
+    const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
+
+#define CASE_VECTOR_KSTEP(LX)                                                  \
+    ax_helm_kernel_vector_kstep<real, LX>                                      \
+    <<<nblcks, nthrds, 0, stream>>> ((real *) au, (real *) av, (real *) aw,    \
+                                     (real *) u, (real *) v, (real *) w,       \
+                                     (real *) dx, (real *) dy, (real *) dz,    \
+                                     (real *) h1, (real *) g11, (real *) g22,  \
+                                     (real *) g33, (real *) g12, (real *) g13, \
+                                     (real *) g23);                            \
+    CUDA_CHECK(cudaGetLastError());
+
+#define CASE_VECTOR_KSTEP_PADDED(LX)                                           \
+    ax_helm_kernel_vector_kstep_padded<real, LX>                               \
+    <<<nblcks, nthrds, 0, stream>>> ((real *) au, (real *) av, (real *) aw,    \
+                                     (real *) u, (real *) v, (real *) w,       \
+                                     (real *) dx, (real *) dy, (real *) dz,    \
+                                     (real *) h1, (real *) g11, (real *) g22,  \
+                                     (real *) g33, (real *) g12, (real *) g13, \
+                                     (real *) g23);                            \
+    CUDA_CHECK(cudaGetLastError());
+
+
+#define CASE_VECTOR(LX)                                                         \
+    case LX:                                                                    \
+      CASE_VECTOR_KSTEP(LX);                                                    \
+       break
+
+#define CASE_VECTOR_PADDED(LX)                                                  \
+    case LX:                                                                    \
+      CASE_VECTOR_KSTEP_PADDED(LX);                                             \
+       break
+      
+    switch(*lx) {
+      CASE_VECTOR(2);
+      CASE_VECTOR(3);
+      CASE_VECTOR_PADDED(4);
+      CASE_VECTOR(5);
+      CASE_VECTOR(6);
+      CASE_VECTOR(7);
+      CASE_VECTOR_PADDED(8);
+      CASE_VECTOR(9);
+      CASE_VECTOR(10);
+      CASE_VECTOR(11);
+      CASE_VECTOR(12);
+      CASE_VECTOR(13);
+      CASE_VECTOR(14);
+      CASE_VECTOR(15);
+      CASE_VECTOR_PADDED(16);
+      default:
+        {
+          fprintf(stderr, __FILE__ ": size not supported: %d\n", *lx);
+          exit(1);
+        }
+      }   
+  }
 }
 
 template < const int LX > 

--- a/src/math/bcknd/device/cuda/ax_helm_kernel.h
+++ b/src/math/bcknd/device/cuda/ax_helm_kernel.h
@@ -347,4 +347,375 @@ __global__ void ax_helm_kernel_kstep_padded(T * __restrict__ w,
   }
 }
 
+/*
+ * Vector versions
+ */
+
+template< typename T, const int LX >
+__global__ void ax_helm_kernel_vector_kstep(T * __restrict__ au,
+                                            T * __restrict__ av,
+                                            T * __restrict__ aw,
+                                            const T * __restrict__ u,
+                                            const T * __restrict__ v,
+                                            const T * __restrict__ w,
+                                            const T * __restrict__ dx,
+                                            const T * __restrict__ dy,
+                                            const T * __restrict__ dz,
+                                            const T * __restrict__ h1,
+                                            const T * __restrict__ g11,
+                                            const T * __restrict__ g22,
+                                            const T * __restrict__ g33,
+                                            const T * __restrict__ g12,
+                                            const T * __restrict__ g13,
+                                            const T * __restrict__ g23) {
+
+  __shared__ T shdx[LX * LX];
+  __shared__ T shdy[LX * LX];
+  __shared__ T shdz[LX * LX];
+    
+  __shared__ T shu[LX * LX];
+  __shared__ T shur[LX * LX];
+  __shared__ T shus[LX * LX];
+
+  __shared__ T shv[LX * LX];
+  __shared__ T shvr[LX * LX];
+  __shared__ T shvs[LX * LX];
+
+  __shared__ T shw[LX * LX];
+  __shared__ T shwr[LX * LX];
+  __shared__ T shws[LX * LX];
+
+  T ru[LX];
+  T rv[LX];
+  T rw[LX];
+  
+  T ruw[LX];
+  T rvw[LX];
+  T rww[LX];
+  
+  T rut;
+  T rvt;
+  T rwt;
+
+  const int e = blockIdx.x;
+  const int j = threadIdx.y;
+  const int i = threadIdx.x;
+  const int ij = i + j*LX;
+  const int ele = e*LX*LX*LX;
+
+  shdx[ij] = dx[ij];
+  shdy[ij] = dy[ij];
+  shdz[ij] = dz[ij];
+  
+#pragma unroll
+  for(int k = 0; k < LX; ++k){
+    ru[k] = u[ij + k*LX*LX + ele];
+    ruw[k] = 0.0;
+
+    rv[k] = v[ij + k*LX*LX + ele];
+    rvw[k] = 0.0;
+
+    rw[k] = w[ij + k*LX*LX + ele];
+    rww[k] = 0.0;
+  }
+
+
+  __syncthreads();
+#pragma unroll
+  for (int k = 0; k < LX; ++k){
+    const int ijk = ij + k*LX*LX; 
+    const T G00 = g11[ijk+ele];
+    const T G11 = g22[ijk+ele];
+    const T G22 = g33[ijk+ele]; 
+    const T G01 = g12[ijk+ele];
+    const T G02 = g13[ijk+ele];
+    const T G12 = g23[ijk+ele];
+    const T H1  = h1[ijk+ele];
+    T uttmp = 0.0;
+    T vttmp = 0.0;
+    T wttmp = 0.0;
+    shu[ij] = ru[k];
+    shv[ij] = rv[k];
+    shw[ij] = rw[k];
+    for (int l = 0; l < LX; l++){
+      uttmp += shdz[k+l*LX] * ru[l];
+      vttmp += shdz[k+l*LX] * rv[l];
+      wttmp += shdz[k+l*LX] * rw[l];
+    }
+    __syncthreads();
+    
+    T urtmp = 0.0;
+    T ustmp = 0.0;
+
+    T vrtmp = 0.0;
+    T vstmp = 0.0;
+
+    T wrtmp = 0.0;
+    T wstmp = 0.0;
+#pragma unroll
+    for (int l = 0; l < LX; l++){
+      urtmp += shdx[i+l*LX] * shu[l+j*LX];
+      ustmp += shdy[j+l*LX] * shu[i+l*LX];
+
+      vrtmp += shdx[i+l*LX] * shv[l+j*LX];
+      vstmp += shdy[j+l*LX] * shv[i+l*LX];
+
+      wrtmp += shdx[i+l*LX] * shw[l+j*LX];
+      wstmp += shdy[j+l*LX] * shw[i+l*LX];
+    }
+    
+    shur[ij] = H1
+	     * (G00 * urtmp
+		+ G01 * ustmp
+		+ G02 * uttmp);
+    shus[ij] = H1
+	     * (G01 * urtmp
+		+ G11 * ustmp
+		+ G12 * uttmp);
+    rut      = H1
+	     * (G02 * urtmp
+		+ G12 * ustmp 
+		+ G22 * uttmp);
+
+    shvr[ij] = H1
+	     * (G00 * vrtmp
+		+ G01 * vstmp
+		+ G02 * vttmp);
+    shvs[ij] = H1
+	     * (G01 * vrtmp
+		+ G11 * vstmp
+		+ G12 * vttmp);
+    rvt      = H1
+	     * (G02 * vrtmp
+		+ G12 * vstmp 
+		+ G22 * vttmp);
+
+    shwr[ij] = H1
+	     * (G00 * wrtmp
+		+ G01 * wstmp
+		+ G02 * wttmp);
+    shws[ij] = H1
+	     * (G01 * wrtmp
+		+ G11 * wstmp
+		+ G12 * wttmp);
+    rwt      = H1
+	     * (G02 * wrtmp
+		+ G12 * wstmp 
+		+ G22 * wttmp);
+
+    __syncthreads();
+
+    T uwijke = 0.0;
+    T vwijke = 0.0;
+    T wwijke = 0.0;
+#pragma unroll
+    for (int l = 0; l < LX; l++){
+      uwijke += shur[l+j*LX] * shdx[l+i*LX];
+      ruw[l] += rut * shdz[k+l*LX];
+      uwijke += shus[i+l*LX] * shdy[l + j*LX];
+
+      vwijke += shvr[l+j*LX] * shdx[l+i*LX];
+      rvw[l] += rvt * shdz[k+l*LX];
+      vwijke += shvs[i+l*LX] * shdy[l + j*LX];
+
+      wwijke += shwr[l+j*LX] * shdx[l+i*LX];
+      rww[l] += rwt * shdz[k+l*LX];
+      wwijke += shws[i+l*LX] * shdy[l + j*LX];
+    }
+    ruw[k] += uwijke;
+    rvw[k] += vwijke;
+    rww[k] += wwijke;
+  }
+#pragma unroll
+  for (int k = 0; k < LX; ++k){
+   au[ij + k*LX*LX + ele] = ruw[k];
+   av[ij + k*LX*LX + ele] = rvw[k];
+   aw[ij + k*LX*LX + ele] = rww[k]; 
+  }
+}
+
+template< typename T, const int LX >
+__global__ void ax_helm_kernel_vector_kstep_padded(T * __restrict__ au,
+                                                   T * __restrict__ av,
+                                                   T * __restrict__ aw,
+                                                   const T * __restrict__ u,
+                                                   const T * __restrict__ v,
+                                                   const T * __restrict__ w,
+                                                   const T * __restrict__ dx,
+                                                   const T * __restrict__ dy,
+                                                   const T * __restrict__ dz,
+                                                   const T * __restrict__ h1,
+                                                   const T * __restrict__ g11,
+                                                   const T * __restrict__ g22,
+                                                   const T * __restrict__ g33,
+                                                   const T * __restrict__ g12,
+                                                   const T * __restrict__ g13,
+                                                   const T * __restrict__ g23) {
+
+  __shared__ T shdx[LX * (LX+1)];
+  __shared__ T shdy[LX * (LX+1)];
+  __shared__ T shdz[LX * (LX+1)];
+    
+  __shared__ T shu[LX * (LX+1)];
+  __shared__ T shur[LX * LX];
+  __shared__ T shus[LX * (LX+1)];
+
+  __shared__ T shv[LX * (LX+1)];
+  __shared__ T shvr[LX * LX];
+  __shared__ T shvs[LX * (LX+1)];
+
+  __shared__ T shw[LX * (LX+1)];
+  __shared__ T shwr[LX * LX];
+  __shared__ T shws[LX * (LX+1)];
+
+  T ru[LX];
+  T rv[LX];
+  T rw[LX];
+  
+  T ruw[LX];
+  T rvw[LX];
+  T rww[LX];
+  
+  T rut;
+  T rvt;
+  T rwt;
+
+  const int e = blockIdx.x;
+  const int j = threadIdx.y;
+  const int i = threadIdx.x;
+  const int ij = i + j*LX;
+  const int ij_p = i + j*(LX+1);
+  const int ele = e*LX*LX*LX;
+
+  shdx[ij_p] = dx[ij];
+  shdy[ij_p] = dy[ij];
+  shdz[ij_p] = dz[ij];
+  
+#pragma unroll
+  for(int k = 0; k < LX; ++k){
+    ru[k] = u[ij + k*LX*LX + ele];
+    ruw[k] = 0.0;
+
+    rv[k] = v[ij + k*LX*LX + ele];
+    rvw[k] = 0.0;
+
+    rw[k] = w[ij + k*LX*LX + ele];
+    rww[k] = 0.0;
+  }
+
+
+  __syncthreads();
+#pragma unroll
+  for (int k = 0; k < LX; ++k){
+    const int ijk = ij + k*LX*LX; 
+    const T G00 = g11[ijk+ele];
+    const T G11 = g22[ijk+ele];
+    const T G22 = g33[ijk+ele]; 
+    const T G01 = g12[ijk+ele];
+    const T G02 = g13[ijk+ele];
+    const T G12 = g23[ijk+ele];
+    const T H1  = h1[ijk+ele];
+    T uttmp = 0.0;
+    T vttmp = 0.0;
+    T wttmp = 0.0;
+    shu[ij_p] = ru[k];
+    shv[ij_p] = rv[k];
+    shw[ij_p] = rw[k];
+    for (int l = 0; l < LX; l++){
+      uttmp += shdz[k+l*LX] * ru[l];
+      vttmp += shdz[k+l*LX] * rv[l];
+      wttmp += shdz[k+l*LX] * rw[l];
+    }
+    __syncthreads();
+    
+    T urtmp = 0.0;
+    T ustmp = 0.0;
+
+    T vrtmp = 0.0;
+    T vstmp = 0.0;
+
+    T wrtmp = 0.0;
+    T wstmp = 0.0;
+#pragma unroll
+    for (int l = 0; l < LX; l++){
+      urtmp += shdx[i+l*LX] * shu[l+j*LX];
+      ustmp += shdy[j+l*LX] * shu[i+l*LX];
+
+      vrtmp += shdx[i+l*LX] * shv[l+j*LX];
+      vstmp += shdy[j+l*LX] * shv[i+l*LX];
+
+      wrtmp += shdx[i+l*LX] * shw[l+j*LX];
+      wstmp += shdy[j+l*LX] * shw[i+l*LX];
+    }
+    
+    shur[ij] = H1
+	     * (G00 * urtmp
+		+ G01 * ustmp
+		+ G02 * uttmp);
+    shus[ij_p] = H1
+               * (G01 * urtmp
+                  + G11 * ustmp
+                  + G12 * uttmp);
+    rut      = H1
+	     * (G02 * urtmp
+		+ G12 * ustmp 
+		+ G22 * uttmp);
+
+    shvr[ij] = H1
+	     * (G00 * vrtmp
+		+ G01 * vstmp
+		+ G02 * vttmp);
+    shvs[ij_p] = H1
+	       * (G01 * vrtmp
+                  + G11 * vstmp
+                  + G12 * vttmp);
+    rvt      = H1
+	     * (G02 * vrtmp
+		+ G12 * vstmp 
+		+ G22 * vttmp);
+
+    shwr[ij] = H1
+	     * (G00 * wrtmp
+		+ G01 * wstmp
+		+ G02 * wttmp);
+    shws[ij_p] = H1
+	       * (G01 * wrtmp
+                  + G11 * wstmp
+                  + G12 * wttmp);
+    rwt      = H1
+	     * (G02 * wrtmp
+		+ G12 * wstmp 
+		+ G22 * wttmp);
+
+    __syncthreads();
+
+    T uwijke = 0.0;
+    T vwijke = 0.0;
+    T wwijke = 0.0;
+#pragma unroll
+    for (int l = 0; l < LX; l++){
+      uwijke += shur[l+j*LX] * shdx[l+i*LX];
+      ruw[l] += rut * shdz[k+l*LX];
+      uwijke += shus[i+l*LX] * shdy[l + j*LX];
+
+      vwijke += shvr[l+j*LX] * shdx[l+i*LX];
+      rvw[l] += rvt * shdz[k+l*LX];
+      vwijke += shvs[i+l*LX] * shdy[l + j*LX];
+
+      wwijke += shwr[l+j*LX] * shdx[l+i*LX];
+      rww[l] += rwt * shdz[k+l*LX];
+      wwijke += shws[i+l*LX] * shdy[l + j*LX];
+    }
+    ruw[k] += uwijke;
+    rvw[k] += vwijke;
+    rww[k] += wwijke;
+  }
+#pragma unroll
+  for (int k = 0; k < LX; ++k){
+   au[ij + k*LX*LX + ele] = ruw[k];
+   av[ij + k*LX*LX + ele] = rvw[k];
+   aw[ij + k*LX*LX + ele] = rww[k]; 
+  }
+}
+
 #endif // __MATH_AX_HELM_KERNEL_H__


### PR DESCRIPTION
The combined ax_helm performs ~20% faster than issuing 3x standard ax_helm kernels (on an Nvidia A100)
