### PR TITLE
Update indentation of logs

### DIFF
--- a/src/common/log.f90
+++ b/src/common/log.f90
@@ -115,7 +115,7 @@ contains
 
     if (pe_rank .eq. 0) then
        do i = 1, this%indent_
-          write(*,'(A)', advance='no') ' '
+          write(*,'(A)', advance = 'no') ' '
        end do
     end if
 
@@ -194,12 +194,12 @@ contains
        write(*,*) ' '
        call this%indent()
        do i = 1, pre
-          write(*,'(A)', advance='no') '-'
+          write(*,'(A)', advance = 'no') '-'
        end do
 
-       write(*,'(A)', advance='no') trim(msg)
+       write(*,'(A)', advance = 'no') trim(msg)
        do i = 1, 30 - (len_trim(msg) + pre)
-          write(*,'(A)', advance='no') '-'
+          write(*,'(A)', advance = 'no') '-'
        end do
        write(*,*) ' '
     end if
@@ -233,14 +233,16 @@ contains
 
     t_prog = 100d0 * t / T_end
 
-    call this%message('----------------------------------------------------------------', &
-                      NEKO_LOG_QUIET)
+    call this%message( &
+      & '----------------------------------------------------------------', &
+      & NEKO_LOG_QUIET)
     write(log_buf, '(A,E15.7,A,F6.2,A)') &
-    't = ', t, '                                  [ ',t_prog,'% ]'
+      't = ', t, '                                  [ ', t_prog, '% ]'
 
     call this%message(log_buf, NEKO_LOG_QUIET)
-    call this%message('----------------------------------------------------------------', &
-                      NEKO_LOG_QUIET)
+    call this%message( &
+      & '----------------------------------------------------------------', &
+      & NEKO_LOG_QUIET)
   end subroutine log_status
 
   !
@@ -249,7 +251,7 @@ contains
 
   !> Write a message to a log (from C)
   !! @note This assumes the global log stream @a neko_log
-  subroutine log_message_c(c_msg) bind(c, name='log_message')
+  subroutine log_message_c(c_msg) bind(c, name = 'log_message')
     use, intrinsic :: iso_c_binding
     character(kind=c_char), dimension(*), intent(in) :: c_msg
     character(len=LOG_SIZE) :: msg
@@ -271,7 +273,7 @@ contains
 
   !> Write an error message to a log (from C)
   !! @note This assumes the global log stream @a neko_log
-  subroutine log_error_c(c_msg) bind(c, name="log_error")
+  subroutine log_error_c(c_msg) bind(c, name = "log_error")
     use, intrinsic :: iso_c_binding
     character(kind=c_char), dimension(*), intent(in) :: c_msg
     character(len=LOG_SIZE) :: msg
@@ -286,14 +288,14 @@ contains
        end do
 
        call neko_log%indent()
-       write(*, '(A,A,A)') '*** ERROR: ',trim(msg(1:len)),'  ***'
+       write(*, '(A,A,A)') '*** ERROR: ', trim(msg(1:len)),'  ***'
     end if
 
   end subroutine log_error_c
 
   !> Write a warning message to a log (from C)
   !! @note This assumes the global log stream @a neko_log
-  subroutine log_warning_c(c_msg) bind(c, name="log_warning")
+  subroutine log_warning_c(c_msg) bind(c, name = "log_warning")
     use, intrinsic :: iso_c_binding
     character(kind=c_char), dimension(*), intent(in) :: c_msg
     character(len=LOG_SIZE) :: msg
@@ -308,14 +310,14 @@ contains
        end do
 
        call neko_log%indent()
-       write(*, '(A,A,A)') '*** WARNING: ',trim(msg(1:len)),'  ***'
+       write(*, '(A,A,A)') '*** WARNING: ', trim(msg(1:len)),'  ***'
     end if
 
   end subroutine log_warning_c
 
   !> Begin a new log section (from C)
   !! @note This assumes the global log stream @a neko_log
-  subroutine log_section_c(c_msg) bind(c, name="log_section")
+  subroutine log_section_c(c_msg) bind(c, name = "log_section")
     use, intrinsic :: iso_c_binding
     character(kind=c_char), dimension(*), intent(in) :: c_msg
     character(len=LOG_SIZE) :: msg
@@ -336,7 +338,7 @@ contains
 
   !> End a log section (from C)
   !! @note This assumes the global log stream @a neko_log
-  subroutine log_end_section_c() bind(c, name="log_end_section")
+  subroutine log_end_section_c() bind(c, name = "log_end_section")
 
     call neko_log%end_section()
 

--- a/src/common/log.f90
+++ b/src/common/log.f90
@@ -76,7 +76,7 @@ contains
     character(len=255) :: log_level
     integer :: envvar_len
 
-    this%indent_ = 1
+    this%indent_ = 0
     this%section_id_ = 0
 
     call get_environment_variable("NEKO_LOG_LEVEL", log_level, envvar_len)

--- a/src/neko.f90
+++ b/src/neko.f90
@@ -128,15 +128,15 @@ contains
     call neko_field_registry%init()
 
     if (pe_rank .eq. 0) then
-       write(*,*) ''
-       write(*,*) '   _  __  ____  __ __  ____ '
-       write(*,*) '  / |/ / / __/ / //_/ / __ \'
-       write(*,*) ' /    / / _/  / ,<   / /_/ /'
-       write(*,*) '/_/|_/ /___/ /_/|_|  \____/ '
-       write(*,*) ''
-       write(*,*) '(version: ', trim(NEKO_VERSION),')'
-       write(*,*) trim(NEKO_BUILD_INFO)
-       write(*,*) ''
+       write(*, '(A)') ''
+       write(*, '(A)') '   _  __  ____  __ __  ____ '
+       write(*, '(A)') '  / |/ / / __/ / //_/ / __ \'
+       write(*, '(A)') ' /    / / _/  / ,<   / /_/ /'
+       write(*, '(A)') '/_/|_/ /___/ /_/|_|  \____/ '
+       write(*, '(A)') ''
+       write(*, '(A)') '(version: ', trim(NEKO_VERSION),')'
+       write(*, '(A)') trim(NEKO_BUILD_INFO)
+       write(*, '(A)') ''
     end if
 
     if (present(C)) then

--- a/src/neko.f90
+++ b/src/neko.f90
@@ -144,7 +144,7 @@ contains
        argc = command_argument_count()
 
        if ((argc .lt. 1) .or. (argc .gt. 1)) then
-          if (pe_rank .eq. 0) write(*,*) 'Usage: ./neko <case file>'
+          if (pe_rank .eq. 0) write(*,*) 'Usage: ./neko < case file >'
           stop
        end if
 

--- a/src/neko.f90
+++ b/src/neko.f90
@@ -117,7 +117,7 @@ contains
     character(8) :: date
     integer :: argc, nthrds, rw, sw
 
-    call date_and_time(time=time, date=date)
+    call date_and_time(time = time, date = date)
 
     call comm_init
     call neko_mpi_types_init
@@ -134,7 +134,7 @@ contains
        write(*, '(A)') ' /    / / _/  / ,<   / /_/ /'
        write(*, '(A)') '/_/|_/ /___/ /_/|_|  \____/ '
        write(*, '(A)') ''
-       write(*, '(A)') '(version: ', trim(NEKO_VERSION),')'
+       write(*, '(A)') '(version: ', trim(NEKO_VERSION), ')'
        write(*, '(A)') trim(NEKO_BUILD_INFO)
        write(*, '(A)') ''
     end if
@@ -160,8 +160,9 @@ contains
        ! Job information
        !
        call neko_log%section("Job Information")
-       write(log_buf, '(A,A,A,A,1x,A,1x,A,A,A,A,A)') 'Start time: ',&
-         time(1:2),':',time(3:4), '/', date(1:4),'-', date(5:6),'-',date(7:8)
+       write(log_buf, '(A,A,A,A,1x,A,1x,A,A,A,A,A)') 'Start time: ', &
+         time(1:2), ':', time(3:4), &
+         '/', date(1:4), '-', date(5:6), '-', date(7:8)
        call neko_log%message(log_buf, NEKO_LOG_QUIET)
        write(log_buf, '(a)') 'Running on: '
        sw = 10


### PR DESCRIPTION
Ensure the neko header is not indented.

Reduce the log default indentation to 0 instead of the entire log being indented by 1 space.