### PR TITLE
Alternative suggestion to the makeneko naming

### DIFF
--- a/makeneko.in
+++ b/makeneko.in
@@ -33,10 +33,8 @@ program usrneko
 end program usrneko
 _ACEOF
 
-
-application=$(echo $1 | cut -d '.' -f 1)
 $FC $FCFLAGS -I$includedir_pkg -L$libdir $1 usr_driver.f90\
-    -lneko @LDFLAGS@ @LIBS@ -o neko_$application
+    -lneko @LDFLAGS@ @LIBS@ -o neko
 
 rm -f usr_driver.f90
 

--- a/reframe/checks.py
+++ b/reframe/checks.py
@@ -282,7 +282,7 @@ class GetTgvDns(rfm.RunOnlyRegressionTest):
 
 class TgvBase(NekoTestBase):
     descr = 'Run TGV and compare with DNS data'
-    executable = './neko_tgv'
+    executable = './neko'
     case = 'tgv.case'
     tgv_dns = fixture(GetTgvDns, scope='session')
 
@@ -362,7 +362,6 @@ class MiniHemi(NekoTestBase):
     build_system = DummyBuildSystem()
     case = 'minihemi.case'
     mesh_file = 'examples/hemi/hemi.nmsh'
-    executable = './neko_hemi'
 
     @run_before('compile')
     def setup_case(self):
@@ -374,7 +373,7 @@ class MiniTgv8(NekoTestBase):
     mesh_file = 'examples/tgv/512.nmsh'
     dt = '1d-2'
     T_end = '0.02'
-    executable = './neko_tgv'
+    executable = './neko'
     case = 'tgv.case'
 
     @run_after('setup')
@@ -388,7 +387,7 @@ class MiniRB(NekoTestBase):
     mesh_file = 'examples/rayleigh-benard/box.nmsh'
     dt = '1d-2'
     T_end = '0.02'
-    executable = './neko_rayleigh'
+    executable = './neko'
     case = 'rayleigh.case'
 
     @run_after('setup')

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -114,7 +114,7 @@ module user_intf
    contains
      procedure, pass(u) :: init => user_intf_init
   end type user_t
-  
+
 contains
   !> User interface initialization
   subroutine user_intf_init(u)
@@ -122,31 +122,37 @@ contains
 
     if (.not. associated(u%fluid_user_ic)) then
        u%fluid_user_ic => dummy_user_ic
+    else
        u%user_extended = .true.
     end if
 
     if (.not. associated(u%fluid_user_f)) then
        u%fluid_user_f => dummy_user_f
+    else
        u%user_extended = .true.
     end if
-    
+
     if (.not. associated(u%fluid_user_f_vector)) then
        u%fluid_user_f_vector => dummy_user_f_vector
+    else
        u%user_extended = .true.
     end if
 
     if (.not. associated(u%scalar_user_f)) then
        u%scalar_user_f => dummy_scalar_user_f
+    else
        u%user_extended = .true.
     end if
-    
+
     if (.not. associated(u%scalar_user_f_vector)) then
        u%scalar_user_f_vector => dummy_user_scalar_f_vector
+    else
        u%user_extended = .true.
     end if
-    
+
     if (.not. associated(u%user_mesh_setup)) then
        u%user_mesh_setup => dummy_user_mesh_setup
+    else
        u%user_extended = .true.
     end if
 
@@ -156,12 +162,13 @@ contains
     end if
     if (.not. associated(u%user_init_modules)) then
        u%user_init_modules => dummy_user_init_no_modules
+    else
        u%user_extended = .true.
     end if
-    
+
   end subroutine user_intf_init
 
-  
+
   !
   ! Below is the dummy user interface
   ! when running in pure turboNEKO mode
@@ -174,14 +181,14 @@ contains
     type(field_t), intent(inout) :: w
     type(field_t), intent(inout) :: p
     type(param_t), intent(inout) :: params
-    call neko_error('Dummy user defined initial condition set')    
+    call neko_error('Dummy user defined initial condition set')
   end subroutine dummy_user_ic
 
   !> Dummy user (fluid) forcing
   subroutine dummy_user_f_vector(f, t)
     class(source_t), intent(inout) :: f
     real(kind=rp), intent(in) :: t
-    call neko_error('Dummy user defined vector valued forcing set')    
+    call neko_error('Dummy user defined vector valued forcing set')
   end subroutine dummy_user_f_vector
 
   !> Dummy user (fluid) forcing
@@ -194,14 +201,14 @@ contains
     integer, intent(in) :: l
     integer, intent(in) :: e
     real(kind=rp), intent(in) :: t
-    call neko_error('Dummy user defined forcing set')    
+    call neko_error('Dummy user defined forcing set')
   end subroutine dummy_user_f
 
   !> Dummy user (scalar) forcing
   subroutine dummy_user_scalar_f_vector(f, t)
     class(source_scalar_t), intent(inout) :: f
     real(kind=rp), intent(in) :: t
-    call neko_error('Dummy user defined vector valued forcing set')    
+    call neko_error('Dummy user defined vector valued forcing set')
   end subroutine dummy_user_scalar_f_vector
 
   !> Dummy user (scalar) forcing
@@ -212,17 +219,17 @@ contains
     integer, intent(in) :: l
     integer, intent(in) :: e
     real(kind=rp), intent(in) :: t
-    call neko_error('Dummy user defined forcing set')    
+    call neko_error('Dummy user defined forcing set')
   end subroutine dummy_scalar_user_f
- 
+
   !> Dummy user mesh apply
   subroutine dummy_user_mesh_setup(msh)
     type(mesh_t), intent(inout) :: msh
   end subroutine dummy_user_mesh_setup
-  
+
   !> Dummy user check
   subroutine dummy_user_check(t, tstep, u, v, w, p, coef, params)
-    real(kind=rp), intent(in) :: t    
+    real(kind=rp), intent(in) :: t
     integer, intent(in) :: tstep
     type(field_t), intent(inout) :: u
     type(field_t), intent(inout) :: v

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -99,6 +99,9 @@ module user_intf
   end interface
 
   type :: user_t
+     !> Logical to indicate if the code have been extended by the user.
+     logical :: user_extended = .false.
+
      procedure(useric), nopass, pointer :: fluid_user_ic => null()
      procedure(user_initialize_modules), nopass, pointer :: user_init_modules => null()
      procedure(usermsh), nopass, pointer :: user_mesh_setup => null()
@@ -119,33 +122,41 @@ contains
 
     if (.not. associated(u%fluid_user_ic)) then
        u%fluid_user_ic => dummy_user_ic
+       u%user_extended = .true.
     end if
 
     if (.not. associated(u%fluid_user_f)) then
        u%fluid_user_f => dummy_user_f
+       u%user_extended = .true.
     end if
     
     if (.not. associated(u%fluid_user_f_vector)) then
        u%fluid_user_f_vector => dummy_user_f_vector
+       u%user_extended = .true.
     end if
 
     if (.not. associated(u%scalar_user_f)) then
        u%scalar_user_f => dummy_scalar_user_f
+       u%user_extended = .true.
     end if
     
     if (.not. associated(u%scalar_user_f_vector)) then
        u%scalar_user_f_vector => dummy_user_scalar_f_vector
+       u%user_extended = .true.
     end if
     
     if (.not. associated(u%user_mesh_setup)) then
        u%user_mesh_setup => dummy_user_mesh_setup
+       u%user_extended = .true.
     end if
 
     if (.not. associated(u%user_check)) then
        u%user_check => dummy_user_check
+       u%user_extended = .true.
     end if
     if (.not. associated(u%user_init_modules)) then
        u%user_init_modules => dummy_user_init_no_modules
+       u%user_extended = .true.
     end if
     
   end subroutine user_intf_init

--- a/src/neko.f90
+++ b/src/neko.f90
@@ -199,6 +199,10 @@ contains
        !
        call case_init(C, case_file)
        
+       if (C%usr%user_extended .eq. .true.) then
+          write(log_buf, '(a)') 'Running neko in user extended mode.'
+          call neko_log%message(log_buf)
+       end if
     end if
     
   end subroutine neko_init


### PR DESCRIPTION
Instead of changing the name of the executable, we can print a message to the log if we are running any user extended functions.

Please note, this PR is to the original PR not to the develop branch as I would not start overriding the work of Måns directly.