### PR TITLE
Check for existence of csv file in `count_lines`

### DIFF
--- a/src/io/csv_file.f90
+++ b/src/io/csv_file.f90
@@ -310,9 +310,9 @@ contains
 
     call this%check_exists()
 
-    open(file = trim(f%fname), status = 'old', newunit = file_unit, &
+    open(file = trim(this%fname), status = 'old', newunit = file_unit, &
          iostat = ierr)
-    if (ierr .ne. 0) call neko_error("Error while opening " // trim(f%fname))
+    if (ierr .ne. 0) call neko_error("Error while opening " // trim(this%fname))
 
     n = 0
 

--- a/src/io/csv_file.f90
+++ b/src/io/csv_file.f90
@@ -308,6 +308,8 @@ contains
     integer :: n
     integer :: ierr, file_unit
 
+    call this%check_exists()
+
     open(file = trim(f%fname), status = 'old', newunit = file_unit, &
          iostat = ierr)
     if (ierr .ne. 0) call neko_error("Error while opening " // trim(f%fname))

--- a/src/io/csv_file.f90
+++ b/src/io/csv_file.f90
@@ -313,6 +313,7 @@ contains
     open(file = trim(this%fname), status = 'old', newunit = file_unit, &
          iostat = ierr)
     if (ierr .ne. 0) call neko_error("Error while opening " // trim(this%fname))
+    rewind(file_unit)
 
     n = 0
 

--- a/src/io/csv_file.f90
+++ b/src/io/csv_file.f90
@@ -308,8 +308,9 @@ contains
     integer :: n
     integer :: ierr, file_unit
 
-    open(file = trim(this%fname), status = 'old', newunit = file_unit)
-    rewind(file_unit)
+    open(file = trim(f%fname), status = 'old', newunit = file_unit, &
+         iostat = ierr)
+    if (ierr .ne. 0) call neko_error("Error while opening " // trim(f%fname))
 
     n = 0
 


### PR DESCRIPTION
Fixes a bug in `csv_file_count_lines` that caused segfault without a proper error message if the csv file did not exist.

Noticed it when using probes with an input csv that did not exist. Since we call `csv_file_count_lines` before `csv_file_read` the usual safeguards were bypassed.

Perhaps could be good to cherry-pick this into `release` as well?