### PR TITLE
"Rework CI for linting and use new linting in main CI"

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -11,6 +11,10 @@ on:
        - ready_for_review
   workflow_dispatch:
   
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   is_draft:
     name: Check if PR is a draft

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -26,7 +26,7 @@ jobs:
       if: github.event.pull_request.draft != true
       uses: ./.github/workflows/lint.yml
       with:
-        global_minimum_score: 9.0
+        global_minimum_score: 8.0
         changed_files_minimum_score: 8.0
 
   GNU:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -63,6 +63,7 @@ jobs:
             sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev autoconf automake autotools-dev libopenblas-dev make git m4 python3  cmake-curses-gui 
         - os: macos-13
           setup-env: export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 && brew install openmpi && brew install automake && brew install gcc@11 && brew install gcc@12
+          
     env:
       FC: ${{ matrix.compiler }}
       OMPI_FC: ${{ matrix.compiler }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -24,7 +24,7 @@ jobs:
   linting:
       name: Flint
       if: github.event.pull_request.draft != true
-      uses: .github/workflows/lint.yml
+      uses: ./.github/workflows/lint.yml
       with:
         global_minimum_score: 9.0
         changed_files_minimum_score: 8.0

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -22,31 +22,13 @@ jobs:
         run: echo "This PR is a draft"
 
   linting:
-      name: "Flint"
+      name: Flint
       if: github.event.pull_request.draft != true
-      runs-on: ubuntu-20.04
-      steps:
-        - name: Setup env.
-          run: |
-            sudo apt-get update && sudo apt-get install -yq python3-dev python3-pip python3-tk
-            pip install nobvisual==0.2.0 flinter==0.4.0
-        - name: Checkout
-          uses: actions/checkout@v4
-          with:
-            fetch-depth: 1
-        - name: Lint
-          run: |
-            flint score src/ -d 10 -r flinter_rc.yml | tee flint.txt
-            score=$(awk '$1==0{print $3}' flint.txt)
-            if (( $(echo "$score < 8.06" |bc -l) )) ; then
-              exit 1
-            fi
-        - name: Archive linter report
-          uses: actions/upload-artifact@v4
-          with:
-            name: flint-report
-            path: flint.txt
-            retention-days: 5
+      uses: .github/workflows/lint.yml
+      with:
+        global_minimum_score: 9.0
+        changed_files_minimum_score: 8.0
+
   GNU:
     if: github.event.pull_request.draft != true
     needs: linting

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,11 +7,11 @@ on:
     inputs:
       global_minimum_score:
         description: "The minimum score required for the repository."
-        required: true
+        default: 10.0
         type: number
       changed_files_minimum_score:
         description: "The minimum score required for changed files."
-        required: true
+        default: 10.0
         type: number
 
 jobs:
@@ -37,8 +37,6 @@ jobs:
           flint score src/ -d 10 -r flinter_rc.yml | tee flint.txt
           score=$(awk '$1==0{print $3}' flint.txt)
 
-          echo "Score, $score"
-          echo "Min score, $min_score"
           if (( $(echo "$score < $min_score" | bc -l) )); then
             echo "Linting requirement not met, $score < $min_score" >&2
             exit 1
@@ -86,7 +84,7 @@ jobs:
           min_score: ${{ inputs.changed_files_minimum_score }}
         run: |
           if [ -z "$changed_files" ]; then
-            echo "No files changed"
+            echo "No fortran files changed"
             exit 0
           fi
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,8 @@ jobs:
           flint score src/ -d 10 -r flinter_rc.yml | tee flint.txt
           score=$(awk '$1==0{print $3}' flint.txt)
 
+          echo "Score: $score"
+          echo "Min score: $min_score"
           if (( $(echo "$score < $min_score" | bc -l) )); then
             echo "Linting requirement not met, $score < $min_score" >&2
             exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,6 +82,10 @@ jobs:
           changed_files: ${{ steps.get-changed-files.outputs.changed-files }}
           min_score: ${{ github.event.inputs.changed_files_minimum_score }}
         run: |
+          if [ -z "$changed_files" ]; then
+            echo "No files changed"
+            exit 0
+          fi
 
           fails=()
           for file in $changed_files; do

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Lint
         env:
-          min_score: ${{ github.event.inputs.global_minimum_score }}
+          min_score: ${{ inputs.global_minimum_score }}
         run: |
           flint score src/ -d 10 -r flinter_rc.yml | tee flint.txt
           score=$(awk '$1==0{print $3}' flint.txt)
@@ -83,7 +83,7 @@ jobs:
       - name: Lint changed files
         env:
           changed_files: ${{ steps.get-changed-files.outputs.changed-files }}
-          min_score: ${{ github.event.inputs.changed_files_minimum_score }}
+          min_score: ${{ inputs.changed_files_minimum_score }}
         run: |
           if [ -z "$changed_files" ]; then
             echo "No files changed"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,8 +37,8 @@ jobs:
           flint score src/ -d 10 -r flinter_rc.yml | tee flint.txt
           score=$(awk '$1==0{print $3}' flint.txt)
 
-          echo "Score: $score"
-          echo "Min score: $min_score"
+          echo "Score, $score"
+          echo "Min score, $min_score"
           if (( $(echo "$score < $min_score" | bc -l) )); then
             echo "Linting requirement not met, $score < $min_score" >&2
             exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Linting
 
 # Controls when the action will run.
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       global_minimum_score:
@@ -37,7 +38,7 @@ jobs:
           score=$(awk '$1==0{print $3}' flint.txt)
 
           if (( $(echo "$score < $min_score" | bc -l) )); then
-            echo "Linting requirement not met: $score < $min_score" >&2
+            echo "Linting requirement not met, $score < $min_score" >&2
             exit 1
           fi
       - name: Archive linter report

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,12 +20,15 @@ jobs:
     steps:
       - name: Setup env.
         run: |
-          sudo apt-get update && sudo apt-get install -yq bc python3-dev python3-pip python3-tk
+          sudo apt-get update
+          sudo apt-get install -yq bc python3-dev python3-pip python3-tk
           pip install nobvisual==0.2.0 flinter==0.4.0
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
       - name: Lint
         env:
           min_score: ${{ github.event.inputs.global_minimum_score }}
@@ -33,7 +36,7 @@ jobs:
           flint score src/ -d 10 -r flinter_rc.yml | tee flint.txt
           score=$(awk '$1==0{print $3}' flint.txt)
 
-          if (( $(echo "$score < $min_score" | bc -l) )) ; then
+          if (( $(echo "$score < $min_score" | bc -l) )); then
             echo "Linting requirement not met: $score < $min_score" >&2
             exit 1
           fi
@@ -104,6 +107,9 @@ jobs:
                   printf "Linting failed for \n\t$fail\n\n"
 
                   report=$(flint lint -r flinter_rc.yml $file 2>/dev/null)
+                  if [ -z "$report" ]; then
+                       report=$(flint stats -r flinter_rc.yml $file 2>/dev/null)
+                  fi
                   echo "$report"
               done
               exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,49 +1,110 @@
 name: Linting
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
-#  pull_request:
-#     branches: [develop,release/*,master]
-  workflow_dispatch:
-  
+  workflow_call:
+    inputs:
+      global_minimum_score:
+        description: "The minimum score required for the repository."
+        required: true
+        type: number
+      changed_files_minimum_score:
+        description: "The minimum score required for changed files."
+        required: true
+        type: number
+
 jobs:
-  linting:
-    name: "Flint"
-    runs-on: ubuntu-latest
+  repository-linting:
+    name: "Lint repository"
+    runs-on: ubuntu-20.04
     steps:
-   #  - name: Cache flinter
-   #     id: cache-flinter
-   #     uses: actions/cache@v2
-   #     with:
-   #       key: flinter
       - name: Setup env.
-        #if: steps.cache-flinter.outputs.cache-hit != 'true'
         run: |
-          sudo apt-get update && sudo apt-get install python-dev python3-tk
+          sudo apt-get update && sudo apt-get install -yq bc python3-dev python3-pip python3-tk
           pip install nobvisual==0.2.0 flinter==0.4.0
-#          pip install anybadge
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Lint
+        env:
+          min_score: ${{ github.event.inputs.global_minimum_score }}
         run: |
           flint score src/ -d 10 -r flinter_rc.yml | tee flint.txt
           score=$(awk '$1==0{print $3}' flint.txt)
-          if (( $(echo "$score < 8.00" |bc -l) )) ; then
+
+          if (( $(echo "$score < $min_score" | bc -l) )) ; then
+            echo "Linting requirement not met: $score < $min_score" >&2
             exit 1
           fi
- #         anybadge -l flint  -o --file=flint.svg -v $score  2=red 4=orange 8=yellow 10=green
-#      - name: Archive linter badge
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: flint-badge
-#          path: flint.svg
-#          retention-days: 5
       - name: Archive linter report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: flint-report
           path: flint.txt
           retention-days: 5
-          
+
+  changes_lint:
+    name: "Lint changed files"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Setup env.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -yq bc python3-dev python3-pip python3-tk
+          pip install flinter nobvisual
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+        # Get a list of the changed files and store them for later use.
+      - name: Get changed files
+        id: get-changed-files
+        env:
+          target: ${{ github.event.pull_request.base.ref }}
+          current: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [ -z "${{ inputs.target }}" ]; then
+            target="develop"
+          fi
+
+          git fetch --unshallow origin $target
+          changes=($(git diff --name-status $current origin/$target | cut -f2))
+          echo "changed-files=${changes[@]}" >> $GITHUB_OUTPUT
+
+      - name: Lint changed files
+        env:
+          changed_files: ${{ steps.get-changed-files.outputs.changed-files }}
+          min_score: ${{ github.event.inputs.changed_files_minimum_score }}
+        run: |
+
+          fails=()
+          for file in $changed_files; do
+
+              # If the file is not a Fortran file, skip it.
+              if [[ ! $file =~ \.f90$ ]]; then continue; fi
+
+              score=$(flint score -r flinter_rc.yml $file 2>/dev/null |
+                  grep -oP '(?<=\>\|)[^\|\<]+(?=\|\<)')
+
+              if (($(echo "$score < $min_score" | bc -l))); then
+                  fails+=($file)
+              fi
+          done
+
+          printf "\n" && printf "%.s=" {1..80} && printf "\n"
+          printf "Files that failed linting:\n"
+          printf "\t${fails[@]}\n"
+
+          if [ ${#fails[@]} -gt 0 ]; then
+              for fail in "${fails[@]}"; do
+                  printf "%.s-" {1..80} && printf "\n"
+                  printf "Linting failed for \n\t$fail\n\n"
+
+                  report=$(flint lint -r flinter_rc.yml $file 2>/dev/null)
+                  echo "$report"
+              done
+              exit 1
+          fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       name: "Flint"
       uses: ./.github/workflows/lint.yml
       with:
-        global_minimum_score: 9.0
+        global_minimum_score: 8.0
         changed_files_minimum_score: 8.0
 
   GNU:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   linting:
       name: "Flint"
-      uses: .github/workflows/lint.yml
+      uses: ./.github/workflows/lint.yml
       with:
         global_minimum_score: 9.0
         changed_files_minimum_score: 8.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,29 +9,11 @@ on:
 jobs:
   linting:
       name: "Flint"
-      runs-on: ubuntu-20.04
-      steps:
-        - name: Setup env.
-          run: |
-            sudo apt-get update && sudo apt-get install -yq python3-dev python3-pip python3-tk
-            pip install nobvisual==0.2.0 flinter==0.4.0
-        - name: Checkout
-          uses: actions/checkout@v4
-          with:
-            fetch-depth: 1
-        - name: Lint
-          run: |
-            flint score src/ -d 10 -r flinter_rc.yml | tee flint.txt
-            score=$(awk '$1==0{print $3}' flint.txt)
-            if (( $(echo "$score < 8.06" |bc -l) )) ; then
-              exit 1
-            fi
-        - name: Archive linter report
-          uses: actions/upload-artifact@v4
-          with:
-            name: flint-report
-            path: flint.txt
-            retention-days: 5
+      uses: .github/workflows/lint.yml
+      with:
+        global_minimum_score: 9.0
+        changed_files_minimum_score: 8.0
+
   GNU:
     needs: linting
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
This pull request includes the following changes:

- Rework of the CI for linting, including separating linting into its own file, performing checks for the repository and all changed files individually, and adding the ability to set a minimum score when calling the action.

- Using the new linting in the main CI workflow.

- Clean up of the workflow.

These changes improve the linting process and make it more clear what can be done to improve it.

As an additional bonus, we now cancel old workflows for a PR when a new commit is submitted. which should help reduce resource usage and speedup return for the valid runs.