### PR TITLE
Fix false restriction on the word "use"

### DIFF
--- a/flinter_rc.yml
+++ b/flinter_rc.yml
@@ -138,7 +138,7 @@ regexp-rules:
 
   scope-not-specified:
     message: Module usage should be explicit
-    regexp: ((use +)(?!(\bneko\b)|(\bdevice\b)|(\bcomm\b)|(\bmpi_f08\b)|(\bhdf5\b))\w+\b)(?!, only)
+    regexp: ((^\s+use +)(?!(\bneko\b)|(\bdevice\b)|(\bcomm\b)|(\bmpi_f08\b)|(\bhdf5\b))\w+\b)(?!, only)
     replacement: null
     active: true
 


### PR DESCRIPTION
Fixes #1428

Solution:
check only lines starting with `use`