### PR TITLE
allocation of xyz

### DIFF
--- a/src/common/global_interpolation.F90
+++ b/src/common/global_interpolation.F90
@@ -471,7 +471,9 @@ contains
     end do
 
     n_points = this%n_points
-    deallocate(xyz)
+    if (allocated(xyz)) then
+       deallocate(xyz)
+    end if
     allocate(xyz(3, n_points))
     call copy(xyz, this%xyz, 3*n_points)
 


### PR DESCRIPTION
The error I was getting was

`Error termination. Backtrace:                                                   
At line 474 of file common/global_interpolation.F90                             
Fortran runtime error: Attempt to DEALLOCATE unallocated 'xyz'`

I'm not sure if this is the correct solution, can someone who knows more about interpolation take a look at this?