### PR TITLE
Fix scalar scheme message for material properties

### DIFF
--- a/src/scalar/scalar_scheme.f90
+++ b/src/scalar/scalar_scheme.f90
@@ -712,8 +712,9 @@ contains
           write(log_buf, '(A)') 'Non-dimensional scalar material properties &
           & input.'
           call neko_log%message(log_buf, lvl = NEKO_LOG_VERBOSE)
-          write(log_buf, '(A)') 'Specific heat capacity will be set to 1, &
-          & conductivity to 1/Pe. Assumes density is 1.'
+          write(log_buf, '(A)') 'Specific heat capacity will be set to 1,'
+          call neko_log%message(log_buf, lvl = NEKO_LOG_VERBOSE)
+          write(log_buf, '(A)') 'conductivity to 1/Pe. Assumes density is 1.'
           call neko_log%message(log_buf, lvl = NEKO_LOG_VERBOSE)
 
           ! Read Pe into lambda for further manipulation.


### PR DESCRIPTION
The commit "scalar scheme message surpassed `LOG_SIZE`" fixes an issue where the specific heat capacity message resulted in a `Fortran runtime error: End of record` due to exceeding the log size. The commit updates the message to ensure it is displayed correctly.