### PR TITLE
Fix/hip_device_count

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -10,7 +10,6 @@ on:
       - reopened
       - ready_for_review
   workflow_dispatch:
-  push:
 
 env:
   FLINT_GLOBAL_MINIMUM: 8.55

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -10,6 +10,7 @@ on:
       - reopened
       - ready_for_review
   workflow_dispatch:
+  push:
 
 env:
   FLINT_GLOBAL_MINIMUM: 8.55

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -235,7 +235,7 @@ contains
 
   subroutine hip_init
     if (hip_device_count() .ne. 1) then
-       call neko_error('Only one device is supported per MPI node')
+       call neko_error('Only one device is supported per MPI rank')
     end if
 
     if (hipDeviceGetStreamPriorityRange(STRM_LOW_PRIO, STRM_HIGH_PRIO) &

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -94,18 +94,14 @@ module hip_intf
        type(c_ptr) :: ptr_d
        integer(c_size_t), value :: s
      end function hipMalloc
-  end interface
 
-  interface
      integer(c_int) function hipFree(ptr_d) &
        bind(c, name='hipFree')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: ptr_d
      end function hipFree
-  end interface
 
-  interface
      integer(c_int) function hipMemcpy(ptr_dst, ptr_src, s, dir) &
        bind(c, name='hipMemcpy')
        use, intrinsic :: iso_c_binding
@@ -114,9 +110,7 @@ module hip_intf
        integer(c_size_t), value :: s
        integer(c_int), value :: dir
      end function hipMemcpy
-  end interface
 
-  interface
      integer(c_int) function hipMemcpyAsync(ptr_dst, ptr_src, s, dir, stream) &
        bind(c, name='hipMemcpyAsync')
        use, intrinsic :: iso_c_binding
@@ -125,17 +119,13 @@ module hip_intf
        integer(c_size_t), value :: s
        integer(c_int), value :: dir
      end function hipMemcpyAsync
-  end interface
 
-  interface
      integer(c_int) function hipDeviceSynchronize() &
        bind(c, name='hipDeviceSynchronize')
        use, intrinsic :: iso_c_binding
        implicit none
      end function hipDeviceSynchronize
-  end interface
 
-  interface
      integer(c_int) function hipDeviceGetName(name, len, device) &
        bind(c, name='hipDeviceGetName')
        use, intrinsic :: iso_c_binding
@@ -144,26 +134,20 @@ module hip_intf
        integer(c_int), value :: len
        integer(c_int), value :: device
      end function hipDeviceGetName
-  end interface
 
-  interface
      type (c_ptr) function hipGetDeviceCount() &
        bind(c, name='hipGetDeviceCount')
        use, intrinsic :: iso_c_binding
        implicit none
      end function hipGetDeviceCount
-  end interface
 
-  interface
      integer(c_int) function hipStreamCreate(stream) &
        bind(c, name='hipStreamCreate')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr) :: stream
      end function hipStreamCreate
-  end interface
 
-  interface
      integer(c_int) function hipStreamCreateWithFlags(stream, flags) &
        bind(c, name='hipStreamCreateWithFlags')
        use, intrinsic :: iso_c_binding
@@ -171,9 +155,7 @@ module hip_intf
        type(c_ptr) :: stream
        integer(c_int), value :: flags
      end function hipStreamCreateWithFlags
-  end interface
 
-  interface
      integer(c_int) function hipStreamCreateWithPriority(stream, flags, prio) &
        bind(c, name='hipStreamCreateWithPriority')
        use, intrinsic :: iso_c_binding
@@ -181,27 +163,21 @@ module hip_intf
        type(c_ptr) :: stream
        integer(c_int), value :: flags, prio
      end function hipStreamCreateWithPriority
-  end interface
 
-  interface
      integer(c_int) function hipStreamDestroy(steam) &
        bind(c, name='hipStreamDestroy')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: steam
      end function hipStreamDestroy
-  end interface
 
-  interface
      integer(c_int) function hipStreamSynchronize(stream) &
        bind(c, name='hipStreamSynchronize')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: stream
      end function hipStreamSynchronize
-  end interface
 
-  interface
      integer(c_int) function hipStreamWaitEvent(stream, event, flags) &
        bind(c, name='hipStreamWaitEvent')
        use, intrinsic :: iso_c_binding
@@ -209,36 +185,28 @@ module hip_intf
        type(c_ptr), value :: stream, event
        integer(c_int), value :: flags
      end function hipStreamWaitEvent
-  end interface
 
-  interface
      integer(c_int) function hipDeviceGetStreamPriorityRange(low_prio, high_prio) &
        bind(c, name='hipDeviceGetStreamPriorityRange')
        use, intrinsic :: iso_c_binding
        implicit none
        integer(c_int) :: low_prio, high_prio
      end function hipDeviceGetStreamPriorityRange
-  end interface
 
-  interface
      integer(c_int) function hipEventCreate(event) &
        bind(c, name='hipEventCreate')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr) :: event
      end function hipEventCreate
-  end interface
 
-  interface
      integer(c_int) function hipEventDestroy(event) &
        bind(c, name='hipEventDestroy')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: event
      end function hipEventDestroy
-  end interface
 
-  interface
      integer(c_int) function hipEventCreateWithFlags(event, flags) &
        bind(c, name='hipEventCreateWithFlags')
        use, intrinsic :: iso_c_binding
@@ -246,18 +214,14 @@ module hip_intf
        type(c_ptr) :: event
        integer(c_int), value :: flags
      end function hipEventCreateWithFlags
-  end interface
 
-  interface
      integer(c_int) function hipEventRecord(event, stream) &
        bind(c, name='hipEventRecord')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: event, stream
      end function hipEventRecord
-  end interface
 
-  interface
      integer(c_int) function hipEventSynchronize(event) &
        bind(c, name='hipEventSynchronize')
        use, intrinsic :: iso_c_binding

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -318,7 +318,7 @@ contains
 
   integer function hip_device_count()
     type(c_ptr) :: device_count_ptr
-    integer, pointer :: device_count
+    integer, pointer, dimension(:) :: device_count
     integer(c_int) :: num_devices, count_error
 
     device_count_ptr = hipGetDeviceCount()

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -87,8 +87,8 @@ module hip_intf
   end enum
 
   interface
-     integer (c_int) function hipMalloc(ptr_d, s) &
-          bind(c, name='hipMalloc')
+     integer(c_int) function hipMalloc(ptr_d, s) &
+       bind(c, name='hipMalloc')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr) :: ptr_d
@@ -97,8 +97,8 @@ module hip_intf
   end interface
 
   interface
-     integer (c_int) function hipFree(ptr_d) &
-          bind(c, name='hipFree')
+     integer(c_int) function hipFree(ptr_d) &
+       bind(c, name='hipFree')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: ptr_d
@@ -106,8 +106,8 @@ module hip_intf
   end interface
 
   interface
-     integer (c_int) function hipMemcpy(ptr_dst, ptr_src, s, dir) &
-          bind(c, name='hipMemcpy')
+     integer(c_int) function hipMemcpy(ptr_dst, ptr_src, s, dir) &
+       bind(c, name='hipMemcpy')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: ptr_dst, ptr_src
@@ -117,8 +117,8 @@ module hip_intf
   end interface
 
   interface
-     integer (c_int) function hipMemcpyAsync(ptr_dst, ptr_src, s, dir, stream) &
-          bind(c, name='hipMemcpyAsync')
+     integer(c_int) function hipMemcpyAsync(ptr_dst, ptr_src, s, dir, stream) &
+       bind(c, name='hipMemcpyAsync')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: ptr_dst, ptr_src, stream
@@ -128,16 +128,16 @@ module hip_intf
   end interface
 
   interface
-     integer (c_int) function hipDeviceSynchronize() &
-          bind(c, name='hipDeviceSynchronize')
+     integer(c_int) function hipDeviceSynchronize() &
+       bind(c, name='hipDeviceSynchronize')
        use, intrinsic :: iso_c_binding
        implicit none
      end function hipDeviceSynchronize
   end interface
 
   interface
-     integer (c_int) function hipDeviceGetName(name, len, device) &
-          bind(c, name='hipDeviceGetName')
+     integer(c_int) function hipDeviceGetName(name, len, device) &
+       bind(c, name='hipDeviceGetName')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: name
@@ -147,17 +147,16 @@ module hip_intf
   end interface
 
   interface
-     integer (c_int) function hipGetDeviceCount(count) &
-          bind(c, name='hipGetDeviceCount')
+     type (c_ptr) function hipGetDeviceCount() &
+       bind(c, name='hipGetDeviceCount')
        use, intrinsic :: iso_c_binding
        implicit none
-       integer(c_int), value :: count
      end function hipGetDeviceCount
   end interface
 
   interface
-     integer (c_int) function hipStreamCreate(stream) &
-          bind(c, name='hipStreamCreate')
+     integer(c_int) function hipStreamCreate(stream) &
+       bind(c, name='hipStreamCreate')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr) :: stream
@@ -165,8 +164,8 @@ module hip_intf
   end interface
 
   interface
-     integer (c_int) function hipStreamCreateWithFlags(stream, flags) &
-          bind(c, name='hipStreamCreateWithFlags')
+     integer(c_int) function hipStreamCreateWithFlags(stream, flags) &
+       bind(c, name='hipStreamCreateWithFlags')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr) :: stream
@@ -175,8 +174,8 @@ module hip_intf
   end interface
 
   interface
-     integer (c_int) function hipStreamCreateWithPriority(stream, flags, prio) &
-          bind(c, name='hipStreamCreateWithPriority')
+     integer(c_int) function hipStreamCreateWithPriority(stream, flags, prio) &
+       bind(c, name='hipStreamCreateWithPriority')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr) :: stream
@@ -185,8 +184,8 @@ module hip_intf
   end interface
 
   interface
-     integer (c_int) function hipStreamDestroy(steam) &
-          bind(c, name='hipStreamDestroy')
+     integer(c_int) function hipStreamDestroy(steam) &
+       bind(c, name='hipStreamDestroy')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: steam
@@ -194,8 +193,8 @@ module hip_intf
   end interface
 
   interface
-     integer (c_int) function hipStreamSynchronize(stream) &
-          bind(c, name='hipStreamSynchronize')
+     integer(c_int) function hipStreamSynchronize(stream) &
+       bind(c, name='hipStreamSynchronize')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: stream
@@ -203,8 +202,8 @@ module hip_intf
   end interface
 
   interface
-     integer (c_int) function hipStreamWaitEvent(stream, event, flags) &
-          bind(c, name='hipStreamWaitEvent')
+     integer(c_int) function hipStreamWaitEvent(stream, event, flags) &
+       bind(c, name='hipStreamWaitEvent')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: stream, event
@@ -213,8 +212,8 @@ module hip_intf
   end interface
 
   interface
-     integer (c_int) function hipDeviceGetStreamPriorityRange(low_prio, high_prio) &
-          bind(c, name='hipDeviceGetStreamPriorityRange')
+     integer(c_int) function hipDeviceGetStreamPriorityRange(low_prio, high_prio) &
+       bind(c, name='hipDeviceGetStreamPriorityRange')
        use, intrinsic :: iso_c_binding
        implicit none
        integer(c_int) :: low_prio, high_prio
@@ -222,8 +221,8 @@ module hip_intf
   end interface
 
   interface
-     integer (c_int) function hipEventCreate(event) &
-          bind(c, name='hipEventCreate')
+     integer(c_int) function hipEventCreate(event) &
+       bind(c, name='hipEventCreate')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr) :: event
@@ -231,8 +230,8 @@ module hip_intf
   end interface
 
   interface
-     integer (c_int) function hipEventDestroy(event) &
-          bind(c, name='hipEventDestroy')
+     integer(c_int) function hipEventDestroy(event) &
+       bind(c, name='hipEventDestroy')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: event
@@ -240,8 +239,8 @@ module hip_intf
   end interface
 
   interface
-     integer (c_int) function hipEventCreateWithFlags(event, flags) &
-          bind(c, name='hipEventCreateWithFlags')
+     integer(c_int) function hipEventCreateWithFlags(event, flags) &
+       bind(c, name='hipEventCreateWithFlags')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr) :: event
@@ -250,8 +249,8 @@ module hip_intf
   end interface
 
   interface
-     integer (c_int) function hipEventRecord(event, stream) &
-          bind(c, name='hipEventRecord')
+     integer(c_int) function hipEventRecord(event, stream) &
+       bind(c, name='hipEventRecord')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: event, stream
@@ -259,8 +258,8 @@ module hip_intf
   end interface
 
   interface
-     integer (c_int) function hipEventSynchronize(event) &
-          bind(c, name='hipEventSynchronize')
+     integer(c_int) function hipEventSynchronize(event) &
+       bind(c, name='hipEventSynchronize')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: event
@@ -270,28 +269,23 @@ module hip_intf
 contains
 
   subroutine hip_init
-    integer(c_int) :: num_devices
 
-    !if (hipGetDeviceCount(num_devices) .ne. hipSuccess) then
-    !   call neko_error('Failed to query device count')
-    !end if
-
-    !if (num_devices .ne. 1) then
-    !    call neko_error('Only one device is supported per MPI node')
-    !end if
+    if (hip_device_count() .ne. 1) then
+       call neko_error('Only one device is supported per MPI node')
+    end if
 
     if (hipDeviceGetStreamPriorityRange(STRM_LOW_PRIO, STRM_HIGH_PRIO) &
-         .ne. hipSuccess) then
+        .ne. hipSuccess) then
        call neko_error('Error retrieving stream priority range')
     end if
 
     if (hipStreamCreateWithPriority(glb_cmd_queue, 1, STRM_HIGH_PRIO) &
-         .ne. hipSuccess) then
+        .ne. hipSuccess) then
        call neko_error('Error creating main stream')
     end if
 
     if (hipStreamCreateWithPriority(aux_cmd_queue, 1, STRM_LOW_PRIO) &
-         .ne. hipSuccess) then
+        .ne. hipSuccess) then
        call neko_error('Error creating main stream')
     end if
   end subroutine hip_init
@@ -321,6 +315,23 @@ contains
     endif
 
   end subroutine hip_device_name
+
+  integer function hip_device_count()
+    type(c_ptr) :: device_count_ptr
+    integer, pointer :: device_count
+    integer(c_int) :: num_devices, count_error
+
+    device_count_ptr = hipGetDeviceCount()
+    call c_f_pointer(device_count_ptr, device_count)
+    count_error = device_count(1)
+    num_devices = device_count(2)
+
+    if (count_error .ne. hipSuccess) then
+       call neko_error('Failed to query device count')
+    end if
+
+    hip_device_count = num_devices
+  end function hip_device_count
 
 #endif
 

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -282,7 +282,7 @@ contains
 
   integer function hip_device_count()
     type(c_ptr) :: hip_count_ptr
-    integer, dimension(0:1), pointer :: count_ptr
+    integer, pointer :: count_ptr(0:1)
 
     hip_count_ptr = hipGetDeviceCount()
     call c_f_pointer(hip_count_ptr, count_ptr, 2)

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -282,16 +282,16 @@ contains
 
   integer function hip_device_count()
     type(c_ptr) :: hip_count_ptr
-    integer, dimension(2), pointer :: count_ptr
+    integer, dimension(0:1), pointer :: count_ptr
 
     hip_count_ptr = hipGetDeviceCount()
     call c_f_pointer(hip_count_ptr, count_ptr, 2)
 
-    if (count_ptr(1) .ne. hipSuccess) then
+    if (count_ptr(0) .ne. hipSuccess) then
        call neko_error('Failed to query device count')
     end if
 
-    hip_device_count = count_ptr(2)
+    hip_device_count = count_ptr(1)
   end function hip_device_count
 
 #endif

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -281,6 +281,7 @@ contains
 
   end subroutine hip_device_name
 
+  !> Return the number of available HIP devices
   integer function hip_device_count()
     type(c_ptr) :: hip_count_ptr
     integer, pointer :: count_ptr(:)

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -282,10 +282,10 @@ contains
 
   integer function hip_device_count()
     type(c_ptr) :: hip_count_ptr
-    integer, pointer :: count_ptr(0:1)
+    integer, pointer :: count_ptr(:)
 
     hip_count_ptr = hipGetDeviceCount()
-    call c_f_pointer(hip_count_ptr, count_ptr, 2)
+    call c_f_pointer(hip_count_ptr, count_ptr, [2])
 
     if (count_ptr(0) .ne. hipSuccess) then
        call neko_error('Failed to query device count')

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -38,8 +38,6 @@ module hip_intf
 
 #ifdef HAVE_HIP
 
-  private :: hipGetDeviceCount
-
   !> Global HIP command queue
   type(c_ptr), bind(c) :: glb_cmd_queue = C_NULL_PTR
 
@@ -137,10 +135,11 @@ module hip_intf
        integer(c_int), value :: device
      end function hipDeviceGetName
 
-     type (c_ptr) function hipGetDeviceCount() &
+     integer(c_int) function hipGetDeviceCount(count) &
        bind(c, name='hipGetDeviceCount')
        use, intrinsic :: iso_c_binding
        implicit none
+       integer(c_int) :: count
      end function hipGetDeviceCount
 
      integer(c_int) function hipStreamCreate(stream) &
@@ -284,16 +283,13 @@ contains
   !> Return the number of available HIP devices
   integer function hip_device_count()
     type(c_ptr) :: hip_count_ptr
-    integer, pointer :: count_ptr(:)
+    integer :: count
 
-    hip_count_ptr = hipGetDeviceCount()
-    call c_f_pointer(hip_count_ptr, count_ptr, [2])
-
-    if (count_ptr(0) .ne. hipSuccess) then
+    if (hipGetDeviceCount(count) .ne. hipSuccess) then
        call neko_error('Failed to query device count')
     end if
 
-    hip_device_count = count_ptr(1)
+    hip_device_count = count
   end function hip_device_count
 
 #endif

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -38,6 +38,8 @@ module hip_intf
 
 #ifdef HAVE_HIP
 
+  private :: hipGetDeviceCount
+
   !> Global HIP command queue
   type(c_ptr), bind(c) :: glb_cmd_queue = C_NULL_PTR
 
@@ -233,7 +235,6 @@ module hip_intf
 contains
 
   subroutine hip_init
-
     if (hip_device_count() .ne. 1) then
        call neko_error('Only one device is supported per MPI node')
     end if

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -317,20 +317,17 @@ contains
   end subroutine hip_device_name
 
   integer function hip_device_count()
-    type(c_ptr) :: device_count_ptr
-    integer, pointer, dimension(:) :: device_count
-    integer(c_int) :: num_devices, count_error
+    type(c_ptr) :: hip_count_ptr
+    integer, dimension(2), pointer :: count_ptr
 
-    device_count_ptr = hipGetDeviceCount()
-    call c_f_pointer(device_count_ptr, device_count)
-    count_error = device_count(1)
-    num_devices = device_count(2)
+    hip_count_ptr = hipGetDeviceCount()
+    call c_f_pointer(hip_count_ptr, count_ptr, 2)
 
-    if (count_error .ne. hipSuccess) then
+    if (count_ptr(1) .ne. hipSuccess) then
        call neko_error('Failed to query device count')
     end if
 
-    hip_device_count = num_devices
+    hip_device_count = count_ptr(2)
   end function hip_device_count
 
 #endif

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -135,11 +135,11 @@ module hip_intf
        integer(c_int), value :: device
      end function hipDeviceGetName
 
-     integer(c_int) function hipGetDeviceCount(count) &
+     integer(c_int) function hipGetDeviceCount(amount) &
        bind(c, name='hipGetDeviceCount')
        use, intrinsic :: iso_c_binding
        implicit none
-       integer(c_int) :: count
+       integer(c_int) :: amount
      end function hipGetDeviceCount
 
      integer(c_int) function hipStreamCreate(stream) &
@@ -283,13 +283,13 @@ contains
   !> Return the number of available HIP devices
   integer function hip_device_count()
     type(c_ptr) :: hip_count_ptr
-    integer :: count
+    integer :: amount
 
-    if (hipGetDeviceCount(count) .ne. hipSuccess) then
+    if (hipGetDeviceCount(amount) .ne. hipSuccess) then
        call neko_error('Failed to query device count')
     end if
 
-    hip_device_count = count
+    hip_device_count = amount
   end function hip_device_count
 
 #endif


### PR DESCRIPTION
Should fix the device count interface for HIP.

We now have a sepparate function `hip_device_count` instead of the direct hip API binding.

Additionally we update to the latest develop branch.

I do not have access to a HIP based device so could you please see if this now works @MartinKarp?