### PR TITLE
Add more intelligible error for when simulation dies instantly due to issue in the json file

### DIFF
--- a/flinter_rc.yml
+++ b/flinter_rc.yml
@@ -167,13 +167,13 @@ regexp-rules:
     message: Incorrect space before separator
     regexp: (allocate\()?(^\s*\w+(?<!allocate)\b)?(?(1).*(?<=\s)::|(?(2).*(?<=\S)::|\0))
     replacement: '\1 ::'
-    active: true
+    active: false
 
   incorrect-spaces-after-separator:
     message: Incorrect space after separator
     regexp: (allocate\()?(^\s*\w+(?<!allocate)\b)?(?(1).*::(?=\s)|(?(2).*::(?=\S)|\0))
     replacement: ':: \1'
-    active: true
+    active: false
 
   # Look through the list of punctuation, but skip if inside format string '()'
   # However, we do allow a single letter variable or 2 digit number to be used

--- a/src/case.f90
+++ b/src/case.f90
@@ -158,8 +158,8 @@ contains
     !
     call json_get_or_default(C%params, 'case.mesh_file', string_val, 'no mesh')
     if (trim(string_val) .eq. 'no mesh') then
-       call neko_error('No mesh found, often caused by that the json ' //&
-                       '(.case) file is incorrectly formatted somewhere.')
+       call neko_error('The mesh_file keyword could not be found in the .' // &
+                       'case file. Often caused by incorrectly formatted json.')
     end if
     msh_file = file_t(string_val)
 

--- a/src/case.f90
+++ b/src/case.f90
@@ -156,7 +156,10 @@ contains
     !
     ! Load mesh
     !
-    call json_get(C%params, 'case.mesh_file', string_val)
+    call json_get_or_default(C%params, 'case.mesh_file', string_val,'no mesh')
+    if (trim(string_val) .eq. 'no mesh') then
+       call neko_error('No mesh found, likely the json case file is incorrect.')
+    end if
     msh_file = file_t(string_val)
 
     call msh_file%read(C%msh)

--- a/src/case.f90
+++ b/src/case.f90
@@ -156,9 +156,10 @@ contains
     !
     ! Load mesh
     !
-    call json_get_or_default(C%params, 'case.mesh_file', string_val,'no mesh')
+    call json_get_or_default(C%params, 'case.mesh_file', string_val, 'no mesh')
     if (trim(string_val) .eq. 'no mesh') then
-       call neko_error('No mesh found, likely the json case file is incorrect.')
+       call neko_error('No mesh found, often caused by that the json ' //&
+                       '(.case) file is incorrectly formatted somewhere.')
     end if
     msh_file = file_t(string_val)
 


### PR DESCRIPTION
Helps troubleshooting when the simulation dies due to `ERROR: Parameter case.mesh_file missing from the case file` and gives hint that the json file is incorrect.