### PR TITLE
Add support for more advanced restarts for simcomps

### DIFF
--- a/src/simulation_components/simulation_component.f90
+++ b/src/simulation_components/simulation_component.f90
@@ -79,6 +79,8 @@ module simulation_component
      procedure, pass(this) :: preprocess_
      !> The main function to be executed during the run.
      procedure, pass(this) :: compute_
+     !> The restart function to be called upon restarting simulation
+     procedure, pass(this) :: restart_
   end type simulation_component_t
 
   !> A helper type that is needed to have an array of polymorphic objects
@@ -216,8 +218,18 @@ contains
 
     call this%compute_controller%set_counter(t)
     call this%output_controller%set_counter(t)
+    call this%restart_(t) 
 
   end subroutine simulation_component_restart_wrapper
+
+  !> Dummy restart function.
+  !! @param t The time value.
+  subroutine restart_(this, t)
+    class(simulation_component_t), intent(inout) :: this
+    real(kind=rp), intent(in) :: t
+
+    ! Do nothing
+  end subroutine restart_
 
   !> Dummy preprocessing function.
   !! @param t The time value.


### PR DESCRIPTION
First step in the process of integrating things from CTR. Provides support for implementing a restart function for all simcomps.

Will be necessary as more functionality is moved to simcomps.