### PR TITLE
Update auto config scripts to fix obsolete warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_PREREQ([2.69])
+AC_PREREQ([2.71])
 AC_INIT([neko],[0.8.99])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_MAINTAINER_MODE

--- a/m4/ax_blas.m4
+++ b/m4/ax_blas.m4
@@ -66,9 +66,9 @@
 
 #serial 17
 
-AU_ALIAS([ACX_BLAS], [AX_BLAS])
+AU_ALIAS([AX_BLAS], [AX_BLAS])
 AC_DEFUN([AX_BLAS], [
-AC_PREREQ([2.55])
+AC_PREREQ([2.71])
 ax_blas_ok=no
 
 AC_ARG_WITH(blas,

--- a/m4/ax_lapack.m4
+++ b/m4/ax_lapack.m4
@@ -67,7 +67,7 @@
 
 #serial 10
 
-AU_ALIAS([ACX_LAPACK], [AX_LAPACK])
+AU_ALIAS([AX_LAPACK], [AX_LAPACK])
 AC_DEFUN([AX_LAPACK], [
 AC_REQUIRE([AX_BLAS])
 ax_lapack_ok=no

--- a/m4/ax_mpi.m4
+++ b/m4/ax_mpi.m4
@@ -65,9 +65,9 @@
 
 #serial 42
 
-AU_ALIAS([ACX_MPI], [AX_MPI])
+AU_ALIAS([AX_MPI], [AX_MPI])
 AC_DEFUN([AX_MPI], [
-AC_PREREQ(2.50) dnl for AC_LANG_CASE
+AC_PREREQ([2.71]) dnl for AC_LANG_CASE
 
 AC_LANG_CASE([C], [
 	AC_REQUIRE([AC_PROG_CC])
@@ -135,16 +135,16 @@ if test x = x"$MPILIBS"; then
 	AC_CHECK_LIB(mpich, MPI_Init, [MPILIBS="-lmpich"])
 fi
 
-dnl We have to use AC_TRY_COMPILE and not AC_CHECK_HEADER because the
+dnl We have to use AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],[],[]) and not AC_CHECK_HEADER because the
 dnl latter uses $CPP, not $CC (which may be mpicc).
 AC_LANG_CASE([C], [if test x != x"$MPILIBS"; then
 	AC_MSG_CHECKING([for mpi.h])
-	AC_TRY_COMPILE([#include <mpi.h>],[],[AC_MSG_RESULT(yes)], [MPILIBS=""
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <mpi.h>]], [[]])],[AC_MSG_RESULT(yes)],[MPILIBS=""
 		AC_MSG_RESULT(no)])
 fi],
 [C++], [if test x != x"$MPILIBS"; then
 	AC_MSG_CHECKING([for mpi.h])
-	AC_TRY_COMPILE([#include <mpi.h>],[],[AC_MSG_RESULT(yes)], [MPILIBS=""
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <mpi.h>]], [[]])],[AC_MSG_RESULT(yes)],[MPILIBS=""
 		AC_MSG_RESULT(no)])
 fi],
 [Fortran 77], [if test x != x"$MPILIBS"; then


### PR DESCRIPTION
Please correct me if we are required to support version `2.69` for some HPC cluster purposes.
Otherwise this update clears the obsolete warnings when configuring.