### PR TITLE
Add option to create aabb tree directly from aabb and fix sorting bug

### DIFF
--- a/src/mesh/aabb_tree.f90
+++ b/src/mesh/aabb_tree.f90
@@ -439,8 +439,9 @@ contains
        minidx = -1
        do imin = 1, size(array)
           if (.not. visited(imin) .and. minidx .eq. -1) minidx = imin
-
-          if (visited(imin) .and. array(imin) .lt. array(minidx)) minidx = imin
+          if (minidx .gt. -1) then
+             if (visited(imin) .and. array(imin) .lt. array(minidx)) minidx = imin
+          end if
        end do
 
        indices(i) = minidx
@@ -641,6 +642,7 @@ contains
           end if
        end if
     end do
+    call simple_stack%free()
   end subroutine aabb_tree_query_overlaps
 
   ! -------------------------------------------------------------------------- !

--- a/src/mesh/search_tree/aabb.f90
+++ b/src/mesh/search_tree/aabb.f90
@@ -188,7 +188,7 @@ contains
     select type(object)
 
       type is (aabb_t)
-       box%init(object%get_min(), object%get_max())
+       call box%init(object%get_min(), object%get_max())
       type is (tri_t)
        box = get_aabb_element(object)
       type is (hex_t)

--- a/src/mesh/search_tree/aabb.f90
+++ b/src/mesh/search_tree/aabb.f90
@@ -187,6 +187,8 @@ contains
 
     select type(object)
 
+      type is (aabb_t)
+       box%init(object%get_min(), object%get_max())
       type is (tri_t)
        box = get_aabb_element(object)
       type is (hex_t)


### PR DESCRIPTION
Maybe it was possible to use the aabb directly previously, but I used it to create my global search tree of the whole domain for the global interpolation.

The sorting seems to have fixed a bug with some kind of race condition I had.