### PR TITLE
Fix interface to CrayPat

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -131,7 +131,7 @@ io/data_streamer.o : io/data_streamer.F90 config/neko_config.o comm/mpi_types.o 
 common/sampler.o : common/sampler.f90 common/time_based_controller.o config/num_types.o common/profiler.o common/utils.o common/log.o comm/comm.o io/fld_file.o io/output.o 
 common/global_interpolation.o : common/global_interpolation.F90 comm/mpi_types.o math/math.o comm/comm.o sem/local_interpolation.o common/utils.o common/log.o mesh/mesh.o sem/dofmap.o sem/space.o config/num_types.o 
 common/profiler.o : common/profiler.F90 common/runtime_statistics.o common/craypat.o device/hip/roctx.o device/cuda/nvtx.o device/device.o config/neko_config.o 
-common/craypat.o : common/craypat.F90 common/utils.o adt/stack.o 
+common/craypat.o : common/craypat.F90 
 bc/bc.o : bc/bc.f90 common/utils.o adt/tuple.o adt/stack.o mesh/facet_zone.o mesh/mesh.o sem/space.o sem/coef.o sem/dofmap.o device/device.o config/num_types.o config/neko_config.o 
 bc/dirichlet.o : bc/dirichlet.f90 bc/bc.o config/num_types.o bc/bcknd/device/device_dirichlet.o 
 bc/neumann.o : bc/neumann.f90 math/math.o sem/coef.o common/utils.o bc/bc.o config/num_types.o 

--- a/src/common/craypat.F90
+++ b/src/common/craypat.F90
@@ -63,7 +63,7 @@ contains
 
     call PAT_record(PAT_STATE_QUERY, ierr)
     if (ierr .eq. PAT_STATE_ON) then
-       call PAT_region_begin(region_id, name, ierr)
+       call PAT_region_begin(region_id, trim(name), ierr)
     end if
 
   end subroutine craypat_region_begin

--- a/src/common/craypat.F90
+++ b/src/common/craypat.F90
@@ -34,7 +34,6 @@
 module craypat
   implicit none
   
-  logical, private :: craypat_on = .false.
 #ifdef CRAYPAT
   include 'pat_apif.h'
 
@@ -44,14 +43,12 @@ contains
   subroutine craypat_record_start
     integer :: ierr
     call PAT_record(PAT_STATE_ON, ierr)
-    craypat_on = .true.
   end subroutine craypat_record_start
 
   !> Turn off CrayPat recording
   subroutine craypat_record_stop
     integer :: ierr
     call PAT_record(PAT_STATE_OFF, ierr)
-    craypat_on = .false.
   end subroutine craypat_record_stop
 
   !> Start a CrayPat region
@@ -60,7 +57,8 @@ contains
     integer, intent(in) :: region_id
     integer :: ierr
 
-    if (craypat_on) then
+    call PAT_record(PAT_STATE_QUERY, ierr)
+    if (ierr .eq. PAT_STATE_ON) then
        call PAT_region_begin(region_id, name, ierr)
     end if
 
@@ -71,7 +69,8 @@ contains
     integer, intent(in) :: region_id
     integer :: ierr
 
-    if (craypat_on) then
+    call PAT_record(PAT_STATE_QUERY, ierr)
+    if (ierr .eq. PAT_STATE_ON) then
        call PAT_region_end(region_id, ierr)
     end if
 

--- a/src/common/craypat.F90
+++ b/src/common/craypat.F90
@@ -1,11 +1,39 @@
+! Copyright (c) 2022-2024, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
 !> Interface to CrayPat F77 API
 module craypat
-  use, intrinsic :: iso_c_binding
-  use stack, only : stack_i4_t
-  use utils, only : neko_error
   implicit none
-
-  type(stack_i4_t), private :: region_depth
+  
   logical, private :: craypat_on = .false.
 #ifdef CRAYPAT
   include 'pat_apif.h'
@@ -15,7 +43,6 @@ contains
   !> Turn on CrayPat recording
   subroutine craypat_record_start
     integer :: ierr
-    call region_depth%init()
     call PAT_record(PAT_STATE_ON, ierr)
     craypat_on = .true.
   end subroutine craypat_record_start
@@ -28,39 +55,24 @@ contains
   end subroutine craypat_record_stop
 
   !> Start a CrayPat region
-  subroutine craypat_region_begin(name)
-    character(kind=c_char,len=*) :: name
-    integer :: ierr, region_id
+  subroutine craypat_region_begin(name, region_id)
+    character(len=*) :: name
+    integer, intent(in) :: region_id
+    integer :: ierr
 
     if (craypat_on) then
-       !> @todo Don't hardcode region names...
-       if (name .eq. 'Time-Step') then
-          region_id = 1
-       else if(name .eq. 'Pressure') then
-          region_id = 2
-       else if (name .eq. 'Velocity') then
-          region_id = 3
-       else if (name .eq. 'gather-scatter') then
-          region_id = 4
-       else ! User defined region
-          region_id = 99
-       end if
-
-       call region_depth%push(region_id)
        call PAT_region_begin(region_id, name, ierr)
     end if
 
   end subroutine craypat_region_begin
 
   !> End a CrayPat region
-  subroutine craypat_region_end
+  subroutine craypat_region_end(region_id)
+    integer, intent(in) :: region_id
     integer :: ierr
 
     if (craypat_on) then
-       if (region_depth%size() .le. 0) then
-          call neko_error('Invalid CrayPat region id')
-       end if
-       call PAT_region_end(region_depth%pop(), ierr)
+       call PAT_region_end(region_id, ierr)
     end if
 
   end subroutine craypat_region_end

--- a/src/common/craypat.F90
+++ b/src/common/craypat.F90
@@ -33,10 +33,14 @@
 !> Interface to CrayPat F77 API
 module craypat
   implicit none
+  private
   
 #ifdef CRAYPAT
   include 'pat_apif.h'
 
+  public :: craypat_record_start, craypat_record_stop, &
+       craypat_region_begin, craypat_region_end
+  
 contains
 
   !> Turn on CrayPat recording

--- a/src/common/profiler.F90
+++ b/src/common/profiler.F90
@@ -38,6 +38,7 @@ module profiler
   use roctx
   use craypat
   use runtime_stats, only : neko_rt_stats
+  use, intrinsic :: iso_c_binding
   implicit none
   private
 

--- a/src/common/profiler.F90
+++ b/src/common/profiler.F90
@@ -86,7 +86,9 @@ contains
 #elif HAVE_ROCTX
     call roctxStartRange(name)
 #elif CRAYPAT
-    !   call craypat_region_begin(name)
+    if (present(region_id)) then
+       call craypat_region_begin(name, region_id)
+    end if
 #endif
 
     if (present(region_id)) then
@@ -97,7 +99,7 @@ contains
 
   !> End the most recently started profiler region
   subroutine profiler_end_region(name, region_id)
-    character(kind=c_char,len=*), optional :: name
+    character(kind=c_char, len=*), optional :: name
     integer, optional :: region_id
     
 #ifdef HAVE_NVTX
@@ -105,7 +107,9 @@ contains
 #elif HAVE_ROCTX
     call roctxRangePop
 #elif CRAYPAT
-    !   call craypat_region_end
+    if (present(region_id)) then
+       call craypat_region_end(region_id)
+    end if
 #endif
 
     if (present(name) .and. present(region_id)) then


### PR DESCRIPTION
This fixes the long broken interface to CrayPat, such that we can record Neko's profiler region to CrayPat profiles.

Example output:

```shell
Table 1:  Profile by Function Group and Function

  Time% |     Time |     Imb. |  Imb. |    Calls | Group
        |          |     Time | Time% |          |  Function
        |          |          |       |          |   PE=HIDE

 100.0% | 2.171254 |       -- |    -- | 50,102.0 | Total
|-----------------------------------------------------------------------
| 100.0% | 2.171254 |       -- |    -- | 50,102.0 | USER
||----------------------------------------------------------------------
||  24.9% | 0.540456 | 0.034187 |  6.8% |    347.0 | #8.HSMG_solve
||  21.2% | 0.460204 | 0.017860 |  4.3% |      5.0 | #3.Pressure_solve
||  13.6% | 0.295521 | 0.114109 | 31.8% |  7,054.0 | #7.gs_nbwait
||   9.8% | 0.212766 | 0.083863 | 32.3% |  7,054.0 | #6.gs_nbsend
||   7.7% | 0.167530 | 0.066844 | 32.6% |  7,054.0 | #12.gs_local
||   5.5% | 0.118498 | 0.009032 |  8.1% |    347.0 | #11.HSMG_coarse-solve
||   4.1% | 0.089166 | 0.019061 | 20.1% |  7,054.0 | #14.gs_gather_shared
||   4.1% | 0.088324 | 0.020171 | 21.2% |  7,054.0 | #15.gs_scatter_shared
||   4.1% | 0.088273 | 0.001743 |  2.2% |  7,054.0 | #5.gather_scatter
||   1.9% | 0.040442 | 0.003382 |  8.8% |      5.0 | #1.Fluid
||   1.0% | 0.021827 | 0.000841 |  4.2% |  7,054.0 | #13.gs_nbrecv
|=======================================================================
```