### PR TITLE
OS Version updates

### DIFF
--- a/.github/workflows/check_depend.yml
+++ b/.github/workflows/check_depend.yml
@@ -16,10 +16,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Setup env.
+      id: setup-env
       run: |
         sudo apt-get update
         sudo apt-get install -y openmpi-bin libopenmpi-dev autoconf \
             automake autotools-dev libopenblas-dev make makedepf90 git gfortran
+        echo "os-version=$(lsb_release -ds | tr " " -)" >> $GITHUB_OUTPUT
 
     - name: Checkout
       uses: actions/checkout@v4
@@ -31,7 +33,7 @@ jobs:
       uses: ./.github/actions/setup_json-fortran
       with:
         version: ${{ inputs.json-fortran-version }}
-        os: ${{ runner.os }}
+        os: ${{ steps.setup-env.outputs.os-version }}
         compiler: gfortran
 
     - name: Add JSON-Fortran to environment

--- a/.github/workflows/check_gnu.yml
+++ b/.github/workflows/check_gnu.yml
@@ -86,7 +86,7 @@ jobs:
         uses: ./.github/actions/setup_json-fortran
         with:
           version: ${{ inputs.json-fortran-version }}
-          os: ${{ matrix.os }}
+          os: ${{ runner.os }}
           compiler: ${{ matrix.compiler }}
 
       - name: Add JSON-Fortran to environment

--- a/.github/workflows/check_gnu.yml
+++ b/.github/workflows/check_gnu.yml
@@ -46,6 +46,8 @@ jobs:
               sudo apt-get install -y openmpi-bin libopenmpi-dev autoconf \
                 automake autotools-dev libopenblas-dev make git m4 python3 \
                 cmake-curses-gui
+              echo "nproc=$(nproc)" >> $GITHUB_OUTPUT
+
           - os: macos-13
             setup-env: |
               export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
@@ -53,6 +55,7 @@ jobs:
               brew install automake
               brew install gcc@11
               brew install gcc@12
+              echo "nproc=$(sysctl -n hw.ncpu)" >> $GITHUB_OUTPUT
 
     name: ${{ matrix.os }} - ${{ matrix.compiler }} - ${{ matrix.backend }} - ${{ matrix.precision }}
     env:
@@ -86,7 +89,7 @@ jobs:
         uses: ./.github/actions/setup_json-fortran
         with:
           version: ${{ inputs.json-fortran-version }}
-          os: ${{ runner.os }}
+          os: ${{ github.env.ImageOS }}.${{ github.env.ImageVersion }}
           compiler: ${{ matrix.compiler }}
 
       - name: Add JSON-Fortran to environment

--- a/.github/workflows/check_gnu.yml
+++ b/.github/workflows/check_gnu.yml
@@ -47,6 +47,7 @@ jobs:
                 automake autotools-dev libopenblas-dev make git m4 python3 \
                 cmake-curses-gui
               echo "nproc=$(nproc)" >> $GITHUB_OUTPUT
+              echo "os-version=$(lsb_release -ds | tr " " -)" >> $GITHUB_OUTPUT
 
           - os: macos-13
             setup-env: |
@@ -56,6 +57,7 @@ jobs:
               brew install gcc@11
               brew install gcc@12
               echo "nproc=$(sysctl -n hw.ncpu)" >> $GITHUB_OUTPUT
+              echo "os-version=$(sw_vers -productName)-$(sw_vers -productVersion)" >> $GITHUB_OUTPUT
 
     name: ${{ matrix.os }} - ${{ matrix.compiler }} - ${{ matrix.backend }} - ${{ matrix.precision }}
     env:
@@ -73,6 +75,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup env.
+        id: setup-env
         run: ${{ matrix.setup-env }}
 
       - name: Get pFunit
@@ -81,7 +84,7 @@ jobs:
         uses: ./.github/actions/setup_pfunit
         with:
           version: ${{ inputs.pfunit-version }}
-          os: ${{ matrix.os }}
+          os: ${{ steps.setup-env.outputs.os-version }}
           compiler: ${{ matrix.compiler }}
 
       - name: Get json-fortran
@@ -89,7 +92,7 @@ jobs:
         uses: ./.github/actions/setup_json-fortran
         with:
           version: ${{ inputs.json-fortran-version }}
-          os: ${{ github.env.ImageOS }}.${{ github.env.ImageVersion }}
+          os: ${{ steps.setup-env.outputs.os-version }}
           compiler: ${{ matrix.compiler }}
 
       - name: Add JSON-Fortran to environment
@@ -106,7 +109,7 @@ jobs:
         run: |
           ./regen.sh
           ./configure FC=${FC} FCFLAGS="-O2 -pedantic -std=f2008" --with-pfunit=$PFUNIT_DIR --enable-real=${RP}
-          make -j$(nproc)
+          make -j${{ steps.setup-env.outputs.nproc }}
 
       - name: Build (CUDA backend)
         if: matrix.backend == 'cuda'
@@ -114,7 +117,7 @@ jobs:
           sudo apt-get install -y nvidia-cuda-toolkit
           ./regen.sh
           ./configure FC=${FC} FCFLAGS="-O2 -pedantic -std=f2008" --enable-real=${RP} --with-cuda=/usr
-          make -j$(nproc)
+          make -j${{ steps.setup-env.outputs.nproc }}
 
       - name: Build (HIP backend)
         if: matrix.backend == 'HIP'
@@ -128,19 +131,19 @@ jobs:
 
           ./regen.sh
           ./configure FC=${FC} FCFLAGS="-O2 -pedantic -std=f2008" HIP_HIPCC_FLAGS="-O2 -fPIE" --enable-real=${RP} --with-hip=$ROCM_DIR
-          make -j$(nproc)
+          make -j ${{ steps.setup-env.outputs.nproc }}
 
       - name: Build (OpenCL backend)
         if: matrix.backend == 'opencl'
         run: |
           ./regen.sh
           ./configure FC=${FC} FCFLAGS="-O2 -pedantic -std=f2008" --enable-real=${RP} --with-opencl
-          make -j$(nproc)
+          make -j ${{ steps.setup-env.outputs.nproc }}
 
       - name: Check
         if: matrix.backend == 'cpu'
         run: |
-          make -j$(nproc) check > tests/test-suite.log
+          make -j ${{ steps.setup-env.outputs.nproc }} check > tests/test-suite.log
 
       - name: Archive test report
         if: matrix.backend == 'cpu' && failure()
@@ -158,7 +161,7 @@ jobs:
           tar xf neko-*.tar.gz -C releng
           cd releng/neko-*
           ./configure FC=${FC} --enable-real=${RP}
-          make -j $(nproc)
+          make -j ${{ steps.setup-env.outputs.nproc }}
 
       - name: Dist (CUDA backend)
         if: matrix.backend == 'cuda'
@@ -168,7 +171,7 @@ jobs:
           tar xf neko-*.tar.gz -C releng
           cd releng/neko-*
           ./configure FC=${FC} --enable-real=${RP} --with-cuda=/usr
-          make -j $(nproc)
+          make -j ${{ steps.setup-env.outputs.nproc }}
 
       - name: Dist (HIP backend)
         if: matrix.backend == 'hip'
@@ -179,7 +182,7 @@ jobs:
           cd releng/neko-*
           ROCM_DIR=$(ls -d /opt/rocm-*)
           ./configure FC=${FC} FCFLAGS="-fPIE" --enable-real=${RP} HIP_HIPCC_FLAGS="-O2 -fPIE" --with-hip=$ROCM_DIR
-          make -j $(nproc)
+          make -j ${{ steps.setup-env.outputs.nproc }}
 
       - name: Dist (OpenCL backend)
         if: matrix.backend == 'opencl'
@@ -189,4 +192,4 @@ jobs:
           tar xf neko-*.tar.gz -C releng
           cd releng/neko-*
           ./configure FC=${FC} --enable-real=${RP} --with-opencl
-          make -j $(nproc)
+          make -j ${{ steps.setup-env.outputs.nproc }}

--- a/.github/workflows/check_intel.yml
+++ b/.github/workflows/check_intel.yml
@@ -32,6 +32,8 @@ jobs:
               INTEL_PATH=$(find /opt/intel/oneapi/compiler/ -name "${FC}" -type f | xargs dirname)
               export PATH=$INTEL_PATH:${PATH}
               printenv >> $GITHUB_ENV
+              echo "os-version=$(lsb_release -ds | tr " " -)" >> $GITHUB_OUTPUT
+
     env:
       CC: icc
       FC: ${{ matrix.compiler }}
@@ -39,6 +41,7 @@ jobs:
     name: ${{ matrix.os }} - ${{ matrix.compiler }} - ${{ matrix.backend }} - ${{ matrix.precision }}
     steps:
       - name: Setup env.
+        id: setup-env
         run: ${{ matrix.setup-env }}
 
       - name: Checkout
@@ -51,7 +54,7 @@ jobs:
         uses: ./.github/actions/setup_json-fortran
         with:
           version: ${{ inputs.json-fortran-version }}
-          os: ${{ matrix.os }}
+          os: ${{ steps.setup-env.outputs.os-version }}
           compiler: ${{ matrix.compiler }}
 
       - name: Add JSON-Fortran to environment

--- a/.github/workflows/check_nvidia.yml
+++ b/.github/workflows/check_nvidia.yml
@@ -36,6 +36,8 @@ jobs:
               PATH=$NVCOMPILERS/$NVARCH/24.3/compilers/bin:$PATH; export PATH
               export PATH=$NVCOMPILERS/$NVARCH/24.3/comm_libs/mpi/bin:$PATH
               printenv >> $GITHUB_ENV
+              echo "os-version=$(lsb_release -ds | tr " " -)" >> $GITHUB_OUTPUT
+
     env:
       CC: gcc
       FC: ${{ matrix.compiler }}
@@ -48,6 +50,7 @@ jobs:
     name: ${{ matrix.os }} - ${{ matrix.compiler }} - ${{ matrix.backend }} - ${{ matrix.precision }}
     steps:
       - name: Setup env.
+        id: setup-env
         run: ${{ matrix.setup-env }}
 
       - name: Checkout
@@ -60,7 +63,7 @@ jobs:
         uses: ./.github/actions/setup_json-fortran
         with:
           version: ${{ inputs.json-fortran-version }}
-          os: ${{ matrix.os }}
+          os: ${{ steps.setup-env.outputs.os-version }}
           compiler: ${{ matrix.compiler }}
 
       - name: Add JSON-Fortran to environment

--- a/.github/workflows/check_reframe.yml
+++ b/.github/workflows/check_reframe.yml
@@ -28,11 +28,13 @@ jobs:
     name: ReFrame - ${{ matrix.compiler}} - ${{ matrix.precision }}
     steps:
       - name: Setup env.
+        id: setup-env
         run: |
           sudo apt-get update
           sudo apt-get install -y openmpi-bin libopenmpi-dev \
             autoconf automake autotools-dev libopenblas-dev make git m4 python3
           pip install reframe-hpc
+          echo "os-version=$(lsb_release -ds | tr " " -)" >> $GITHUB_OUTPUT
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,7 +46,7 @@ jobs:
         uses: ./.github/actions/setup_json-fortran
         with:
           version: ${{ inputs.json-fortran-version }}
-          os: ${{ runner.os }}
+          os: ${{ steps.setup-env.outputs.os-version }}
           compiler: ${{ matrix.compiler }}
 
       - name: Add JSON-Fortran to environment


### PR DESCRIPTION
Update the CI to determine the full OS version currently used. This improves caching of dependencies, as an update to the minor version of the runner os might require a recompilation which was not caught previously.