### PR TITLE
Appending a source term to a case with no source terms

### DIFF
--- a/src/source_terms/source_term_handler.f90
+++ b/src/source_terms/source_term_handler.f90
@@ -226,9 +226,9 @@ contains
     integer :: n_sources, i
 
     if(allocated(this%source_terms)) then
-    	n_sources = size(this%source_terms)
+       n_sources = size(this%source_terms)
     else
-    	n_sources = 0
+       n_sources = 0
     endif
 
     call move_alloc(this%source_terms, temp)

--- a/src/source_terms/source_term_handler.f90
+++ b/src/source_terms/source_term_handler.f90
@@ -225,7 +225,12 @@ contains
 
     integer :: n_sources, i
 
-    n_sources = size(this%source_terms)
+	 if(allocated(this%source_terms)) then
+    	n_sources = size(this%source_terms)
+    else
+    	n_sources = 0
+    endif
+
     call move_alloc(this%source_terms, temp)
     allocate(this%source_terms(n_sources + 1))
 

--- a/src/source_terms/source_term_handler.f90
+++ b/src/source_terms/source_term_handler.f90
@@ -225,7 +225,7 @@ contains
 
     integer :: n_sources, i
 
-	 if(allocated(this%source_terms)) then
+    if(allocated(this%source_terms)) then
     	n_sources = size(this%source_terms)
     else
     	n_sources = 0


### PR DESCRIPTION
I was having trouble appending source terms to a case with no source terms read from the JSON.

n_sources = size(this%source_terms) would return 1, then it would append the additional source term in position 2.
Then it would segfault trying to execute the unallocated source_terms(1).
