### PR TITLE
Fix/flint_loophole

### DIFF
--- a/.github/workflows/check_lint.yml
+++ b/.github/workflows/check_lint.yml
@@ -107,7 +107,9 @@ jobs:
 
           printf "Detected fortran changes:\n"
           for file in $changes; do
-            if [[ ${file: -4} != ".f90" ]]; then continue; fi
+            if [[ ${file: -4} != ".f90" || ${file: -4} != ".F90" ]]; then
+              continue
+            fi
             printf "\t- $file"
           done
 
@@ -128,7 +130,9 @@ jobs:
           for file in $changed_files; do
 
             # If the file is not a Fortran file, skip it.
-            if [[ ${file: -4} != ".f90" ]]; then continue; fi
+            if [[ ${file: -4} != ".f90" || ${file: -4} != ".F90" ]]; then
+              continue
+            fi
 
             printf "\t- $file"
             score=$(flint score -r flinter_rc.yml $(realpath $file) 2> /dev/null |


### PR DESCRIPTION
Close a loophole where `F90` files are not checked for our code style.