### PR TITLE
Add linting action and create post merge job for develop

### DIFF
--- a/.github/actions/flint/action.yml
+++ b/.github/actions/flint/action.yml
@@ -1,0 +1,52 @@
+name: Execution of Flint
+description: |
+  This action executes the Flint linter on the specified directory.
+
+inputs:
+  directory:
+    description: "The directory to lint."
+    required: true
+    default: "."
+
+  depth:
+    description: "The depth to lint."
+    required: false
+    default: "10"
+
+  rc-file:
+    description: "The configuration file to use."
+    required: false
+    default: "flinter_rc.yml"
+
+outputs:
+  score:
+    description: "The score of the linting."
+    value: ${{ steps.lint.outputs.score }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup the python environment
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+        cache: "pip"
+        cache-dependency-path: "**/requirements-flint.txt"
+
+    - name: Install the linter
+      shell: bash
+      run: pip install -r ${{ github.action_path }}/requirements-flint.txt
+
+    - name: Lint the repository
+      shell: bash
+      id: lint
+      run: |
+        flint score ${{ inputs.directory }} -d ${{ inputs.depth }} -r ${{ inputs.rc-file }} | tee flint.txt
+        score=$(awk '$1==0{print $3}' flint.txt)
+
+        if [ -z "$score" ]; then
+          echo "No score found, check flint.txt"
+          exit 1
+        fi
+        echo "Score=$score"
+        echo "score=$score" >> $GITHUB_OUTPUT

--- a/.github/actions/flint/readme.md
+++ b/.github/actions/flint/readme.md
@@ -1,0 +1,3 @@
+# Execution of Flint linting tool
+
+This action executes the Flint linting tool on the specified files.

--- a/.github/actions/flint/requirements-flint.txt
+++ b/.github/actions/flint/requirements-flint.txt
@@ -1,0 +1,2 @@
+nobvisual==0.2.0
+flinter==0.4.0

--- a/.github/workflows/check_lint.yml
+++ b/.github/workflows/check_lint.yml
@@ -3,13 +3,14 @@ name: Linting
 # Controls when the action will run.
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   lint-develop:
     name: "Lint develop branch"
     runs-on: ubuntu-20.04
     outputs:
-      develop_score: ${{ steps.check-lint.outputs.develop_score }}
+      score: ${{ steps.save-score.outputs.score }}
 
     steps:
       - name: Checkout
@@ -18,33 +19,25 @@ jobs:
           fetch-depth: 1
           ref: develop
 
-      - name: Setup env.
-        run: |
-          sudo apt-get update
-          sudo apt-get install -yq bc python3-dev python3-pip python3-tk
-          pip install nobvisual==0.2.0 flinter==0.4.0
-
-      - name: Lint repository
-        run: |
-          flint score src/ -d 10 -r flinter_rc.yml | tee flint.txt
+      - name: Run flint
+        id: lint
+        uses: ./.github/actions/flint
+        with:
+          directory: src/
+          depth: 10
+          rc-file: flinter_rc.yml
 
       - name: Save the score
-        id: check-lint
+        id: save-score
         run: |
-          score=$(awk '$1==0{print $3}' flint.txt)
-
-          if [ -z "$score" ]; then
-            echo "No score found, check flint.txt"
-            exit 1
-          fi
-          echo "Develop score=$score"
-          echo "develop_score=$score" >> $GITHUB_OUTPUT
+          echo "Develop score=${{ steps.lint.outputs.score }}"
+          echo "score=${{ steps.lint.outputs.score }}" >> $GITHUB_OUTPUT
 
   lint-current:
     name: "Lint current branch"
     runs-on: ubuntu-20.04
     outputs:
-      current_score: ${{ steps.check-lint.outputs.current_score }}
+      score: ${{ steps.save-score.outputs.score }}
 
     steps:
       - name: Checkout
@@ -52,27 +45,19 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup env.
-        run: |
-          sudo apt-get update
-          sudo apt-get install -yq bc python3-dev python3-pip python3-tk
-          pip install nobvisual==0.2.0 flinter==0.4.0
-
       - name: Lint repository
-        run: |
-          flint score src/ -d 10 -r flinter_rc.yml | tee flint.txt
+        id: lint
+        uses: ./.github/actions/flint
+        with:
+          directory: src/
+          depth: 10
+          rc-file: flinter_rc.yml
 
       - name: Save the score
-        id: check-lint
+        id: save-score
         run: |
-          score=$(awk '$1==0{print $3}' flint.txt)
-
-          if [ -z "$score" ]; then
-            echo "No score found, check flint.txt"
-            exit 1
-          fi
-          echo "Current score=$score"
-          echo "current_score=$score" >> $GITHUB_OUTPUT
+          echo "Current score=${{ steps.lint.outputs.score }}"
+          echo "score=${{ steps.lint.outputs.score }}" >> $GITHUB_OUTPUT
 
   lint-changed-files:
     name: "Lint changed files"
@@ -88,8 +73,8 @@ jobs:
       - name: Check the scores
         id: check-score
         env:
-          develop_score: ${{ needs.lint-develop.outputs.develop_score }}
-          current_score: ${{ needs.lint-current.outputs.current_score }}
+          develop_score: ${{ needs.lint-develop.outputs.score }}
+          current_score: ${{ needs.lint-current.outputs.score }}
         run: |
           if [ -z "$develop_score" ]; then
             echo "Develop score not set: '$develop_score'" >&2
@@ -122,17 +107,7 @@ jobs:
         # Get a list of the changed files and store them for later use.
       - name: Get changed files
         id: get-changed-files
-        env:
-          target: ${{ github.event.pull_request.base.ref }}
-          current: ${{ github.event.pull_request.head.ref }}
         run: |
-          if [ -z "$target" ]; then
-            target="develop"
-          fi
-          if [ -z "$current" ]; then
-            current="HEAD"
-          fi
-
           git fetch --unshallow origin $target
           changes=($(git diff --name-only --diff-filter=d origin/$target))
 
@@ -141,7 +116,7 @@ jobs:
             if [[ ${file: -4} != ".f90" && ${file: -4} != ".F90" ]]; then
               continue
             fi
-            printf "\t- $file"
+            printf "\t- $file\n"
           done
 
           echo "changed-files=${changes[@]}" >> $GITHUB_OUTPUT
@@ -156,7 +131,7 @@ jobs:
             exit 0
           fi
 
-          fails=()
+          failed_files=()
           printf "Linting files:\n"
           for file in $changed_files; do
 
@@ -171,39 +146,38 @@ jobs:
             printf ": $score\n"
 
             if (($(echo "$score < 10" | bc -l))); then
-                fails+=($file)
+                failed_files+=($file)
             fi
           done
 
-          echo "failed-files=${fails[@]}" >> $GITHUB_OUTPUT
+          echo "failed-files=${failed_files[@]}" >> $GITHUB_OUTPUT
 
-      - name: Print failed files and their errors
+      - name: Print possible improvements
         if: ${{ steps.lint-changed-files.outputs.failed-files != '' }}
         env:
           failed_files: ${{ steps.lint-changed-files.outputs.failed-files }}
           degraded: ${{ steps.check-score.outputs.degraded }}
         run: |
-          printf "Files that failed linting:\n"
-          printf "\t${failed_files[@]}\n"
+          printf "Files that can be improved:\n"
+          for file in ${failed_files[@]}; do
+            printf "\t- $file\n"
+          done
 
           if [ ${#failed_files[@]} -gt 0 ]; then
-            for fail in ${failed_files[@]}; do
+            for file in ${failed_files[@]}; do
               printf "%.s-" {1..80} && printf "\n"
-              printf "Linting failed for \n\t$fail\n\n"
+              printf "Linting improvements for \n\t$file\n\n"
 
-              report=$(flint lint -r flinter_rc.yml $fail)
+              report=$(flint lint -r flinter_rc.yml $file)
               if [ -z "$report" ]; then
-                report=$(flint stats -r flinter_rc.yml $fail)
+                report=$(flint stats -r flinter_rc.yml $file)
               fi
               echo "$report"
             done
 
-            if [ "$degraded" == "false" ]; then
-              echo "Linting failed, but the score is higher than the develop branch."
-              echo "Please update files at your convenience."
-            else
+            if [ "$degraded" == "true" ]; then
               echo "Linting failed, and the score is lower than the develop branch."
-              echo "Please fix the linting errors."
+              echo "Please improve linting by applying above suggestions."
               exit 2
             fi
           fi

--- a/.github/workflows/post_develop.yml
+++ b/.github/workflows/post_develop.yml
@@ -1,0 +1,207 @@
+# Description: This workflow is triggered when a PR is closed and merged into
+# the develop branch.
+# Currently we execute the following steps:
+# 1. Check if the PR was merged.
+# 2. Create a badge for the flint score.
+# 3. Create badges for the compilation status of the different compilers.
+# 4. Upload the badges to the repository.
+
+name: Post merge develop
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+
+env:
+  PFUNIT_VERSION: v4.4.2
+  JSON_FORTRAN_VERSION: 8.3.0
+
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued. We do not wish to waste time on old runs if a
+# newer one is available.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check_pr_status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR status
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            exit 0
+          fi
+          if [ "${{ github.event.pull_request.merged }}" == "true" ]; then
+            echo "PR was merged"
+            exit 0
+          else
+            echo "PR was closed without merging"
+            exit 1
+          fi
+
+  prepare:
+    name: Prepare the environment
+    needs: check_pr_status
+    runs-on: ubuntu-latest
+    outputs:
+      pfunit-version: ${{ steps.store.outputs.pfunit-version }}
+      json-fortran-version: ${{ steps.store.outputs.json-fortran-version }}
+
+    steps:
+      - name: Store environment variables
+        id: store
+        run: |
+          echo "flint-global-minimum=$FLINT_GLOBAL_MINIMUM" >> $GITHUB_OUTPUT
+          echo "flint-changed-minimum=$FLINT_CHANGED_FILES_MINIMUM" >> $GITHUB_OUTPUT
+          echo "pfunit-version=$PFUNIT_VERSION" >> $GITHUB_OUTPUT
+          echo "json-fortran-version=$JSON_FORTRAN_VERSION" >> $GITHUB_OUTPUT
+
+  # ========================================================================== #
+  # Run the compiler checks
+
+  GNU:
+    needs: prepare
+    uses: ./.github/workflows/check_gnu.yml
+    with:
+      json-fortran-version: ${{ needs.prepare.outputs.json-fortran-version }}
+      pfunit-version: ${{ needs.prepare.outputs.pfunit-version }}
+
+  Intel:
+    needs: prepare
+    uses: ./.github/workflows/check_intel.yml
+    with:
+      json-fortran-version: ${{ needs.prepare.outputs.json-fortran-version }}
+
+  Nvidia:
+    needs: prepare
+    uses: ./.github/workflows/check_nvidia.yml
+    with:
+      json-fortran-version: ${{ needs.prepare.outputs.json-fortran-version }}
+
+  # ========================================================================== #
+  # Badge creation
+
+  # Create a badge for the flint score
+  create-badge-lint:
+    name: "Create linting badge"
+    runs-on: ubuntu-20.04
+    needs: check_pr_status
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup env.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -yq python3-pip
+          pip install anybadge
+
+      - name: Lint repository
+        uses: ./.github/actions/flint
+        id: lint-repository
+        with:
+          directory: src/
+          depth: 10
+          rc-file: flinter_rc.yml
+
+      - name: Create badge
+        env:
+            score: ${{ steps.lint-repository.outputs.score }}
+        run: |
+            mkdir -p doc/media
+            anybadge -l Flint -o --file=doc/media/lint-badge.svg -v $score 9.0=red 9.9=yellow 10=green
+
+      - name: Save artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-badge
+          path: doc/media/lint-badge.svg
+
+  create-compilation-badges:
+    if: ${{ !cancelled() }}
+    name: "Create Compilation badges"
+    runs-on: ubuntu-20.04
+    needs:
+      - GNU
+      - Intel
+      - Nvidia
+
+    steps:
+      - name: Check status
+        run: |
+          [ ${{ needs.GNU.result }} == "skipped" ] && exit 1
+          [ ${{ needs.Intel.result }} == "skipped" ] && exit 1
+          [ ${{ needs.Nvidia.result }} == "skipped" ] && exit 1
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup env.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -yq python3-pip
+          pip install anybadge
+
+      - name: create directory
+        run: |
+          mkdir -p doc/media
+
+      - name: Create badge GNU
+        run: |
+          anybadge -l GNU -v ${{ needs.GNU.result }} -o \
+            -f=doc/media/gnu-badge.svg success=green failure=red
+
+      - name: Create badge Intel
+        run: |
+          anybadge -l Intel -v ${{ needs.Intel.result }} -o \
+            -f=doc/media/intel-badge.svg success=green failure=red
+
+      - name: Create badge Nvidia
+        run: |
+          anybadge -l Nvidia -v ${{ needs.Nvidia.result }} -o \
+            -f=doc/media/nvidia-badge.svg success=green failure=red
+
+      - name: Save artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: compilation-badge
+          path: doc/media/*-badge.svg
+
+  # ========================================================================== #
+  # Upload the badges
+
+  upload-badges:
+    name: "Upload badges"
+    runs-on: ubuntu-20.04
+    needs:
+      - create-badge-lint
+      - create-compilation-badges
+
+    if: ${{ !cancelled() }} &&
+        ${{ needs.create-badge-lint.result == 'success' }} &&
+        ${{ needs.create-compilation-badges.result == 'success' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download lint badge
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "*-badge"
+          path: doc/media/
+          merge-multiple: true
+
+      - name: Push badges
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: "doc/media/*-badge.svg"
+          message: "Add badges"
+          author_name: "GitHub Actions"
+          default_author: github_actor

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # ![Neko](https://user-images.githubusercontent.com/750135/169531665-313c3471-50d1-4c44-964a-fee7312d6459.png)
-![CI](https://github.com/ExtremeFLOW/neko/workflows/CI/badge.svg) ![develop](https://github.com/ExtremeFLOW/neko/workflows/develop/badge.svg) [![DOI](https://zenodo.org/badge/338607716.svg)](https://zenodo.org/doi/10.5281/zenodo.6631055)
+[![DOI](https://zenodo.org/badge/338607716.svg)](https://zenodo.org/doi/10.5281/zenodo.6631055)
+![Flint](./doc/media/lint-badge.svg)
+![GNU](./doc/media/gnu-badge.svg)
+![Intel](./doc/media/intel-badge.svg)
+![Nvidia](./doc/media/nvidia-badge.svg)
+
 ## About
 Neko is a portable framework for high-order spectral element flow simulations. Written in modern Fortran, Neko adopts an object-oriented approach, allowing multi-tier abstractions of the solver stack and facilitating various hardware backends ranging from general-purpose processors, CUDA and HIP enabled accelerators to SX-Aurora vector processors. Neko has its roots in the spectral element code Nek5000 from UChicago/ANL, from where many of the namings, code structure and numerical methods are adopted.
 


### PR DESCRIPTION
This pull request adds a linting action to execute the Flint linter on the specified directory. It also creates a post merge job for the develop branch that runs compilation checks and creates badges based on the results. Additionally, the badges for the linting score and compiler support are used to show the status of the code.

At the moment, the post merge job on develop should trigger whenever a PR is merged into develop succesfully.
Alternatively we can let it run as part of the nightly documentation update, this could be part of a nightly release job.