### PR TITLE
Add timer for generating mesh connectivity

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -110,7 +110,7 @@ io/fld_file.o : io/fld_file.f90 comm/mpi_types.o math/math.o common/datadist.o c
 io/fld_file_data.o : io/fld_file_data.f90 math/vector.o math/math.o config/num_types.o 
 io/vtk_file.o : io/vtk_file.f90 comm/comm.o common/log.o mesh/tri_mesh.o mesh/tet_mesh.o field/mesh_field.o sem/dofmap.o field/field.o mesh/mesh.o common/utils.o io/generic_file.o config/num_types.o 
 io/stl_file.o : io/stl_file.f90 io/format/stl.o comm/comm.o common/utils.o comm/mpi_types.o mesh/point.o common/log.o mesh/tri_mesh.o io/generic_file.o config/num_types.o 
-io/nmsh_file.o : io/nmsh_file.f90 common/log.o comm/mpi_types.o common/datadist.o mesh/element.o io/format/nmsh.o adt/tuple.o mesh/point.o common/utils.o mesh/mesh.o comm/comm.o io/generic_file.o 
+io/nmsh_file.o : io/nmsh_file.f90 common/log.o comm/mpi_types.o common/datadist.o mesh/element.o io/format/nmsh.o adt/tuple.o mesh/point.o common/utils.o mesh/mesh.o config/num_types.o comm/comm.o io/generic_file.o 
 io/chkp_file.o : io/chkp_file.f90 common/global_interpolation.o comm/comm.o comm/mpi_types.o sem/interpolation.o math/math.o mesh/mesh.o sem/space.o common/utils.o math/bcknd/device/device_math.o sem/dofmap.o field/field.o config/num_types.o common/checkpoint.o field/field_series.o io/generic_file.o 
 io/csv_file.o : io/csv_file.f90 comm/comm.o common/log.o config/num_types.o common/utils.o io/generic_file.o math/matrix.o math/vector.o 
 io/hdf5_file.o : io/hdf5_file.F90 comm/comm.o common/log.o sem/dofmap.o field/field_series.o field/field_list.o field/field.o mesh/mesh.o common/utils.o common/checkpoint.o io/generic_file.o config/num_types.o 

--- a/src/io/nmsh_file.f90
+++ b/src/io/nmsh_file.f90
@@ -78,6 +78,7 @@ contains
     type(point_t), target :: p(8)
     type(linear_dist_t) :: dist
     character(len=LOG_SIZE) :: log_buf
+    real(kind=rp) :: t_start, t_end
 
     call this%check_exists()
 
@@ -240,9 +241,16 @@ contains
 
        call MPI_File_close(fh, ierr)
        call neko_log%message('Mesh read, setting up connectivity')
-
+       
+       t_start = MPI_WTIME()
        call msh%finalize()
-       call neko_log%message('Done setting up mesh and connectivity')
+       call MPI_Barrier(NEKO_COMM, ierr)
+       t_end = MPI_WTIME()
+       write(log_buf, '(A)') 'Done setting up mesh and connectivity'
+       call neko_log%message(log_buf)
+       write(log_buf, '(A,F9.6)') 'Mesh and connectivity setup (excluding read) time (s): ', & 
+                                  t_end - t_start
+       call neko_log%message(log_buf)
 
        call neko_log%end_section()
     end if

--- a/src/io/nmsh_file.f90
+++ b/src/io/nmsh_file.f90
@@ -32,18 +32,24 @@
 !
 !> Neko binary mesh data
 module nmsh_file
-  use generic_file
-  use comm
-  use mesh
-  use utils
-  use point
-  use tuple
-  use nmsh
-  use element
-  use datadist
-  use neko_mpi_types
-  use mpi_f08
-  use logger
+  use generic_file, only: generic_file_t
+  use comm, only: NEKO_COMM, pe_rank, pe_size
+  use num_types, only: rp, dp, i4, i8
+  use mesh, only: mesh_t, NEKO_MSH_MAX_ZLBLS
+  use utils, only: neko_error
+  use point, only: point_t
+  use tuple, only: tuple4_i4_t
+  use nmsh, only: nmsh_hex_t, nmsh_quad_t, nmsh_zone_t, nmsh_curve_el_t
+  use element, only: element_t
+  use datadist, only: linear_dist_t
+  use neko_mpi_types, only: MPI_NMSH_HEX, MPI_NMSH_QUAD, MPI_NMSH_ZONE, &
+       MPI_NMSH_CURVE, MPI_INTEGER_SIZE
+  use mpi_f08, only: MPI_Wtime, MPI_Status, MPI_File, MPI_OFFSET_KIND, &
+       MPI_MODE_WRONLY, MPI_MODE_CREATE, MPI_MODE_RDONLY, MPI_INFO_NULL, &
+       MPI_File_open, MPI_File_close, MPI_File_read_all, MPI_File_write_all, &
+       MPI_File_write_at_all, MPI_File_read_at_all, MPI_INTEGER, MPI_SUM, &
+       MPI_Exscan, MPI_Barrier, MPI_Type_size
+  use logger, only: neko_log, LOG_SIZE
   implicit none
 
   private
@@ -82,10 +88,10 @@ contains
 
     call this%check_exists()
 
-    select type(data)
-    type is(mesh_t)
+    select type (data)
+      type is (mesh_t)
        msh => data
-    class default
+      class default
        call neko_error('Invalid output data')
     end select
 
@@ -101,14 +107,14 @@ contains
          MPI_MODE_RDONLY, MPI_INFO_NULL, fh, ierr)
 
     if (ierr > 0) then
-       call neko_error('Could not open the mesh file ' // this%fname  // &
-                       'for reading!')
+       call neko_error('Could not open the mesh file ' // this%fname // &
+            'for reading!')
     end if
     call MPI_File_read_all(fh, nelv, 1, MPI_INTEGER, status, ierr)
     call MPI_File_read_all(fh, gdim, 1, MPI_INTEGER, status, ierr)
 
     write(log_buf,1) gdim, nelv
-1   format('gdim = ', i1, ', nelements =', i9)
+1   format('gdim = ', i1, ', nelements = ', i9)
     call neko_log%message(log_buf)
 
     if (gdim .eq. 2) then
@@ -126,9 +132,10 @@ contains
 
        if (msh%gdim .eq. 2) then
           allocate(nmsh_quad(msh%nelv))
-          mpi_offset = int(2 * MPI_INTEGER_SIZE,i8) + int(element_offset,i8) * int(nmsh_quad_size,i8)
+          mpi_offset = int(2 * MPI_INTEGER_SIZE, i8) + &
+               int(element_offset, i8) * int(nmsh_quad_size, i8)
           call MPI_File_read_at_all(fh, mpi_offset, &
-            nmsh_quad, msh%nelv, MPI_NMSH_QUAD, status, ierr)
+               nmsh_quad, msh%nelv, MPI_NMSH_QUAD, status, ierr)
           do i = 1, nelv
              do j = 1, 4
                 p(j) = point_t(nmsh_quad(i)%v(j)%v_xyz, nmsh_quad(i)%v(j)%v_idx)
@@ -137,22 +144,25 @@ contains
              call msh%add_element(i, p(1), p(2), p(4), p(3))
           end do
           deallocate(nmsh_quad)
-          mpi_el_offset = int(2 * MPI_INTEGER_SIZE,i8) + int(dist%num_global(),i8) * int(nmsh_quad_size,i8)
+          mpi_el_offset = int(2 * MPI_INTEGER_SIZE, i8) + &
+               int(dist%num_global(), i8) * int(nmsh_quad_size, i8)
        else if (msh%gdim .eq. 3) then
           allocate(nmsh_hex(msh%nelv))
-          mpi_offset = int(2 * MPI_INTEGER_SIZE,i8) + int(element_offset,i8) * int(nmsh_hex_size,i8)
+          mpi_offset = int(2 * MPI_INTEGER_SIZE, i8) + &
+               int(element_offset, i8) * int(nmsh_hex_size, i8)
           call MPI_File_read_at_all(fh, mpi_offset, &
-            nmsh_hex, msh%nelv, MPI_NMSH_HEX, status, ierr)
+               nmsh_hex, msh%nelv, MPI_NMSH_HEX, status, ierr)
           do i = 1, nelv
              do j = 1, 8
                 p(j) = point_t(nmsh_hex(i)%v(j)%v_xyz, nmsh_hex(i)%v(j)%v_idx)
              end do
              ! swap vertices to keep symmetric vertex numbering in neko
              call msh%add_element(i, &
-               p(1), p(2), p(4), p(3), p(5), p(6), p(8), p(7))
+                  p(1), p(2), p(4), p(3), p(5), p(6), p(8), p(7))
           end do
           deallocate(nmsh_hex)
-          mpi_el_offset = int(2 * MPI_INTEGER_SIZE,i8) + int(dist%num_global(),i8) * int(nmsh_hex_size,i8)
+          mpi_el_offset = int(2 * MPI_INTEGER_SIZE, i8) + &
+               int(dist%num_global(), i8) * int(nmsh_hex_size, i8)
        else
           if (pe_rank .eq. 0) call neko_error('Invalid dimension of mesh')
        end if
@@ -160,7 +170,7 @@ contains
 
        mpi_offset = mpi_el_offset
        call MPI_File_read_at_all(fh, mpi_offset, &
-         nzones, 1, MPI_INTEGER, status, ierr)
+            nzones, 1, MPI_INTEGER, status, ierr)
        if (nzones .gt. 0) then
           allocate(nmsh_zone(nzones))
 
@@ -169,31 +179,33 @@ contains
           !!a piece and pass the pieces around, filtering out matching zones
           !!in the local mesh.
           !!
-          mpi_offset = mpi_el_offset + int(MPI_INTEGER_SIZE,i8)
+          mpi_offset = mpi_el_offset + int(MPI_INTEGER_SIZE, i8)
           call MPI_File_read_at_all(fh, mpi_offset, &
-            nmsh_zone, nzones, MPI_NMSH_ZONE, status, ierr)
+               nmsh_zone, nzones, MPI_NMSH_ZONE, status, ierr)
 
           do i = 1, nzones
              el_idx = nmsh_zone(i)%e
              if (el_idx .gt. msh%offset_el .and. &
-               el_idx .le. msh%offset_el + msh%nelv) then
+                  el_idx .le. msh%offset_el + msh%nelv) then
                 el_idx = el_idx - msh%offset_el
-                select case(nmsh_zone(i)%type)
-                case(1)
+                select case (nmsh_zone(i)%type)
+                  case (1)
                    call msh%mark_wall_facet(nmsh_zone(i)%f, el_idx)
-                case(2)
+                  case (2)
                    call msh%mark_inlet_facet(nmsh_zone(i)%f, el_idx)
-                case(3)
+                  case (3)
                    call msh%mark_outlet_facet(nmsh_zone(i)%f, el_idx)
-                case(4)
+                  case (4)
                    call msh%mark_sympln_facet(nmsh_zone(i)%f, el_idx)
-                case(5)
+                  case (5)
                    call msh%mark_periodic_facet(nmsh_zone(i)%f, el_idx, &
-                     nmsh_zone(i)%p_f, nmsh_zone(i)%p_e, nmsh_zone(i)%glb_pt_ids)
-                case(6)
+                        nmsh_zone(i)%p_f, nmsh_zone(i)%p_e, &
+                        nmsh_zone(i)%glb_pt_ids)
+                  case (6)
                    call msh%mark_outlet_normal_facet(nmsh_zone(i)%f, el_idx)
-                case(7)
-                   call msh%mark_labeled_facet(nmsh_zone(i)%f, el_idx,nmsh_zone(i)%p_f)
+                  case (7)
+                   call msh%mark_labeled_facet(nmsh_zone(i)%f, el_idx, &
+                        nmsh_zone(i)%p_f)
                 end select
              end if
           end do
@@ -201,12 +213,13 @@ contains
           do i = 1, nzones
              el_idx = nmsh_zone(i)%e
              if (el_idx .gt. msh%offset_el .and. &
-               el_idx .le. msh%offset_el + msh%nelv) then
+                  el_idx .le. msh%offset_el + msh%nelv) then
                 el_idx = el_idx - msh%offset_el
-                select case(nmsh_zone(i)%type)
-                case(5)
+                select case (nmsh_zone(i)%type)
+                  case (5)
                    call msh%apply_periodic_facet(nmsh_zone(i)%f, el_idx, &
-                     nmsh_zone(i)%p_f, nmsh_zone(i)%p_e, nmsh_zone(i)%glb_pt_ids)
+                        nmsh_zone(i)%p_f, nmsh_zone(i)%p_e, &
+                        nmsh_zone(i)%glb_pt_ids)
                 end select
              end if
           end do
@@ -215,23 +228,25 @@ contains
        end if
        call neko_log%message('Reading deformation data')
 
-       mpi_offset = mpi_el_offset + int(MPI_INTEGER_SIZE,i8) + int(nzones,i8)*int(nmsh_zone_size,i8)
+       mpi_offset = mpi_el_offset + int(MPI_INTEGER_SIZE, i8) + &
+            int(nzones, i8)*int(nmsh_zone_size, i8)
        call MPI_File_read_at_all(fh, mpi_offset, &
-         ncurves, 1, MPI_INTEGER, status, ierr)
+            ncurves, 1, MPI_INTEGER, status, ierr)
 
        if (ncurves .gt. 0) then
 
           allocate(nmsh_curve(ncurves))
-          mpi_offset = mpi_el_offset + int(2 * MPI_INTEGER_SIZE,i8) + int(nzones,i8)*int(nmsh_zone_size,i8)
+          mpi_offset = mpi_el_offset + int(2 * MPI_INTEGER_SIZE, i8) + &
+               int(nzones, i8)*int(nmsh_zone_size, i8)
           call MPI_File_read_at_all(fh, mpi_offset, &
-            nmsh_curve, ncurves, MPI_NMSH_CURVE, status, ierr)
+               nmsh_curve, ncurves, MPI_NMSH_CURVE, status, ierr)
 
           do i = 1, ncurves
              el_idx = nmsh_curve(i)%e - msh%offset_el
              if (el_idx .gt. 0 .and. &
-              el_idx .le. msh%nelv) then
+                  el_idx .le. msh%nelv) then
                 call msh%mark_curve_element(el_idx, &
-                  nmsh_curve(i)%curve_data, nmsh_curve(i)%type)
+                     nmsh_curve(i)%curve_data, nmsh_curve(i)%type)
              end if
 
           end do
@@ -241,15 +256,16 @@ contains
 
        call MPI_File_close(fh, ierr)
        call neko_log%message('Mesh read, setting up connectivity')
-       
+
        t_start = MPI_WTIME()
        call msh%finalize()
        call MPI_Barrier(NEKO_COMM, ierr)
        t_end = MPI_WTIME()
        write(log_buf, '(A)') 'Done setting up mesh and connectivity'
        call neko_log%message(log_buf)
-       write(log_buf, '(A,F9.6)') 'Mesh and connectivity setup (excluding read) time (s): ', & 
-                                  t_end - t_start
+       write(log_buf, '(A,F9.6)') &
+            'Mesh and connectivity setup (excluding read) time (s): ', &
+            t_end - t_start
        call neko_log%message(log_buf)
 
        call neko_log%end_section()
@@ -301,7 +317,8 @@ contains
     call msh%init(gdim, nelv)
 
     allocate(nmsh_quad(msh%nelv))
-    mpi_offset = int(2 * MPI_INTEGER_SIZE,i8) + int(element_offset,i8) * int(nmsh_quad_size,i8)
+    mpi_offset = int(2 * MPI_INTEGER_SIZE, i8) + &
+         int(element_offset, i8) * int(nmsh_quad_size, i8)
     call MPI_File_read_at_all(fh, mpi_offset, &
          nmsh_quad, msh%nelv, MPI_NMSH_QUAD, status, ierr)
     do i = 1, nelv
@@ -321,7 +338,8 @@ contains
             p(1), p(2), p(4), p(3), p(5), p(6), p(8), p(7))
     end do
     deallocate(nmsh_quad)
-    mpi_el_offset = int(2 * MPI_INTEGER_SIZE,i8) + int(dist%num_global(),i8) * int(nmsh_quad_size,i8)
+    mpi_el_offset = int(2 * MPI_INTEGER_SIZE, i8) + &
+         int(dist%num_global(), i8) * int(nmsh_quad_size, i8)
 
     mpi_offset = mpi_el_offset
     call MPI_File_read_at_all(fh, mpi_offset, &
@@ -334,7 +352,7 @@ contains
        !!a piece and pass the pieces around, filtering out matching zones
        !!in the local mesh.
        !!
-       mpi_offset = mpi_el_offset + int(MPI_INTEGER_SIZE,i8)
+       mpi_offset = mpi_el_offset + int(MPI_INTEGER_SIZE, i8)
        call MPI_File_read_at_all(fh, mpi_offset, &
             nmsh_zone, nzones, MPI_NMSH_ZONE, status, ierr)
 
@@ -343,18 +361,20 @@ contains
           if (el_idx .gt. msh%offset_el .and. &
                el_idx .le. msh%offset_el + msh%nelv) then
              el_idx = el_idx - msh%offset_el
-             select case(nmsh_zone(i)%type)
-             case(1)
+             select case (nmsh_zone(i)%type)
+               case (1)
                 call msh%mark_wall_facet(nmsh_zone(i)%f, el_idx)
-             case(2)
+               case (2)
                 call msh%mark_inlet_facet(nmsh_zone(i)%f, el_idx)
-             case(3)
+               case (3)
                 call msh%mark_outlet_facet(nmsh_zone(i)%f, el_idx)
-             case(4)
+               case (4)
                 call msh%mark_sympln_facet(nmsh_zone(i)%f, el_idx)
-             case(5)
-                nmsh_zone(i)%glb_pt_ids(3) = nmsh_zone(i)%glb_pt_ids(1)+msh%glb_nelv*8
-                nmsh_zone(i)%glb_pt_ids(4) = nmsh_zone(i)%glb_pt_ids(2)+msh%glb_nelv*8
+               case (5)
+                nmsh_zone(i)%glb_pt_ids(3) = nmsh_zone(i)%glb_pt_ids(1) + &
+                     msh%glb_nelv * 8
+                nmsh_zone(i)%glb_pt_ids(4) = nmsh_zone(i)%glb_pt_ids(2) + &
+                     msh%glb_nelv * 8
                 if (nmsh_zone(i)%f .eq. 1 .or. nmsh_zone(i)%f .eq. 2) then
                    ids(1) = nmsh_zone(i)%glb_pt_ids(1)
                    ids(2) = nmsh_zone(i)%glb_pt_ids(3)
@@ -369,10 +389,11 @@ contains
                 nmsh_zone(i)%glb_pt_ids = ids
                 call msh%mark_periodic_facet(nmsh_zone(i)%f, el_idx, &
                      nmsh_zone(i)%p_f, nmsh_zone(i)%p_e, ids)
-             case(6)
+               case (6)
                 call msh%mark_outlet_normal_facet(nmsh_zone(i)%f, el_idx)
-             case(7)
-                call msh%mark_labeled_facet(nmsh_zone(i)%f, el_idx,nmsh_zone(i)%p_f)
+               case (7)
+                call msh%mark_labeled_facet(nmsh_zone(i)%f, el_idx, &
+                     nmsh_zone(i)%p_f)
              end select
           end if
        end do
@@ -382,10 +403,11 @@ contains
           if (el_idx .gt. msh%offset_el .and. &
                el_idx .le. msh%offset_el + msh%nelv) then
              el_idx = el_idx - msh%offset_el
-             select case(nmsh_zone(i)%type)
-             case(5)
+             select case (nmsh_zone(i)%type)
+               case (5)
                 call msh%apply_periodic_facet(nmsh_zone(i)%f, el_idx, &
-                     nmsh_zone(i)%p_f, nmsh_zone(i)%p_e, nmsh_zone(i)%glb_pt_ids)
+                     nmsh_zone(i)%p_f, nmsh_zone(i)%p_e, &
+                     nmsh_zone(i)%glb_pt_ids)
              end select
           end if
        end do
@@ -411,7 +433,7 @@ contains
     end if
 
     mpi_offset = mpi_el_offset + &
-         int(MPI_INTEGER_SIZE,i8) + int(nzones,i8)*int(nmsh_zone_size,i8)
+         int(MPI_INTEGER_SIZE, i8) + int(nzones, i8)*int(nmsh_zone_size, i8)
     call MPI_File_read_at_all(fh, mpi_offset, &
          ncurves, 1, MPI_INTEGER, status, ierr)
 
@@ -419,14 +441,15 @@ contains
 
        allocate(nmsh_curve(ncurves))
        mpi_offset = mpi_el_offset + &
-            int(2*MPI_INTEGER_SIZE,i8) + int(nzones,i8)*int(nmsh_zone_size,i8)
+            int(2*MPI_INTEGER_SIZE, i8) + &
+            int(nzones, i8)*int(nmsh_zone_size, i8)
        call MPI_File_read_at_all(fh, mpi_offset, &
             nmsh_curve, ncurves, MPI_NMSH_CURVE, status, ierr)
 
        do i = 1, ncurves
           el_idx = nmsh_curve(i)%e - msh%offset_el
           if (el_idx .gt. 0 .and. &
-              el_idx .le. msh%nelv) then
+               el_idx .le. msh%nelv) then
              call msh%mark_curve_element(el_idx, &
                   nmsh_curve(i)%curve_data, nmsh_curve(i)%type)
           end if
@@ -462,13 +485,13 @@ contains
     integer :: nmsh_quad_size, nmsh_hex_size, nmsh_zone_size, nmsh_curve_size
     integer :: nzones, ncurves
     class(element_t), pointer :: ep
-    integer(i4),  dimension(8), parameter :: vcyc_to_sym = (/1, 2, 4, 3, 5, &
-    & 6, 8, 7/) ! cyclic to symmetric vertex mapping
+    integer(i4), dimension(8), parameter :: vcyc_to_sym = [1, 2, 4, 3, 5, &
+         & 6, 8, 7] ! cyclic to symmetric vertex mapping
 
-    select type(data)
-    type is (mesh_t)
+    select type (data)
+      type is (mesh_t)
        msh => data
-    class default
+      class default
        call neko_error('Invalid output data')
     end select
 
@@ -503,11 +526,13 @@ contains
              nmsh_quad(i)%v(j)%v_xyz = ep%pts(vcyc_to_sym(j))%p%x
           end do
        end do
-       mpi_offset = int(2 * MPI_INTEGER_SIZE,i8) + int(element_offset,i8) * int(nmsh_quad_size,i8)
+       mpi_offset = int(2 * MPI_INTEGER_SIZE, i8) + &
+            int(element_offset, i8) * int(nmsh_quad_size, i8)
        call MPI_File_write_at_all(fh, mpi_offset, &
             nmsh_quad, msh%nelv, MPI_NMSH_QUAD, status, ierr)
        deallocate(nmsh_quad)
-       mpi_el_offset = int(2 * MPI_INTEGER_SIZE,i8) + int(nelgv,i8) * int(nmsh_quad_size,i8)
+       mpi_el_offset = int(2 * MPI_INTEGER_SIZE, i8) + &
+            int(nelgv, i8) * int(nmsh_quad_size, i8)
     else if (msh%gdim .eq. 3) then
        allocate(nmsh_hex(msh%nelv))
        do i = 1, msh%nelv
@@ -518,16 +543,21 @@ contains
              nmsh_hex(i)%v(j)%v_xyz = ep%pts(vcyc_to_sym(j))%p%x
           end do
        end do
-       mpi_offset = int(2 * MPI_INTEGER_SIZE,i8) + int(element_offset,i8) * int(nmsh_hex_size,i8)
+       mpi_offset = int(2 * MPI_INTEGER_SIZE, i8) + &
+            int(element_offset, i8) * int(nmsh_hex_size, i8)
        call MPI_File_write_at_all(fh, mpi_offset, &
-            nmsh_HEX, min(msh%nelv,max_write_nel), MPI_NMSH_HEX, status, ierr)
+            nmsh_HEX, min(msh%nelv, max_write_nel), MPI_NMSH_HEX, status, ierr)
        do i = 1, msh%nelv/max_write_nel
-          mpi_offset = int(2 * MPI_INTEGER_SIZE,i8) + int(element_offset+i*max_write_nel,i8) * int(nmsh_hex_size,i8)
+          mpi_offset = int(2 * MPI_INTEGER_SIZE, i8) + &
+               int(element_offset+i*max_write_nel, i8) * int(nmsh_hex_size, i8)
           call MPI_File_write_at_all(fh, mpi_offset, &
-               nmsh_HEX(i*max_write_nel+1), min(msh%nelv-i*max_write_nel,max_write_nel), MPI_NMSH_HEX, status, ierr)
+               nmsh_HEX(i*max_write_nel+1), &
+               min(msh%nelv-i*max_write_nel, max_write_nel), &
+               MPI_NMSH_HEX, status, ierr)
        end do
        deallocate(nmsh_hex)
-       mpi_el_offset = int(2 * MPI_INTEGER_SIZE,i8) + int(nelgv,i8) * int(nmsh_hex_size,i8)
+       mpi_el_offset = int(2 * MPI_INTEGER_SIZE, i8) + &
+            int(nelgv, i8) * int(nmsh_hex_size, i8)
     else
        call neko_error('Invalid dimension of mesh')
     end if
@@ -593,7 +623,8 @@ contains
        end do
        do k = 1, NEKO_MSH_MAX_ZLBLS
           do i = 1, msh%labeled_zones(k)%size
-             nmsh_zone(j)%e = msh%labeled_zones(k)%facet_el(i)%x(2) + msh%offset_el
+             nmsh_zone(j)%e = msh%labeled_zones(k)%facet_el(i)%x(2) + &
+                  msh%offset_el
              nmsh_zone(j)%f = msh%labeled_zones(k)%facet_el(i)%x(1)
              nmsh_zone(j)%p_f = k
              nmsh_zone(j)%type = 7
@@ -602,7 +633,7 @@ contains
        end do
 
 
-       mpi_offset = mpi_el_offset + int(MPI_INTEGER_SIZE,i8)
+       mpi_offset = mpi_el_offset + int(MPI_INTEGER_SIZE, i8)
        call MPI_File_write_at_all(fh, mpi_offset, &
             nmsh_zone, nzones, MPI_NMSH_ZONE, status, ierr)
 
@@ -610,7 +641,8 @@ contains
     end if
 
     ncurves = msh%curve%size
-    mpi_offset = mpi_el_offset + int(MPI_INTEGER_SIZE,i8) + int(nzones,i8)*int(nmsh_zone_size,i8)
+    mpi_offset = mpi_el_offset + int(MPI_INTEGER_SIZE, i8) + &
+         int(nzones, i8)*int(nmsh_zone_size, i8)
 
     call MPI_File_write_at_all(fh, mpi_offset, &
          ncurves, 1, MPI_INTEGER, status, ierr)
@@ -626,7 +658,8 @@ contains
           nmsh_curve(i)%curve_data = msh%curve%curve_el(i)%curve_data
           nmsh_curve(i)%type = msh%curve%curve_el(i)%curve_type
        end do
-       mpi_offset = mpi_el_offset + int(2*MPI_INTEGER_SIZE,i8) + int(nzones,i8)*int(nmsh_zone_size,i8)
+       mpi_offset = mpi_el_offset + int(2*MPI_INTEGER_SIZE, i8) + &
+            int(nzones, i8)*int(nmsh_zone_size, i8)
        call MPI_File_write_at_all(fh, mpi_offset, &
             nmsh_curve, ncurves, MPI_NMSH_CURVE, status, ierr)
 


### PR DESCRIPTION
Adds time for generating mesh connectivity in the log. 

Helps when one has a big case and it takes a long time and one does not know if the simulation has frozen.

If we think this is a good idea perhaps we should add something for gs as well as that also sometimes takes some time. I was thinking one could perhaps generate the buffers from a previous gs_t to drive down the initialization time.