### PR TITLE
Add intersection detector for meshes

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -67,6 +67,7 @@ mesh/search_tree/aabb.o : mesh/search_tree/aabb.f90 common/utils.o mesh/tet_mesh
 mesh/aabb_tree.o : mesh/aabb_tree.f90 adt/stack.o common/utils.o config/num_types.o mesh/tri.o mesh/search_tree/aabb.o 
 mesh/tet_mesh.o : mesh/tet_mesh.f90 common/utils.o mesh/point.o mesh/tet.o mesh/mesh.o 
 mesh/tri_mesh.o : mesh/tri_mesh.f90 mesh/point.o mesh/tri.o 
+mesh/intersection_detector.o : mesh/intersection_detector.f90 mesh/search_tree/aabb.o adt/stack.o common/utils.o mesh/point.o mesh/hex.o mesh/mesh.o mesh/aabb_tree.o config/num_types.o 
 field/field_registry.o : field/field_registry.f90 adt/htable.o common/utils.o sem/dofmap.o field/field.o 
 field/scratch_registry.o : field/scratch_registry.f90 sem/dofmap.o field/field.o 
 field/field.o : field/field.f90 sem/dofmap.o sem/space.o mesh/mesh.o math/math.o device/device.o config/num_types.o math/bcknd/device/device_math.o config/neko_config.o 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -70,6 +70,7 @@ neko_fortran_SOURCES = \
 	mesh/aabb_tree.f90\
 	mesh/tet_mesh.f90\
 	mesh/tri_mesh.f90\
+	mesh/intersection_detector.f90\
 	field/field_registry.f90\
 	field/scratch_registry.f90\
 	field/field.f90\

--- a/src/mesh/intersection_detector.f90
+++ b/src/mesh/intersection_detector.f90
@@ -1,0 +1,117 @@
+! Copyright (c) 2024, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Implements a mesh intersection detector
+module intersection_detector
+  use num_types, only : dp
+  use aabb_tree, only : aabb_tree_t
+  use mesh, only : mesh_t
+  use hex, only : hex_t
+  use point, only : point_t
+  use utils, only : neko_error
+  use stack, only : stack_i4_t
+  use aabb
+  implicit none
+  private
+
+  type, public :: intersect_detector_t
+     type(mesh_t), private, pointer :: msh => null()
+     type(aabb_tree_t), private :: search_tree
+   contains
+     procedure, pass(this) :: init => intersect_detector_init
+     procedure, pass(this) :: free => intersect_detector_free
+     procedure, pass(this) :: overlap => intersect_detector_overlap
+  end type intersect_detector_t
+
+contains
+
+  !> Initialise an intersector detector for a given mesh @a msh
+  subroutine intersect_detector_init(this, msh, padding)
+    class(intersect_detector_t), intent(inout) :: this
+    type(mesh_t), target, intent(in) :: msh
+    real(kind=dp), intent(in), optional :: padding
+    type(hex_t), allocatable :: elements(:)
+    integer :: i
+
+    call this%free()
+    this%msh => msh
+
+    call this%search_tree%init(msh%nelv)
+    
+    !> @todo Rework this part once the new mesh structure is in place
+    allocate(elements(msh%nelv))
+    do i = 1, msh%nelv
+       select type(el => msh%elements(i)%e)
+       type is (hex_t)
+          elements(i) = el
+       class default
+          call neko_error('Unsupported element type')
+       end select
+    end do
+
+    if (present(padding)) then
+       call this%search_tree%build(elements, padding)
+    else
+       call this%search_tree%build(elements)
+    end if
+
+    deallocate(elements)
+    
+    if (this%search_tree%get_size() .ne. (msh%nelv)) then
+       call neko_error("Error building the search tree.")
+    end if
+
+  end subroutine intersect_detector_init
+
+  !> Destroy an intersector detector
+  subroutine intersect_detector_free(this)
+    class(intersect_detector_t), intent(inout) :: this
+
+    if (associated(this%msh)) then
+       nullify(this%msh)
+    end if
+
+    !> @todo cleanup the aabb tree
+    
+  end subroutine intersect_detector_free
+
+  !> Computes the overlap between elements and a given point @a p
+  subroutine intersect_detector_overlap(this, p, overlaps)
+    class(intersect_detector_t), intent(inout) :: this
+    type(point_t), intent(in) :: p
+    type(stack_i4_t), intent(inout) :: overlaps
+
+    call this%search_tree%query_overlaps(p, -1, overlaps)      
+    
+  end subroutine intersect_detector_overlap
+  
+end module intersection_detector  

--- a/src/mesh/search_tree/aabb.f90
+++ b/src/mesh/search_tree/aabb.f90
@@ -187,6 +187,8 @@ contains
 
     select type(object)
 
+      type is (point_t)
+       box = get_aabb_point(object)
       type is (tri_t)
        box = get_aabb_element(object)
       type is (hex_t)
@@ -195,7 +197,10 @@ contains
        box = get_aabb_element(object)
       type is (quad_t)
        box = get_aabb_element(object)
-
+      class is (element_t)
+       box = get_aabb_element(object)
+         
+         
       type is (mesh_t)
        box = get_aabb_mesh(object)
       type is (tri_mesh_t)
@@ -229,6 +234,27 @@ contains
     call this%init(box_min, box_max)
   end subroutine add_padding
 
+
+  !> @brief Get the aabb of a point.
+  !!
+  !! @details This function calculates the aabb of a point.
+  !!
+  !! @param object The point to get the aabb of.
+  !! @return The aabb of the point.
+  function get_aabb_point(object) result(box)
+    type(point_t), intent(in) :: object
+    type(aabb_t) :: box
+
+    integer :: i
+    real(kind=dp) :: box_min(3), box_max(3)
+
+    box_min = huge(0.0_dp); box_max = -huge(0.0_dp)
+    box_min = min(box_min, object%x)
+    box_max = max(box_max, object%x)
+
+    call box%init(box_min, box_max)
+  end function get_aabb_point
+  
   !> @brief Get the aabb of an arbitrary element.
   !!
   !! @details This function calculates the aabb of an element. The aabb is
@@ -436,7 +462,6 @@ contains
        !  call neko_error("aabb_overlaps: One or both aabbs are not initialized")
        is_overlapping = .false.
     else
-
        is_overlapping = all(this%box_min .le. other%box_max) .and. &
          all(this%box_max .ge. other%box_min)
     end if


### PR DESCRIPTION
Intersection detector for meshes, based on the aabb search tree.

Can be used to return a list of elements that overlaps with a given point 

Usage:

```f90
type(intersect_detector_t) :: intersect
type(stack_i4_t) :: overlaps

call intersect%init(mesh, aabb_padding)
call intersect%overlap(point, overlaps)
do while(.not. overlaps%is_empty())
     Process overlaped elements
end do
```