### PR TITLE
Remove deprecated compiler

### DIFF
--- a/.github/workflows/check_intel.yml
+++ b/.github/workflows/check_intel.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        compiler: [ifort, ifx]
+        compiler: [ifx]
         precision: [sp, dp]
         backend: [cpu]
         include:


### PR DESCRIPTION
https://community.intel.com/t5/Blogs/Tech-Innovation/Tools/Deprecation-of-The-Intel-Fortran-Compiler-Classic-ifort/post/1541699