### PR TITLE
Fix volflow type

### DIFF
--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -787,9 +787,9 @@ contains
 
       if (this%forced_flow_rate) then
          call this%vol_flow%adjust( u, v, w, p, u_res, v_res, w_res, p_res, &
-              c_Xh, gs_Xh, ext_bdf, rho, mu,&
-              dt, this%bclst_dp, this%bclst_du, this%bclst_dv, &
-              this%bclst_dw, this%bclst_vel_res, Ax_vel, this%ksp_prs, &
+              c_Xh, gs_Xh, ext_bdf, rho, mu, dt, &
+              this%bclst_dp, this%bclst_du, this%bclst_dv, &
+              this%bclst_dw, this%bclst_vel_res, Ax_vel, Ax_prs, this%ksp_prs, &
               this%ksp_vel, this%pc_prs, this%pc_vel, this%ksp_prs%max_iter, &
               this%ksp_vel%max_iter)
       end if

--- a/src/fluid/fluid_volflow.f90
+++ b/src/fluid/fluid_volflow.f90
@@ -151,7 +151,7 @@ contains
   subroutine fluid_vol_flow_compute(this, u_res, v_res, w_res, p_res, &
        ext_bdf, gs_Xh, c_Xh, rho, mu, bd, dt, &
        bclst_dp, bclst_du, bclst_dv, bclst_dw, bclst_vel_res, &
-       Ax, ksp_prs, ksp_vel, pc_prs, pc_vel, prs_max_iter, vel_max_iter)
+       Ax_vel, Ax_prs, ksp_prs, ksp_vel, pc_prs, pc_vel, prs_max_iter, vel_max_iter)
     class(fluid_volflow_t), intent(inout) :: this
     type(field_t), intent(inout) :: u_res, v_res, w_res, p_res
     type(coef_t), intent(inout) :: c_Xh
@@ -159,7 +159,8 @@ contains
     type(time_scheme_controller_t), intent(inout) :: ext_bdf
     type(bc_list_t), intent(inout) :: bclst_dp, bclst_du, bclst_dv, bclst_dw
     type(bc_list_t), intent(inout) :: bclst_vel_res
-    class(ax_t), intent(inout) :: Ax
+    class(ax_t), intent(inout) :: Ax_vel
+    class(ax_t), intent(inout) :: Ax_prs
     class(ksp_t), intent(inout) :: ksp_prs, ksp_vel
     class(pc_t), intent(inout) :: pc_prs, pc_vel
     real(kind=rp), intent(inout) :: bd
@@ -169,7 +170,7 @@ contains
     real(kind=rp) :: xlmin, xlmax
     real(kind=rp) :: ylmin, ylmax
     real(kind=rp) :: zlmin, zlmax
-    type(ksp_monitor_t) :: ksp_result
+    type(ksp_monitor_t) :: ksp_results(4)
     type(field_t), pointer :: ta1, ta2, ta3
     integer :: temp_indices(3)
 
@@ -226,7 +227,7 @@ contains
       call gs_Xh%op(p_res, GS_OP_ADD)
       call bc_list_apply_scalar(bclst_dp, p_res%x, n)
       call pc_prs%update()
-      ksp_result = ksp_prs%solve(Ax, p_vol, p_res%x, n, &
+      ksp_results(1) = ksp_prs%solve(Ax_prs, p_vol, p_res%x, n, &
            c_Xh, bclst_dp, gs_Xh, prs_max_iter)
 
       !   Compute velocity
@@ -287,12 +288,12 @@ contains
             u_res%x, v_res%x, w_res%x, n)
       call pc_vel%update()
 
-      ksp_result = ksp_vel%solve(Ax, u_vol, u_res%x, n, &
-            c_Xh, bclst_du, gs_Xh, vel_max_iter)
-      ksp_result = ksp_vel%solve(Ax, v_vol, v_res%x, n, &
-            c_Xh, bclst_dv, gs_Xh, vel_max_iter)
-      ksp_result = ksp_vel%solve(Ax, w_vol, w_res%x, n, &
-            c_Xh, bclst_dw, gs_Xh, vel_max_iter)
+      ksp_results(2:4) = ksp_vel%solve_coupled(Ax_vel, &
+           u_vol, v_vol, u_vol,  &
+           u_res%x, v_res%x, w_res%x, &
+           n, c_Xh, &
+           bclst_du, bclst_dv, bclst_dw, &
+           gs_Xh, vel_max_iter)
 
       if (NEKO_BCKND_DEVICE .eq. 1) then
          if (this%flow_dir .eq. 1) then
@@ -339,7 +340,7 @@ contains
   subroutine fluid_vol_flow(this, u, v, w, p, u_res, v_res, w_res, p_res, &
        c_Xh, gs_Xh, ext_bdf, rho, mu, dt, &
        bclst_dp, bclst_du, bclst_dv, bclst_dw, bclst_vel_res, &
-       Ax, ksp_prs, ksp_vel, pc_prs, pc_vel, prs_max_iter, vel_max_iter)
+       Ax_vel, Ax_prs, ksp_prs, ksp_vel, pc_prs, pc_vel, prs_max_iter, vel_max_iter)
 
     class(fluid_volflow_t), intent(inout) :: this
     type(field_t), intent(inout) :: u, v, w, p
@@ -350,7 +351,8 @@ contains
     real(kind=rp), intent(in) :: rho, mu, dt
     type(bc_list_t), intent(inout) :: bclst_dp, bclst_du, bclst_dv, bclst_dw
     type(bc_list_t), intent(inout) :: bclst_vel_res
-    class(ax_t), intent(inout) :: Ax
+    class(ax_t), intent(inout) :: Ax_vel
+    class(ax_t), intent(inout) :: Ax_prs
     class(ksp_t), intent(inout) :: ksp_prs, ksp_vel
     class(pc_t), intent(inout) :: pc_prs, pc_vel
     integer, intent(in) :: prs_max_iter, vel_max_iter
@@ -384,7 +386,8 @@ contains
          call this%compute(u_res, v_res, w_res, p_res, &
               ext_bdf, gs_Xh, c_Xh, rho, mu, ext_bdf%diffusion_coeffs(1), dt, &
               bclst_dp, bclst_du, bclst_dv, bclst_dw, bclst_vel_res, &
-              Ax, ksp_prs, ksp_vel, pc_prs, pc_vel, prs_max_iter, vel_max_iter)
+              Ax_vel, Ax_prs, ksp_prs, ksp_vel, pc_prs, pc_vel, prs_max_iter, &
+              vel_max_iter)
       end if
 
       if (NEKO_BCKND_DEVICE .eq. 1) then

--- a/src/krylov/bcknd/cpu/cg_coupled.f90
+++ b/src/krylov/bcknd/cpu/cg_coupled.f90
@@ -195,7 +195,7 @@ contains
     integer, optional, intent(in) :: niter
 
     ! Throw and error
-    call neko_error('Only defined for coupled solves')
+    call neko_error('The cpldcg solver is only defined for coupled solves')
 
     ksp_results%res_final = 0.0
     ksp_results%iter = 0

--- a/src/krylov/bcknd/device/fusedcg_cpld_device.F90
+++ b/src/krylov/bcknd/device/fusedcg_cpld_device.F90
@@ -67,7 +67,7 @@ module fusedcg_cpld_device
      real(kind=rp), allocatable :: alpha(:)
      type(c_ptr) :: w1_d = C_NULL_PTR
      type(c_ptr) :: w2_d = C_NULL_PTR
-     type(c_ptr) :: w3_d = C_NULL_PTR     
+     type(c_ptr) :: w3_d = C_NULL_PTR
      type(c_ptr) :: r1_d = C_NULL_PTR
      type(c_ptr) :: r2_d = C_NULL_PTR
      type(c_ptr) :: r3_d = C_NULL_PTR
@@ -263,10 +263,10 @@ contains
     do i = 1, DEVICE_FUSEDCG_CPLD_P_SPACE+1
        this%p1_d(i) = C_NULL_PTR
        call device_map(this%p1(:,i), this%p1_d(i), n)
-       
+
        this%p2_d(i) = C_NULL_PTR
        call device_map(this%p2(:,i), this%p2_d(i), n)
-       
+
        this%p3_d(i) = C_NULL_PTR
        call device_map(this%p3(:,i), this%p3_d(i), n)
     end do
@@ -283,7 +283,7 @@ contains
                       HOST_TO_DEVICE, sync=.false.)
     ptr = c_loc(this%p3_d)
     call device_memcpy(ptr, this%p3_d_d, p_size, &
-                       HOST_TO_DEVICE, sync=.false.)   
+                       HOST_TO_DEVICE, sync=.false.)
     if (present(rel_tol) .and. present(abs_tol) .and. present(monitor)) then
        call this%ksp_init(max_iter, rel_tol, abs_tol, monitor = monitor)
     else if (present(rel_tol) .and. present(abs_tol)) then
@@ -318,11 +318,11 @@ contains
     if (allocated(this%w1)) then
        deallocate(this%w1)
     end if
-    
+
     if (allocated(this%w2)) then
        deallocate(this%w2)
     end if
-    
+
     if (allocated(this%w3)) then
        deallocate(this%w3)
     end if
@@ -448,7 +448,7 @@ contains
     if (c_associated(this%gs_event2)) then
        call device_event_destroy(this%gs_event2)
     end if
-    
+
     if (c_associated(this%gs_event3)) then
        call device_event_destroy(this%gs_event3)
     end if
@@ -505,8 +505,8 @@ contains
       rtz1 = 1.0_rp
       p_prev = DEVICE_FUSEDCG_CPLD_P_SPACE
       p_cur = 1
-          
- 
+
+
       call device_rzero(x%x_d, n)
       call device_rzero(y%x_d, n)
       call device_rzero(z%x_d, n)
@@ -521,7 +521,7 @@ contains
                                      r2_d, r3_d, tmp_d, n)
 
       rtr = device_glsc3(tmp_d, coef%mult_d, coef%binv_d, n)
-      
+
       rnorm = sqrt(rtr)*norm_fac
       ksp_results%res_start = rnorm
       ksp_results%res_final = rnorm
@@ -541,7 +541,7 @@ contains
 
          beta = rtz1 / rtz2
          if (iter .eq. 1) beta = 0.0_rp
-         
+
          call device_fusedcg_cpld_update_p(p1_d(p_cur), p2_d(p_cur), p3_d(p_cur), &
               z1_d, z2_d, z3_d, p1_d(p_prev), p2_d(p_prev), p3_d(p_prev), beta, n)
 
@@ -561,7 +561,7 @@ contains
                                         p2_d(p_cur), p3_d(p_cur), tmp_d, n)
 
          pap = device_glsc2(tmp_d, coef%mult_d, n)
-                  
+
          alpha(p_cur) = rtz1 / pap
          rtr = device_fusedcg_cpld_part2(r1_d, r2_d, r3_d, coef%mult_d, &
               w1_d, w2_d, w3_d, alpha_d, alpha(p_cur), p_cur, n)
@@ -602,13 +602,13 @@ contains
     integer, optional, intent(in) :: niter
 
     ! Throw and error
-    call neko_error('Only defined for coupled solves')
+    call neko_error('The cpldcg solver is only defined for coupled solves')
 
     ksp_results%res_final = 0.0
     ksp_results%iter = 0
-    
+
   end function fusedcg_cpld_device_solve
-  
+
 end module fusedcg_cpld_device
 
 


### PR DESCRIPTION
The volflow type crashes when a coupled solver for velocity is used. This is because the decoupling of the velocity and pressure Ax in the fluid scheme did not propagate there, and the ksp solver was not called via the coupled call.

This fixes this. But I have to admit that I don't fully understand what the type does all together, and why one needs ksp solves for enforcing the volflow. It would be good if someone can add documentation. 

So please check if this is correct :-).