### PR TITLE
Temp fix to be able to run on LUMI

### DIFF
--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -272,13 +272,13 @@ contains
   subroutine hip_init
     integer(c_int) :: num_devices
 
-    if (hipGetDeviceCount(num_devices) .ne. hipSuccess) then
-       call neko_error('Failed to query device count')
-    end if
+    !if (hipGetDeviceCount(num_devices) .ne. hipSuccess) then
+    !   call neko_error('Failed to query device count')
+    !end if
 
-    if (num_devices .ne. 1) then
-        call neko_error('Only one device is supported per MPI node')
-    end if
+    !if (num_devices .ne. 1) then
+    !    call neko_error('Only one device is supported per MPI node')
+    !end if
 
     if (hipDeviceGetStreamPriorityRange(STRM_LOW_PRIO, STRM_HIGH_PRIO) &
          .ne. hipSuccess) then


### PR DESCRIPTION
Dont know exactly what goes wrong, but something is iffy with hipGetDeviceCount. Do you have any idea what can be the issue @timfelle ?

To be clear, if one does not comment these lines Neko segfaults directly on LUMI.