### PR TITLE
Ignore warnings in GNU

### DIFF
--- a/.github/workflows/check_intel.yml
+++ b/.github/workflows/check_intel.yml
@@ -81,4 +81,4 @@ jobs:
         run: |
           ./regen.sh
           ./configure FC=${FC} CC=${CC} MPIFC"=mpiifort -fc=${FC}" --enable-real=${RP}
-          make FCFLAGS="-diag-disable:10448 -O2 -stand f08 -warn errors `pkg-config --cflags json-fortran`" -j$(nproc)
+          make FCFLAGS="-O2 -stand f08 -warn errors `pkg-config --cflags json-fortran`" -j$(nproc)


### PR DESCRIPTION
Adds -w to GNU checks to avoid unloadable logs with 80k lines.

For intel, I try to disable the ifort deprecation remark, which also adds some noise to the log. I thinkt the `-warn errors` already kill the warning for intel and the logs are indeed short.