### PR TITLE
Reduce probe output in the log file

### DIFF
--- a/src/simulation_components/probes.F90
+++ b/src/simulation_components/probes.F90
@@ -572,7 +572,7 @@ contains
   subroutine probes_show(this)
     class(probes_t), intent(in) :: this
     character(len=LOG_SIZE) :: log_buf ! For logging status
-    integer :: i
+    integer :: i, n_show
 
     ! Probes summary
     call neko_log%section('Probes')
@@ -580,10 +580,28 @@ contains
     call neko_log%message(log_buf)
     call neko_log%message("xyz-coordinates:")
 
-    do i = 1, this%n_local_probes
+    n_show = min(this%n_local_probes, NEKO_MAX_LOG_PROBES)
+
+    ! Output the first half of the probes
+    do i = 1, n_show/2
        write(log_buf, '("(",F10.6,",",F10.6,",",F10.6,")")') this%xyz(:,i)
        call neko_log%message(log_buf)
     end do
+
+    ! If we have too many probes, show how many we are skipping
+    if (this%n_local_probes .lt. NEKO_MAX_LOG_PROBES) then
+       write (log_buf, '(A,I9,A)') "(Skipping ", &
+            this%n_local_probes - NEKO_MAX_LOG_PROBES ," probes)"
+       call neko_log%message(log_buf)
+    end if
+
+    ! Show the other half of the probes, with special care for the lower
+    ! bound of the loop in case there is only 1 probe to show
+    do i = max(1, n_show/2), n_show
+       write(log_buf, '("(",F10.6,",",F10.6,",",F10.6,")")') this%xyz(:,i)
+       call neko_log%message(log_buf)
+    end do
+
     ! Field summary
     write(log_buf, '(A,I6)') "Number of fields: ", this%n_fields
     call neko_log%message(log_buf)

--- a/src/simulation_components/probes.F90
+++ b/src/simulation_components/probes.F90
@@ -572,7 +572,8 @@ contains
   subroutine probes_show(this)
     class(probes_t), intent(in) :: this
     character(len=LOG_SIZE) :: log_buf ! For logging status
-    integer :: i, n_show
+    integer :: i, n_show, leading_space_pos
+    character(len=80) :: char_n_skip_probes
 
     ! Probes summary
     call neko_log%section('Probes')
@@ -589,9 +590,15 @@ contains
     end do
 
     ! If we have too many probes, show how many we are skipping
-    if (this%n_local_probes .lt. NEKO_MAX_LOG_PROBES) then
-       write (log_buf, '(A,I9,A)') "(Skipping ", &
-            this%n_local_probes - NEKO_MAX_LOG_PROBES ," probes)"
+    if (this%n_local_probes .gt. NEKO_MAX_LOG_PROBES) then
+
+       ! We do this to print the number of probes to skip in a nice way
+       write (char_n_skip_probes, *) this%n_local_probes - NEKO_MAX_LOG_PROBES
+       leading_space_pos = scan(trim(char_n_skip_probes), " ", back = .true.)
+       char_n_skip_probes = trim(char_n_skip_probes(leading_space_pos + 1:))
+
+       write (log_buf, '(A,A,A)') "... skipping ", trim(char_n_skip_probes),&
+            " probes"
        call neko_log%message(log_buf)
     end if
 

--- a/src/simulation_components/probes.F90
+++ b/src/simulation_components/probes.F90
@@ -572,7 +572,7 @@ contains
   subroutine probes_show(this)
     class(probes_t), intent(in) :: this
     character(len=LOG_SIZE) :: log_buf ! For logging status
-    integer :: i, n_show, leading_space_pos
+    integer :: i, n_show, leading_space_pos, n_skip_probes
     character(len=80) :: char_n_skip_probes
 
     ! Probes summary
@@ -581,10 +581,12 @@ contains
     call neko_log%message(log_buf)
     call neko_log%message("xyz-coordinates:")
 
+    ! Number of probes to show
     n_show = min(this%n_local_probes, NEKO_MAX_LOG_PROBES)
 
-    ! Output the first half of the probes
-    do i = 1, n_show/2
+    ! Output the first half of the probes (with special treatment for the loop
+    ! in case number of probes is = 1)
+    do i = 1, max(1, n_show/2)
        write(log_buf, '("(",F10.6,",",F10.6,",",F10.6,")")') this%xyz(:,i)
        call neko_log%message(log_buf)
     end do
@@ -602,9 +604,8 @@ contains
        call neko_log%message(log_buf)
     end if
 
-    ! Show the other half of the probes, with special care for the lower
-    ! bound of the loop in case there is only 1 probe to show
-    do i = max(1, n_show/2), n_show
+    ! Show the other half of the probes
+    do i = this%n_local_probes - n_show/2 + 1, this%n_local_probes
        write(log_buf, '("(",F10.6,",",F10.6,",",F10.6,")")') this%xyz(:,i)
        call neko_log%message(log_buf)
     end do

--- a/src/simulation_components/probes.F90
+++ b/src/simulation_components/probes.F90
@@ -572,7 +572,7 @@ contains
   subroutine probes_show(this)
     class(probes_t), intent(in) :: this
     character(len=LOG_SIZE) :: log_buf ! For logging status
-    integer :: i, n_show, leading_space_pos, n_skip_probes
+    integer :: i, n_show, leading_space_pos
     character(len=80) :: char_n_skip_probes
 
     ! Probes summary

--- a/src/simulation_components/probes.F90
+++ b/src/simulation_components/probes.F90
@@ -59,6 +59,8 @@ module probes
   implicit none
   private
 
+  integer, parameter :: NEKO_MAX_LOG_PROBES = 20
+
   type, public, extends(simulation_component_t) :: probes_t
      !> Number of output fields
      integer :: n_fields = 0
@@ -577,7 +579,8 @@ contains
     write(log_buf, '(A,I6)') "Number of probes: ", this%n_global_probes
     call neko_log%message(log_buf)
     call neko_log%message("xyz-coordinates:")
-    do i=1,this%n_local_probes
+
+    do i = 1, this%n_local_probes
        write(log_buf, '("(",F10.6,",",F10.6,",",F10.6,")")') this%xyz(:,i)
        call neko_log%message(log_buf)
     end do


### PR DESCRIPTION
Fixes a maximal number of probes to write to the log file to not flood the output if we use a large number of probes with the variable `NEKO_MAX_LOG_PROBES`. 