### PR TITLE
Harmonize dofmap constructor and destructor, bump style

### DIFF
--- a/bench/gs/driver.f90
+++ b/bench/gs/driver.f90
@@ -38,7 +38,7 @@ program gsbench
 
   call Xh%init(GLL, lx, lx, lx)
 
-  dm = dofmap_t(msh, Xh)
+  call dm%init(msh, Xh)
   call gs_h%init(dm)
 
   n = Xh%lx * Xh%ly * Xh%lz * msh%nelv

--- a/bench/nekbone/driver.f90
+++ b/bench/nekbone/driver.f90
@@ -34,7 +34,7 @@ program nekobone
 
   call space_init(Xh, GLL, lx, lx, lx)
 
-  dm = dofmap_t(msh, Xh)
+  call dm%init(msh, Xh)
   call gs_init(gs_h, dm)
   
   call field_init(x, msh, Xh, "x")

--- a/contrib/average_field_in_space/average_field_in_space.f90
+++ b/contrib/average_field_in_space/average_field_in_space.f90
@@ -97,7 +97,7 @@ program average_field_in_space
 
   call Xh%init(GLL, field_data%lx, field_data%ly, field_data%lz)
 
-  dof = dofmap_t(msh, Xh)
+  call dof%init(msh, Xh)
   call gs_h%init(dof)
   call coef%init(gs_h)
 

--- a/contrib/calc_lift_from_field/calc_lift_from_field.f90
+++ b/contrib/calc_lift_from_field/calc_lift_from_field.f90
@@ -97,7 +97,7 @@ program calc_lift_from_field
 
   call Xh%init(GLL, field_data%lx, field_data%ly, field_data%lz)
 
-  call dof%(msh, Xh)
+  call dof%init(msh, Xh)
   call gs_h%init(dof)
   call coef%init(gs_h)
   ! Center around which we calculate the torque

--- a/contrib/calc_lift_from_field/calc_lift_from_field.f90
+++ b/contrib/calc_lift_from_field/calc_lift_from_field.f90
@@ -97,7 +97,7 @@ program calc_lift_from_field
 
   call Xh%init(GLL, field_data%lx, field_data%ly, field_data%lz)
 
-  dof = dofmap_t(msh, Xh)
+  call dof%(msh, Xh)
   call gs_h%init(dof)
   call coef%init(gs_h)
   ! Center around which we calculate the torque

--- a/contrib/postprocess_fluid_stats/postprocess_fluid_stats.f90
+++ b/contrib/postprocess_fluid_stats/postprocess_fluid_stats.f90
@@ -102,7 +102,7 @@ program postprocess_fluid_stats
 
   call Xh%init(GLL, mean_data%lx, mean_data%ly, mean_data%lz)
 
-  dof = dofmap_t(msh, Xh)
+  call dof%init(msh, Xh)
   call gs_h%init(dof)
   call coef%init(gs_h)
 

--- a/examples/poisson/driver.f90
+++ b/examples/poisson/driver.f90
@@ -43,7 +43,7 @@ program poisson
 
   call Xh%init(GLL, lx, lx, lx)
 
-  dm = dofmap_t(msh, Xh)
+  call dm%init(msh, Xh)
   call gs_h%init(dm)
 
   call coef%init(gs_h)

--- a/src/field/field.f90
+++ b/src/field/field.f90
@@ -96,7 +96,7 @@ contains
     this%msh => msh
 
     allocate(this%dof)
-    this%dof = dofmap_t(this%msh, this%Xh)
+    call this%dof%init(this%msh, this%Xh)
     this%internal_dofmap = .true.
 
     if (present(fld_name)) then

--- a/src/fluid/fluid_plan1.f90
+++ b/src/fluid/fluid_plan1.f90
@@ -39,7 +39,7 @@ contains
        call this%Yh%init(GLL, lx2, lx2, lx2)
     end if
 
-    this%dm_Yh = dofmap_t(msh, this%Yh)
+    call this%dm_Yh%init(msh, this%Yh)
 
     call this%p%init(this%dm_Yh)
 

--- a/src/fluid/fluid_scheme.f90
+++ b/src/fluid/fluid_scheme.f90
@@ -276,7 +276,7 @@ contains
        call this%Xh%init(GLL, lx, lx, lx)
     end if
 
-    this%dm_Xh = dofmap_t(msh, this%Xh)
+    call this%dm_Xh%init(msh, this%Xh)
 
     call this%gs_Xh%init(this%dm_Xh)
 

--- a/src/io/chkp_file.f90
+++ b/src/io/chkp_file.f90
@@ -478,7 +478,7 @@ contains
        call this%chkp_Xh%init(GLL, lx, lx)
     end if
     if (this%mesh2mesh) then
-       dof = dofmap_t(msh, this%chkp_Xh)
+       call dof%init(msh, this%chkp_Xh)
        allocate(x_coord(u%Xh%lx,u%Xh%ly,u%Xh%lz,u%msh%nelv))
        allocate(y_coord(u%Xh%lx,u%Xh%ly,u%Xh%lz,u%msh%nelv))
        allocate(z_coord(u%Xh%lx,u%Xh%ly,u%Xh%lz,u%msh%nelv))

--- a/src/krylov/pc_hsmg.f90
+++ b/src/krylov/pc_hsmg.f90
@@ -173,13 +173,13 @@ contains
     call this%wf%init(dof, 'work 2')
 
     call this%Xh_crs%init(GLL, lx_crs, lx_crs, lx_crs)
-    this%dm_crs = dofmap_t(msh, this%Xh_crs)
+    call this%dm_crs%init(msh, this%Xh_crs)
     call this%gs_crs%init(this%dm_crs)
     call this%e_crs%init(this%dm_crs, 'work crs')
     call this%c_crs%init(this%gs_crs)
 
     call this%Xh_mg%init(GLL, lx_mid, lx_mid, lx_mid)
-    this%dm_mg = dofmap_t(msh, this%Xh_mg)
+    call this%dm_mg%init(msh, this%Xh_mg)
     call this%gs_mg%init(this%dm_mg)
     call this%e_mg%init(this%dm_mg, 'work midl')
     call this%c_mg%init(this%gs_mg)

--- a/src/math/schwarz.f90
+++ b/src/math/schwarz.f90
@@ -111,7 +111,7 @@ contains
     call this%free()
 
     call this%Xh_schwarz%init(GLL, Xh%lx+2, Xh%lx+2, Xh%lx+2)
-    this%dm_schwarz = dofmap_t(msh, this%Xh_schwarz)
+    call this%dm_schwarz%init(msh, this%Xh_schwarz)
     call this%gs_schwarz%init(this%dm_schwarz)
 
     allocate(this%work1(this%dm_schwarz%size()))

--- a/src/mesh/point_zone_registry.f90
+++ b/src/mesh/point_zone_registry.f90
@@ -125,7 +125,7 @@ contains
     else
        call Xh%init(GLL, order, order, order)
     end if
-    dof = dofmap_t(msh, Xh)
+    call dof%init(msh, Xh)
 
     call this%free()
 

--- a/src/sem/dofmap.f90
+++ b/src/sem/dofmap.f90
@@ -69,20 +69,21 @@ module dofmap
      type(c_ptr) :: z_d = C_NULL_PTR
 
    contains
+     !> Constructor
+     procedure, pass(this) :: init => dofmap_init
      procedure, pass(this) :: size => dofmap_size
 !     final :: dofmap_free
   end type dofmap_t
 
-  interface dofmap_t
-     module procedure dofmap_init
-  end interface dofmap_t
-
 contains
 
-  function dofmap_init(msh, Xh) result(this)
-    type(mesh_t), target, intent(inout) :: msh !< Mesh
-    type(space_t), target, intent(inout) :: Xh !< Function space \f$ X_h \f$
-    type(dofmap_t) :: this
+  !> Constructor.
+  !! @param msh The mesh.
+  !! @param Xh The SEM function space.
+  subroutine dofmap_init(this, msh, Xh)
+    class(dofmap_t) :: this
+    type(mesh_t), target, intent(inout) :: msh
+    type(space_t), target, intent(inout) :: Xh
 
     if ((msh%gdim .eq. 3 .and. Xh%lz .eq. 1) .or. &
          (msh%gdim .eq. 2 .and. Xh%lz .gt. 1)) then
@@ -145,7 +146,7 @@ contains
                           HOST_TO_DEVICE, sync=.false.)
     end if
 
-  end function dofmap_init
+   end subroutine dofmap_init
 
   !> Deallocate the dofmap
   subroutine dofmap_free(this)

--- a/src/sem/dofmap.f90
+++ b/src/sem/dofmap.f90
@@ -33,16 +33,16 @@
 !> Defines a mapping of the degrees of freedom
 !! @details A mapping defined based on a function space and a mesh
 module dofmap
-  use neko_config
+  use neko_config, only : NEKO_BCKND_DEVICE
   use mesh, only : mesh_t
-  use space
+  use space, only : space_t, GLL
   use tuple, only : tuple_i4_t, tuple4_i4_t
   use num_types, only : i4, i8, rp
   use utils, only : neko_error, neko_warning
-  use fast3d
-  use tensor
+  use fast3d, only : fd_weights_full
+  use tensor, only : tensr3, tnsr2d_el, trsp, addtnsr
   use device
-  use math
+  use math, only : add3, copy, rone, rzero
   use element, only : element_t
   use quad, only : quad_t
   use hex, only : hex_t
@@ -69,11 +69,11 @@ module dofmap
      type(c_ptr) :: z_d = C_NULL_PTR
 
    contains
-     !> Constructor
+     !> Constructor.
      procedure, pass(this) :: init => dofmap_init
-     !> Destructor
+     !> Destructor.
      procedure, pass(this) :: free => dofmap_free
-     !> Return ntot
+     !> Return the total number of degrees of freedom, lx*ly*lz*nelv
      procedure, pass(this) :: size => dofmap_size
   end type dofmap_t
 
@@ -91,7 +91,6 @@ contains
          (msh%gdim .eq. 2 .and. Xh%lz .gt. 1)) then
        call neko_error("Invalid dimension of function space for the given mesh")
     end if
-
 
     call this%free()
 
@@ -141,11 +140,11 @@ contains
        call device_map(this%z, this%z_d, this%ntot)
 
        call device_memcpy(this%x, this%x_d, this%ntot, &
-                          HOST_TO_DEVICE, sync=.false.)
+                          HOST_TO_DEVICE, sync = .false.)
        call device_memcpy(this%y, this%y_d, this%ntot, &
-                          HOST_TO_DEVICE, sync=.false.)
+                          HOST_TO_DEVICE, sync = .false.)
        call device_memcpy(this%z, this%z_d, this%ntot, &
-                          HOST_TO_DEVICE, sync=.false.)
+                          HOST_TO_DEVICE, sync = .false.)
     end if
 
    end subroutine dofmap_init
@@ -245,7 +244,7 @@ contains
 
     do i = 1, msh%nelv
 
-       select type(ep=>msh%elements(i)%e)
+       select type (ep => msh%elements(i)%e)
        type is (hex_t)
           !
           ! Number edges in r-direction
@@ -255,7 +254,7 @@ contains
           global_id = msh%get_global(edge)
           edge_id = edge_offset + int((global_id - 1), i8) * num_dofs_edges(1)
           !Reverse order of tranversal if edge is reversed
-          if(int(edge%x(1), i8) .ne. this%dof(1,1,1,i)) then
+          if (int(edge%x(1), i8) .ne. this%dof(1,1,1,i)) then
              do concurrent (j = 2:Xh%lx - 1)
                 k = Xh%lx+1-j
                 this%dof(k, 1, 1, i) = edge_id + (j-2)
@@ -273,7 +272,7 @@ contains
           shared_dof = msh%is_shared(edge)
           global_id = msh%get_global(edge)
           edge_id = edge_offset + int((global_id - 1), i8) * num_dofs_edges(1)
-          if(int(edge%x(1), i8) .ne. this%dof(1,1,Xh%lz,i)) then
+          if (int(edge%x(1), i8) .ne. this%dof(1, 1, Xh%lz, i)) then
              do concurrent (j = 2:Xh%lx - 1)
                 k = Xh%lx+1-j
                 this%dof(k, 1, Xh%lz, i) = edge_id + (j-2)
@@ -291,7 +290,7 @@ contains
           shared_dof = msh%is_shared(edge)
           global_id = msh%get_global(edge)
           edge_id = edge_offset + int((global_id - 1), i8) * num_dofs_edges(1)
-          if(int(edge%x(1), i8) .ne. this%dof(1,Xh%ly,1,i)) then
+          if (int(edge%x(1), i8) .ne. this%dof(1, Xh%ly, 1, i)) then
              do concurrent (j = 2:Xh%lx - 1)
                 k = Xh%lx+1-j
                 this%dof(k, Xh%ly, 1, i) = edge_id + (j-2)
@@ -309,7 +308,7 @@ contains
           shared_dof = msh%is_shared(edge)
           global_id = msh%get_global(edge)
           edge_id = edge_offset + int((global_id - 1), i8) * num_dofs_edges(1)
-          if(int(edge%x(1), i8) .ne. this%dof(1,Xh%ly,Xh%lz,i)) then
+          if (int(edge%x(1), i8) .ne. this%dof(1, Xh%ly, Xh%lz, i)) then
              do concurrent (j = 2:Xh%lx - 1)
                 k = Xh%lx+1-j
                 this%dof(k, Xh%ly, Xh%lz, i) = edge_id + (j-2)
@@ -331,7 +330,7 @@ contains
           shared_dof = msh%is_shared(edge)
           global_id = msh%get_global(edge)
           edge_id = edge_offset + int((global_id - 1), i8) * num_dofs_edges(2)
-          if(int(edge%x(1), i8) .ne. this%dof(1,1,1,i)) then
+          if (int(edge%x(1), i8) .ne. this%dof(1,1,1,i)) then
              do concurrent (j = 2:Xh%ly - 1)
                 k = Xh%ly+1-j
                 this%dof(1, k, 1, i) = edge_id + (j-2)
@@ -349,7 +348,7 @@ contains
           shared_dof = msh%is_shared(edge)
           global_id = msh%get_global(edge)
           edge_id = edge_offset + int((global_id - 1), i8) * num_dofs_edges(2)
-          if(int(edge%x(1), i8) .ne. this%dof(1,1,Xh%lz,i)) then
+          if (int(edge%x(1), i8) .ne. this%dof(1, 1, Xh%lz, i)) then
              do concurrent (j = 2:Xh%ly - 1)
                 k = Xh%ly+1-j
                 this%dof(1, k, Xh%lz, i) = edge_id + (j-2)
@@ -367,7 +366,7 @@ contains
           shared_dof = msh%is_shared(edge)
           global_id = msh%get_global(edge)
           edge_id = edge_offset + int((global_id - 1), i8) * num_dofs_edges(2)
-          if(int(edge%x(1), i8) .ne. this%dof(Xh%lx,1,1,i)) then
+          if (int(edge%x(1), i8) .ne. this%dof(Xh%lx, 1, 1, i)) then
              do concurrent (j = 2:Xh%ly - 1)
                 k = Xh%ly+1-j
                 this%dof(Xh%lx, k, 1, i) = edge_id + (j-2)
@@ -385,7 +384,7 @@ contains
           shared_dof = msh%is_shared(edge)
           global_id = msh%get_global(edge)
           edge_id = edge_offset + int((global_id - 1), i8) * num_dofs_edges(2)
-          if(int(edge%x(1), i8) .ne. this%dof(Xh%lx,1,Xh%lz,i)) then
+          if (int(edge%x(1), i8) .ne. this%dof(Xh%lx, 1, Xh%lz, i)) then
              do concurrent (j = 2:Xh%ly - 1)
                 k = Xh%lz+1-j
                 this%dof(Xh%lx, k, Xh%lz, i) = edge_id + (j-2)
@@ -406,7 +405,7 @@ contains
           shared_dof = msh%is_shared(edge)
           global_id = msh%get_global(edge)
           edge_id = edge_offset + int((global_id - 1), i8) * num_dofs_edges(3)
-          if(int(edge%x(1), i8) .ne. this%dof(1,1,1,i)) then
+          if (int(edge%x(1), i8) .ne. this%dof(1,1,1,i)) then
              do concurrent (j = 2:Xh%lz - 1)
                 k = Xh%lz+1-j
                 this%dof(1, 1, k, i) = edge_id + (j-2)
@@ -424,7 +423,7 @@ contains
           shared_dof = msh%is_shared(edge)
           global_id = msh%get_global(edge)
           edge_id = edge_offset + int((global_id - 1), i8) * num_dofs_edges(3)
-          if(int(edge%x(1), i8) .ne. this%dof(Xh%lx,1,1,i))  then
+          if (int(edge%x(1), i8) .ne. this%dof(Xh%lx,1,1,i))  then
              do concurrent (j = 2:Xh%lz - 1)
                 k = Xh%lz+1-j
                 this%dof(Xh%lx, 1, k, i) = edge_id + (j-2)
@@ -442,7 +441,7 @@ contains
           shared_dof = msh%is_shared(edge)
           global_id = msh%get_global(edge)
           edge_id = edge_offset + int((global_id - 1), i8) * num_dofs_edges(3)
-          if(int(edge%x(1), i8) .ne. this%dof(1,Xh%ly,1,i)) then
+          if (int(edge%x(1), i8) .ne. this%dof(1, Xh%ly, 1, i)) then
              do concurrent (j = 2:Xh%lz - 1)
                 k = Xh%lz+1-j
                 this%dof(1, Xh%ly, k, i) = edge_id + (j-2)
@@ -460,7 +459,7 @@ contains
           shared_dof = msh%is_shared(edge)
           global_id = msh%get_global(edge)
           edge_id = edge_offset + int((global_id - 1), i8) * num_dofs_edges(3)
-          if(int(edge%x(1), i8) .ne. this%dof(Xh%lx,Xh%ly,1,i)) then
+          if (int(edge%x(1), i8) .ne. this%dof(Xh%lx, Xh%ly, 1, i)) then
              do concurrent (j = 2:Xh%lz - 1)
                 k = Xh%lz+1-j
                 this%dof(Xh%lx, Xh%ly, k, i) = edge_id + (j-2)
@@ -482,7 +481,7 @@ contains
           global_id = msh%get_global(edge)
           edge_id = edge_offset + int((global_id - 1), i8) * num_dofs_edges(1)
           !Reverse order of tranversal if edge is reversed
-          if(int(edge%x(1), i8) .ne. this%dof(1,1,1,i)) then
+          if (int(edge%x(1), i8) .ne. this%dof(1,1,1,i)) then
              do concurrent (j = 2:Xh%lx - 1)
                 k = Xh%lx+1-j
                 this%dof(k, 1, 1, i) = edge_id + (j-2)
@@ -500,7 +499,7 @@ contains
           shared_dof = msh%is_shared(edge)
           global_id = msh%get_global(edge)
           edge_id = edge_offset + int((global_id - 1), i8) * num_dofs_edges(1)
-          if(int(edge%x(1), i8) .ne. this%dof(1,Xh%ly,1,i)) then
+          if (int(edge%x(1), i8) .ne. this%dof(1, Xh%ly, 1, i)) then
              do concurrent (j = 2:Xh%lx - 1)
                 k = Xh%lx+1-j
                 this%dof(k, Xh%ly, 1, i) = edge_id + (j-2)
@@ -521,7 +520,7 @@ contains
           shared_dof = msh%is_shared(edge)
           global_id = msh%get_global(edge)
           edge_id = edge_offset + int((global_id - 1), i8) * num_dofs_edges(2)
-          if(int(edge%x(1), i8) .ne. this%dof(1,1,1,i)) then
+          if (int(edge%x(1), i8) .ne. this%dof(1,1,1,i)) then
              do concurrent (j = 2:Xh%ly - 1)
                 k = Xh%ly+1-j 
                 this%dof(1, k, 1, i) = edge_id + (j-2)
@@ -539,7 +538,7 @@ contains
           shared_dof = msh%is_shared(edge)
           global_id = msh%get_global(edge)
           edge_id = edge_offset + int((global_id - 1), i8) * num_dofs_edges(2)
-          if(int(edge%x(1), i8) .ne. this%dof(Xh%lx,1,1,i)) then
+          if (int(edge%x(1), i8) .ne. this%dof(Xh%lx,1,1,i)) then
              do concurrent (j = 2:Xh%ly - 1)
                 k = Xh%ly+1-j
                 this%dof(Xh%lx, k, 1, i) = edge_id + (j-2)
@@ -593,7 +592,7 @@ contains
        facet_id = facet_offset + int((global_id - 1), i8) * num_dofs_faces(1)
        do concurrent (j = 2:(Xh%ly - 1), k = 2:(Xh%lz -1))
           this%dof(1, j, k, i) = &
-               dofmap_facetidx(face_order,face,facet_id,j,k,Xh%lz,Xh%ly)
+               dofmap_facetidx(face_order, face, facet_id, j, k, Xh%lz, Xh%ly)
           this%shared_dof(1, j, k, i) = shared_dof
        end do
 
@@ -604,7 +603,7 @@ contains
        facet_id = facet_offset + int((global_id - 1), i8) * num_dofs_faces(1)
        do concurrent (j = 2:(Xh%ly - 1), k = 2:(Xh%lz -1))
           this%dof(Xh%lx, j, k, i) = &
-                  dofmap_facetidx(face_order,face,facet_id,j,k,Xh%lz,Xh%ly)
+               dofmap_facetidx(face_order, face, facet_id, j, k, Xh%lz, Xh%ly)
           this%shared_dof(Xh%lx, j, k, i) = shared_dof
        end do
 
@@ -619,7 +618,7 @@ contains
        facet_id = facet_offset + int((global_id - 1), i8) * num_dofs_faces(2)
        do concurrent (j = 2:(Xh%lx - 1), k = 2:(Xh%lz - 1))
           this%dof(j, 1, k, i) = &
-               dofmap_facetidx(face_order,face,facet_id,k,j,Xh%lz,Xh%lx)
+               dofmap_facetidx(face_order, face, facet_id, k, j, Xh%lz, Xh%lx)
           this%shared_dof(j, 1, k, i) = shared_dof
        end do
 
@@ -630,7 +629,7 @@ contains
        facet_id = facet_offset + int((global_id - 1), i8) * num_dofs_faces(2)
        do concurrent (j = 2:(Xh%lx - 1), k = 2:(Xh%lz - 1))
           this%dof(j, Xh%ly, k, i) = &
-               dofmap_facetidx(face_order,face,facet_id,k,j,Xh%lz,Xh%lx)
+               dofmap_facetidx(face_order, face, facet_id, k, j, Xh%lz, Xh%lx)
           this%shared_dof(j, Xh%ly, k, i) = shared_dof
        end do
 
@@ -645,7 +644,7 @@ contains
        facet_id = facet_offset + int((global_id - 1), i8) * num_dofs_faces(3)
        do concurrent (j = 2:(Xh%lx - 1), k = 2:(Xh%ly - 1))
           this%dof(j, k, 1, i) = &
-               dofmap_facetidx(face_order,face,facet_id,k,j,Xh%ly,Xh%lx)
+               dofmap_facetidx(face_order, face, facet_id, k, j, Xh%ly, Xh%lx)
           this%shared_dof(j, k, 1, i) = shared_dof
        end do
 
@@ -656,7 +655,7 @@ contains
        facet_id = facet_offset + int((global_id - 1), i8) * num_dofs_faces(3)
        do concurrent (j = 2:(Xh%lx - 1), k = 2:(Xh%ly - 1))
           this%dof(j, k, Xh%lz, i) = &
-               dofmap_facetidx(face_order,face,facet_id,k,j,Xh%lz,Xh%lx)
+               dofmap_facetidx(face_order, face, facet_id, k, j, Xh%lz, Xh%lx)
           this%shared_dof(j, k, Xh%lz, i) = shared_dof
        end do
     end do
@@ -664,12 +663,13 @@ contains
   end subroutine dofmap_number_faces
 
   !> Get idx for GLL point on face depending on face ordering k and j
-  pure function dofmap_facetidx(face_order, face, facet_id, k1, j1, lk1, lj1) result(facet_idx)
+  pure function dofmap_facetidx(face_order, face, facet_id, k1, j1, lk1, &
+       lj1) result(facet_idx)
     type(tuple4_i4_t), intent(in) :: face_order, face
     integer(kind=i8), intent(in) :: facet_id
     integer(kind=i8) :: facet_idx
     integer, intent(in) :: k1, j1, lk1, lj1
-    integer :: k,j,lk,lj
+    integer :: k, j, lk, lj
 
     k = k1 - 2
     j = j1 - 2
@@ -690,26 +690,26 @@ contains
     !   1 -------- 2    0--->j
 
 
-    if(face_order%x(1) .eq. face%x(1)) then
-       if(face_order%x(2) .lt. face_order%x(4)) then
+    if (face_order%x(1) .eq. face%x(1)) then
+       if (face_order%x(2) .lt. face_order%x(4)) then
           facet_idx = facet_id + j + k*lj
        else
           facet_idx = facet_id + j*lk + k
        end if
-    else  if(face_order%x(2) .eq. face%x(1)) then
-       if(face_order%x(3) .lt. face_order%x(1)) then
+    else  if (face_order%x(2) .eq. face%x(1)) then
+       if (face_order%x(3) .lt. face_order%x(1)) then
           facet_idx = facet_id + lk*(lj-1-j) + k
        else
           facet_idx = facet_id + (lj-1-j) + k*lj
        end if
-    else if(face_order%x(3) .eq. face%x(1)) then
-       if(face_order%x(4) .lt. face_order%x(2)) then
+    else if (face_order%x(3) .eq. face%x(1)) then
+       if (face_order%x(4) .lt. face_order%x(2)) then
           facet_idx = facet_id + (lj-1-j) + lj*(lk-1-k)
        else
           facet_idx = facet_id + lk*(lj-1-j) + (lk-1-k)
        end if
-    else if(face_order%x(4) .eq. face%x(1)) then
-       if(face_order%x(1) .lt. face_order%x(3)) then
+    else if (face_order%x(4) .eq. face%x(1)) then
+       if (face_order%x(1) .lt. face_order%x(3)) then
           facet_idx = facet_id + lk*j + (lk-1-k)
        else
           facet_idx = facet_id + j + lj*(lk-1-k)
@@ -742,7 +742,7 @@ contains
        call dofmap_xyzlin(Xh, msh, msh%elements(i)%e, this%x(1,1,1,i), &
                           this%y(1,1,1,i), this%z(1,1,1,i))
     end do
-    do i =1, msh%curve%size
+    do i = 1, msh%curve%size
        midpoint = .false.
        el_idx = msh%curve%curve_el(i)%el_idx
        curve_type = msh%curve%curve_el(i)%curve_type
@@ -754,19 +754,19 @@ contains
        end do
        if (midpoint .and. Xh%lx .gt. 2) then
           call dofmap_xyzquad(Xh, msh, msh%elements(el_idx)%e, &
-                              this%x(1,1,1,el_idx), this%y(1,1,1,el_idx),&
-                              this%z(1,1,1,el_idx),curve_type, curve_data_tot)
+               this%x(1, 1, 1, el_idx), this%y(1, 1, 1, el_idx), &
+               this%z(1 ,1, 1, el_idx), curve_type, curve_data_tot)
        end if
     end do
-    do i =1, msh%curve%size
+    do i = 1, msh%curve%size
        el_idx = msh%curve%curve_el(i)%el_idx
        do j = 1, 8
           if (msh%curve%curve_el(i)%curve_type(j) .eq. 3) then
              rp_curve_data = msh%curve%curve_el(i)%curve_data(1:5,j)
              call arc_surface(j, rp_curve_data, &
-                              this%x(1,1,1,el_idx), &
-                              this%y(1,1,1,el_idx), &
-                              this%z(1,1,1, el_idx), &
+                              this%x(1, 1, 1, el_idx), &
+                              this%y(1, 1, 1, el_idx), &
+                              this%z(1, 1, 1, el_idx), &
                               Xh, msh%elements(el_idx)%e, msh%gdim)
           end if
        end do
@@ -795,7 +795,7 @@ contains
     real(kind=rp) :: jx(Xh%lx*2)
     real(kind=rp) :: jxt(Xh%lx*2), jyt(Xh%lx*2), jzt(Xh%lx*2)
     real(kind=rp) :: w(4*Xh%lx**3), tmp(Xh%lx, Xh%lx, Xh%lx)
-    real(kind=rp), dimension(2), parameter :: zlin = (/-1d0, 1d0/)
+    real(kind=rp), dimension(2), parameter :: zlin = [-1d0, 1d0]
 
     integer :: j, k
 
@@ -867,16 +867,16 @@ contains
     integer :: curve_type(12), eindx(12)
     real(kind=rp) :: curve_data(5,12), x3(3,3,3), y3(3,3,3), z3(3,3,3)
     type(space_t), target :: Xh3
-    real(kind=rp), dimension(3), parameter :: zquad = (/-1d0, 0d0,1d0/)
+    real(kind=rp), dimension(3), parameter :: zquad = [-1d0, 0d0,1d0]
     real(kind=rp) :: zg(3)
-    real(kind=rp), dimension(Xh%lx,Xh%lx,Xh%lx) :: tmp
+    real(kind=rp), dimension(Xh%lx, Xh%lx, Xh%lx) :: tmp
     real(kind=rp) :: jx(Xh%lx*3)
     real(kind=rp) :: jxt(Xh%lx*3), jyt(Xh%lx*3), jzt(Xh%lx*3)
     real(kind=rp) :: w(4*Xh%lxyz,2)
     integer :: j, k, n_edges
-    eindx = (/2 ,  6 ,  8 ,  4, &
-              20 , 24 , 26 , 22, &
-              10 , 12 , 18 , 16 /)
+    eindx = [2 ,  6 ,  8 ,  4, &
+             20 , 24 , 26 , 22, &
+             10 , 12 , 18 , 16]
 
     w = 0d0
     if (msh%gdim .eq. 3) then
@@ -899,20 +899,20 @@ contains
     zg(2) =  0
     zg(3) =  1
     if (msh%gdim .eq. 3) then
-       call gh_face_extend_3d(x3,zg,3,2,w(1,1),w(1,2)) ! 2 --> edge extend
-       call gh_face_extend_3d(y3,zg,3,2,w(1,1),w(1,2))
-       call gh_face_extend_3d(z3,zg,3,2,w(1,1),w(1,2))
+       call gh_face_extend_3d(x3, zg, 3, 2, w(1,1), w(1,2)) ! 2 --> edge extend
+       call gh_face_extend_3d(y3, zg, 3, 2, w(1,1), w(1,2))
+       call gh_face_extend_3d(z3, zg, 3, 2, w(1,1), w(1,2))
     else
        call neko_warning(' m deformation not supported for 2d yet')
-       call gh_face_extend_2d(x3,zg,3,2,w(1,1),w(1,2)) ! 2 --> edge extend
-       call gh_face_extend_2d(y3,zg,3,2,w(1,1),w(1,2))
+       call gh_face_extend_2d(x3, zg, 3, 2, w(1,1), w(1,2)) ! 2 --> edge extend
+       call gh_face_extend_2d(y3, zg, 3, 2, w(1,1), w(1,2))
     end if
-    k =1
+    k = 1
     do j = 1, Xh%lx
-       call fd_weights_full(Xh%zg(j,1),zquad,2,0,jxt(k))
-       call fd_weights_full(Xh%zg(j,2),zquad,2,0,jyt(k))
+       call fd_weights_full(Xh%zg(j,1), zquad, 2, 0, jxt(k))
+       call fd_weights_full(Xh%zg(j,2), zquad, 2, 0, jyt(k))
        if (msh%gdim .gt. 2) then
-          call fd_weights_full(Xh%zg(j,3),zquad,2,0,jzt(k))
+          call fd_weights_full(Xh%zg(j,3), zquad, 2, 0, jzt(k))
        end if
        k = k + 3
     end do
@@ -961,7 +961,7 @@ contains
        si       = 0.5*((n-ii)*(1-zg(i))+(ii-1)*(1+zg(i)))/(n-1)
        sj       = 0.5*((n-jj)*(1-zg(j))+(jj-1)*(1+zg(j)))/(n-1)
        sk       = 0.5*((n-kk)*(1-zg(k))+(kk-1)*(1+zg(k)))/(n-1)
-       v(i,j,k) = v(i,j,k) + si*sj*sk*x(ii,jj,kk)
+       v(i,j,k) = v(i,j,k) + si * sj* sk * x(ii, jj, kk)
     end do
 
     if (gh_type .eq. 1) then
@@ -979,10 +979,10 @@ contains
     !
     !  x-edges
     !
-    do concurrent (i = 1:n, j = 1:n, k = 1:n, jj=1:n:n-1, kk = 1:n:n-1)
+    do concurrent (i = 1:n, j = 1:n, k = 1:n, jj = 1:n:n-1, kk = 1:n:n-1)
        hj       = 0.5*((n-jj)*(1-zg(j))+(jj-1)*(1+zg(j)))/(n-1)
        hk       = 0.5*((n-kk)*(1-zg(k))+(kk-1)*(1+zg(k)))/(n-1)
-       e(i,j,k) = e(i,j,k) + hj*hk*(x(i,jj,kk)-v(i,jj,kk))
+       e(i,j,k) = e(i,j,k) + hj*hk*(x(i, jj, kk) - v(i, jj, kk))
     end do
     !
     !  y-edges
@@ -990,7 +990,7 @@ contains
     do concurrent (i = 1:n, j = 1:n, k = 1:n, ii = 1:n:n-1, kk = 1:n:n-1)
        hi       = 0.5*((n-ii)*(1-zg(i))+(ii-1)*(1+zg(i)))/(n-1)
        hk       = 0.5*((n-kk)*(1-zg(k))+(kk-1)*(1+zg(k)))/(n-1)
-       e(i,j,k) = e(i,j,k) + hi*hk*(x(ii,j,kk)-v(ii,j,kk))
+       e(i,j,k) = e(i,j,k) + hi*hk*(x(ii, j, kk) - v(ii, j, kk))
     end do
     !
     !  z-edges
@@ -998,7 +998,7 @@ contains
     do concurrent (i = 1:n, j = 1:n, k = 1:n, ii = 1:n:n-1, jj = 1:n:n-1)
        hi       = 0.5*((n-ii)*(1-zg(i))+(ii-1)*(1+zg(i)))/(n-1)
        hj       = 0.5*((n-jj)*(1-zg(j))+(jj-1)*(1+zg(j)))/(n-1)
-       e(i,j,k) = e(i,j,k) + hi*hj*(x(ii,jj,k)-v(ii,jj,k))
+       e(i,j,k) = e(i,j,k) + hi*hj*(x(ii, jj, k) - v(ii, jj, k))
     end do
 
     do concurrent (i = 1:ntot)
@@ -1030,7 +1030,7 @@ contains
     !
     do concurrent (i = 1:n, j = 1:n, k = 1:n, jj = 1:n:n-1)
        hj       = 0.5*((n-jj)*(1-zg(j))+(jj-1)*(1+zg(j)))/(n-1)
-       v(i,j,k) = v(i,j,k) + hj*(x(i,jj,k)-e(i,jj,k))
+       v(i,j,k) = v(i,j,k) + hj*(x(i, jj, k) - e(i, jj, k))
     end do
 
     !
@@ -1038,7 +1038,7 @@ contains
     !
     do concurrent (i = 1:n, j = 1:n, k = 1:n, kk = 1:n:n-1)
        hk       = 0.5*((n-kk)*(1-zg(k))+(kk-1)*(1+zg(k)))/(n-1)
-       v(i,j,k) = v(i,j,k) + hk*(x(i,j,kk)-e(i,j,kk))
+       v(i,j,k) = v(i,j,k) + hk*(x(i, j, kk) - e(i, j, kk))
     end do
 
     do concurrent (i = 1:ntot)
@@ -1063,26 +1063,26 @@ contains
 
     !Build vertex interpolant
 
-    ntot=n*n
-    call rzero(v,ntot)
+    ntot = n*n
+    call rzero(v, ntot)
     do jj = 1, n, n-1
        do ii = 1, n, n-1
           do j = 1, n
              do i = 1, n
                 si     = 0.5*((n-ii)*(1-zg(i))+(ii-1)*(1+zg(i)))/(n-1)
                 sj     = 0.5*((n-jj)*(1-zg(j))+(jj-1)*(1+zg(j)))/(n-1)
-                v(i,j) = v(i,j) + si*sj*x(ii,jj)
+                v(i,j) = v(i,j) + si*sj*x(ii, jj)
              end do
           end do
        end do
     end do
     if (gh_type .eq. 1) then
-       call copy(x,v,ntot)
+       call copy(x, v, ntot)
        return
     end if
 
     !Extend 4 edges
-    call rzero(e,ntot)
+    call rzero(e, ntot)
 
     !x-edges
 
@@ -1090,7 +1090,7 @@ contains
        do j = 1, n
           do i = 1, n
              hj     = 0.5*((n-jj)*(1-zg(j))+(jj-1)*(1+zg(j)))/(n-1)
-             e(i,j) = e(i,j) + hj*(x(i,jj)-v(i,jj))
+             e(i,j) = e(i,j) + hj*(x(i, jj) - v(i, jj))
           end do
        end do
     end do
@@ -1123,11 +1123,15 @@ contains
     real(kind=rp) :: theta0, xcenn, ycenn, h(Xh%lx, 3, 2)
     real(kind=rp) :: xcrved(Xh%lx), ycrved(Xh%lx), xs, ys
     integer :: isid1, ixt, iyt, izt, ix, itmp
-    integer(i4),  dimension(6), parameter :: fcyc_to_sym = (/3, 2, 4, 1, 5, 6/) ! cyclic to symmetric face mapping
-    integer(i4),  dimension(12), parameter :: ecyc_to_sym = (/1, 6, 2, 5, 3, 8, &
-    & 4, 7, 9, 10, 12, 11/) ! cyclic to symmetric edge mapping
-    integer, parameter, dimension(2, 12) :: edge_nodes = reshape((/1, 2, 3, 4, 5, 6, &
-    & 7, 8, 1, 3, 2, 4, 5, 7, 6, 8, 1, 5, 2, 6, 3, 7, 4, 8/), (/2,12/)) ! symmetric edge to vertex mapping
+    ! Cyclic to symmetric face mapping
+    integer(i4),  dimension(6), parameter :: fcyc_to_sym = [3, 2, 4, 1, 5, 6]
+    ! Cyclic to symmetric edge mapping
+    integer(i4),  dimension(12), parameter :: ecyc_to_sym = [1, 6, 2, 5, 3, 8,&
+         & 4, 7, 9, 10, 12, 11]
+    ! Symmetric edge to vertex mapping
+    integer, parameter, dimension(2, 12) :: edge_nodes = reshape([1, 2, 3, 4, &
+         & 5, 6, 7, 8, 1, 3, 2, 4, 5, 7, 6, 8, 1, 5, 2, 6, 3, 7, 4, 8], &
+         & [2,12]) 
     ! copy from hex as this has private attribute there
 
     ! this subroutine is a mess of symmetric and cyclic edge/face numberring and
@@ -1135,17 +1139,17 @@ contains
     ! a cyclic edge number)
     ! following according to cyclic edge numbering and orientation
     itmp = ecyc_to_sym(isid)
-    select case(isid)
-    case(1:2,5:6)
-       pt1x = element%pts(edge_nodes(1,itmp))%p%x(1)
-       pt1y = element%pts(edge_nodes(1,itmp))%p%x(2)
-       pt2x = element%pts(edge_nodes(2,itmp))%p%x(1)
-       pt2y = element%pts(edge_nodes(2,itmp))%p%x(2)
-    case(3:4,7:8)
-       pt1x = element%pts(edge_nodes(2,itmp))%p%x(1)
-       pt1y = element%pts(edge_nodes(2,itmp))%p%x(2)
-       pt2x = element%pts(edge_nodes(1,itmp))%p%x(1)
-       pt2y = element%pts(edge_nodes(1,itmp))%p%x(2)
+    select case (isid)
+    case (1:2,5:6)
+       pt1x = element%pts(edge_nodes(1, itmp))%p%x(1)
+       pt1y = element%pts(edge_nodes(1, itmp))%p%x(2)
+       pt2x = element%pts(edge_nodes(2, itmp))%p%x(1)
+       pt2y = element%pts(edge_nodes(2, itmp))%p%x(2)
+    case (3:4,7:8)
+       pt1x = element%pts(edge_nodes(2, itmp))%p%x(1)
+       pt1y = element%pts(edge_nodes(2, itmp))%p%x(2)
+       pt2x = element%pts(edge_nodes(1, itmp))%p%x(1)
+       pt2y = element%pts(edge_nodes(1, itmp))%p%x(2)
     end select
     ! find slope of perpendicular
     radius = curve_data(1)
@@ -1167,10 +1171,10 @@ contains
     isid1 = mod(isid+4-1, 4)+1
     call compute_h(h, Xh%zg, gdim, Xh%lx)
     if (radius < 0.0) dtheta = -dtheta
-    do ix=1,Xh%lx
-       ixt=ix
-       if (isid1.gt.2) ixt=Xh%lx+1-ix
-       r=Xh%zg(ix,1)
+    do ix = 1, Xh%lx
+       ixt = ix
+       if (isid1 .gt. 2) ixt = Xh%lx+1-ix
+       r = Xh%zg(ix,1)
        xcrved(ixt) = xcenn + abs(radius) * cos(theta0 + r*dtheta) &
                            - ( h(ix,1,1)*pt1x + h(ix,1,2)*pt2x )
        ycrved(ixt) = ycenn + abs(radius) * sin(theta0 + r*dtheta) &
@@ -1184,15 +1188,15 @@ contains
     iyt = isid1-2
     ixt = isid1
     if (isid1 .le. 2) then
-       call addtnsr(x, h(1,1,ixt), xcrved, h(1,3,izt) &
-                   ,Xh%lx, Xh%ly, Xh%lz)
-       call addtnsr(y, h(1,1,ixt), ycrved, h(1,3,izt) &
-                   ,Xh%lx, Xh%ly, Xh%lz)
+       call addtnsr(x, h(1, 1, ixt), xcrved, h(1, 3, izt), &
+                   Xh%lx, Xh%ly, Xh%lz)
+       call addtnsr(y, h(1, 1, ixt), ycrved, h(1, 3, izt), &
+                   Xh%lx, Xh%ly, Xh%lz)
     else
-       call addtnsr(x, xcrved, h(1,2,iyt), h(1,3,izt) &
-                   ,Xh%lx, Xh%ly, Xh%lz)
-       call addtnsr(y, ycrved, h(1,2,iyt), h(1,3,izt) &
-                   ,Xh%lx, Xh%ly, Xh%lz)
+       call addtnsr(x, xcrved, h(1, 2, iyt), h(1, 3, izt), &
+                    Xh%lx, Xh%ly, Xh%lz)
+       call addtnsr(y, ycrved, h(1, 2, iyt), h(1, 3, izt), &
+                    Xh%lx, Xh%ly, Xh%lz)
     end if
   end subroutine arc_surface
 

--- a/src/sem/dofmap.f90
+++ b/src/sem/dofmap.f90
@@ -71,8 +71,10 @@ module dofmap
    contains
      !> Constructor
      procedure, pass(this) :: init => dofmap_init
+     !> Destructor
+     procedure, pass(this) :: free => dofmap_free
+     !> Return ntot
      procedure, pass(this) :: size => dofmap_size
-!     final :: dofmap_free
   end type dofmap_t
 
 contains
@@ -91,7 +93,7 @@ contains
     end if
 
 
-    call dofmap_free(this)
+    call this%free()
 
     this%msh => msh
     this%Xh => Xh
@@ -148,9 +150,9 @@ contains
 
    end subroutine dofmap_init
 
-  !> Deallocate the dofmap
+  !> Destructor.
   subroutine dofmap_free(this)
-    type(dofmap_t), intent(inout) :: this
+    class(dofmap_t), intent(inout) :: this
 
     if (allocated(this%dof)) then
        deallocate(this%dof)

--- a/tests/dofmap/dofmap_parallel.pf
+++ b/tests/dofmap/dofmap_parallel.pf
@@ -71,7 +71,7 @@ contains
     call Xh%init(GLL, 2, 2, 2)
 
     call m%generate_conn()
-    d = dofmap_t(m, Xh)
+    call d%init(m, Xh)
 
     @assertEqual(d%x(1,1,1,1), p(1)%x(1), tolerance=1d-14)
     @assertEqual(d%x(2,1,1,1), p(2)%x(1), tolerance=1d-14)
@@ -138,7 +138,7 @@ contains
          p(6), p(11), p(7), p(12))
     
     call m%generate_conn() 
-    d = dofmap_t(m, Xh)
+    call d%init(m, Xh)
     do i = 1,lx
       do j = 1,lx
       @assertEqual(d%dof(lx,j,i,1), d%dof(1,j,i,2))
@@ -212,7 +212,7 @@ contains
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
-    d = dofmap_t(m, Xh)
+    call d%init(m, Xh)
     do i = 1,lx
       do j = 1,lx
       @assertEqual(d%dof(lx+1-i,j,lx,1), d%dof(1,j,i,2))
@@ -284,7 +284,7 @@ contains
     call m%add_element(2, p(2), p(9), p(3), p(10), &
          p(6), p(11), p(7), p(12))
     call m%generate_conn()
-    d = dofmap_t(m, Xh)
+    call d%init(m, Xh)
     do i = 1,lx
       do j = 1,lx
       @assertEqual(d%dof(1,lx+1-j,lx+1-i,1), d%dof(1,j,i,2))
@@ -357,7 +357,7 @@ contains
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
-    d = dofmap_t(m, Xh)
+    call d%init(m, Xh)
     do i = 1,lx
       do j = 1,lx
       @assertEqual(d%dof(1,j,lx+1-i,1), d%dof(1,j,i,2))
@@ -431,7 +431,7 @@ contains
     call m%generate_conn()
 
     call m%generate_conn()
-    d = dofmap_t(m, Xh)
+    call d%init(m, Xh)
     do i = 1,lx
       do j = 1,lx
       @assertEqual(d%dof(i,j,1,1), d%dof(1,j,i,2))
@@ -504,7 +504,7 @@ contains
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
-    d = dofmap_t(m, Xh)
+    call d%init(m, Xh)
     do i = 1,lx
       do j = 1,lx
       @assertEqual(d%dof(lx+1-j,lx,i,1), d%dof(1,j,i,2))
@@ -577,7 +577,7 @@ contains
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
-    d = dofmap_t(m, Xh)
+    call d%init(m, Xh)
     do i = 1,lx
       do j = 1,lx
       @assertEqual(d%dof(j,1,i,1), d%dof(1,j,i,2))

--- a/tests/field/field_parallel.pf
+++ b/tests/field/field_parallel.pf
@@ -102,7 +102,7 @@ contains
     @assertEqual(size(f_msh_Xh%x), 2 * lx**3)
     @assertEqual(maxval(f_msh_Xh%x), 0d0)
 
-    dm = dofmap_t(msh, Xh)
+    call dm%init(msh, Xh)
     call f_dm%init(msh, Xh, 'test')
     @assertTrue(allocated(f_dm%x))
     @assertTrue(associated(f_dm%Xh))

--- a/tests/gather_scatter/gather_scatter_parallel.pf
+++ b/tests/gather_scatter/gather_scatter_parallel.pf
@@ -77,7 +77,7 @@ contains
 
     call m%generate_conn()
 
-    d = dofmap_t(m, Xh)
+    call d%init(m, Xh)
     call gs_h%init(d)
     call x%init(m, Xh, "x")   
     n = Xh%lx * Xh%ly * Xh%lz * m%nelv
@@ -166,7 +166,7 @@ contains
          p(6), p(11), p(7), p(12))
     call m%generate_conn()
 
-    d = dofmap_t(m, Xh)
+    call d%init(m, Xh)
     call gs_h%init(d)
     call x%init(m, Xh, "x")   
     n = Xh%lx * Xh%ly * Xh%lz * m%nelv
@@ -254,7 +254,7 @@ contains
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
-    d = dofmap_t(m, Xh)
+    call d%init(m, Xh)
     call gs_h%init(d)
     call x%init(m, Xh, "x")   
     n = Xh%lx * Xh%ly * Xh%lz * m%nelv
@@ -342,7 +342,7 @@ contains
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
-    d = dofmap_t(m, Xh)
+    call d%init(m, Xh)
     call gs_h%init(d)
     call x%init(m, Xh, "x")   
     n = Xh%lx * Xh%ly * Xh%lz * m%nelv
@@ -430,7 +430,7 @@ contains
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
-    d = dofmap_t(m, Xh)
+    call d%init(m, Xh)
     call gs_h%init(d)
     call x%init(m, Xh, "x")   
     n = Xh%lx * Xh%ly * Xh%lz * m%nelv
@@ -518,7 +518,7 @@ contains
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
-    d = dofmap_t(m, Xh)
+    call d%init(m, Xh)
     call gs_h%init(d)
     call x%init(m, Xh, "x")   
     n = Xh%lx * Xh%ly * Xh%lz * m%nelv
@@ -606,7 +606,7 @@ contains
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
-    d = dofmap_t(m, Xh)
+    call d%init(m, Xh)
     call gs_h%init(d)
     call x%init(m, Xh, "x")   
     n = Xh%lx * Xh%ly * Xh%lz * m%nelv

--- a/tests/point_interpolation/point_interpolation_parallel.pf
+++ b/tests/point_interpolation/point_interpolation_parallel.pf
@@ -74,7 +74,7 @@ contains
     type(space_t) :: Xh
 
     call Xh%init(GLL, lx, lx, lx)
-    dof = dofmap_t(msh, Xh)
+    call dof%init(msh, Xh)
     call gs%init(dof)
     call coef%init(gs)
 
@@ -106,7 +106,7 @@ contains
 
     call msh%generate_conn()
     call Xh%init(GLL, lx, lx, lx)
-    dof = dofmap_t(msh, Xh)
+    call dof%init(msh, Xh)
     call gs%init(dof)
     call coef%init(gs)
 
@@ -145,7 +145,7 @@ contains
     call msh%add_element(1, p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8))
     call msh%generate_conn()
     call Xh%init(GLL, lx, lx, lx)
-    dof = dofmap_t(msh, Xh)
+    call dof%init(msh, Xh)
     call gs%init(dof)
     call coef%init(gs)
 
@@ -209,7 +209,7 @@ contains
     call msh%add_element(1, p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8))
     call msh%generate_conn()
     call Xh%init(GLL, lx, lx, lx)
-    dof = dofmap_t(msh, Xh)
+    call dof%init(msh, Xh)
     call gs%init(dof)
     call coef%init(gs)
 

--- a/tests/scratch_registry/test_scratch_registry.pf
+++ b/tests/scratch_registry/test_scratch_registry.pf
@@ -63,7 +63,7 @@ contains
     call test_scratch_registry_gen_msh(msh)
   
     call Xh%init(GLL, lx, lx, lx)
-    dm = dofmap_t(msh, Xh)
+    call dm%init(msh, Xh)
     
     scratch = scratch_registry_t(dm) 
 
@@ -86,7 +86,7 @@ contains
 
     call test_scratch_registry_gen_msh(msh)
     call Xh%init(GLL, lx, lx, lx)
-    dm = dofmap_t(msh, Xh)
+    call dm%init(msh, Xh)
     
     scratch = scratch_registry_t(dm, 5, 3) 
 
@@ -110,7 +110,7 @@ contains
     ! write(*,*) "TEST FRESH"
     call test_scratch_registry_gen_msh(msh)
     call Xh%init(GLL, lx, lx, lx)
-    dm = dofmap_t(msh, Xh)
+    call dm%init(msh, Xh)
     
     scratch = scratch_registry_t(dm, 5, 3) 
     
@@ -145,7 +145,7 @@ contains
 
     call test_scratch_registry_gen_msh(msh)
     call Xh%init(GLL, lx, lx, lx)
-    dm = dofmap_t(msh, Xh)
+    call dm%init(msh, Xh)
     
     scratch = scratch_registry_t(dm, 5, 3) 
     
@@ -170,7 +170,7 @@ contains
 
     call test_scratch_registry_gen_msh(msh)
     call Xh%init(GLL, lx, lx, lx)
-    dm = dofmap_t(msh, Xh)
+    call dm%init(msh, Xh)
     
     scratch = scratch_registry_t(dm, 1, 1) 
 
@@ -208,7 +208,7 @@ contains
 
    call test_scratch_registry_gen_msh(msh)
    call Xh%init(GLL, lx, lx, lx)
-   dm = dofmap_t(msh, Xh)
+   call dm%init(msh, Xh)
     
   !  write(*,*) "TEST COMBO"
    scratch = scratch_registry_t(dm, 2, 2) 
@@ -282,7 +282,7 @@ end subroutine test_scratch_registry_combo
 
    call test_scratch_registry_gen_msh(msh)
    call Xh%init(GLL, lx, lx, lx)
-   dm = dofmap_t(msh, Xh)
+   call dm%init(msh, Xh)
     
   !  write(*,*) "TEST COMBO"
    scratch = scratch_registry_t(dm, 2, 2) 


### PR DESCRIPTION
Converts the dofmap constructor to a %init procedure, just like all other types have. Same for destructor. Bumps code style score.

Question, why is the dofmap destructor not called in some places. There is a comment in schwarz.f90 on line 155. I was generally surprised that I didn't have to refactor a single destructor call, excluding the one from the init.