### PR TITLE
A mesh checker utility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -384,6 +384,7 @@ if test "x${enable_contrib}" = xyes; then
 		    contrib/postprocess_fluid_stats/Makefile\
 		    contrib/average_field_in_space/Makefile\
 		    contrib/map_to_equidistant_1d/Makefile\
+		    contrib/mesh_checker/Makefile\
 		    contrib/prepart/Makefile])
 fi
 # Doxygen

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -5,5 +5,6 @@ SUBDIRS = rea2nbin\
 	  average_field_in_space\
 	  calc_lift_from_field\
 	  postprocess_fluid_stats\
+	  mesh_checker\
 	  map_to_equidistant_1d
 

--- a/contrib/mesh_checker/Makefile.am
+++ b/contrib/mesh_checker/Makefile.am
@@ -1,0 +1,5 @@
+bin_PROGRAMS = mesh_checker
+mesh_checker_SOURCES = mesh_checker.f90
+mesh_checker_LDADD = $(top_builddir)/src/libneko.a
+mesh_checker_LDFLAGS = $(LDFLAGS) $(LIBS) 
+AM_FCFLAGS = -I@top_builddir@/src

--- a/contrib/mesh_checker/mesh_checker.f90
+++ b/contrib/mesh_checker/mesh_checker.f90
@@ -1,0 +1,99 @@
+! Copyright (c) 2018-2023, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+! Mesh diagnostics tool
+program mesh_checker
+  use neko
+  implicit none
+
+  character(len=NEKO_FNAME_LEN) :: inputchar, mesh_fname
+  type(file_t) :: mesh_file
+  type(coef_t) :: coef
+  type(dofmap_t), target :: dof
+  type(space_t) :: Xh
+  type(mesh_t) :: msh
+  type(gs_t) :: gs_h
+  integer :: argc, i, n_labeled
+  character(len=LOG_SIZE) :: log_buf
+
+  argc = command_argument_count()
+
+  if (argc .lt. 1) then
+     if (pe_rank .eq. 0) then
+        write(*,*) 'Usage: ./mesh_checker mesh.nmsh'
+     end if
+     stop
+  end if
+
+  call neko_init
+
+  call get_command_argument(1, inputchar)
+  read(inputchar, *) mesh_fname
+
+  mesh_file = file_t(trim(mesh_fname))
+
+  call mesh_file%read(msh)
+
+
+  if (pe_rank .eq. 0) then
+      write(*,*) ''
+      write(*,*) '--------------Size-------------'
+      write(*,*) 'Number of elements: ', msh%glb_nelv
+      write(*,*) 'Number of points:   ', msh%glb_mpts
+      write(*,*) 'Number of faces:    ', msh%glb_mfcs
+      write(*,*) 'Number of edges:    ', msh%glb_meds
+      write(*,*) ''
+      write(*,*) '--------------Zones------------'
+      write(*,*) 'Number of built-in inlet faces:         ', msh%inlet%size
+      write(*,*) 'Number of built-in wall faces:          ', msh%wall%size
+      write(*,*) 'Number of built-in outlet faces:        ', msh%outlet%size
+      write(*,*) 'Number of built-in outlet-normal faces: ', &
+           msh%outlet_normal%size
+      write(*,*) 'Number of built-in symmetry faces:      ', &
+            msh%sympln%size
+      write(*,*) 'Number of periodic faces:               ', msh%periodic%size
+
+      write(*,*) 'Labeled zones: '
+      do i = 1, size(msh%labeled_zones) 
+         if (msh%labeled_zones(i)%size .gt. 0) then
+            write(*,'(A,I2,A,I0,A)') '    Zone ', i, ': ', &
+                 msh%labeled_zones(i)%size, ' faces'
+            
+         end if
+      end do
+  end if
+
+  if (pe_rank .eq. 0) write(*,*) 'Done'
+  call neko_finalize
+
+end program mesh_checker
+

--- a/contrib/mesh_checker/mesh_checker.f90
+++ b/contrib/mesh_checker/mesh_checker.f90
@@ -37,11 +37,7 @@ program mesh_checker
 
   character(len=NEKO_FNAME_LEN) :: inputchar, mesh_fname
   type(file_t) :: mesh_file
-  type(coef_t) :: coef
-  type(dofmap_t), target :: dof
-  type(space_t) :: Xh
   type(mesh_t) :: msh
-  type(gs_t) :: gs_h
   integer :: argc, i, n_labeled
   character(len=LOG_SIZE) :: log_buf
 


### PR DESCRIPTION
Adds a mesh checker utility, currently in rudimentary and serial form, but already quite useful to detect what kind of zones one has in a mesh.

The idea is to add more diagnostics further on, and output associated fields as an option.