### PR TITLE
Add enforcement of `only` specifications.

### DIFF
--- a/doc/pages/developer-guide/dev_patterns.md
+++ b/doc/pages/developer-guide/dev_patterns.md
@@ -89,9 +89,10 @@ base as of now, but we should at least make all new code as clean as possible.
 
 ## B. Scope
 
-1. Always use `only` when `using` something from another module.  The `neko`
-   module is an exception and imports everything. 
-   
+1. Always use `only` when `using` something from another module. The `neko`
+   module is an exception and imports everything. Additionally, current compiler
+   limitations make it impossible to use `only` with `comm` and `device`.
+
    This latter is done so that the user `.f90` files need only `use` the `neko`
    module to get access to everything.
 

--- a/flinter_rc.yml
+++ b/flinter_rc.yml
@@ -136,6 +136,12 @@ regexp-rules:
     replacement: null
     active: true
 
+  scope-not-specified:
+    message: Module usage should be explicit
+    regexp: ((use +)(?!\bneko\b)\w+\b)(?!, only)
+    replacement: null
+    active: true
+
   # -------------------------------------------------------------------------- #
   # Formatting and code style rules
 

--- a/flinter_rc.yml
+++ b/flinter_rc.yml
@@ -138,7 +138,7 @@ regexp-rules:
 
   scope-not-specified:
     message: Module usage should be explicit
-    regexp: ((use +)(?!(\bneko\b)|(\bdevice\b)|(\bcomm\b))\w+\b)(?!, only)
+    regexp: ((use +)(?!(\bneko\b)|(\bdevice\b)|(\bcomm\b)|(\bmpi_f08\b)|(\bhdf5\b))\w+\b)(?!, only)
     replacement: null
     active: true
 

--- a/flinter_rc.yml
+++ b/flinter_rc.yml
@@ -138,7 +138,7 @@ regexp-rules:
 
   scope-not-specified:
     message: Module usage should be explicit
-    regexp: ((use +)(?!\bneko\b)\w+\b)(?!, only)
+    regexp: ((use +)(?!(\bneko\b)|(\bdevice\b)|(\bcomm\b))\w+\b)(?!, only)
     replacement: null
     active: true
 


### PR DESCRIPTION
According to our guidelines we must use `only` when using modules.
https://neko.cfd/docs/develop/d0/d47/dev_patterns.html#autotoc_md16

This PR will enforce this.

Closes: #1418