### PR TITLE
glmin/max tolerant to n=0

### DIFF
--- a/src/math/math.f90
+++ b/src/math/math.f90
@@ -379,12 +379,8 @@ contains
     real(kind=rp) :: tmp, glmax
     integer :: i, ierr
 
-    if (n .lt. 1) then
-       tmp = -huge(0.0_rp)
-    else
-       tmp = a(1)
-    end if
-    do i = 2, n
+    tmp = -huge(0.0_rp)
+    do i = 1, n
        tmp = max(tmp,a(i))
     end do
     call MPI_Allreduce(tmp, glmax, 1, &
@@ -397,12 +393,9 @@ contains
     integer, dimension(n) :: a
     integer :: tmp, glimax
     integer :: i, ierr
-    if (n .lt. 1) then
-       tmp = -huge(0)
-    else
-       tmp = a(1)
-    end if
-    do i = 2, n
+
+    tmp = -huge(0)
+    do i = 1, n
        tmp = max(tmp,a(i))
     end do
     call MPI_Allreduce(tmp, glimax, 1, &
@@ -415,12 +408,9 @@ contains
     real(kind=rp), dimension(n) :: a
     real(kind=rp) :: tmp, glmin
     integer :: i, ierr
-    if (n .lt. 1) then
-       tmp = huge(0.0_rp)
-    else
-       tmp = a(1)
-    end if
-    do i = 2, n
+
+    tmp = huge(0.0_rp)
+    do i = 1, n
        tmp = min(tmp,a(i))
     end do
     call MPI_Allreduce(tmp, glmin, 1, &
@@ -433,12 +423,9 @@ contains
     integer, dimension(n) :: a
     integer :: tmp, glimin
     integer :: i, ierr
-    if (n .lt. 1) then
-       tmp = huge(0)
-    else
-       tmp = a(1)
-    end if
-    do i = 2, n
+
+    tmp = huge(0)
+    do i = 1, n
        tmp = min(tmp,a(i))
     end do
     call MPI_Allreduce(tmp, glimin, 1, &

--- a/src/math/math.f90
+++ b/src/math/math.f90
@@ -434,7 +434,7 @@ contains
     integer :: tmp, glimin
     integer :: i, ierr
     if (n < 1) then
-       tmp = -huge(0)
+       tmp = huge(0)
     else
        tmp = a(1)
     end if

--- a/src/math/math.f90
+++ b/src/math/math.f90
@@ -379,7 +379,7 @@ contains
     real(kind=rp) :: tmp, glmax
     integer :: i, ierr
 
-    if (n < 1) then
+    if (n .lt. 1) then
        tmp = -huge(0.0_rp)
     else
        tmp = a(1)
@@ -397,7 +397,7 @@ contains
     integer, dimension(n) :: a
     integer :: tmp, glimax
     integer :: i, ierr
-    if (n < 1) then
+    if (n .lt. 1) then
        tmp = -huge(0)
     else
        tmp = a(1)
@@ -415,7 +415,7 @@ contains
     real(kind=rp), dimension(n) :: a
     real(kind=rp) :: tmp, glmin
     integer :: i, ierr
-    if (n < 1) then
+    if (n .lt. 1) then
        tmp = huge(0.0_rp)
     else
        tmp = a(1)
@@ -433,7 +433,7 @@ contains
     integer, dimension(n) :: a
     integer :: tmp, glimin
     integer :: i, ierr
-    if (n < 1) then
+    if (n .lt. 1) then
        tmp = huge(0)
     else
        tmp = a(1)

--- a/src/math/math.f90
+++ b/src/math/math.f90
@@ -378,7 +378,12 @@ contains
     real(kind=rp), dimension(n) :: a
     real(kind=rp) :: tmp, glmax
     integer :: i, ierr
-    tmp = a(1)
+
+    if (n < 1) then
+       tmp = -huge(0.0_rp)
+    else
+       tmp = a(1)
+    end if
     do i = 2, n
        tmp = max(tmp,a(i))
     end do
@@ -392,7 +397,11 @@ contains
     integer, dimension(n) :: a
     integer :: tmp, glimax
     integer :: i, ierr
-    tmp = a(1)
+    if (n < 1) then
+       tmp = -huge(0)
+    else
+       tmp = a(1)
+    end if
     do i = 2, n
        tmp = max(tmp,a(i))
     end do
@@ -406,7 +415,11 @@ contains
     real(kind=rp), dimension(n) :: a
     real(kind=rp) :: tmp, glmin
     integer :: i, ierr
-    tmp = a(1)
+    if (n < 1) then
+       tmp = huge(0.0_rp)
+    else
+       tmp = a(1)
+    end if
     do i = 2, n
        tmp = min(tmp,a(i))
     end do
@@ -420,7 +433,11 @@ contains
     integer, dimension(n) :: a
     integer :: tmp, glimin
     integer :: i, ierr
-    tmp = a(1)
+    if (n < 1) then
+       tmp = -huge(0)
+    else
+       tmp = a(1)
+    end if
     do i = 2, n
        tmp = min(tmp,a(i))
     end do


### PR DESCRIPTION
Uses `huge` to make glmin/max operation s tolerant to some processors having n=0.