### PR TITLE
fix/parallelizing loop using DO CONCURRENT construct

### DIFF
--- a/src/common/bcknd/cpu/rhs_maker_cpu.f90
+++ b/src/common/bcknd/cpu/rhs_maker_cpu.f90
@@ -227,7 +227,7 @@ contains
     real(kind=rp), intent(inout) :: phi_x(n), phi_y(n), phi_z(n)
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        bf_x(i) = bf_x(i) + phi_x(i) * (rho / dt)
        bf_y(i) = bf_y(i) + phi_y(i) * (rho / dt)
        bf_z(i) = bf_z(i) + phi_z(i) * (rho / dt)
@@ -242,7 +242,7 @@ contains
     real(kind=rp), intent(inout) :: phi_s(n)
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        bf_s(i) = bf_s(i) + phi_s(i) * (rho / dt)
     end do
 

--- a/src/common/time_interpolator.f90
+++ b/src/common/time_interpolator.f90
@@ -147,7 +147,7 @@ contains
     call fd_weights_full(t, tlag, no, 0, wt) ! interpolation weights
     call rzero(f_interpolated, n)
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        do l = 0, no
         f_interpolated(i) = f_interpolated(i) + wt(l) * f_n(i,l)
       end do


### PR DESCRIPTION
Optimizing loops with DO CONCURRENT for parallel execution for time_interpolator_scalar, rhs_maker_oifs_cpu, and scalar_rhs_maker_oifs_cpu