### PR TITLE
The OIFS Scheme

### DIFF
--- a/examples/tgv/results/bdry0.nek5000
+++ b/examples/tgv/results/bdry0.nek5000
@@ -1,0 +1,4 @@
+filetemplate:         bdry%01d.f%05d
+firsttimestep:     0
+numtimesteps:     1
+type: binary

--- a/examples/tgv/results/bdry0.nek5000
+++ b/examples/tgv/results/bdry0.nek5000
@@ -1,4 +1,0 @@
-filetemplate:         bdry%01d.f%05d
-firsttimestep:     0
-numtimesteps:     1
-type: binary

--- a/examples/tgv/results/field0.nek5000
+++ b/examples/tgv/results/field0.nek5000
@@ -1,4 +1,0 @@
-filetemplate:         field%01d.f%05d
-firsttimestep:     0
-numtimesteps:    22
-type: binary

--- a/examples/tgv/results/field0.nek5000
+++ b/examples/tgv/results/field0.nek5000
@@ -1,0 +1,4 @@
+filetemplate:         field%01d.f%05d
+firsttimestep:     0
+numtimesteps:    22
+type: binary

--- a/examples/tgv/tgv.case
+++ b/examples/tgv/tgv.case
@@ -9,11 +9,12 @@
   "load_balance": false,
   "job_timelimit": "00:00:00",
   "end_time": 3.0,
-  "timestep": 1e-2,
+  "timestep": 1e-1,
   "numerics": {
     "time_order": 3,
     "polynomial_order": 7,
-    "dealias": true
+    "dealias": true,
+    "oifs": true
   },
   "fluid": {
     "scheme": "pnpn",

--- a/src/.depends
+++ b/src/.depends
@@ -76,18 +76,22 @@ io/format/rea.o : io/format/rea.f90 mesh/mesh.o config/num_types.o
 math/bcknd/cpu/cdtp.o : math/bcknd/cpu/cdtp.f90 config/num_types.o 
 math/bcknd/cpu/conv1.o : math/bcknd/cpu/conv1.f90 config/num_types.o 
 math/bcknd/cpu/dudxyz.o : math/bcknd/cpu/dudxyz.f90 config/num_types.o 
-math/bcknd/cpu/opgrad.o : math/bcknd/cpu/opgrad.f90 config/num_types.o 
+math/bcknd/cpu/opgrad.o : math/bcknd/cpu/opgrad.f90 config/num_types.o
+math/bcknd/cpu/conv_fst_3d.o : math/bcknd/cpu/conv_fst_3d.f90 config/num_types.o sem/coef.o sem/space.o sem/interpolation.o math/math.o gs/gather_scatter.o
+math/bcknd/cpu/set_convect_new.o : math/bcknd/cpu/set_convect_new.f90 config/num_types.o 
 math/bcknd/sx/sx_cdtp.o : math/bcknd/sx/sx_cdtp.f90 math/math.o config/num_types.o 
 math/bcknd/sx/sx_conv1.o : math/bcknd/sx/sx_conv1.f90 config/num_types.o 
 math/bcknd/sx/sx_dudxyz.o : math/bcknd/sx/sx_dudxyz.f90 math/math.o config/num_types.o 
 math/bcknd/sx/sx_opgrad.o : math/bcknd/sx/sx_opgrad.f90 config/num_types.o 
 math/bcknd/sx/sx_cfl.o : math/bcknd/sx/sx_cfl.f90 config/num_types.o 
-math/bcknd/sx/sx_lambda2.o : math/bcknd/sx/sx_lambda2.f90 math/math.o config/num_types.o 
+math/bcknd/sx/sx_lambda2.o : math/bcknd/sx/sx_lambda2.f90 math/math.o config/num_types.o
+math/bcknd/sx/sx_conv_fst_3d.o : math/bcknd/sx/sx_conv_fst_3d.f90 config/num_types.o sem/coef.o sem/space.o sem/interpolation.o math/math.o gs/gather_scatter.o
+math/bcknd/sx/sx_set_convect_new.o : math/bcknd/sx/sx_set_convect_new.f90 config/num_types.o 
 math/operators.o : math/operators.f90 comm/comm.o field/scratch_registry.o math/bcknd/device/device_math.o device/device.o math/math.o field/field.o sem/coef.o sem/space.o math/bcknd/device/opr_device.o math/bcknd/xsmm/opr_xsmm.o math/bcknd/sx/opr_sx.o math/bcknd/cpu/opr_cpu.o config/num_types.o config/neko_config.o 
-math/bcknd/cpu/opr_cpu.o : math/bcknd/cpu/opr_cpu.f90 math/mathops.o gs/gather_scatter.o field/field.o math/math.o sem/coef.o sem/space.o config/num_types.o math/bcknd/cpu/conv1.o math/bcknd/cpu/cdtp.o math/bcknd/cpu/opgrad.o math/bcknd/cpu/dudxyz.o 
-math/bcknd/sx/opr_sx.o : math/bcknd/sx/opr_sx.f90 math/mathops.o field/field.o math/math.o sem/coef.o sem/space.o config/num_types.o gs/gather_scatter.o math/bcknd/sx/sx_lambda2.o math/bcknd/sx/sx_cfl.o math/bcknd/sx/sx_cdtp.o math/bcknd/sx/sx_conv1.o math/bcknd/sx/sx_opgrad.o math/bcknd/sx/sx_dudxyz.o 
+math/bcknd/cpu/opr_cpu.o : math/bcknd/cpu/opr_cpu.f90 math/mathops.o gs/gather_scatter.o field/field.o math/math.o sem/coef.o sem/space.o config/num_types.o math/bcknd/cpu/conv1.o math/bcknd/cpu/cdtp.o math/bcknd/cpu/opgrad.o math/bcknd/cpu/dudxyz.o math/bcknd/cpu/conv_fst_3d.o math/bcknd/cpu/set_convect_new.o
+math/bcknd/sx/opr_sx.o : math/bcknd/sx/opr_sx.f90 math/mathops.o field/field.o math/math.o sem/coef.o sem/space.o config/num_types.o gs/gather_scatter.o math/bcknd/sx/sx_lambda2.o math/bcknd/sx/sx_cfl.o math/bcknd/sx/sx_cdtp.o math/bcknd/sx/sx_conv1.o math/bcknd/sx/sx_opgrad.o math/bcknd/sx/sx_dudxyz.o math/bcknd/sx/sx_conv_fst_3d.o math/bcknd/sx/sx_set_convect_new.o
 math/bcknd/xsmm/opr_xsmm.o : math/bcknd/xsmm/opr_xsmm.F90 math/mathops.o gs/gather_scatter.o field/field.o mesh/mesh.o math/math.o sem/coef.o sem/space.o math/mxm_wrapper.o config/num_types.o 
-math/bcknd/device/opr_device.o : math/bcknd/device/opr_device.F90 comm/comm.o common/utils.o field/field.o mesh/mesh.o sem/coef.o sem/space.o device/device.o math/bcknd/device/device_mathops.o math/bcknd/device/device_math.o config/num_types.o gs/gather_scatter.o 
+math/bcknd/device/opr_device.o : math/bcknd/device/opr_device.F90 comm/comm.o common/utils.o field/field.o mesh/mesh.o sem/coef.o sem/space.o device/device.o math/bcknd/device/device_mathops.o math/bcknd/device/device_math.o config/num_types.o gs/gather_scatter.o sem/interpolation.o
 math/tensor.o : math/tensor.f90 device/device.o config/neko_config.o math/mxm_wrapper.o config/num_types.o math/bcknd/device/tensor_device.o math/bcknd/sx/tensor_sx.o math/bcknd/cpu/tensor_cpu.o math/bcknd/xsmm/tensor_xsmm.o 
 math/bcknd/cpu/tensor_cpu.o : math/bcknd/cpu/tensor_cpu.f90 math/mxm_wrapper.o config/num_types.o 
 math/bcknd/sx/tensor_sx.o : math/bcknd/sx/tensor_sx.f90 math/mxm_wrapper.o config/num_types.o 
@@ -193,9 +197,10 @@ fluid/mean_sqr_flow.o : fluid/mean_sqr_flow.f90 field/field.o field/mean_sqr_fie
 fluid/flow_profile.o : fluid/flow_profile.f90 config/num_types.o 
 fluid/flow_ic.o : fluid/flow_ic.f90 mesh/point_zone_registry.o mesh/point_zone.o common/json_utils.o common/user_intf.o math/bcknd/device/device_math.o math/math.o sem/coef.o common/utils.o field/field.o device/device.o fluid/flow_profile.o config/neko_config.o gs/gather_scatter.o config/num_types.o 
 fluid/advection.o : fluid/advection.f90 sem/coef.o field/field.o sem/space.o config/num_types.o 
-fluid/advection_fctry.o : fluid/advection_fctry.f90 fluid/bcknd/advection/adv_no_dealias.o fluid/bcknd/advection/adv_dealias.o fluid/advection.o common/json_utils.o sem/coef.o 
+fluid/advection_fctry.o : fluid/advection_fctry.f90 fluid/bcknd/advection/adv_no_dealias.o fluid/bcknd/advection/adv_dealias.o fluid/bcknd/advection/adv_oifs.o fluid/advection.o common/json_utils.o sem/coef.o 
 fluid/bcknd/advection/adv_dealias.o : fluid/bcknd/advection/adv_dealias.f90 device/device.o sem/interpolation.o math/operators.o config/neko_config.o math/bcknd/device/device_math.o sem/coef.o field/field.o sem/space.o math/math.o config/num_types.o fluid/advection.o 
 fluid/bcknd/advection/adv_no_dealias.o : fluid/bcknd/advection/adv_no_dealias.f90 device/device.o math/operators.o config/neko_config.o math/bcknd/device/device_math.o sem/coef.o field/field.o sem/space.o math/math.o config/num_types.o fluid/advection.o 
+fluid/bcknd/advection/adv_oifs.o : fluid/bcknd/advection/adv_oifs.f90 device/device.o sem/interpolation.o math/operators.o config/neko_config.o sem/coef.o field/field.o sem/space.o config/num_types.o fluid/advection.o common/time_interpolator.o time_schemes/time_scheme_controller.o
 fluid/bcknd/cpu/pnpn_res_cpu.o : fluid/bcknd/cpu/pnpn_res_cpu.f90 sem/space.o config/num_types.o mesh/mesh.o field/scratch_registry.o fluid/pnpn_res.o bc/facet_normal.o sem/coef.o math/ax.o field/field.o math/operators.o gs/gather_scatter.o 
 fluid/bcknd/sx/pnpn_res_sx.o : fluid/bcknd/sx/pnpn_res_sx.f90 sem/space.o config/num_types.o mesh/mesh.o field/scratch_registry.o fluid/pnpn_res.o bc/facet_normal.o sem/coef.o math/ax.o field/field.o math/operators.o gs/gather_scatter.o 
 fluid/bcknd/device/pnpn_res_device.o : fluid/bcknd/device/pnpn_res_device.F90 field/scratch_registry.o fluid/pnpn_res.o math/bcknd/device/device_mathops.o math/bcknd/device/device_math.o sem/space.o config/num_types.o mesh/mesh.o bc/facet_normal.o sem/coef.o math/ax.o field/field.o math/operators.o gs/gather_scatter.o 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -199,6 +199,7 @@ neko_fortran_SOURCES = \
 	fluid/advection_fctry.f90\
         fluid/bcknd/advection/adv_dealias.f90\
         fluid/bcknd/advection/adv_no_dealias.f90\
+	fluid/bcknd/advection/adv_oifs.f90\
 	fluid/bcknd/cpu/pnpn_res_cpu.f90\
 	fluid/bcknd/sx/pnpn_res_sx.f90\
 	fluid/bcknd/device/pnpn_res_device.F90\
@@ -211,7 +212,11 @@ neko_fortran_SOURCES = \
 	math/ax_helm_full.f90\
 	math/bcknd/cpu/ax_helm_cpu.f90\
 	math/bcknd/cpu/ax_helm_full_cpu.f90\
+	math/bcknd/cpu/conv_fst_3d.f90\
+	math/bcknd/cpu/set_convect_new.f90\
 	math/bcknd/sx/ax_helm_sx.f90\
+	math/bcknd/sx/sx_conv_fst_3d.f90\
+	math/bcknd/sx/sx_set_convect_new.f90\
 	math/bcknd/xsmm/ax_helm_xsmm.F90\
 	math/bcknd/device/ax_helm_device.F90\
 	common/projection.f90\

--- a/src/common/bcknd/cpu/rhs_maker_cpu.f90
+++ b/src/common/bcknd/cpu/rhs_maker_cpu.f90
@@ -1,5 +1,5 @@
 module rhs_maker_cpu
-  use rhs_maker, only : rhs_maker_bdf_t, rhs_maker_ext_t, rhs_maker_sumab_t
+  use rhs_maker, only : rhs_maker_bdf_t, rhs_maker_ext_t, rhs_maker_sumab_t, rhs_maker_oifs_t
   use field_series, only : field_series_t
   use field, only : field_t
   use num_types, only : rp, c_rp
@@ -23,6 +23,12 @@ module rhs_maker_cpu
      procedure, nopass :: compute_fluid => rhs_maker_bdf_cpu
      procedure, nopass :: compute_scalar => scalar_rhs_maker_bdf_cpu
   end type rhs_maker_bdf_cpu_t
+
+  type, public, extends(rhs_maker_oifs_t) :: rhs_maker_oifs_cpu_t
+   contains
+     procedure, nopass :: compute_fluid => rhs_maker_oifs_cpu
+     procedure, nopass :: compute_scalar => scalar_rhs_maker_oifs_cpu
+  end type rhs_maker_oifs_cpu_t
 
 contains
 
@@ -209,6 +215,37 @@ contains
 
     call neko_scratch_registry%relinquish_field(temp_indices)
   end subroutine scalar_rhs_maker_bdf_cpu
+  
+
+  subroutine rhs_maker_oifs_cpu(phix, phiy, phiz, bfx, bfy, bfz, &
+       rho, dt, n)
+    real(kind=rp), intent(in) :: rho, dt
+    integer, intent(in) :: n
+    real(kind=rp), intent(inout) :: bfx(n), bfy(n), bfz(n)
+    real(kind=rp), intent(inout) :: phix(n), phiy(n), phiz(n)
+    integer :: i
+
+    do i = 1, n
+       bfx(i) = bfx(i) + phix(i) * (rho / dt) 
+       bfy(i) = bfy(i) + phiy(i) * (rho / dt) 
+       bfz(i) = bfz(i) + phiz(i) * (rho / dt)  
+    end do
+
+
+  end subroutine rhs_maker_oifs_cpu
+
+  subroutine scalar_rhs_maker_oifs_cpu(phis, bfs, rho, dt, n)
+    real(kind=rp), intent(in) :: rho, dt
+    integer, intent(in) :: n
+    real(kind=rp), intent(inout) :: bfs(n)
+    real(kind=rp), intent(inout) :: phis(n)
+    integer :: i
+
+    do i = 1, n
+       bfs(i) = bfs(i) + phis(i) * (rho / dt) 
+    end do
+        
+  end subroutine scalar_rhs_maker_oifs_cpu
 
 end module rhs_maker_cpu
 

--- a/src/common/bcknd/device/cuda/makeoifs_kernel.h
+++ b/src/common/bcknd/device/cuda/makeoifs_kernel.h
@@ -1,0 +1,78 @@
+/*
+ Copyright (c) 2022, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef __COMMON_MAKEOIFS_KERNEL__
+#define __COMMON_MAKEOIFS_KERNEL__
+
+template< typename T >
+__global__ void makeoifs_kernel(const T * __restrict__ phix,
+                               const T * __restrict__ phiy,
+                               const T * __restrict__ phiz,
+                               T * __restrict__ bfx,
+                               T * __restrict__ bfy,
+                               T * __restrict__ bfz,
+                               const T rho,
+                               const T dt,
+                               const int n) {
+
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  for (int i = idx; i < n; i += str) {
+        
+    bfx[i] = bfx[i] + phix[i] * (rho / dt);
+    bfy[i] = bfy[i] + phiy[i] * (rho / dt);
+    bfz[i] = bfz[i] + phiz[i] * (rho / dt);
+  }
+  
+}
+
+template< typename T >
+__global__ void scalar_makeoifs_kernel(const T * __restrict__ phis,
+                                      T * __restrict__ bfs,
+                                      const T rho,
+                                      const T dt,
+                                      const int n) {
+
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  for (int i = idx; i < n; i += str) {
+    
+    bfs[i] = bfs[i] + phis[i] * (rho / dt);
+  }
+  
+}
+
+#endif // __COMMON_MAKEOIFS_KERNEL__

--- a/src/common/bcknd/device/cuda/rhs_maker.cu
+++ b/src/common/bcknd/device/cuda/rhs_maker.cu
@@ -38,6 +38,7 @@
 #include "sumab_kernel.h"
 #include "makeext_kernel.h"
 #include "makebdf_kernel.h"
+#include "makeoifs_kernel.h"
 
 extern "C" {
   void rhs_maker_sumab_cuda(void *u, void *v, void *w,
@@ -135,5 +136,35 @@ extern "C" {
                                       *rho, *dt, *bd2, *bd3, *bd4, *nbd,  *n);
     CUDA_CHECK(cudaGetLastError());
   }
+  
+  void rhs_maker_oifs_cuda(void *phix, void *phiy, void *phiz,
+                          void *bfx, void *bfy, void *bfz,
+                          real *rho, real *dt, int *n) {
+
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
+    const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
+
+    makeoifs_kernel<real>
+      <<<nblcks, nthrds, 0, stream>>>((real *) phix, (real *) phiy, (real *) phiz, 
+                                      (real *) bfx, (real *) bfy, (real *) bfz,
+                                      *rho, *dt, *n);
+    CUDA_CHECK(cudaGetLastError());
+  }
+
+  void scalar_rhs_maker_oifs_cuda(void *phis, void *bfs,
+                          real *rho, real *dt, int *n) {
+
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
+    const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
+
+    scalar_makeoifs_kernel<real>
+      <<<nblcks, nthrds, 0, stream>>>((real *) phis, 
+                                      (real *) bfs,
+                                      *rho, *dt, *n);
+    CUDA_CHECK(cudaGetLastError());
+  }
+  
 }
 

--- a/src/common/bcknd/device/hip/makeoifs_kernel.h
+++ b/src/common/bcknd/device/hip/makeoifs_kernel.h
@@ -1,0 +1,79 @@
+/*
+ Copyright (c) 2022, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef __COMMON_MAKEOIFS_KERNEL__
+#define __COMMON_MAKEOIFS_KERNEL__
+
+template< typename T >
+__global__ void makeoifs_kernel(const T * __restrict__ phix,
+                               const T * __restrict__ phiy,
+                               const T * __restrict__ phiz,
+                               T * __restrict__ bfx,
+                               T * __restrict__ bfy,
+                               T * __restrict__ bfz,
+                               const T rho,
+                               const T dt,
+                               const int n) {
+
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  for (int i = idx; i < n; i += str) {
+    
+    bfx[i] = bfx[i] + phix[i] * (rho / dt);
+    bfy[i] = bfy[i] + phiy[i] * (rho / dt);
+    bfz[i] = bfz[i] + phiz[i] * (rho / dt);
+  }
+
+}
+
+template< typename T >
+__global__ void scalar_makeoifs_kernel(const T * __restrict__ phis,
+                                      T * __restrict__ bfs,
+                                      const T rho,
+                                      const T dt,
+                                      const int n) {
+
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  for (int i = idx; i < n; i += str) {
+    
+    // todo: probably not just rho here
+    bfs[i] = bfs[i] + phis[i] * (rho / dt);
+  }
+
+}
+
+#endif // __COMMON_MAKEOIFS_KERNEL__

--- a/src/common/bcknd/device/hip/rhs_maker.hip
+++ b/src/common/bcknd/device/hip/rhs_maker.hip
@@ -39,6 +39,7 @@
 #include "sumab_kernel.h"
 #include "makeext_kernel.h"
 #include "makebdf_kernel.h"
+#include "makeoifs_kernel.h"
 
 extern "C" {
   void rhs_maker_sumab_hip(void *u, void *v, void *w,
@@ -125,6 +126,34 @@ extern "C" {
                        (real *) s_lag, (real *) s_laglag, (real *) fs,
                        (real *) s, (real *) B, *rho, *dt, *bd2, *bd3,
                        *bd4, *nbd,  *n);
+    HIP_CHECK(hipGetLastError());
+  }
+  
+  void rhs_maker_oifs_hip(void *phix, void *phiy, void *phiz,
+                         void *bfx, void *bfy, void *bfz,
+                         real *rho, real *dt, int *n) {
+
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
+
+    hipLaunchKernelGGL(HIP_KERNEL_NAME( makeoifs_kernel<real> ),
+                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
+                       (real *) phix, (real *) phiy, (real *) phiz,
+                       (real *) bfx, (real *) bfy, (real *) bfz,
+                       *rho, *dt, *n);
+    HIP_CHECK(hipGetLastError());
+  }
+
+  void scalar_rhs_maker_oifs_hip(void *phis, void *bfs, real *rho, real *dt,
+                                int *n) {
+
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
+
+    hipLaunchKernelGGL(HIP_KERNEL_NAME( scalar_makeoifs_kernel<real> ),
+                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
+                       (real *) phis, (real *) bfs,
+                       *rho, *dt, *n);
     HIP_CHECK(hipGetLastError());
   }
 }

--- a/src/common/bcknd/device/opencl/rhs_maker.c
+++ b/src/common/bcknd/device/opencl/rhs_maker.c
@@ -232,3 +232,61 @@ void scalar_rhs_maker_bdf_opencl(void *s_lag, void *s_laglag, void *fs,
                                   0, NULL, NULL));
   
 }
+
+void rhs_maker_oifs_opencl(void *phix, void *phiy, void *phiz,
+                          void *bfx, void *bfy, void *bfz,
+                          real *rho, real *dt, int *n) {
+  cl_int err;
+  
+  if (rhs_maker_program == NULL)
+    opencl_kernel_jit(rhs_maker_kernel, (cl_program *) &rhs_maker_program);
+
+  cl_kernel kernel = clCreateKernel(rhs_maker_program, "makeoifs_kernel", &err);
+  CL_CHECK(err);
+
+  CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &phix));
+  CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &phiy));
+  CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &phiz));
+  CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_mem), (void *) &bfx));
+  CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_mem), (void *) &bfy));
+  CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_mem), (void *) &bfz));
+  CL_CHECK(clSetKernelArg(kernel, 13, sizeof(real), rho));
+  CL_CHECK(clSetKernelArg(kernel, 14, sizeof(real), dt));
+  CL_CHECK(clSetKernelArg(kernel, 19, sizeof(int), n));
+  
+  const int nb = ((*n) + 256 - 1) / 256;
+  const size_t global_item_size = 256 * nb;
+  const size_t local_item_size = 256;
+
+  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
+                                  NULL, &global_item_size, &local_item_size,
+                                  0, NULL, NULL));
+  
+}
+
+void scalar_rhs_maker_oifs_opencl(void *phis, void *bfs, real  *rho, real *dt,
+                                 int *n) {
+  cl_int err;
+  
+  if (rhs_maker_program == NULL)
+    opencl_kernel_jit(rhs_maker_kernel, (cl_program *) &rhs_maker_program);
+
+  cl_kernel kernel = clCreateKernel(rhs_maker_program, "scalar_makeoifs_kernel", &err);
+  CL_CHECK(err);
+
+  CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &phis));
+  CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_mem), (void *) &bfs));
+  CL_CHECK(clSetKernelArg(kernel, 13, sizeof(real), rho));
+  CL_CHECK(clSetKernelArg(kernel, 14, sizeof(real), dt));
+  CL_CHECK(clSetKernelArg(kernel, 19, sizeof(int), n));
+  
+  const int nb = ((*n) + 256 - 1) / 256;
+  const size_t global_item_size = 256 * nb;
+  const size_t local_item_size = 256;
+
+  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
+                                  NULL, &global_item_size, &local_item_size,                
+                                  0, NULL, NULL));
+  
+}
+

--- a/src/common/bcknd/device/opencl/rhs_maker_kernel.cl
+++ b/src/common/bcknd/device/opencl/rhs_maker_kernel.cl
@@ -213,6 +213,42 @@ __kernel void scalar_makebdf_kernel(__global const real * __restrict__ s_lag,
   }
   
 }
+  kernel void makeoifs_kernel(__global const real * __restrict__ phix,
+                             __global const real * __restrict__ phiy,
+                             __global const real * __restrict__ phiz,
+                             __global real * __restrict__ bfx,
+                             __global real * __restrict__ bfy,
+                             __global real * __restrict__ bfz,
+                             const real rho,
+                             const real dt,
+                             const int n) {
 
+  const int idx = get_global_id(0);
+  const int str = get_global_size(0);
+
+  for (int i = idx; i < n; i += str) {
+
+    bfx[i] = bfx[i] + phix[i] * (rho/dt);
+    bfy[i] = bfy[i] + phiy[i] * (rho/dt);
+    bfz[i] = bfz[i] + phiz[i] * (rho/dt);
+  }
+}
+
+__kernel void scalar_makeoifs_kernel(__global const real * __restrict__ phis,
+                             __global real * __restrict__ bfs,
+                             const real rho,
+                             const real dt,
+                             const int n) {
+
+  const int idx = get_global_id(0);
+  const int str = get_global_size(0);
+
+  for (int i = idx; i < n; i += str) {
+
+
+    bfs[i] = bfs[i] + phis[i] * (rho/dt);
+
+  }
+}
 
 #endif // __COMMON_RHS_MAKER_KENEL__

--- a/src/common/bcknd/device/rhs_maker_device.F90
+++ b/src/common/bcknd/device/rhs_maker_device.F90
@@ -58,6 +58,12 @@ module rhs_maker_device
      procedure, nopass :: compute_scalar => scalar_rhs_maker_bdf_device
   end type rhs_maker_bdf_device_t
 
+  type, public, extends(rhs_maker_oifs_t) :: rhs_maker_oifs_device_t
+   contains
+     procedure, nopass :: compute_fluid => rhs_maker_oifs_device
+     procedure, nopass :: compute_scalar => scalar_rhs_maker_oifs_device
+  end type rhs_maker_oifs_device_t
+
 #ifdef HAVE_HIP
   interface
      subroutine rhs_maker_sumab_hip(u_d, v_d, w_d, uu_d, vv_d, ww_d, &
@@ -126,6 +132,31 @@ module rhs_maker_device
        integer(c_int) :: nbd, n
      end subroutine scalar_rhs_maker_bdf_hip
   end interface
+  
+  interface
+     subroutine rhs_maker_oifs_hip(phix_d, phiy_d, phiz_d, bfx_d, bfy_d, bfz_d, &
+          rho, dt, n) bind(c, name='rhs_maker_oifs_hip')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       type(c_ptr), value :: phix_d, phiy_d, phiz_d
+       type(c_ptr), value :: bfx_d, bfy_d, bfz_d
+       reaL(c_rp) :: rho, dt
+       integer(c_int) :: n
+     end subroutine rhs_maker_oifs_hip
+  end interface 
+
+  interface
+     subroutine scalar_rhs_maker_oifs_hip(phis_d, bfs_d, rho, dt, n) &
+          bind(c, name='scalar_rhs_maker_oifs_hip')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       type(c_ptr), value :: phis_d
+       type(c_ptr), value :: bfs_d
+       reaL(c_rp) :: rho, dt
+       integer(c_int) :: n
+     end subroutine scalar_rhs_maker_oifs_hip
+  end interface  
+
 #elif HAVE_CUDA
   interface
      subroutine rhs_maker_sumab_cuda(u_d, v_d, w_d, uu_d, vv_d, ww_d, &
@@ -194,6 +225,31 @@ module rhs_maker_device
        integer(c_int) :: nbd, n
      end subroutine scalar_rhs_maker_bdf_cuda
   end interface
+
+  interface
+     subroutine rhs_maker_oifs_cuda(phix_d, phiy_d, phiz_d, bfx_d, bfy_d, bfz_d, &
+          rho, dt, n) bind(c, name='rhs_maker_oifs_cuda')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       type(c_ptr), value :: phix_d, phiy_d, phiz_d
+       type(c_ptr), value :: bfx_d, bfy_d, bfz_d
+       reaL(c_rp) :: rho, dt
+       integer(c_int) :: n
+     end subroutine rhs_maker_oifs_cuda
+  end interface 
+
+  interface
+     subroutine scalar_rhs_maker_oifs_cuda(phis_d, bfs_d, rho, dt, n) &
+          bind(c, name='scalar_rhs_maker_oifs_cuda')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       type(c_ptr), value :: phis_d
+       type(c_ptr), value :: bfs_d
+       reaL(c_rp) :: rho, dt
+       integer(c_int) :: n
+     end subroutine scalar_rhs_maker_oifs_cuda
+  end interface  
+
 #elif HAVE_OPENCL
   interface
      subroutine rhs_maker_sumab_opencl(u_d, v_d, w_d, uu_d, vv_d, ww_d, &
@@ -262,6 +318,31 @@ module rhs_maker_device
        integer(c_int) :: nbd, n
      end subroutine scalar_rhs_maker_bdf_opencl
   end interface
+
+  interface
+     subroutine rhs_maker_oifs_opencl(phix_d, phiy_d, phiz_d, bfx_d, bfy_d, bfz_d, &
+          rho, dt, n) bind(c, name='rhs_maker_oifs_opencl')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       type(c_ptr), value :: phix_d, phiy_d, phiz_d
+       type(c_ptr), value :: bfx_d, bfy_d, bfz_d
+       reaL(c_rp) :: rho, dt
+       integer(c_int) :: n
+     end subroutine rhs_maker_oifs_opencl
+  end interface 
+
+  interface
+     subroutine scalar_rhs_maker_oifs_opencl(phis_d, bfs_d, rho, dt, n) &
+          bind(c, name='scalar_rhs_maker_oifs_opencl')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       type(c_ptr), value :: phis_d
+       type(c_ptr), value :: bfs_d
+       reaL(c_rp) :: rho, dt
+       integer(c_int) :: n
+     end subroutine scalar_rhs_maker_oifs_opencl
+  end interface  
+
 #endif
 
 contains
@@ -414,5 +495,53 @@ contains
 #endif
 
   end subroutine scalar_rhs_maker_bdf_device
+
+  subroutine rhs_maker_oifs_device(phix, phiy, phiz, bfx, bfy, bfz, &
+                                   rho, dt, n)    
+    real(kind=rp), intent(in) :: rho, dt
+    integer, intent(in) :: n
+    real(kind=rp), intent(inout) :: bfx(n), bfy(n), bfz(n)
+    real(kind=rp), intent(inout) :: phix(n), phiy(n), phiz(n)
+    type(c_ptr) :: bfx_d, bfy_d, bfz_d, phix_d, phiy_d, phiz_d
+
+    bfx_d = device_get_ptr(bfx)
+    bfy_d = device_get_ptr(bfy)
+    bfz_d = device_get_ptr(bfz)
+    phix_d = device_get_ptr(phix)
+    phiy_d = device_get_ptr(phiy)
+    phiz_d = device_get_ptr(phiz)
+
+#ifdef HAVE_HIP
+    call rhs_maker_oif_hip(phix_d, phiy_d, phiz_d, &
+                               bfx_d, bfy_d, bfz_d, rho, dt, n)
+#elif HAVE_CUDA
+    call rhs_maker_oifs_cuda(phix_d, phiy_d, phiz_d, &
+                               bfx_d, bfy_d, bfz_d, rho, dt, n)
+#elif HAVE_OPENCL
+    call rhs_maker_oifs_opencl(phix_d, phiy_d, phiz_d, &
+                               bfx_d, bfy_d, bfz_d, rho, dt, n)
+#endif
+
+  end subroutine rhs_maker_oifs_device
+
+  subroutine scalar_rhs_maker_oifs_device(phis, bfs, rho, dt, n)    
+    real(kind=rp), intent(in) :: rho, dt
+    integer, intent(in) :: n
+    real(kind=rp), intent(inout) :: bfs(n)
+    real(kind=rp), intent(inout) :: phis(n)
+    type(c_ptr) :: bfs_d, phis_d
+
+    bfs_d = device_get_ptr(bfs)
+    phis_d = device_get_ptr(phis)
+
+#ifdef HAVE_HIP
+    call scalar_rhs_maker_oifs_hip(phis_d, bfs_d, rho, dt, n)
+#elif HAVE_CUDA
+    call scalar_rhs_maker_oifs_cuda(phis_d, bfs_d, rho, dt, n)
+#elif HAVE_OPENCL
+    call scalar_rhs_maker_oifs_opencl(phis_d, bfs_d, rho, dt, n)
+#endif
+
+  end subroutine scalar_rhs_maker_oifs_device
 
 end module rhs_maker_device

--- a/src/common/bcknd/sx/rhs_maker_sx.f90
+++ b/src/common/bcknd/sx/rhs_maker_sx.f90
@@ -24,6 +24,12 @@ module rhs_maker_sx
      procedure, nopass :: compute_scalar => scalar_rhs_maker_bdf_sx
   end type rhs_maker_bdf_sx_t
 
+  type, public, extends(rhs_maker_oifs_t) :: rhs_maker_oifs_sx_t
+   contains
+     procedure, nopass :: compute_fluid => rhs_maker_oifs_sx
+     procedure, nopass :: compute_scalar => scalar_rhs_maker_oifs_sx
+  end type rhs_maker_oifs_sx_t
+
 contains
 
   subroutine rhs_maker_sumab_sx(u, v, w, uu, vv, ww, uulag, vvlag, wwlag, ab, nab)
@@ -209,6 +215,37 @@ contains
 
     call neko_scratch_registry%relinquish_field(temp_indices)
   end subroutine scalar_rhs_maker_bdf_sx
+
+  subroutine rhs_maker_oifs_sx(phix, phiy, phiz, bfx, bfy, bfz, &
+       rho, dt, n)
+    real(kind=rp), intent(in) :: rho, dt
+    integer, intent(in) :: n
+    real(kind=rp), intent(inout) :: bfx(n), bfy(n), bfz(n)
+    real(kind=rp), intent(inout) :: phix(n), phiy(n), phiz(n)
+    integer :: i
+
+    do i = 1, n
+       bfx(i) = bfx(i) + phix(i) * (rho / dt) 
+       bfy(i) = bfy(i) + phiy(i) * (rho / dt) 
+       bfz(i) = bfz(i) + phiz(i) * (rho / dt)  
+    end do
+
+
+  end subroutine rhs_maker_oifs_sx
+
+  subroutine scalar_rhs_maker_oifs_sx(phis, bfs, rho, dt, n)
+    real(kind=rp), intent(in) :: rho, dt
+    integer, intent(in) :: n
+    real(kind=rp), intent(inout) :: bfs(n)
+    real(kind=rp), intent(inout) :: phis(n)
+    integer :: i
+    
+    do i = 1, n
+       bfs(i) = bfs(i) + phis(i) * (rho / dt) 
+    end do
+    
+    
+  end subroutine scalar_rhs_maker_oifs_sx
 
 end module rhs_maker_sx
 

--- a/src/common/rhs_maker.f90
+++ b/src/common/rhs_maker.f90
@@ -62,6 +62,13 @@ module rhs_maker
      procedure(scalar_rhs_maker_bdf), nopass, deferred :: compute_scalar
   end type rhs_maker_bdf_t
 
+  !> Abstract type to sum up contributions to kth order extrapolation scheme
+  type, public, abstract :: rhs_maker_oifs_t
+   contains
+     procedure(rhs_maker_oifs), nopass, deferred :: compute_fluid
+     procedure(scalar_rhs_maker_oifs), nopass, deferred :: compute_scalar
+  end type rhs_maker_oifs_t
+
   abstract interface
      subroutine rhs_maker_sumab(u, v, w, uu, vv, ww, uulag, vvlag, wwlag, ab, nab)
        import field_t
@@ -130,6 +137,28 @@ module rhs_maker
        real(kind=rp), intent(in) :: B(n)
        real(kind=rp), intent(in) :: dt, rho, bd(4)
      end subroutine scalar_rhs_maker_bdf
+  end interface
+
+  abstract interface
+     subroutine rhs_maker_oifs(phix, phiy, phiz, bfx, bfy, bfz, &
+          rho, dt, n)
+       import rp
+       real(kind=rp), intent(in) :: rho, dt
+       integer, intent(in) :: n
+       real(kind=rp), intent(inout) :: bfx(n), bfy(n), bfz(n)
+       real(kind=rp), intent(inout) :: phix(n), phiy(n), phiz(n)
+     end subroutine rhs_maker_oifs
+  end interface
+
+  abstract interface
+     subroutine scalar_rhs_maker_oifs(phis, bfs, rho, dt, n)
+       import rp
+       real(kind=rp), intent(in) :: rho, dt
+       integer, intent(in) :: n
+       real(kind=rp), intent(inout) :: bfs(n)
+       real(kind=rp), intent(inout) :: phis(n)
+       
+     end subroutine scalar_rhs_maker_oifs
   end interface
 
 end module rhs_maker

--- a/src/common/rhs_maker_fctry.f90
+++ b/src/common/rhs_maker_fctry.f90
@@ -32,17 +32,17 @@
 !
 !> Fluid abbdf factory for the Pn-Pn formulation
 module rhs_maker_fctry
-  use rhs_maker, only : rhs_maker_bdf_t, rhs_maker_ext_t, rhs_maker_sumab_t
+  use rhs_maker, only : rhs_maker_bdf_t, rhs_maker_ext_t, rhs_maker_sumab_t, rhs_maker_oifs_t
   use rhs_maker_cpu, only : rhs_maker_bdf_cpu_t, rhs_maker_ext_cpu_t, &
-                            rhs_maker_sumab_cpu_t
+                            rhs_maker_sumab_cpu_t, rhs_maker_oifs_cpu_t
   use rhs_maker_sx, only : rhs_maker_bdf_sx_t, rhs_maker_ext_sx_t, &
-                           rhs_maker_sumab_sx_t
+                           rhs_maker_sumab_sx_t, rhs_maker_oifs_sx_t
   use rhs_maker_device
   use neko_config, only : NEKO_BCKND_DEVICE, NEKO_BCKND_SX
   implicit none
   private
 
-  public :: rhs_maker_sumab_fctry, rhs_maker_ext_fctry, rhs_maker_bdf_fctry
+  public :: rhs_maker_sumab_fctry, rhs_maker_ext_fctry, rhs_maker_bdf_fctry, rhs_maker_oifs_fctry
 
 contains
 
@@ -96,5 +96,22 @@ contains
     end if
 
   end subroutine rhs_maker_bdf_fctry
+
+  subroutine rhs_maker_oifs_fctry(makeoifs)
+   class(rhs_maker_oifs_t), allocatable, intent(inout) :: makeoifs
+      
+   if (allocated(makeoifs)) then
+      deallocate(makeoifs)
+   end if
+
+   if (NEKO_BCKND_SX .eq. 1) then
+      allocate(rhs_maker_oifs_sx_t::makeoifs)
+   else if (NEKO_BCKND_DEVICE .eq. 1) then
+      allocate(rhs_maker_oifs_device_t::makeoifs)
+   else       
+      allocate(rhs_maker_oifs_cpu_t::makeoifs)
+   end if
+
+ end subroutine rhs_maker_oifs_fctry
 
 end module rhs_maker_fctry

--- a/src/fluid/advection.f90
+++ b/src/fluid/advection.f90
@@ -59,7 +59,8 @@ module advection
      !! @param Xh The function space.
      !! @param coef The coefficients of the (Xh, mesh) pair.
      !! @param n Typically the size of the mesh.
-     subroutine compute_adv(this, vx, vy, vz, fx, fy, fz, Xh, coef, n)
+     !! @param dt Current time step used in OIFS method.
+     subroutine compute_adv(this, vx, vy, vz, fx, fy, fz, Xh, coef, n, dt)
        import :: advection_t
        import :: coef_t
        import :: space_t
@@ -71,6 +72,7 @@ module advection
        type(field_t), intent(inout) :: vx, vy, vz
        type(field_t), intent(inout) :: fx, fy, fz
        integer, intent(in) :: n
+       real(kind=rp), intent(in), optional :: dt
      end subroutine compute_adv
   end interface
 
@@ -85,7 +87,8 @@ module advection
      !! @param Xh The function space.
      !! @param coef The coefficients of the (Xh, mesh) pair.
      !! @param n Typically the size of the mesh.
-     subroutine compute_scalar_adv(this, vx, vy, vz, s, fs, Xh, coef, n)
+     !! @param dt Current time step used in OIFS method.
+     subroutine compute_scalar_adv(this, vx, vy, vz, s, fs, Xh, coef, n, dt)
        import :: advection_t
        import :: coef_t
        import :: space_t
@@ -98,6 +101,7 @@ module advection
        type(space_t), intent(inout) :: Xh
        type(coef_t), intent(inout) :: coef
        integer, intent(in) :: n
+       real(kind=rp), intent(in), optional :: dt
      end subroutine compute_scalar_adv
   end interface
 

--- a/src/fluid/bcknd/advection/adv_dealias.f90
+++ b/src/fluid/bcknd/advection/adv_dealias.f90
@@ -167,14 +167,15 @@ contains
   !! @param Xh The function space.
   !! @param coef The coefficients of the (Xh, mesh) pair.
   !! @param n Typically the size of the mesh.
-  subroutine compute_advection_dealias(this, vx, vy, vz, fx, fy, fz, Xh, coef, n)
+  subroutine compute_advection_dealias(this, vx, vy, vz, fx, fy, fz, Xh, coef, n, dt)
     class(adv_dealias_t), intent(inout) :: this
     type(space_t), intent(inout) :: Xh
     type(coef_t), intent(inout) :: coef
     type(field_t), intent(inout) :: vx, vy, vz
     type(field_t), intent(inout) :: fx, fy, fz
     integer, intent(in) :: n
-
+    real(kind=rp), intent(in), optional :: dt
+    
     real(kind=rp), dimension(this%Xh_GL%lxyz) :: tx, ty, tz
     real(kind=rp), dimension(this%Xh_GL%lxyz) :: tfx, tfy, tfz
     real(kind=rp), dimension(this%Xh_GL%lxyz) :: vr, vs, vt
@@ -283,7 +284,7 @@ contains
   !! @param coef The coefficients of the (Xh, mesh) pair.
   !! @param n Typically the size of the mesh.
   subroutine compute_scalar_advection_dealias(this, vx, vy, vz, s, fs, Xh, &
-                                              coef, n)
+                                              coef, n, dt)
     class(adv_dealias_t), intent(inout) :: this
     type(field_t), intent(inout) :: vx, vy, vz
     type(field_t), intent(inout) :: s
@@ -291,6 +292,7 @@ contains
     type(space_t), intent(inout) :: Xh
     type(coef_t), intent(inout) :: coef
     integer, intent(in) :: n
+    real(kind=rp), intent(in), optional :: dt
 
     real(kind=rp), dimension(this%Xh_GL%lxyz) :: vx_GL, vy_GL, vz_GL, s_GL
     real(kind=rp), dimension(this%Xh_GL%lxyz) :: dsdx, dsdy, dsdz

--- a/src/fluid/bcknd/advection/adv_no_dealias.f90
+++ b/src/fluid/bcknd/advection/adv_no_dealias.f90
@@ -103,13 +103,14 @@ contains
   !! @param Xh The function space.
   !! @param coef The coefficients of the (Xh, mesh) pair.
   !! @param n Typically the size of the mesh.
-  subroutine compute_advection_no_dealias(this, vx, vy, vz, fx, fy, fz, Xh, coef, n)
+  subroutine compute_advection_no_dealias(this, vx, vy, vz, fx, fy, fz, Xh, coef, n, dt)
     class(adv_no_dealias_t), intent(inout) :: this
     type(space_t), intent(inout) :: Xh
     type(coef_t), intent(inout) :: coef
     type(field_t), intent(inout) :: vx, vy, vz
     type(field_t), intent(inout) :: fx, fy, fz
     integer, intent(in) :: n
+    real(kind=rp), intent(in), optional :: dt
 
     if (NEKO_BCKND_DEVICE .eq. 1) then
 
@@ -150,7 +151,7 @@ contains
   !! @param coef The coefficients of the (Xh, mesh) pair.
   !! @param n Typically the size of the mesh.
   subroutine compute_scalar_advection_no_dealias(this, vx, vy, vz, s, fs, Xh, &
-                                                 coef, n)
+                                                 coef, n, dt)
     class(adv_no_dealias_t), intent(inout) :: this
     type(field_t), intent(inout) :: vx, vy, vz
     type(field_t), intent(inout) :: s
@@ -158,6 +159,7 @@ contains
     type(space_t), intent(inout) :: Xh
     type(coef_t), intent(inout) :: coef
     integer, intent(in) :: n
+    real(kind=rp), intent(in), optional :: dt
 
     if (NEKO_BCKND_DEVICE .eq. 1) then
 

--- a/src/fluid/bcknd/advection/adv_oifs.f90
+++ b/src/fluid/bcknd/advection/adv_oifs.f90
@@ -1,0 +1,403 @@
+! Copyright (c) 2021-2024, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Subroutines to add advection terms to the RHS of a transport equation.
+module adv_oifs
+  use advection, only: advection_t
+  use num_types, only: rp
+  use space, only: space_t, GL
+  use field, only: field_t
+  use coefs, only: coef_t
+  use math
+  use operators, only: runge_kutta, set_convect_new
+  use neko_config, only: NEKO_BCKND_DEVICE, NEKO_BCKND_SX, NEKO_BCKND_XSMM, &
+    NEKO_BCKND_OPENCL, NEKO_BCKND_CUDA, NEKO_BCKND_HIP
+  use interpolation, only: interpolator_t
+  use time_interpolator, only: time_interpolator_t
+  use field_series, only: field_series_t
+  use time_scheme_controller, only: time_scheme_controller_t
+  use device, only: device_map, device_get_ptr
+  use, intrinsic :: iso_c_binding, only: c_ptr, C_NULL_PTR
+  implicit none
+  private
+
+  !> Type encapsulating advection routines with dealiasing
+  !> Type encapsulating operator-integration-factor splitting advection routines with no dealiasing applied
+  type, public, extends(advection_t) :: adv_oifs_t
+     !> Number of RK4 sub-steps
+     integer :: ntaubd 
+     !> Coeffs of the higher-order space
+     type(coef_t) :: coef_GL
+     !> Coeffs of the original space in the simulation
+     type(coef_t), pointer :: coef_GLL
+     !> Interpolator between the original and higher-order spaces
+     type(interpolator_t) :: GLL_to_GL
+     !> The additional higher-order space used in dealiasing
+     type(space_t) :: Xh_GL
+     !> The original space used in the simulation
+     type(space_t), pointer :: Xh_GLL
+     !> The time interpolator scheme
+     type(time_interpolator_t) :: dtime
+     !> The lagged velocity and scalar fields
+     type(field_series_t), pointer :: ulag, vlag, wlag, slag
+     !> The times corresponding to the lagged fields
+     real(kind=rp), pointer :: ctlag(:)
+     !> The time-steps corresponding to the lagged fields
+     real(kind=rp), pointer :: dctlag(:)
+     !> The time scheme controller for the oifs scheme
+     type(time_scheme_controller_t), pointer :: oifs_scheme
+     !> The convecting velocity field in GLL space
+     real(kind=rp), allocatable :: cx(:), cy(:), cz(:)
+     !> The convecting field in GL space
+     real(kind=rp), allocatable :: c(:,:)
+     !> Device pointer for `cx`
+     type(c_ptr) :: cx_d = C_NULL_PTR
+     !> Device pointer for `cy`
+     type(c_ptr) :: cy_d = C_NULL_PTR
+     !> Device pointer for `cz`
+     type(c_ptr) :: cz_d = C_NULL_PTR
+     !> Device pointer for `c`
+     type(c_ptr) :: c_d = C_NULL_PTR     
+   contains
+     !> Add the advection term for the fluid, i.e. \f$u \cdot \nabla u \f$, to
+     !! the RHS
+     procedure, pass(this) :: compute => compute_adv_oifs
+     !> Add the advection term for a scalar, i.e. \f$u \cdot \nabla s \f$, to
+     !! the RHS
+     procedure, pass(this) :: compute_scalar => &
+          compute_scalar_adv_oifs
+     !> Constructor
+     procedure, pass(this) :: init => init_oifs
+     !> setting characteristic convecting field
+     procedure, pass(this) :: set_conv_char_fst
+     !> Destructor
+     procedure, pass(this) :: free => free_oifs
+  end type adv_oifs_t
+
+contains
+
+  !> Constructor
+  !! @param lxd The polynomial order of the space used in the dealiasing.
+  !! @param coef The coefficients of the (space, mesh) pair.
+  subroutine init_oifs(this, lxd, coef, ctarget, ulag, vlag, wlag, dtlag, tlag, time_scheme, slag)
+    implicit none
+    class(adv_oifs_t) :: this
+    integer, intent(in) :: lxd
+    type(coef_t), target :: coef
+    real(kind=rp), intent(in) :: ctarget
+    type(field_series_t), target, intent(in) :: ulag, vlag, wlag
+    real(kind=rp), target, intent(in) :: dtlag(10)
+    real(kind=rp), target, intent(in) :: tlag(10)
+    type(time_scheme_controller_t), target, intent(in):: time_scheme
+    type(field_series_t), target, optional :: slag
+    integer :: nel, n_GL, n_GL_t, n, idx, idy, idz
+    real(kind=rp) :: max_cfl_rk4
+    
+    ! stability limit for RK4 including safety factor
+    max_cfl_rk4 = 2.0
+    this%ntaubd = max(int(ctarget/max_cfl_rk4),1)
+
+    call this%Xh_GL%init(GL, lxd, lxd, lxd)
+    this%Xh_GLL => coef%Xh
+    this%coef_GLL => coef
+    call this%GLL_to_GL%init(this%Xh_GL, this%Xh_GLL)
+
+    call this%coef_GL%init(this%Xh_GL, coef%msh)
+
+    nel = coef%msh%nelv
+    n_GL = nel*this%Xh_GL%lxyz
+    n = nel*coef%Xh%lxyz
+    n_GL_t = 3 * n_GL
+
+    idx = 1
+    idy = idx + n_GL
+    idz = idy + n_GL
+
+
+    call this%GLL_to_GL%map(this%coef_GL%drdx, coef%drdx, nel, this%Xh_GL)
+    call this%GLL_to_GL%map(this%coef_GL%dsdx, coef%dsdx, nel, this%Xh_GL)
+    call this%GLL_to_GL%map(this%coef_GL%dtdx, coef%dtdx, nel, this%Xh_GL)
+    call this%GLL_to_GL%map(this%coef_GL%drdy, coef%drdy, nel, this%Xh_GL)
+    call this%GLL_to_GL%map(this%coef_GL%dsdy, coef%dsdy, nel, this%Xh_GL)
+    call this%GLL_to_GL%map(this%coef_GL%dtdy, coef%dtdy, nel, this%Xh_GL)
+    call this%GLL_to_GL%map(this%coef_GL%drdz, coef%drdz, nel, this%Xh_GL)
+    call this%GLL_to_GL%map(this%coef_GL%dsdz, coef%dsdz, nel, this%Xh_GL)
+    call this%GLL_to_GL%map(this%coef_GL%dtdz, coef%dtdz, nel, this%Xh_GL)
+
+    allocate(this%cx(n_GL))
+    allocate(this%cy(n_GL))
+    allocate(this%cz(n_GL))
+    allocate(this%c(n_GL_t, 3))
+    
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_map(this%cx, this%cx_d, n_GL)
+       call device_map(this%cy, this%cy_d, n_GL)
+       call device_map(this%cz, this%cz_d, n_GL)
+       call device_map(this%c, this%c_d, 3 * n_GL_t)
+    end if
+
+    call this%dtime%init(1)
+    this%ulag => ulag
+    this%vlag => vlag
+    this%wlag => wlag
+    this%ctlag => tlag
+    this%dctlag => dtlag
+    this%oifs_scheme => time_scheme
+
+    ! Initializing the convecting fields
+    ! Map the velocity fields from GLL space to GL space
+    call this%GLL_to_GL%map(this%cx, this%ulag%f%x, nel, this%Xh_GL)
+    call this%GLL_to_GL%map(this%cy, this%vlag%f%x, nel, this%Xh_GL)
+    call this%GLL_to_GL%map(this%cz, this%wlag%f%x, nel, this%Xh_GL)
+   
+    ! Set the convecting field in the rst format
+    call set_convect_new(this%c(idx,1), this%c(idy,1), this%c(idz,1), &
+                         this%cx, this%cy, this%cz, this%Xh_GL, this%coef_GL) 
+
+    call this%GLL_to_GL%map(this%cx, this%ulag%lf(1)%x, nel, this%Xh_GL)
+    call this%GLL_to_GL%map(this%cy, this%vlag%lf(1)%x, nel, this%Xh_GL)
+    call this%GLL_to_GL%map(this%cz, this%wlag%lf(1)%x, nel, this%Xh_GL)
+
+    call set_convect_new(this%c(idx,2), this%c(idy,2), this%c(idz,2), &
+                         this%cx, this%cy, this%cz, this%Xh_GL, this%coef_GL)  
+
+    call this%GLL_to_GL%map(this%cx, this%ulag%lf(2)%x, nel, this%Xh_GL)
+    call this%GLL_to_GL%map(this%cy, this%vlag%lf(2)%x, nel, this%Xh_GL)
+    call this%GLL_to_GL%map(this%cz, this%wlag%lf(2)%x, nel, this%Xh_GL)
+
+    call set_convect_new(this%c(idx,3), this%c(idy,3), this%c(idz,3), &
+                         this%cx, this%cy, this%cz, this%Xh_GL, this%coef_GL) 
+
+
+    if (present(slag)) then
+      this%slag => slag
+    end if
+    
+  end subroutine init_oifs
+
+  !> Destructor
+  subroutine free_oifs(this)
+    class(adv_oifs_t), intent(inout) :: this
+  end subroutine free_oifs
+
+  !> Mapping the velocity fields to GL space and transforming them to the rst format
+  !! @param u Velocity component in x-direction
+  !! @param v Velocity component in y-direction
+  !! @param w Velocity component in z-direction
+  !! @note similar to set_ct_cvx in NEK5000
+  subroutine set_conv_char_fst(this, u, v, w)
+    implicit none
+    class(adv_oifs_t), intent(inout) :: this
+    type(field_t), intent(inout) :: u, v, w
+    integer :: i, nel, n_GL, n_GL_t, idx, idy, idz
+
+    nel = this%coef_GLL%msh%nelv
+    n_GL = nel*this%Xh_GL%lxyz
+    n_GL_t = 3 * n_GL
+    call copy(this%c(:,3), this%c(:,2), n_GL_t)
+    call copy(this%c(:,2), this%c(:,1), n_GL_t)
+
+    call this%GLL_to_GL%map(this%cx, u%x, nel, this%Xh_GL)
+    call this%GLL_to_GL%map(this%cy, v%x, nel, this%Xh_GL)
+    call this%GLL_to_GL%map(this%cz, w%x, nel, this%Xh_GL)
+    
+    idx = 1
+    idy = idx + n_GL
+    idz = idy + n_GL
+
+    call set_convect_new(this%c(idx,1), this%c(idy,1), this%c(idz,1), &
+                         this%cx, this%cy, this%cz, this%Xh_GL, this%coef_GL) 
+
+  end subroutine set_conv_char_fst
+
+
+  !> Add the advection term for the fluid, i.e. \f$u \cdot \nabla u \f$, to
+  !! the RHS using the OIFS method.
+  !! @param vx The x component of velocity.
+  !! @param vy The y component of velocity.
+  !! @param vz The z component of velocity.
+  !! @param fx The x component of source term.
+  !! @param fy The y component of source term.
+  !! @param fz The z component of source term.
+  !! @param Xh The function space.
+  !! @param coef The coefficients of the (Xh, mesh) pair.
+  !! @param n Typically the size of the mesh.
+  !! @param dt Current time-step
+  subroutine compute_adv_oifs(this, vx, vy, vz, fx, fy, fz, Xh, coef, n, dt)
+    implicit none
+    class(adv_oifs_t), intent(inout) :: this
+    type(field_t), intent(inout) :: vx, vy, vz
+    type(field_t), intent(inout) :: fx, fy, fz
+    type(space_t), intent(inout) :: Xh
+    type(coef_t), intent(inout) :: coef
+    integer, intent(in) :: n
+    real(kind=rp), intent(in), optional :: dt
+    real(kind=rp) :: tau, tau1, th, dtau
+    integer :: i, ilag, itau, nel, n_GL, n_GL_t
+    real(kind=rp), dimension(3 * coef%msh%nelv * this%Xh_GL%lxyz) ::  c_r1, c_r23, c_r4
+    nel = coef%msh%nelv
+    n_GL = nel * this%Xh_GL%lxyz
+    n_GL_t = 3 * n_GL
+
+    associate(ulag => this%ulag, vlag => this%vlag, wlag => this%wlag, &
+      ctlag => this%ctlag, dctlag => this%dctlag, dtime => this%dtime, & 
+      oifs_scheme => this%oifs_scheme, ntaubd => this%ntaubd, c => this%c)
+
+      call dtime%init(oifs_scheme%ndiff)
+
+      tau = ctlag(oifs_scheme%ndiff)
+
+      call rzero(fx%x,n)
+      call rzero(fy%x,n)
+      call rzero(fz%x,n)
+
+      call this%set_conv_char_fst(vx, vy, vz)
+
+      do ilag = oifs_scheme%ndiff, 1, -1
+
+
+         if (ilag.eq.1) then
+            do i = 1, n
+               fx%x(i, 1, 1, 1) = fx%x(i, 1, 1, 1) + oifs_scheme%diffusion_coeffs(2) * vx%x(i,1,1,1) * coef%B(i,1,1,1)
+               fy%x(i, 1, 1, 1) = fy%x(i, 1, 1, 1) + oifs_scheme%diffusion_coeffs(2) * vy%x(i,1,1,1) * coef%B(i,1,1,1)
+               fz%x(i, 1, 1, 1) = fz%x(i, 1, 1, 1) + oifs_scheme%diffusion_coeffs(2) * vz%x(i,1,1,1) * coef%B(i,1,1,1)
+            end do
+         else
+            do i = 1, n
+               fx%x(i, 1, 1, 1) = fx%x(i, 1, 1, 1) + &
+                                  oifs_scheme%diffusion_coeffs(ilag+1) * ulag%lf(ilag-1)%x(i,1,1,1) * coef%B(i,1,1,1)
+               fy%x(i, 1, 1, 1) = fy%x(i, 1, 1, 1) + &
+                                  oifs_scheme%diffusion_coeffs(ilag+1) * vlag%lf(ilag-1)%x(i,1,1,1) * coef%B(i,1,1,1)
+               fz%x(i, 1, 1, 1) = fz%x(i, 1, 1, 1) + &
+                                  oifs_scheme%diffusion_coeffs(ilag+1) * wlag%lf(ilag-1)%x(i,1,1,1) * coef%B(i,1,1,1)
+            end do
+         end if
+                  
+         if (dctlag(ilag).lt.1e-10) then 
+            dtau = dt/real(ntaubd)
+         else
+            dtau = dctlag(ilag)/real(ntaubd)
+         end if
+         do itau = 1, ntaubd
+            th = tau + dtau/2.
+            tau1 = tau + dtau
+            call dtime%interpolate_velocity(tau, c_r1, c, ctlag, n_GL_t) 
+            call dtime%interpolate_velocity(th, c_r23, c, ctlag, n_GL_t) 
+            call dtime%interpolate_velocity(tau1, c_r4, c, ctlag, n_GL_t) 
+            call runge_kutta(fx%x, c_r1, c_r23, c_r4, Xh, this%Xh_GL, coef, this%coef_GL, &
+                             this%GLL_to_GL, tau, dtau, n, nel, n_GL)
+            call runge_kutta(fy%x, c_r1, c_r23, c_r4, Xh, this%Xh_GL, coef, this%coef_GL, &
+                             this%GLL_to_GL, tau, dtau, n, nel, n_GL)
+            call runge_kutta(fz%x, c_r1, c_r23, c_r4, Xh, this%Xh_GL, coef, this%coef_GL, &
+                             this%GLL_to_GL, tau, dtau, n, nel, n_GL)
+            tau = tau1
+         end do
+      end do
+    end associate
+
+
+  end subroutine compute_adv_oifs
+  !> Add the advection term for a scalar, i.e. \f$u \cdot \nabla s \f$, to the
+  !! RHS.
+  !! @param this The object.
+  !! @param vx The x component of velocity.
+  !! @param vy The y component of velocity.
+  !! @param vz The z component of velocity.
+  !! @param s The scalar.
+  !! @param fs The source term.
+  !! @param Xh The function space.
+  !! @param coef The coefficients of the (Xh, mesh) pair.
+  !! @param n Typically the size of the mesh.
+  !! @param dt Current time-step
+  subroutine compute_scalar_adv_oifs(this, vx, vy, vz, s, fs, Xh, coef, n, dt)
+    implicit none
+    class(adv_oifs_t), intent(inout) :: this
+    type(field_t), intent(inout) :: vx, vy, vz
+    type(field_t), intent(inout) :: fs
+    type(field_t), intent(inout) :: s
+    type(space_t), intent(inout) :: Xh
+    type(coef_t), intent(inout) :: coef
+    integer, intent(in) :: n
+    real(kind=rp), intent(in), optional :: dt
+    real(kind=rp) :: tau, tau1, th, dtau
+    integer :: i, ilag, itau, nel, n_GL, n_GL_t
+    real(kind=rp), dimension(3 * coef%msh%nelv * this%Xh_GL%lxyz) ::  c_r1, c_r23, c_r4
+    nel = coef%msh%nelv
+    n_GL = nel * this%Xh_GL%lxyz
+    n_GL_t = 3 * n_GL
+
+    associate(slag => this%slag, ctlag => this%ctlag, &
+      dctlag => this%dctlag, dtime => this%dtime, & 
+      oifs_scheme => this%oifs_scheme, ntaubd => this%ntaubd, c => this%c)
+
+      call dtime%init(oifs_scheme%ndiff)
+
+      tau = ctlag(oifs_scheme%ndiff)
+
+      call rzero(fs%x,n)
+
+      call this%set_conv_char_fst(vx, vy, vz)
+
+      do ilag = oifs_scheme%ndiff, 1, -1
+         if (ilag.eq.1) then
+            do i = 1, n
+               fs%x(i,1,1,1) = fs%x(i,1,1,1) + oifs_scheme%diffusion_coeffs(2) * s%x(i,1,1,1) * coef%B(i,1,1,1)
+            end do
+         else
+            do i = 1, n
+               fs%x(i,1,1,1) = fs%x(i,1,1,1) + &
+                               oifs_scheme%diffusion_coeffs(ilag+1) * slag%lf(ilag-1)%x(i,1,1,1) * coef%B(i,1,1,1)
+            end do
+         end if
+                  
+         if (dctlag(ilag).lt.1e-10) then 
+            dtau = dt/real(ntaubd)
+         else
+            dtau = dctlag(ilag)/real(ntaubd)
+         end if
+         do itau = 1, ntaubd
+            th = tau + dtau/2.
+            tau1 = tau + dtau
+            call dtime%interpolate_velocity(tau, c_r1, c, ctlag, n_GL_t) 
+            call dtime%interpolate_velocity(th, c_r23, c, ctlag, n_GL_t) 
+            call dtime%interpolate_velocity(tau1, c_r4, c, ctlag, n_GL_t) 
+            call runge_kutta(fs%x, c_r1, c_r23, c_r4, Xh, this%Xh_GL, coef, this%coef_GL, &
+                             this%GLL_to_GL, tau, dtau, n, nel, n_GL)
+            tau = tau1
+         end do
+      end do
+      
+    end associate
+
+  end subroutine compute_scalar_adv_oifs
+
+end module adv_oifs

--- a/src/fluid/bcknd/device/fluid_abbdf_device.F90
+++ b/src/fluid/bcknd/device/fluid_abbdf_device.F90
@@ -53,6 +53,11 @@ module rhs_maker_device
      procedure, nopass :: compute_fluid => rhs_maker_bdf_device
   end type rhs_maker_bdf_device_t
 
+  type, public, extends(rhs_maker_oifs_t) :: rhs_maker_oifs_device_t
+   contains
+     procedure, nopass :: compute_fluid => rhs_maker_oifs_device
+  end type rhs_maker_oifs_device_t
+
 #ifdef HAVE_HIP
   interface
      subroutine rhs_maker_sumab_hip(u_d, v_d, w_d, uu_d, vv_d, ww_d, &
@@ -96,6 +101,19 @@ module rhs_maker_device
        integer(c_int) :: nbd, n
      end subroutine rhs_maker_bdf_hip
   end interface
+
+  interface
+     subroutine rhs_maker_oifs_hip(phix_d, phiy_d, phiz_d, bfx_d, bfy_d, bfz_d, &
+          rho, dt, n) bind(c, name='rhs_maker_oifs_hip')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       type(c_ptr), value :: phix_d, phiy_d, phiz_d
+       type(c_ptr), value :: bfx_d, bfy_d, bfz_d
+       reaL(c_rp) :: rho, dt
+       integer(c_int) :: n
+     end subroutine rhs_maker_oifs_hip
+  end interface 
+
 #elif HAVE_CUDA
   interface
      subroutine rhs_maker_sumab_cuda(u_d, v_d, w_d, uu_d, vv_d, ww_d, &
@@ -139,6 +157,19 @@ module rhs_maker_device
        integer(c_int) :: nbd, n
      end subroutine rhs_maker_bdf_cuda
   end interface
+
+  interface
+     subroutine rhs_maker_oifs_cuda(phix_d, phiy_d, phiz_d, bfx_d, bfy_d, bfz_d, &
+          rho, dt, n) bind(c, name='rhs_maker_oifs_cuda')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       type(c_ptr), value :: phix_d, phiy_d, phiz_d
+       type(c_ptr), value :: bfx_d, bfy_d, bfz_d
+       reaL(c_rp) :: rho, dt
+       integer(c_int) :: n
+     end subroutine rhs_maker_oifs_cuda
+  end interface 
+
 #elif HAVE_OPENCL
   interface
      subroutine rhs_maker_sumab_opencl(u_d, v_d, w_d, uu_d, vv_d, ww_d, &
@@ -182,6 +213,19 @@ module rhs_maker_device
        integer(c_int) :: nbd, n
      end subroutine rhs_maker_bdf_opencl
   end interface
+
+  interface
+     subroutine rhs_maker_oifs_opencl(phix_d, phiy_d, phiz_d, bfx_d, bfy_d, bfz_d, &
+          rho, dt, n) bind(c, name='rhs_maker_oifs_opencl')
+       use, intrinsic :: iso_c_binding
+       import c_rp
+       type(c_ptr), value :: phix_d, phiy_d, phiz_d
+       type(c_ptr), value :: bfx_d, bfy_d, bfz_d
+       reaL(c_rp) :: rho, dt
+       integer(c_int) :: n
+     end subroutine rhs_maker_oifs_opencl
+  end interface 
+
 #endif
 
 contains
@@ -285,5 +329,33 @@ contains
 #endif
 
   end subroutine rhs_maker_bdf_device
+
+  subroutine rhs_maker_oifs_device(phix, phiy, phiz, bfx, bfy, bfz, &
+                                   rho, dt, n)    
+    real(kind=rp), intent(in) :: rho, dt
+    integer, intent(in) :: n
+    real(kind=rp), intent(inout) :: bfx(n), bfy(n), bfz(n)
+    real(kind=rp), intent(inout) :: phix(n), phiy(n), phiz(n)
+    type(c_ptr) :: bfx_d, bfy_d, bfz_d, phix_d, phiy_d, phiz_d
+
+    bfx_d = device_get_ptr(bfx)
+    bfy_d = device_get_ptr(bfy)
+    bfz_d = device_get_ptr(bfz)
+    phix_d = device_get_ptr(phix)
+    phiy_d = device_get_ptr(phiy)
+    phiz_d = device_get_ptr(phiz)
+
+#ifdef HAVE_HIP
+    call rhs_maker_oif_hip(phix_d, phiy_d, phiz_d, &
+                               bfx_d, bfy_d, bfz_d, rho, dt, n)
+#elif HAVE_CUDA
+    call rhs_maker_oifs_cuda(phix_d, phiy_d, phiz_d, &
+                               bfx_d, bfy_d, bfz_d, rho, dt, n)
+#elif HAVE_OPENCL
+    call rhs_maker_oifs_opencl(phix_d, phiy_d, phiz_d, &
+                               bfx_d, bfy_d, bfz_d, rho, dt, n)
+#endif
+
+  end subroutine rhs_maker_oifs_device
 
 end module rhs_maker_device

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -38,8 +38,9 @@ module fluid_pnpn
   use pnpn_residual, only : pnpn_prs_res_t, pnpn_vel_res_t
   use ax_helm_fctry, only : ax_helm_factory
   use rhs_maker_fctry, only : rhs_maker_sumab_fctry, rhs_maker_bdf_fctry, &
-                              rhs_maker_ext_fctry
-  use rhs_maker, only : rhs_maker_sumab_t, rhs_maker_bdf_t, rhs_maker_ext_t
+                              rhs_maker_ext_fctry, rhs_maker_oifs_fctry
+  use rhs_maker, only : rhs_maker_sumab_t, rhs_maker_bdf_t, rhs_maker_ext_t, &
+                        rhs_maker_oifs_t
   use fluid_volflow, only : fluid_volflow_t
   use fluid_scheme, only : fluid_scheme_t
   use field_series, only : field_series_t
@@ -52,7 +53,7 @@ module fluid_pnpn
   use logger, only : neko_log
   use advection, only : advection_t
   use profiler, only : profiler_start_region, profiler_end_region
-  use json_utils, only : json_get
+  use json_utils, only : json_get, json_get_or_default
   use json_module, only : json_file
   use material_properties, only : material_properties_t
   use advection_fctry, only : advection_factory
@@ -103,9 +104,14 @@ module fluid_pnpn
 
      class(advection_t), allocatable :: adv
 
+     ! Time interpolation scheme
+     logical :: oifs
+
      ! Time variables
      type(field_t) :: abx1, aby1, abz1
      type(field_t) :: abx2, aby2, abz2
+     ! Advection terms for the oifs method
+     type(field_t) :: advx, advy, advz
 
      !> Pressure residual
      class(pnpn_prs_res_t), allocatable :: prs_res
@@ -121,6 +127,8 @@ module fluid_pnpn
 
      !> Contributions to F from lagged BD terms
      class(rhs_maker_bdf_t), allocatable :: makebdf
+     !> Contributions for the operator-integrator factoring scheme
+     class(rhs_maker_oifs_t), allocatable :: makef
 
      !> Adjust flow volume
      type(fluid_volflow_t) :: vol_flow
@@ -134,13 +142,14 @@ module fluid_pnpn
 
 contains
 
-  subroutine fluid_pnpn_init(this, msh, lx, params, user, material_properties)
+  subroutine fluid_pnpn_init(this, msh, lx, params, user, material_properties, time_scheme)
     class(fluid_pnpn_t), target, intent(inout) :: this
     type(mesh_t), target, intent(inout) :: msh
     integer, intent(inout) :: lx
     type(json_file), target, intent(inout) :: params
     type(user_t), intent(in) :: user
     type(material_properties_t), target, intent(inout) :: material_properties
+    type(time_scheme_controller_t), target, intent(in):: time_scheme
     character(len=15), parameter :: scheme = 'Modular (Pn/Pn)'
 
     call this%free()
@@ -167,6 +176,9 @@ contains
     ! Setup backend depenent contributions to F from lagged BD terms
     call rhs_maker_bdf_fctry(this%makebdf)
 
+    ! Setup backend dependent summations of the operator-integrator-factoring scheme
+    call rhs_maker_oifs_fctry(this%makef)
+
     ! Initialize variables specific to this plan
     associate(Xh_lx => this%Xh%lx, Xh_ly => this%Xh%ly, Xh_lz => this%Xh%lz, &
          dm_Xh => this%dm_Xh, nelv => this%msh%nelv)
@@ -181,12 +193,18 @@ contains
       call this%abx2%init(dm_Xh, "abx2")
       call this%aby2%init(dm_Xh, "aby2")
       call this%abz2%init(dm_Xh, "abz2")
+      call this%advx%init(dm_Xh, "advx")
+      call this%advy%init(dm_Xh, "advy")
+      call this%advz%init(dm_Xh, "advz")
       this%abx1 = 0.0_rp
       this%aby1 = 0.0_rp
       this%abz1 = 0.0_rp
       this%abx2 = 0.0_rp
       this%aby2 = 0.0_rp
       this%abz2 = 0.0_rp
+      this%advx = 0.0_rp
+      this%advy = 0.0_rp
+      this%advz = 0.0_rp
 
       call this%du%init(dm_Xh, 'du')
       call this%dv%init(dm_Xh, 'dv')
@@ -306,7 +324,13 @@ contains
     ! Add lagged term to checkpoint
     call this%chkp%add_lag(this%ulag, this%vlag, this%wlag)
 
-    call advection_factory(this%adv, params, this%c_Xh)
+    ! Determine the time-interpolation scheme
+    call json_get_or_default(params, 'case.numerics.oifs', this%oifs, .false.)
+
+
+    call advection_factory(this%adv, params, this%c_Xh, &
+                           this%ulag, this%vlag, this%wlag, &
+                           this%chkp%dtlag, this%chkp%tlag, time_scheme)
 
     if (params%valid_path('case.fluid.flow_rate_force')) then
        call this%vol_flow%init(this%dm_Xh, params)
@@ -371,6 +395,12 @@ contains
          call device_memcpy(this%abz1%x, this%abz1%x_d, &
                             w%dof%size(), HOST_TO_DEVICE, sync=.false.)
          call device_memcpy(this%abz2%x, this%abz2%x_d, &
+                            w%dof%size(), HOST_TO_DEVICE, sync=.false.)
+         call device_memcpy(this%advx%x, this%advx%x_d, &
+                            w%dof%size(), HOST_TO_DEVICE, sync=.false.)
+         call device_memcpy(this%advy%x, this%advy%x_d, &
+                            w%dof%size(), HOST_TO_DEVICE, sync=.false.)
+         call device_memcpy(this%advz%x, this%advz%x_d, &
                             w%dof%size(), HOST_TO_DEVICE, sync=.false.)
        end associate
     end if
@@ -471,6 +501,10 @@ contains
     call this%aby2%free()
     call this%abz2%free()
 
+    call this%advx%free()
+    call this%advy%free()
+    call this%advz%free()
+
     if (allocated(this%Ax)) then
        deallocate(this%Ax)
     end if
@@ -493,6 +527,10 @@ contains
 
     if (allocated(this%makebdf)) then
        deallocate(this%makebdf)
+    end if
+
+    if (allocated(this%makef)) then
+      deallocate(this%makef)
     end if
 
     call this%vol_flow%free()
@@ -533,13 +571,14 @@ contains
          c_Xh => this%c_Xh, dm_Xh => this%dm_Xh, gs_Xh => this%gs_Xh, &
          ulag => this%ulag, vlag => this%vlag, wlag => this%wlag, &
          msh => this%msh, prs_res => this%prs_res, &
-         source_term => this%source_term, &
-         vel_res => this%vel_res, sumab => this%sumab, &
+         source_term => this%source_term, vel_res => this%vel_res, &
+         sumab => this%sumab, makef => this%makef, &
          makeabf => this%makeabf, makebdf => this%makebdf, &
          vel_projection_dim => this%vel_projection_dim, &
          pr_projection_dim => this%pr_projection_dim, &
-         rho => this%rho, mu => this%mu, &
+         rho => this%rho, mu => this%mu, oifs => this%oifs, &
          f_x => this%f_x, f_y => this%f_y, f_z => this%f_z, &
+         advx => this%advx, advy => this%advy, advz => this%advz, &
          if_variable_dt => dt_controller%if_variable_dt, &
          dt_last_change => dt_controller%dt_last_change)
 
@@ -559,25 +598,48 @@ contains
       else
          call opcolv(f_x%x, f_y%x, f_z%x, c_Xh%B, msh%gdim, n)
       end if
+      
 
-      ! Add the advection operators to the right-hand-side.
-      call this%adv%compute(u, v, w, &
-                            f_x, f_y, f_z, &
-                            Xh, this%c_Xh, dm_Xh%size())
+      if (oifs) then
+         ! Add the advection operators to the right-hand-side.
+         call this%adv%compute(u, v, w, &
+                               advx, advy, advz, &
+                               Xh, this%c_Xh, dm_Xh%size(), dt)
 
-      ! At this point the RHS contains the sum of the advection operator and
-      ! additional source terms, evaluated using the velocity field from the
-      ! previous time-step. Now, this value is used in the explicit time
-      ! scheme to advance both terms in time.
-      call makeabf%compute_fluid(this%abx1, this%aby1, this%abz1,&
-                           this%abx2, this%aby2, this%abz2, &
-                           f_x%x, f_y%x, f_z%x, &
-                           rho, ext_bdf%advection_coeffs, n)
+         ! At this point the RHS contains the sum of the advection operator and
+         ! additional source terms, evaluated using the velocity field from the
+         ! previous time-step. Now, this value is used in the explicit time
+         ! scheme to advance both terms in time. 
+         call makeabf%compute_fluid(this%abx1, this%aby1, this%abz1,&
+                                    this%abx2, this%aby2, this%abz2, &
+                                    f_x%x, f_y%x, f_z%x, &
+                                    rho, ext_bdf%advection_coeffs, n)
 
-      ! Add the RHS contributions coming from the BDF scheme.
-      call makebdf%compute_fluid(ulag, vlag, wlag, f_x%x, f_y%x, f_z%x, &
-                           u, v, w, c_Xh%B, rho, dt, &
-                           ext_bdf%diffusion_coeffs, ext_bdf%ndiff, n)
+         ! Now, the source terms from the previous time step are added to the RHS.
+         call makef%compute_fluid(advx%x, advy%x, advz%x, &
+                                  f_x%x, f_y%x, f_z%x, &
+                                  rho, dt, n)
+      else
+
+        ! Add the advection operators to the right-hand-side.
+         call this%adv%compute(u, v, w, &
+                               f_x, f_y, f_z, &
+                               Xh, this%c_Xh, dm_Xh%size())
+
+         ! At this point the RHS contains the sum of the advection operator and
+         ! additional source terms, evaluated using the velocity field from the
+         ! previous time-step. Now, this value is used in the explicit time
+         ! scheme to advance both terms in time.
+         call makeabf%compute_fluid(this%abx1, this%aby1, this%abz1,&
+                              this%abx2, this%aby2, this%abz2, &
+                              f_x%x, f_y%x, f_z%x, &
+                              rho, ext_bdf%advection_coeffs, n)
+
+         ! Add the RHS contributions coming from the BDF scheme.
+         call makebdf%compute_fluid(ulag, vlag, wlag, f_x%x, f_y%x, f_z%x, &
+                              u, v, w, c_Xh%B, rho, dt, &
+                              ext_bdf%diffusion_coeffs, ext_bdf%ndiff, n)
+      end if
 
       call ulag%update()
       call vlag%update()

--- a/src/fluid/fluid_scheme.f90
+++ b/src/fluid/fluid_scheme.f90
@@ -151,18 +151,20 @@ module fluid_scheme
   !> Abstract interface to initialize a fluid formulation
   abstract interface
      subroutine fluid_scheme_init_intrf(this, msh, lx, params, user, &
-                                        material_properties)
+                                        material_properties, time_scheme)
        import fluid_scheme_t
        import json_file
        import mesh_t
        import user_t
        import material_properties_t
+       import time_scheme_controller_t
        class(fluid_scheme_t), target, intent(inout) :: this
        type(mesh_t), target, intent(inout) :: msh
        integer, intent(inout) :: lx
        type(json_file), target, intent(inout) :: params
        type(user_t), intent(in) :: user
        type(material_properties_t), target, intent(inout) :: material_properties
+       type(time_scheme_controller_t), target, intent(in):: time_scheme
      end subroutine fluid_scheme_init_intrf
   end interface
 

--- a/src/math/bcknd/cpu/conv_fst_3d.f90
+++ b/src/math/bcknd/cpu/conv_fst_3d.f90
@@ -1,0 +1,639 @@
+! Copyright (c) 2021, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> 
+module cpu_conv_fst_3d
+  use num_types, only : rp
+  use coefs, only : coef_t
+  use space, only : space_t
+  use interpolation
+  use math
+  use gather_scatter 
+  use mxm_wrapper  
+  implicit none
+
+contains
+
+  subroutine cpu_conv_fst_3d_lx(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv, lx)
+    integer, intent(in) :: nelv, lx
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+
+  end subroutine cpu_conv_fst_3d_lx
+
+  subroutine cpu_conv_fst_3d_lx18(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 18
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+
+  end subroutine cpu_conv_fst_3d_lx18
+
+  subroutine cpu_conv_fst_3d_lx17(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 17
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+
+  end subroutine cpu_conv_fst_3d_lx17
+
+  subroutine cpu_conv_fst_3d_lx16(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 16
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+
+  end subroutine cpu_conv_fst_3d_lx16
+
+  subroutine cpu_conv_fst_3d_lx15(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 15
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+
+  end subroutine cpu_conv_fst_3d_lx15
+
+  subroutine cpu_conv_fst_3d_lx14(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 14
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+
+  end subroutine cpu_conv_fst_3d_lx14
+
+  subroutine cpu_conv_fst_3d_lx13(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 13
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+
+  end subroutine cpu_conv_fst_3d_lx13
+
+  subroutine cpu_conv_fst_3d_lx12(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 12
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+    
+  end subroutine cpu_conv_fst_3d_lx12
+
+  subroutine cpu_conv_fst_3d_lx11(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 11
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+
+  end subroutine cpu_conv_fst_3d_lx11
+
+  subroutine cpu_conv_fst_3d_lx10(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 10
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+
+  end subroutine cpu_conv_fst_3d_lx10
+
+  subroutine cpu_conv_fst_3d_lx9(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 9
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+
+  end subroutine cpu_conv_fst_3d_lx9
+
+  subroutine cpu_conv_fst_3d_lx8(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 8
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+
+  end subroutine cpu_conv_fst_3d_lx8
+
+  subroutine cpu_conv_fst_3d_lx7(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 7
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+
+  end subroutine cpu_conv_fst_3d_lx7
+
+  subroutine cpu_conv_fst_3d_lx6(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 6
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+
+  end subroutine cpu_conv_fst_3d_lx6
+
+  subroutine cpu_conv_fst_3d_lx5(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 5
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+
+  end subroutine cpu_conv_fst_3d_lx5
+
+  subroutine cpu_conv_fst_3d_lx4(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 4
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine cpu_conv_fst_3d_lx4
+
+  subroutine cpu_conv_fst_3d_lx3(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 3
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+
+  end subroutine cpu_conv_fst_3d_lx3
+
+  subroutine cpu_conv_fst_3d_lx2(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 2
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp), dimension(lx,lx,lx) :: ur, us, ut
+    real(kind=rp):: ud(lx*lx*lx)
+    integer :: e, i, k, m, idx, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    m = lx * lx
+    do e = 1, nelv
+       call mxm(dx,lx,u(1,1,1,e),lx,ur,m)
+       do k=1,lx
+          call mxm(u(1,1,k,e),lx,dy,lx,us(1,1,k),lx)
+       enddo
+       call mxm(u(1,1,1,e),m,dz,lx,ut,lx)
+       do i=1, lx * lx * lx
+          ud(i) = c(i,e,1) * ur(i,1,1) + c(i,e,2) * us(i,1,1) + c(i,e,3) * ut(i,1,1)
+       enddo
+       idx = (e-1) * Xh_GLL%lxyz+1
+       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+    end do
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)
+    
+  end subroutine cpu_conv_fst_3d_lx2
+
+end module cpu_conv_fst_3d

--- a/src/math/bcknd/cpu/opr_cpu.f90
+++ b/src/math/bcknd/cpu/opr_cpu.f90
@@ -36,18 +36,21 @@ module opr_cpu
   use cpu_opgrad
   use cpu_cdtp
   use cpu_conv1
+  use cpu_conv_fst_3d
+  use cpu_set_convect_new
   use num_types, only : rp
   use space, only : space_t
   use coefs, only : coef_t
   use math
   use field, only : field_t
+  use interpolation
   use gather_scatter
   use mathops
   implicit none
   private
 
   public :: opr_cpu_dudxyz, opr_cpu_opgrad, opr_cpu_cdtp, &
-       opr_cpu_conv1, opr_cpu_curl, opr_cpu_cfl, opr_cpu_lambda2
+       opr_cpu_conv1, opr_cpu_curl, opr_cpu_cfl, opr_cpu_lambda2, opr_cpu_conv_fst_3d, opr_cpu_set_convect_new
 
 contains
 
@@ -418,6 +421,78 @@ contains
 
   end subroutine opr_cpu_conv1
 
+  subroutine opr_cpu_conv_fst_3d(du, u, c, Xh_GLL, Xh_GL, coef_GLL, coef_GL, GLL_to_GL)
+    type(space_t), intent(in) :: Xh_GL
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(coef_t), intent(in) :: coef_GL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), intent(inout) :: du(Xh_GLL%lx, Xh_GLL%ly, Xh_GLL%lz, coef_GL%msh%nelv)
+    real(kind=rp), intent(inout) :: u(Xh_GL%lx, Xh_GL%lx, Xh_GL%lx, coef_GL%msh%nelv)
+    real(kind=rp), intent(inout) :: c(Xh_GL%lxyz,coef_GL%msh%nelv,3)
+    associate(dx => Xh_GL%dx, dy => Xh_GL%dyt, dz => Xh_GL%dzt, &
+         lx => Xh_GL%lx, nelv => coef_GL%msh%nelv)
+      
+      select case(lx)
+      case(18)
+         call cpu_conv_fst_3d_lx18(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(17)
+         call cpu_conv_fst_3d_lx17(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(16)
+         call cpu_conv_fst_3d_lx16(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(15)
+         call cpu_conv_fst_3d_lx15(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(14)
+         call cpu_conv_fst_3d_lx14(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(13)
+         call cpu_conv_fst_3d_lx13(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(12)
+         call cpu_conv_fst_3d_lx12(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(11)
+         call cpu_conv_fst_3d_lx11(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(10)
+         call cpu_conv_fst_3d_lx10(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(9)
+         call cpu_conv_fst_3d_lx9(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(8)
+         call cpu_conv_fst_3d_lx8(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(7)
+         call cpu_conv_fst_3d_lx7(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(6)
+         call cpu_conv_fst_3d_lx6(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(5)
+         call cpu_conv_fst_3d_lx5(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(4)
+         call cpu_conv_fst_3d_lx4(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(3)
+         call cpu_conv_fst_3d_lx3(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(2)
+         call cpu_conv_fst_3d_lx2(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case default
+         call cpu_conv_fst_3d_lx(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv, lx)
+      end select
+    end associate
+
+  end subroutine opr_cpu_conv_fst_3d
+
   subroutine opr_cpu_curl(w1, w2, w3, u1, u2, u3, work1, work2, c_Xh)
     type(field_t), intent(inout) :: w1
     type(field_t), intent(inout) :: w2
@@ -596,5 +671,75 @@ contains
     end do
        
   end subroutine opr_cpu_lambda2  
+
+  subroutine opr_cpu_set_convect_new(cr, cs, ct, cx, cy, cz, Xh, coef)   
+   type(space_t), intent(inout) :: Xh
+   type(coef_t), intent(inout) :: coef
+   real(kind=rp), dimension(Xh%lxyz, coef%msh%nelv), intent(inout) :: cr, cs, ct
+   real(kind=rp), dimension(Xh%lxyz, coef%msh%nelv), intent(in) :: cx, cy, cz
+   associate(drdx => coef%drdx, drdy => coef%drdy, drdz => coef%drdz, &
+     dsdx => coef%dsdx, dsdy => coef%dsdy, dsdz => coef%dsdz, &
+     dtdx => coef%dtdx, dtdy => coef%dtdy, dtdz => coef%dtdz, &  
+     nelv => coef%msh%nelv, lx=>Xh%lx, w3 => Xh%w3)
+     select case(lx)
+     case(18)
+        call cpu_set_convect_new_lx18(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case(17)
+        call cpu_set_convect_new_lx17(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case(16)
+        call cpu_set_convect_new_lx16(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case(15)
+        call cpu_set_convect_new_lx15(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case(14)
+        call cpu_set_convect_new_lx14(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case(13)
+        call cpu_set_convect_new_lx13(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case(12)
+        call cpu_set_convect_new_lx12(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case(11)
+        call cpu_set_convect_new_lx11(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case(10)
+        call cpu_set_convect_new_lx10(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case(9)
+        call cpu_set_convect_new_lx9(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case(8)
+        call cpu_set_convect_new_lx8(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case(7)
+        call cpu_set_convect_new_lx7(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case(6)
+        call cpu_set_convect_new_lx6(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case(5)
+        call cpu_set_convect_new_lx5(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case(4)
+        call cpu_set_convect_new_lx4(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case(3)
+        call cpu_set_convect_new_lx3(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case(2)
+        call cpu_set_convect_new_lx2(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+     case default
+        call cpu_set_convect_new_lx(cr, cs, ct, cx, cy, cz, &
+             drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv, lx)
+     end select
+   end associate
+ end subroutine opr_cpu_set_convect_new
+
+
 
 end module opr_cpu

--- a/src/math/bcknd/cpu/set_convect_new.f90
+++ b/src/math/bcknd/cpu/set_convect_new.f90
@@ -1,0 +1,580 @@
+! Copyright (c) 2021, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Gradient kernels
+module cpu_set_convect_new
+  use num_types, only : rp
+  implicit none
+
+contains
+
+  subroutine cpu_set_convect_new_lx(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n, lx)
+    integer, intent(in) :: n, lx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx
+
+  subroutine cpu_set_convect_new_lx18(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 18
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx18
+
+  subroutine cpu_set_convect_new_lx17(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 17
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx17
+
+  subroutine cpu_set_convect_new_lx16(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 16
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx16
+
+  subroutine cpu_set_convect_new_lx15(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 15
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx15
+
+  subroutine cpu_set_convect_new_lx14(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 14
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx14
+
+  subroutine cpu_set_convect_new_lx13(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 13
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx13
+
+  subroutine cpu_set_convect_new_lx12(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 12
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx12
+
+  subroutine cpu_set_convect_new_lx11(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 11
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx11
+
+  subroutine cpu_set_convect_new_lx10(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 10
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx10
+
+  subroutine cpu_set_convect_new_lx9(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 9
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx9
+
+  subroutine cpu_set_convect_new_lx8(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 8
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx8 
+
+  subroutine cpu_set_convect_new_lx7(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 7
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx7
+
+  subroutine cpu_set_convect_new_lx6(cr, cs, ct, cx, cy, cz, &
+   drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+integer, parameter :: lx = 6
+integer, intent(in) :: n
+real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+integer :: e, i
+
+do e = 1, n
+   do i = 1, lx * lx * lx
+      cr(i,1,1,e) = w3(i,1,1) &
+                  * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                    + cy(i,1,1,e) * drdy(i,1,1,e) &
+                    + cz(i,1,1,e) * drdz(i,1,1,e) )
+      cs(i,1,1,e) = w3(i,1,1) &
+                  * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                    + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                    + cz(i,1,1,e) * dsdz(i,1,1,e))
+      ct(i,1,1,e) = w3(i,1,1) &
+                  * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                    + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                    + cz(i,1,1,e) * dtdz(i,1,1,e))
+   end do
+end do
+end subroutine cpu_set_convect_new_lx6
+
+subroutine cpu_set_convect_new_lx5(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 5
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx5
+  
+  subroutine cpu_set_convect_new_lx4(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 4
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx4
+  
+  subroutine cpu_set_convect_new_lx3(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 3
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx3 
+
+  subroutine cpu_set_convect_new_lx2(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 2
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do e = 1, n
+       do i = 1, lx * lx * lx
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine cpu_set_convect_new_lx2
+
+
+end module cpu_set_convect_new

--- a/src/math/bcknd/device/opencl/conv_fst_3d_kernel.cl
+++ b/src/math/bcknd/device/opencl/conv_fst_3d_kernel.cl
@@ -1,0 +1,128 @@
+#ifndef __MATH_CONV_FST_3D_KERNEL_CL__
+#define __MATH_CONV_FST_3D_KERNEL_CL__
+/*
+ Copyright (c) 2021-2024, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/**
+ * Device kernel for conv_fst_3d
+ */
+
+#define DEFINE_CONV_FST_3D_KERNEL(LX, CHUNKS)                                      \
+__kernel void conv_fst_3d_kernel_lx##LX(__global real * __restrict__ ud,           \
+                                        __global const real * __restrict__ u,      \
+                                        __global const real * __restrict__ cr,     \
+                                        __global const real * __restrict__ cs,     \
+                                        __global const real * __restrict__ ct,     \
+                                        __global const real * __restrict__ dx,     \
+                                        __global const real * __restrict__ dy,     \
+                                        __global const real * __restrict__ dz) {   \
+                                                                                   \
+  __local real shu[LX * LX * LX];                                                  \
+                                                                                   \
+  __local real shcr[LX * LX * LX];                                                 \
+  __local real shcs[LX * LX * LX];                                                 \
+  __local real shct[LX * LX * LX];                                                 \
+                                                                                   \
+  __local real shdx[LX * LX];                                                      \
+  __local real shdy[LX * LX];                                                      \
+  __local real shdz[LX * LX];                                                      \
+                                                                                   \
+  int i,j,k;                                                                       \
+                                                                                   \
+  const int e = get_group_id(0);                                                   \
+  const int iii = get_local_id(0);                                                 \
+  const int nchunks = (LX * LX * LX - 1) / CHUNKS + 1;                             \
+                                                                                   \
+  if (iii < (LX * LX)) {                                                           \
+    shdx[iii] = dx[iii];                                                           \
+    shdy[iii] = dy[iii];                                                           \
+    shdz[iii] = dz[iii];                                                           \
+  }                                                                                \
+                                                                                   \
+  j = iii;                                                                         \
+  while(j < (LX * LX * LX)) {                                                      \
+    shu[j] = u[j + e * LX * LX * LX];                                              \
+                                                                                   \
+    shcr[j] = cr[j + e * LX * LX * LX];                                            \
+    shcs[j] = cs[j + e * LX * LX * LX];                                            \
+    shct[j] = ct[j + e * LX * LX * LX];                                            \
+                                                                                   \
+    j = j + CHUNKS;                                                                \
+  }                                                                                \
+                                                                                   \
+  barrier(CLK_LOCAL_MEM_FENCE);                                                    \
+                                                                                   \
+  for (int n = 0; n < nchunks; n++) {                                              \
+    const int ijk = iii + n * CHUNKS;                                              \
+    const int jk = ijk / LX;                                                       \
+    i = ijk - jk * LX;                                                             \
+    k = jk / LX;                                                                   \
+    j = jk - k * LX;                                                               \
+    if ( i < LX && j < LX && k < LX) {                                             \
+      real rtmp = 0.0;                                                             \
+      real stmp = 0.0;                                                             \
+      real ttmp = 0.0;                                                             \
+      for (int l = 0; l < LX; l++) {                                               \
+        rtmp += shdx[i + l * LX] * shu[l + j * LX + k * LX * LX];                  \
+        stmp += shdy[j + l * LX] * shu[i + l * LX + k * LX * LX];                  \
+        ttmp += shdz[k + l * LX] * shu[i + j * LX + l * LX * LX];                  \
+      }                                                                            \
+                                                                                   \
+      ud[ijk + e * LX * LX * LX] =                                                 \
+          (shcr[ijk] * rtmp + shcs[ijk] * stmp + shct[ijk] * ttmp);                \
+                                                                                   \
+    }                                                                              \
+  }                                                                                \
+}        
+
+DEFINE_OPGRAD_KERNEL(18, 256)
+DEFINE_OPGRAD_KERNEL(17, 256)
+DEFINE_OPGRAD_KERNEL(16, 256)
+DEFINE_OPGRAD_KERNEL(15, 256)
+DEFINE_OPGRAD_KERNEL(14, 256)
+DEFINE_OPGRAD_KERNEL(13, 256)
+DEFINE_OPGRAD_KERNEL(12, 256)
+DEFINE_OPGRAD_KERNEL(11, 256)
+DEFINE_OPGRAD_KERNEL(10, 256)
+DEFINE_OPGRAD_KERNEL(9, 256)
+DEFINE_OPGRAD_KERNEL(8, 256)
+DEFINE_OPGRAD_KERNEL(7, 256)
+DEFINE_OPGRAD_KERNEL(6, 256)
+DEFINE_OPGRAD_KERNEL(5, 256)
+DEFINE_OPGRAD_KERNEL(4, 256)
+DEFINE_OPGRAD_KERNEL(3, 256)
+DEFINE_OPGRAD_KERNEL(2, 256)
+
+
+#endif // __MATH_CONV_FST_3D_KERNEL_CL__

--- a/src/math/bcknd/device/opencl/opr_conv_fst_3d.c
+++ b/src/math/bcknd/device/opencl/opr_conv_fst_3d.c
@@ -1,0 +1,111 @@
+/*
+ Copyright (c) 2021-2024, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifdef __APPLE__
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
+
+#include <stdio.h>
+#include <device/device_config.h>
+#include <device/opencl/jit.h>
+#include <device/opencl/prgm_lib.h>
+#include <device/opencl/check.h>
+
+#include "conv_fst_3d_kernel.cl.h"
+
+/** 
+ * Fortran wrapper for device OpenCL convection
+ */
+void opencl_conv_fst_3d(void *ud, void *u,
+                   void *cr, void *cs, void *ct,
+                   void *dx, void *dy, void *dz,
+                   int *nel, int *lx) {
+  cl_int err;
+  
+  if (conv_fst_3d_program == NULL)
+    opencl_kernel_jit(conv_fst_3d_kernel, (cl_program *) &conv_fst_3d_program);
+  
+  const size_t global_item_size = 256 * (*nel);
+  const size_t local_item_size = 256;
+
+#define STR(X) #X
+#define CASE(LX)                                                                \
+  case LX:                                                                      \
+    {                                                                           \
+      cl_kernel kernel = clCreateKernel(conv_fst_3d_program,                    \
+                                        STR(conv_fst_3d_kernel_lx##LX), &err);  \
+      CL_CHECK(err);                                                            \
+                                                                                \
+      CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &ud));        \
+      CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &u));         \
+      CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &cr));        \
+      CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &cs));        \
+      CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), (void *) &ct));        \
+      CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_mem), (void *) &dx));        \
+      CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_mem), (void *) &dy));        \
+      CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_mem), (void *) &dz));        \
+                                                                                \
+      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,         \
+                                      kernel, 1, NULL, &global_item_size,       \
+                                      &local_item_size,0, NULL, NULL));         \
+    }                                                                           \
+    break     
+  
+  switch(*lx) {
+    CASE(2);
+    CASE(3);
+    CASE(4);
+    CASE(5);
+    CASE(6);
+    CASE(7);
+    CASE(8);
+    CASE(9);
+    CASE(10);
+    CASE(11);
+    CASE(12);
+    CASE(13);
+    CASE(14);
+    CASE(15);
+    CASE(16);
+    CASE(17);
+    CASE(18);
+  default:
+    {
+      fprintf(stderr, __FILE__ ": size not supported: %d\n", *lx);
+      exit(1);
+    }
+  }
+} 

--- a/src/math/bcknd/sx/opr_sx.f90
+++ b/src/math/bcknd/sx/opr_sx.f90
@@ -1,23 +1,26 @@
 !> Operators SX-Aurora backend
 module opr_sx
-  use sx_dudxyz
-  use sx_opgrad
-  use sx_conv1
-  use sx_cdtp
-  use sx_cfl
-  use sx_lambda2
-  use gather_scatter
-  use num_types, only : rp
-  use space, only : space_t
-  use coefs, only : coef_t
-  use math
-  use field, only : field_t
-  use mathops
+   use sx_dudxyz
+   use sx_opgrad
+   use sx_conv1
+   use sx_cdtp
+   use sx_cfl
+   use sx_lambda2
+   use sx_conv_fst_3d
+   use sx_set_convect_new
+   use gather_scatter
+   use interpolation
+   use num_types, only : rp
+   use space, only : space_t
+   use coefs, only : coef_t
+   use math
+   use field, only : field_t
+   use mathops
   implicit none
   private
 
   public :: opr_sx_dudxyz, opr_sx_opgrad, opr_sx_cdtp, opr_sx_conv1, &
-       opr_sx_curl, opr_sx_cfl, opr_sx_lambda2
+       opr_sx_curl, opr_sx_cfl, opr_sx_lambda2, opr_sx_conv_fst_3d, opr_sx_set_convect_new
 
 contains
 
@@ -385,6 +388,78 @@ contains
 
   end subroutine opr_sx_conv1
 
+  subroutine opr_sx_conv_fst_3d(du, u, c, Xh_GLL, Xh_GL, coef_GLL, coef_GL, GLL_to_GL)
+    type(space_t), intent(in) :: Xh_GL
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(coef_t), intent(in) :: coef_GL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), intent(inout) :: du(Xh_GLL%lx, Xh_GLL%ly, Xh_GLL%lz, coef_GL%msh%nelv)
+    real(kind=rp), intent(inout) :: u(Xh_GL%lx, Xh_GL%lx, Xh_GL%lx, coef_GL%msh%nelv)
+    real(kind=rp), intent(inout) :: c(Xh_GL%lxyz,coef_GL%msh%nelv,3)
+    associate(dx => Xh_GL%dx, dy => Xh_GL%dy, dz => Xh_GL%dz, &
+         lx => Xh_GL%lx, nelv => coef_GL%msh%nelv)
+      
+      select case(lx)
+      case(18)
+         call sx_conv_fst_3d_lx18(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(17)
+         call sx_conv_fst_3d_lx17(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(16)
+         call sx_conv_fst_3d_lx16(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(15)
+         call sx_conv_fst_3d_lx15(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(14)
+         call sx_conv_fst_3d_lx14(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(13)
+         call sx_conv_fst_3d_lx13(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(12)
+         call sx_conv_fst_3d_lx12(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(11)
+         call sx_conv_fst_3d_lx11(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(10)
+         call sx_conv_fst_3d_lx10(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(9)
+         call sx_conv_fst_3d_lx9(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(8)
+         call sx_conv_fst_3d_lx8(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(7)
+         call sx_conv_fst_3d_lx7(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(6)
+         call sx_conv_fst_3d_lx6(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(5)
+         call sx_conv_fst_3d_lx5(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(4)
+         call sx_conv_fst_3d_lx4(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(3)
+         call sx_conv_fst_3d_lx3(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case(2)
+         call sx_conv_fst_3d_lx2(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+      case default
+         call sx_conv_fst_3d_lx(du, u, c, dx, dy, dz, &
+              Xh_GLL, coef_GLL, GLL_to_GL, nelv, lx)
+      end select
+    end associate
+
+  end subroutine opr_sx_conv_fst_3d
+
   subroutine opr_sx_curl(w1, w2, w3, u1, u2, u3, work1, work2, c_Xh)
     type(field_t), intent(inout) :: w1
     type(field_t), intent(inout) :: w2
@@ -680,5 +755,74 @@ contains
     end associate
     
   end subroutine opr_sx_lambda2  
+
+  subroutine opr_sx_set_convect_new(cr, cs, ct, cx, cy, cz, Xh, coef)   
+    type(space_t), intent(inout) :: Xh
+    type(coef_t), intent(inout) :: coef
+    real(kind=rp), dimension(Xh%lxyz, coef%msh%nelv), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(Xh%lxyz, coef%msh%nelv), intent(in) :: cx, cy, cz
+    associate(drdx => coef%drdx, drdy => coef%drdy, drdz => coef%drdz, &
+      dsdx => coef%dsdx, dsdy => coef%dsdy, dsdz => coef%dsdz, &
+      dtdx => coef%dtdx, dtdy => coef%dtdy, dtdz => coef%dtdz, &  
+      nelv => coef%msh%nelv, lx=>Xh%lx, w3 => Xh%w3)
+     
+      select case(lx)
+      case(18)
+         call sx_set_convect_new_lx18(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case(17)
+         call sx_set_convect_new_lx17(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case(16)
+         call sx_set_convect_new_lx16(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case(15)
+         call sx_set_convect_new_lx15(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case(14)
+         call sx_set_convect_new_lx14(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case(13)
+         call sx_set_convect_new_lx13(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case(12)
+         call sx_set_convect_new_lx12(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case(11)
+         call sx_set_convect_new_lx11(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case(10)
+         call sx_set_convect_new_lx10(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case(9)
+         call sx_set_convect_new_lx9(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case(8)
+         call sx_set_convect_new_lx8(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case(7)
+         call sx_set_convect_new_lx7(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case(6)
+         call sx_set_convect_new_lx6(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case(5)
+         call sx_set_convect_new_lx5(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case(4)
+         call sx_set_convect_new_lx4(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case(3)
+         call sx_set_convect_new_lx3(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case(2)
+         call sx_set_convect_new_lx2(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv)
+      case default
+         call sx_set_convect_new_lx(cr, cs, ct, cx, cy, cz, &
+              drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, nelv, lx)
+      end select
+    end associate
+ end subroutine opr_sx_set_convect_new
 
 end module opr_sx

--- a/src/math/bcknd/sx/sx_conv_fst_3d.f90
+++ b/src/math/bcknd/sx/sx_conv_fst_3d.f90
@@ -1,0 +1,1340 @@
+! Copyright (c) 2021, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> 
+module sx_conv_fst_3d
+  use num_types, only : rp
+  use coefs, only : coef_t
+  use space, only : space_t
+  use interpolation
+  use math
+  use gather_scatter 
+  implicit none
+
+contains
+
+  subroutine sx_conv_fst_3d_lx(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv, lx)
+    integer, intent(in) :: nelv, lx
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx
+
+  subroutine sx_conv_fst_3d_lx18(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 18
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx18
+
+  subroutine sx_conv_fst_3d_lx17(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 17
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx17
+
+  subroutine sx_conv_fst_3d_lx16(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 16
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx16
+
+  subroutine sx_conv_fst_3d_lx15(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 15
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx15
+
+  subroutine sx_conv_fst_3d_lx14(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 14
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx14
+
+  subroutine sx_conv_fst_3d_lx13(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 13
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL)  
+
+  end subroutine sx_conv_fst_3d_lx13
+
+  subroutine sx_conv_fst_3d_lx12(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 12
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx12
+
+  subroutine sx_conv_fst_3d_lx11(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 11
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx11
+
+  subroutine sx_conv_fst_3d_lx10(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 10
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx10
+
+  subroutine sx_conv_fst_3d_lx9(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 9
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx9
+
+  subroutine sx_conv_fst_3d_lx8(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 8
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx8
+
+  subroutine sx_conv_fst_3d_lx7(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 7
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx7
+
+  subroutine sx_conv_fst_3d_lx6(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 6
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx6
+
+  subroutine sx_conv_fst_3d_lx5(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 5
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx5
+
+  subroutine sx_conv_fst_3d_lx4(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 4
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx4
+
+  subroutine sx_conv_fst_3d_lx3(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 3
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx3
+
+  subroutine sx_conv_fst_3d_lx2(du, u, c, dx, dy, dz, &
+        Xh_GLL, coef_GLL, GLL_to_GL, nelv)
+    integer, parameter :: lx = 2
+    integer, intent(in) :: nelv
+    type(space_t), intent(in) :: Xh_GLL
+    type(coef_t), intent(in) :: coef_GLL
+    type(interpolator_t), intent(inout) :: GLL_to_GL
+    real(kind=rp), dimension(Xh_GLL%lx,Xh_GLL%lx,Xh_GLL%lx, nelv), intent(inout) :: du
+    real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: u
+    !real(kind=rp), dimension(lx,lx,lx,nelv), intent(in) :: cr, cs, ct
+    real(kind=rp), dimension(lx*lx*lx,nelv,3), intent(in) :: c
+    real(kind=rp), dimension(lx,lx), intent(in) :: dx, dy, dz
+    real(kind=rp) :: ur(lx,lx,lx,nelv)
+    real(kind=rp) :: us(lx,lx,lx,nelv)
+    real(kind=rp) :: ut(lx,lx,lx,nelv)
+    real(kind=rp) :: ud(lx,lx,lx,nelv)
+    real(kind=rp) :: wr, ws, wt
+    integer :: e, i, j, k, jj, kk, n_GLL
+    n_GLL = nelv * Xh_GLL%lxyz
+    do i = 1, lx
+       do jj = 1, lx * lx * nelv
+          wr = 0d0
+          do kk = 1, lx
+             wr = wr + dx(i,kk)*u(kk,jj,1,1)
+          end do
+          ur(i,jj,1,1) = wr
+       end do
+    end do
+ 
+    do k = 1, lx
+       do i = 1, lx
+          do j = 1, lx
+             do e = 1, nelv
+                ws = 0d0
+                !NEC$ unroll_completely
+                do kk = 1,lx
+                   ws = ws + dy(j,kk)*u(i,kk,k,e)
+                end do
+                us(i,j,k,e) = ws
+             end do
+          end do
+       end do
+    end do
+
+    do j = 1, lx
+       do i = 1, lx
+          do k = 1, lx
+             do e = 1, nelv
+                wt = 0d0
+                !NEC$ unroll_completely
+                do kk = 1, lx
+                   wt = wt + dz(k,kk)*u(i,j,kk,e)
+                end do
+                ut(i,j,k,e) = wt
+             end do
+          end do
+       end do
+    end do
+
+    do i = 1, lx * lx * lx
+       do e = 1, nelv
+         ud(i,1,1,e) = ( c(i,e,1) * ur(i,1,1,e) &
+                     + c(i,e,2) * us(i,1,1,e) &
+                     + c(i,e,3) * ut(i,1,1,e) )
+       end do
+    end do
+    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
+    call col2(du, coef_GLL%Binv, n_GLL) 
+
+  end subroutine sx_conv_fst_3d_lx2
+
+end module sx_conv_fst_3d

--- a/src/math/bcknd/sx/sx_set_convect_new.f90
+++ b/src/math/bcknd/sx/sx_set_convect_new.f90
@@ -1,0 +1,579 @@
+! Copyright (c) 2021, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Gradient kernels
+module sx_set_convect_new
+  use num_types, only : rp
+  implicit none
+
+contains
+
+  subroutine sx_set_convect_new_lx(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n, lx)
+    integer, intent(in) :: n, lx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx
+
+  subroutine sx_set_convect_new_lx18(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 18
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx18
+
+  subroutine sx_set_convect_new_lx17(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 17
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx17
+
+  subroutine sx_set_convect_new_lx16(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 16
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx16
+
+  subroutine sx_set_convect_new_lx15(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 15
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx15
+
+  subroutine sx_set_convect_new_lx14(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 14
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx14
+
+  subroutine sx_set_convect_new_lx13(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 13
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx13
+
+  subroutine sx_set_convect_new_lx12(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 12
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx12
+
+  subroutine sx_set_convect_new_lx11(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 11
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx11
+
+  subroutine sx_set_convect_new_lx10(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 10
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx10
+
+  subroutine sx_set_convect_new_lx9(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 9
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx9
+
+  subroutine sx_set_convect_new_lx8(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 8
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx8 
+
+  subroutine sx_set_convect_new_lx7(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 7
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx7
+
+  subroutine sx_set_convect_new_lx6(cr, cs, ct, cx, cy, cz, &
+   drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+integer, parameter :: lx = 6
+integer, intent(in) :: n
+real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+integer :: e, i
+
+do i = 1, lx * lx * lx
+   do e = 1, n
+      cr(i,1,1,e) = w3(i,1,1) &
+                  * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                    + cy(i,1,1,e) * drdy(i,1,1,e) &
+                    + cz(i,1,1,e) * drdz(i,1,1,e) )
+      cs(i,1,1,e) = w3(i,1,1) &
+                  * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                    + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                    + cz(i,1,1,e) * dsdz(i,1,1,e))
+      ct(i,1,1,e) = w3(i,1,1) &
+                  * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                    + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                    + cz(i,1,1,e) * dtdz(i,1,1,e))
+   end do
+end do
+end subroutine sx_set_convect_new_lx6
+
+subroutine sx_set_convect_new_lx5(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 5
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx5
+  
+  subroutine sx_set_convect_new_lx4(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 4
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx4
+  
+  subroutine sx_set_convect_new_lx3(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 3
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx3 
+
+  subroutine sx_set_convect_new_lx2(cr, cs, ct, cx, cy, cz, &
+       drdx, dsdx, dtdx, drdy, dsdy, dtdy, drdz, dsdz, dtdz, w3, n)
+    integer, parameter :: lx = 2
+    integer, intent(in) :: n
+    real(kind=rp), dimension(lx,lx,lx,n), intent(inout) :: cr, cs, ct
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: cx, cy, cz
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdx, dsdx, dtdx
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdy, dsdy, dtdy
+    real(kind=rp), dimension(lx,lx,lx,n), intent(in) :: drdz, dsdz, dtdz    
+    real(kind=rp), dimension(lx, lx), intent(in) :: w3(lx,lx,lx)
+    integer :: e, i
+
+    do i = 1, lx * lx * lx
+       do e = 1, n
+          cr(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * drdx(i,1,1,e) &
+                        + cy(i,1,1,e) * drdy(i,1,1,e) &
+                        + cz(i,1,1,e) * drdz(i,1,1,e) )
+          cs(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dsdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dsdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dsdz(i,1,1,e))
+          ct(i,1,1,e) = w3(i,1,1) &
+                      * ( cx(i,1,1,e) * dtdx(i,1,1,e) &
+                        + cy(i,1,1,e) * dtdy(i,1,1,e) &
+                        + cz(i,1,1,e) * dtdz(i,1,1,e))
+       end do
+    end do
+  end subroutine sx_set_convect_new_lx2
+
+end module sx_set_convect_new

--- a/src/math/operators.f90
+++ b/src/math/operators.f90
@@ -36,27 +36,32 @@ module operators
                           NEKO_DEVICE_MPI
   use num_types, only : rp
   use opr_cpu, only : opr_cpu_cfl, opr_cpu_curl, opr_cpu_opgrad, opr_cpu_conv1,&
-                      opr_cpu_cdtp, opr_cpu_dudxyz, opr_cpu_lambda2
+                      opr_cpu_conv_fst_3d, opr_cpu_cdtp, opr_cpu_dudxyz, &
+                      opr_cpu_lambda2, opr_cpu_set_convect_new
   use opr_sx, only : opr_sx_cfl, opr_sx_curl, opr_sx_dudxyz, opr_sx_opgrad, &
-                     opr_sx_cdtp, opr_sx_conv1, opr_sx_lambda2
+                     opr_sx_cdtp, opr_sx_conv1, opr_sx_lambda2, &
+                     opr_sx_conv_fst_3d, opr_sx_set_convect_new
   use opr_xsmm, only : opr_xsmm_cdtp, opr_xsmm_conv1, opr_xsmm_curl, &
-                       opr_xsmm_dudxyz, opr_xsmm_opgrad
+                       opr_xsmm_dudxyz, opr_xsmm_opgrad, opr_xsmm_conv_fst_3d, &
+                       opr_xsmm_set_convect_new
   use opr_device, only : opr_device_cdtp, opr_device_cfl, opr_device_curl, &
                          opr_device_conv1, opr_device_dudxyz, &
-                         opr_device_lambda2, opr_device_opgrad
+                         opr_device_lambda2, opr_device_opgrad, opr_device_conv_fst_3d
   use space, only : space_t
   use coefs, only : coef_t
   use field, only : field_t
-  use math, only : glsum, cmult, add2, cadd, copy
+  use math, only : glsum, cmult, add2, add3s2, cadd, copy, col2, invcol2, invcol3, rzero
   use device, only : c_ptr, device_get_ptr
   use device_math, only : device_add2, device_cmult, device_copy
   use scratch_registry, only : neko_scratch_registry
+  use interpolation
+  use gather_scatter 
   use comm
   implicit none
   private
 
   public :: dudxyz, opgrad, ortho, cdtp, conv1, curl, cfl,&
-            lambda2op, strain_rate, div, grad
+            lambda2op, strain_rate, div, grad, set_convect_new, runge_kutta
 
 contains
 
@@ -285,8 +290,44 @@ contains
     end associate
 
   end subroutine conv1
+  
+  !> Apply the convecting velocity c to the to the scalar field u
+  !! @param du Holds the result.
+  !! @param c The convecting velocity
+  !! @param u The convected scalar field
+  !! @param Xh_GLL The GLL space used in simulation 
+  !! @param Xh_GL The GL space used for dealiasing
+  !! @param coef The coefficients of the original space in simulation
+  !! @param coef_GL The coefficients of the GL space used for dealiasing 
+  !! @param GLL_to_GL the interpolator between the GLL and GL spaces
+  !! @note This subroutine is equal to the convop_fst_3d of the NEK5000
+  subroutine convop_fst_3d(du, u, c, Xh_GLL, Xh_GL, coef_GLL, coef_GL, GLL_to_GL)
+   type(space_t), intent(in) :: Xh_GL
+   type(space_t), intent(in) :: Xh_GLL
+   type(coef_t), intent(in) :: coef_GLL
+   type(coef_t), intent(in) :: coef_GL
+   type(interpolator_t), intent(inout) :: GLL_to_GL
+   real(kind=rp), intent(inout) :: du(Xh_GLL%lx, Xh_GLL%ly, Xh_GLL%lz, coef_GL%msh%nelv)
+   real(kind=rp), intent(inout) :: u(Xh_GL%lx, Xh_GL%lx, Xh_GL%lx, coef_GL%msh%nelv)
+   real(kind=rp), intent(inout) :: c(Xh_GL%lxyz,coef_GL%msh%nelv, 3)
 
-  !! Compute the curl fo a vector field.
+   if (NEKO_BCKND_SX .eq. 1) then 
+      call opr_sx_conv_fst_3d(du, u, c, Xh_GLL, Xh_GL, &
+                              coef_GLL, coef_GL, GLL_to_GL)
+   else if (NEKO_BCKND_XSMM .eq. 1) then
+      call opr_xsmm_conv_fst_3d(du, u, c, Xh_GLL, Xh_GL, &
+                                coef_GLL, coef_GL, GLL_to_GL)
+   else if (NEKO_BCKND_DEVICE .eq. 1) then
+      call opr_device_conv_fst_3d(du, u, c, Xh_GLL, Xh_GL, &
+                                  coef_GLL, coef_GL, GLL_to_GL)
+   else
+      call opr_cpu_conv_fst_3d(du, u, c, Xh_GLL, Xh_GL, &
+                               coef_GLL, coef_GL, GLL_to_GL)
+   end if
+
+ end subroutine convop_fst_3d
+
+  !! Compute the curl for a vector field.
   !! @param w1 Will store the x component of the curl.
   !! @param w2 Will store the y component of the curl.
   !! @param w3 Will store the z component of the curl.
@@ -451,5 +492,106 @@ contains
     end if
 
   end subroutine lambda2op
+
+  !> Transforms the convecting velocity field to the rst form of the GL space
+  !! @param cr convecting velocity in r-direction
+  !! @param cs convecting velocity in s-direction
+  !! @param ct convecting velocity in t-direction
+  !! @param cx convecting velocity in x-direction
+  !! @param cy convecting velocity in y-direction
+  !! @param cz convecting velocity in z-direction
+  !! @param Xh The GL space used for dealiasing 
+  !! @param coef The coeffiecients of the GL space used for dealiasing 
+  !! @note This subroutine is equal to the set_convect_new subroutine of NEK5000
+  subroutine set_convect_new(cr, cs, ct, cx, cy, cz, Xh, coef)   
+   type(space_t), intent(inout) :: Xh
+   type(coef_t), intent(inout) :: coef
+   real(kind=rp), dimension(Xh%lxyz, coef%msh%nelv), intent(inout) :: cr, cs, ct
+   real(kind=rp), dimension(Xh%lxyz, coef%msh%nelv), intent(in) :: cx, cy, cz
+
+   if (NEKO_BCKND_SX .eq. 1) then 
+      call opr_sx_set_convect_new(cr, cs, ct, cx, cy, cz, Xh, coef) 
+   else if (NEKO_BCKND_XSMM .eq. 1) then
+      call opr_xsmm_set_convect_new(cr, cs, ct, cx, cy, cz, Xh, coef) 
+   else
+      call opr_cpu_set_convect_new(cr, cs, ct, cx, cy, cz, Xh, coef) 
+   end if
+   
+ end subroutine set_convect_new
+
+
+  !> Compute one step of Runge Kutta time interpolatio for OIFS scheme.
+  !! @param phi The iterpolated field
+  !! @param c_r1 The covecting velocity for the first stage.
+  !! @param c_r23 The convecting velocity for the second and third stage.
+  !! @param c_r4 The convecting velocity for the fourth stage.
+  !! @param Xh_GLL The GLL space used in simulation 
+  !! @param Xh_GL The GL space used for dealiasing
+  !! @param coef The coefficients of the original space in simulation
+  !! @param coef_GL The coefficients of the GL space used for dealiasing 
+  !! @param GLL_to_GL the interpolator between the GLL and GL spaces
+  !! @param tau The the starting time
+  !! @param dtau The time step used for the Runge Kutta scheme
+  !! @param n size of phi
+  !! @param nel Total number of elements
+  !! @param n_GL the size in the GL space 
+  subroutine runge_kutta(phi, c_r1, c_r23, c_r4, Xh_GLL, Xh_GL, coef, coef_GL, &
+                        GLL_to_GL, tau, dtau, n, nel, n_GL)
+    type(space_t), intent(inout) :: Xh_GLL
+    type(space_t), intent(inout) :: Xh_GL
+    type(coef_t), intent(inout) :: coef
+    type(coef_t), intent(inout) :: coef_GL
+    type(interpolator_t) :: GLL_to_GL
+    real(kind=rp), intent(inout) :: tau, dtau
+    integer, intent(in) :: n, nel, n_GL
+    real(kind=rp), dimension(n), intent(inout) :: phi
+    real(kind=rp), dimension(3 * n_GL), intent(inout) :: c_r1, c_r23, c_r4
+    real(kind=rp) :: c1, c2, c3
+    ! Work Arrays
+    real(kind=rp), dimension(n) ::  u1, r1, r2, r3, r4
+    real(kind=rp), dimension(n_GL) :: u1_GL
+    integer :: i, e
+
+
+    c1 = 1.
+    c2 = -dtau/2.
+    c3 = -dtau
+
+    ! Stage 1:
+    call invcol3 (u1, phi, coef%B, n)
+    call GLL_to_GL%map(u1_GL, u1, nel, Xh_GL)
+    call convop_fst_3d(r1, u1_GL, c_r1, Xh_GLL, Xh_GL, coef, coef_GL, GLL_to_GL)
+    call col2(r1, coef%B, n)    
+                   
+    ! Stage 2:
+    call add3s2 (u1, phi, r1, c1, c2, n)
+    call invcol2 (u1, coef%B, n)  
+    call GLL_to_GL%map(u1_GL, u1, nel, Xh_GL)
+    call convop_fst_3d(r2, u1_GL, c_r23, Xh_GLL, Xh_GL, coef, coef_GL, GLL_to_GL)
+    call col2(r2, coef%B, n)   
+   
+
+    ! Stage 3:
+    call add3s2 (u1, phi, r2, c1, c2, n)           
+    call invcol2 (u1,  coef%B, n)
+    call GLL_to_GL%map(u1_GL, u1, nel, Xh_GL)
+    call convop_fst_3d(r3, u1_GL, c_r23, Xh_GLL, Xh_GL, coef, coef_GL, GLL_to_GL)
+    call col2(r3, coef%B, n)  
+
+    ! Stage 4:
+    call add3s2 (u1, phi, r3, c1, c3, n)
+    call invcol2 (u1, coef%B, n)                   
+    call GLL_to_GL%map(u1_GL, u1, nel, Xh_GL)
+    call convop_fst_3d(r4, u1_GL, c_r4, Xh_GLL, Xh_GL, coef, coef_GL, GLL_to_GL)
+    call col2(r4, coef%B, n)  
+   
+    c1 = -dtau/6.
+    c2 = -dtau/3.
+    do i = 1, n
+       phi(i) = phi(i) + c1 * (r1(i)+r4(i)) + c2 * (r2(i)+r3(i))
+    end do
+
+
+  end subroutine runge_kutta
 
 end module operators

--- a/src/scalar/scalar_scheme.f90
+++ b/src/scalar/scalar_scheme.f90
@@ -159,7 +159,7 @@ module scalar_scheme
   !> Abstract interface to initialize a scalar formulation
   abstract interface
      subroutine scalar_scheme_init_intrf(this, msh, coef, gs, params, user,&
-                                         material_properties)
+                                         material_properties, time_scheme)
        import scalar_scheme_t
        import json_file
        import coef_t
@@ -167,6 +167,7 @@ module scalar_scheme
        import mesh_t
        import user_t
        import material_properties_t
+       import time_scheme_controller_t
        class(scalar_scheme_t), target, intent(inout) :: this
        type(mesh_t), target, intent(inout) :: msh
        type(coef_t), target, intent(inout) :: coef
@@ -174,6 +175,7 @@ module scalar_scheme
        type(json_file), target, intent(inout) :: params
        type(user_t), target, intent(in) :: user
        type(material_properties_t), intent(inout) :: material_properties
+       type(time_scheme_controller_t), target, intent(in):: time_scheme
      end subroutine scalar_scheme_init_intrf
   end interface
 


### PR DESCRIPTION
The following changes relates to the implementation of the OIFS scheme:
1. Adding the OIFS advection derived type in fluid.
2. Adding the makeoifs rhs_maker in common. 
3. adding the higher order time interpolator for the convecting field.
4. changes in fluid_scheme and fluid_pnpn.
5. changes in scalar_scheme and scalar_pnpn.
6. adding the Runge_kutta operator, conv_fst_3d, and set_convect_new in math.
7. changes in simulation and case files. 
Note: There is also an implementation of conv_fst_3d available that calculates the local gradients similar to conv1 by using nested loops. However, the current implementation showed better performance so I uploaded this version. 