### PR TITLE
Order of user-init

### DIFF
--- a/src/neko.f90
+++ b/src/neko.f90
@@ -277,6 +277,12 @@ contains
        call case_init(C, case_file)
 
        !
+       ! User-init
+       !
+       call C%usr%user_init_modules(t, C%fluid%u, C%fluid%v, C%fluid%w,&
+                                    C%fluid%p, C%fluid%c_Xh, C%params)
+
+       !
        ! Setup runtime statistics
        !
        call neko_rt_stats%init(C%params)

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -88,12 +88,10 @@ contains
        call neko_simcomps%restart(t)
     end if
 
-    !> Execute outputs and user-init before time loop
+    !> Execute outputs before time loop
     call neko_log%section('Postprocessing')
     call C%output_controller%execute(t, tstep)
 
-    call C%usr%user_init_modules(t, C%fluid%u, C%fluid%v, C%fluid%w,&
-                                 C%fluid%p, C%fluid%c_Xh, C%params)
     call neko_log%end_section()
     call neko_log%newline()
 


### PR DESCRIPTION
Hoping to get people's opinion on switching the order of the user-init to occur before the simcomps.

For me personally, this is motivated by the probes simcomp. 
If I want to probe some quantity I plan to calculate in the future, eg dudx etc, I need a way to put them in the registry prior to the probes simcomps initialization.