### PR TITLE
Fix the linter issue by only checking full words matching `structs`

### DIFF
--- a/flinter_rc.yml
+++ b/flinter_rc.yml
@@ -180,7 +180,7 @@ regexp-rules:
 
   missing-space-before-parenthesis:
     message: Missing space before parenthesis
-    regexp: ({structs})\(
+    regexp: (\b{structs}\b)\(
     replacement: \1 (
     active: true
 


### PR DESCRIPTION
fixes The rule for spaces between builtin commands and paranthesis also trigger on variables with names ending in the builtin name. (example `phis`, triggers because of `is` ExtremeFLOW/neko#1421