### PR TITLE
Debug: Update TS wave test

### DIFF
--- a/examples/TS_channel/TS_channel.case
+++ b/examples/TS_channel/TS_channel.case
@@ -10,7 +10,8 @@
     "checkpoint_value": 100,
     "end_time": 200,
     "timestep": 0.02,
-    "constant_cfl": 0.4,
+    "variable_timestep": true,
+    "target_cfl": 0.4,
     "numerics": {
         "time_order": 3,
         "polynomial_order": 7,


### PR DESCRIPTION
Two point to update with the TS wave test examples:

1. Update the outdated case file to keep accordance with the current time step controller setting. (committed already)
2. Change to a 16^3 elements mesh for a matching result with Schlatter 2005. (under discussion now)