### PR TITLE
Automatic detection of intel compiler version

### DIFF
--- a/.github/workflows/check_intel.yml
+++ b/.github/workflows/check_intel.yml
@@ -29,7 +29,8 @@ jobs:
               sudo apt install -y --no-install-recommends intel-oneapi-compiler-fortran intel-oneapi-mpi intel-oneapi-mpi-devel intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
               source /opt/intel/oneapi/setvars.sh
               sudo apt install -y autoconf automake autotools-dev libopenblas-dev make git m4 python3 ca-certificates cmake
-              INTEL_PATH=$(realpath /opt/intel/oneapi/compiler/*/bin)
+              echo 'INTEL_PATH=find /opt/intel/oneapi/compiler/ -name "${FC}" -type f | xargs dirname'
+              INTEL_PATH=$(find /opt/intel/oneapi/compiler/ -name "${FC}" -type f | xargs dirname)
               echo "compiler found at: $INTEL_PATH"
               export PATH=/opt/intel/oneapi/compiler/2024.1/bin:${PATH}
               printenv >> $GITHUB_ENV

--- a/.github/workflows/check_intel.yml
+++ b/.github/workflows/check_intel.yml
@@ -29,10 +29,8 @@ jobs:
               sudo apt install -y --no-install-recommends intel-oneapi-compiler-fortran intel-oneapi-mpi intel-oneapi-mpi-devel intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
               source /opt/intel/oneapi/setvars.sh
               sudo apt install -y autoconf automake autotools-dev libopenblas-dev make git m4 python3 ca-certificates cmake
-              echo 'INTEL_PATH=find /opt/intel/oneapi/compiler/ -name "${FC}" -type f | xargs dirname'
               INTEL_PATH=$(find /opt/intel/oneapi/compiler/ -name "${FC}" -type f | xargs dirname)
-              echo "compiler found at: $INTEL_PATH"
-              export PATH=/opt/intel/oneapi/compiler/2024.1/bin:${PATH}
+              export PATH=$INTEL_PATH:${PATH}
               printenv >> $GITHUB_ENV
     env:
       CC: icc

--- a/.github/workflows/check_intel.yml
+++ b/.github/workflows/check_intel.yml
@@ -29,6 +29,8 @@ jobs:
               sudo apt install -y --no-install-recommends intel-oneapi-compiler-fortran intel-oneapi-mpi intel-oneapi-mpi-devel intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
               source /opt/intel/oneapi/setvars.sh
               sudo apt install -y autoconf automake autotools-dev libopenblas-dev make git m4 python3 ca-certificates cmake
+              INTEL_PATH=$(find /opt/intel/oneapi/compiler -name ${FC} -exec test -e {}/bin/icc \; -print -quit)
+              echo "compiler found at: $INTEL_PATH"
               export PATH=/opt/intel/oneapi/compiler/2024.1/bin:${PATH}
               printenv >> $GITHUB_ENV
     env:

--- a/.github/workflows/check_intel.yml
+++ b/.github/workflows/check_intel.yml
@@ -29,7 +29,7 @@ jobs:
               sudo apt install -y --no-install-recommends intel-oneapi-compiler-fortran intel-oneapi-mpi intel-oneapi-mpi-devel intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
               source /opt/intel/oneapi/setvars.sh
               sudo apt install -y autoconf automake autotools-dev libopenblas-dev make git m4 python3 ca-certificates cmake
-              INTEL_PATH=$(find /opt/intel/oneapi/compiler -name ${FC} -exec test -e {}/bin/icc \; -print -quit)
+              INTEL_PATH=$(realpath /opt/intel/oneapi/compiler/*/bin)
               echo "compiler found at: $INTEL_PATH"
               export PATH=/opt/intel/oneapi/compiler/2024.1/bin:${PATH}
               printenv >> $GITHUB_ENV


### PR DESCRIPTION
Currntly we rely on manually updating the path to intel compilers when a new version comes out.

This PR solves that by automatically finding the compiler and adding its location to the path.