### PR TITLE
Improvements to simulation components

### DIFF
--- a/doc/pages/user-guide/simcomps.md
+++ b/doc/pages/user-guide/simcomps.md
@@ -37,12 +37,14 @@ in Neko. The list will be updated as new simcomps are added.
 Each simulation component is, by default, executed once per time step to perform
 associated computations and output. However, this can be modified by using the
 `compute_control` and `compute_value` parameters for the computation and the
-`output_control and` and `output_value` for the output to disk. The parameters
+`output_control` and `output_value` for the output to disk. The parameters
 for the `_control` values are the same as for the fluid and checkpointing.
 Additionally, one can set `output_control` to `global` and `never`. The former
 will sync the `output_` parameter to that of the fluid. Choosing `never` will
 suppress output all together. If no parameters for the `output_` parameters are
- provided, they are set to be the same as for `compute_`.
+provided, they are set to be the same as for `compute_`. In order to simplify
+the configuration, the `compute_control` can be set to `fluid_output` to sync
+the computation to the fluid output. 
 
 For simcomps that compute 3D fields, the output can be either added to the main
 `.fld` file, containing velocity and pressure, or saved to a separate file. For

--- a/src/simulation_components/simcomp_executor.f90
+++ b/src/simulation_components/simcomp_executor.f90
@@ -61,21 +61,21 @@ module simcomp_executor
      logical, private :: finalized = .false.
    contains
      !> Constructor.
-     procedure, public, pass(this) :: init => simcomp_executor_init
+     procedure, pass(this) :: init => simcomp_executor_init
      !> Destructor.
-     procedure, public, pass(this) :: free => simcomp_executor_free
+     procedure, pass(this) :: free => simcomp_executor_free
      !> Appending a new simcomp to the executor.
-     procedure, public, pass(this) :: add_user_simcomp => simcomp_executor_add
+     procedure, pass(this) :: add_user_simcomp => simcomp_executor_add
      !> Execute preprocess_ for all simcomps.
-     procedure, public, pass(this) :: preprocess => simcomp_executor_preprocess
+     procedure, pass(this) :: preprocess => simcomp_executor_preprocess
      !> Execute compute_ for all simcomps.
-     procedure, public, pass(this) :: compute => simcomp_executor_compute
+     procedure, pass(this) :: compute => simcomp_executor_compute
      !> Execute restart for all simcomps.
-     procedure, public, pass(this) :: restart=> simcomp_executor_restart
+     procedure, pass(this) :: restart=> simcomp_executor_restart
      !> Finalize the initialization.
-     procedure, pass(this) :: finalize => simcomp_executor_finalize
+     procedure, private, pass(this) :: finalize => simcomp_executor_finalize
      !> Get the number of simcomps.
-     procedure, public, pass(this) :: get_n => simcomp_executor_get_n
+     procedure, pass(this) :: get_n => simcomp_executor_get_n
   end type simcomp_executor_t
 
   !> Global variable for the simulation component driver.

--- a/src/simulation_components/simcomp_executor.f90
+++ b/src/simulation_components/simcomp_executor.f90
@@ -50,15 +50,15 @@ module simcomp_executor
   !! The execution order is based on the order property of each simcomp.
   !! By default, the order is by the order of apparence in the case file.
   type, public :: simcomp_executor_t
-     private
+
      !> The simcomps.
      class(simulation_component_wrapper_t), allocatable :: simcomps(:)
      !> Number of simcomps
-     integer :: n_simcomps
+     integer, private :: n_simcomps
      !> The case
-     type(case_t), pointer :: case
+     type(case_t), pointer, private :: case
      !> Flag to indicate if the simcomp executor has been finalized.
-     logical :: finalized = .false.
+     logical, private :: finalized = .false.
    contains
      !> Constructor.
      procedure, public, pass(this) :: init => simcomp_executor_init
@@ -74,6 +74,8 @@ module simcomp_executor
      procedure, public, pass(this) :: restart=> simcomp_executor_restart
      !> Finalize the initialization.
      procedure, pass(this) :: finalize => simcomp_executor_finalize
+     !> Get the number of simcomps.
+     procedure, public, pass(this) :: get_n => simcomp_executor_get_n
   end type simcomp_executor_t
 
   !> Global variable for the simulation component driver.
@@ -381,5 +383,13 @@ contains
     end if
 
   end subroutine simcomp_executor_restart
+
+  !> Get the number of simcomps.
+  pure function simcomp_executor_get_n(this) result(n)
+    class(simcomp_executor_t), intent(in) :: this
+    integer :: n
+
+    n = this%n_simcomps
+  end function simcomp_executor_get_n
 
 end module simcomp_executor

--- a/src/simulation_components/simulation_component.f90
+++ b/src/simulation_components/simulation_component.f90
@@ -146,12 +146,18 @@ contains
                              "tsteps")
     call json_get_or_default(json, "compute_value", compute_value, 1.0_rp)
 
+    if (compute_control .eq. "fluid_output") then
+      call json_get(this%case%params, 'case.fluid.output_control', &
+            compute_control)
+      call json_get(this%case%params, 'case.fluid.output_value', &
+            compute_value)
+    end if
+
     ! We default to output whenever we execute
     call json_get_or_default(json, "output_control", output_control, &
                              compute_control)
     call json_get_or_default(json, "output_value", output_value, &
                              compute_value)
-
 
     if (output_control == "global") then
        call json_get(this%case%params, 'case.fluid.output_control', &


### PR DESCRIPTION
- We can now add a fully initialized simcomp to the executor.
- We call finalize internally if needed instead of outside.
- Fix member accesibility.
- Add `fluid_output` as a compute control type.