### PR TITLE
Rename s to sampler

### DIFF
--- a/src/case.f90
+++ b/src/case.f90
@@ -69,7 +69,7 @@ module case
      real(kind=rp) :: dt
      real(kind=rp) :: end_time
      character(len=:), allocatable :: output_directory
-     type(sampler_t) :: s
+     type(sampler_t) :: sampler
      type(fluid_output_t) :: f_out
      type(chkp_output_t) :: f_chkp
      type(user_t) :: usr
@@ -383,7 +383,7 @@ contains
     !
     ! Setup sampler
     !
-    call this%s%init(this%end_time)
+    call this%sampler%init(this%end_time)
     if (scalar) then
        this%f_out = fluid_output_t(precision, this%fluid, this%scalar, &
             path = trim(this%output_directory))
@@ -398,15 +398,15 @@ contains
     if (trim(string_val) .eq. 'org') then
        ! yes, it should be real_val below for type compatibility
        call json_get(this%params, 'case.nsamples', real_val)
-       call this%s%add(this%f_out, real_val, 'nsamples')
+       call this%sampler%add(this%f_out, real_val, 'nsamples')
     else if (trim(string_val) .eq. 'never') then
        ! Fix a dummy 0.0 output_value
        call json_get_or_default(this%params, 'case.fluid.output_value', &
             real_val, 0.0_rp)
-       call this%s%add(this%f_out, 0.0_rp, string_val)
+       call this%sampler%add(this%f_out, 0.0_rp, string_val)
     else
        call json_get(this%params, 'case.fluid.output_value', real_val)
-       call this%s%add(this%f_out, real_val, string_val)
+       call this%sampler%add(this%f_out, real_val, string_val)
     end if
 
     !
@@ -423,7 +423,7 @@ contains
             string_val, "simulationtime")
        call json_get_or_default(this%params, 'case.checkpoint_value', real_val,&
             1e10_rp)
-       call this%s%add(this%f_chkp, real_val, string_val)
+       call this%sampler%add(this%f_chkp, real_val, string_val)
     end if
 
     !
@@ -454,7 +454,7 @@ contains
 
     call this%msh%free()
 
-    call this%s%free()
+    call this%sampler%free()
 
   end subroutine case_free
 

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -90,7 +90,7 @@ contains
 
     !> Call stats, samplers and user-init before time loop
     call neko_log%section('Postprocessing')
-    call C%s%sample(t, tstep)
+    call C%sampler%sample(t, tstep)
 
     call C%usr%user_init_modules(t, C%fluid%u, C%fluid%v, C%fluid%w,&
                                  C%fluid%p, C%fluid%c_Xh, C%params)
@@ -155,7 +155,7 @@ contains
        ! Execute all simulation components
        call neko_simcomps%compute(t, tstep)
 
-       call C%s%sample(t, tstep)
+       call C%sampler%sample(t, tstep)
 
        ! Update material properties
        call C%usr%material_properties(t, tstep, C%fluid%rho,&
@@ -184,7 +184,7 @@ contains
 
     call json_get_or_default(C%params, 'case.output_at_end',&
                              output_at_end, .true.)
-    call C%s%sample(t, tstep, output_at_end)
+    call C%sampler%sample(t, tstep, output_at_end)
 
     if (.not. (output_at_end) .and. t .lt. C%end_time) then
        call simulation_joblimit_chkp(C, t)
@@ -275,7 +275,7 @@ contains
     call neko_log%message(log_buf)
     call neko_log%end_section()
 
-    call C%s%set_counter(t)
+    call C%sampler%set_counter(t)
   end subroutine simulation_restart
 
   !> Write a checkpoint at joblimit

--- a/src/simulation_components/field_writer.f90
+++ b/src/simulation_components/field_writer.f90
@@ -128,9 +128,9 @@ contains
           call this%output%fields%assign(i, neko_field_registry%get_field(fieldi))
        end do
 
-       call this%case%s%add(this%output, &
-                            this%output_controller%control_value, &
-                            this%output_controller%control_mode)
+       call this%case%sampler%add(this%output, &
+            this%output_controller%control_value, &
+            this%output_controller%control_mode)
     else
       do i=1, size(fields)
          fieldi = trim(fields(i))

--- a/src/simulation_components/fluid_stats_simcomp.f90
+++ b/src/simulation_components/fluid_stats_simcomp.f90
@@ -153,7 +153,7 @@ contains
     call this%stats_output%init(this%stats, this%start_time, & 
          hom_dir = hom_dir, path = this%case%output_directory)
 
-    call this%case%s%add(this%stats_output, &
+    call this%case%sampler%add(this%stats_output, &
          this%output_controller%control_value, &
          this%output_controller%control_mode)
  


### PR DESCRIPTION
Renames case%s to case%sampler. 

s is just too short to convey any meaning. I sometimes confused with scalar also, because that is the typical name of the scalar field.

@MartinKarp I know you don't like the type being called sampler in the first place (me as well I think), but we can maybe have this small improvement for now. 