### PR TITLE
nvhpc: workaround for submodule bug

### DIFF
--- a/src/krylov/krylov.f90
+++ b/src/krylov/krylov.f90
@@ -189,7 +189,7 @@ module krylov
      !! @param monitor Enable/disable monitoring, optional.
      module subroutine krylov_solver_factory(object, n, type_name, &
           max_iter, abstol, M, monitor)
-       class(ksp_t), allocatable, target, intent(inout) :: object
+       class(ksp_t), allocatable, intent(inout) :: object
        integer, intent(in), value :: n
        character(len=*), intent(in) :: type_name
        integer, intent(in) :: max_iter

--- a/src/krylov/krylov_fctry.f90
+++ b/src/krylov/krylov_fctry.f90
@@ -76,7 +76,7 @@ contains
   !! @param monitor Enable/disable residual history, optional.
   module subroutine krylov_solver_factory(object, n, type_name, &
        max_iter, abstol, M, monitor)
-    class(ksp_t), allocatable, target, intent(inout) :: object
+    class(ksp_t), allocatable, intent(inout) :: object
     integer, intent(in), value :: n
     character(len=*), intent(in) :: type_name
     integer, intent(in) :: max_iter

--- a/src/krylov/precon.f90
+++ b/src/krylov/precon.f90
@@ -68,7 +68,7 @@ module precon
   interface
      !> Create a preconditioner
      module subroutine precon_factory(pc, type_name)
-       class(pc_t), target, allocatable, intent(inout) :: pc
+       class(pc_t),  allocatable, intent(inout) :: pc
        character(len=*), intent(in) :: type_name
      end subroutine precon_factory
 

--- a/src/krylov/precon_fctry.f90
+++ b/src/krylov/precon_fctry.f90
@@ -51,7 +51,7 @@ contains
 
   !> Create a preconditioner
   module subroutine precon_factory(pc, type_name)
-    class(pc_t), target, allocatable, intent(inout) :: pc
+    class(pc_t), allocatable, intent(inout) :: pc
     character(len=*), intent(in) :: type_name
     character(len=:), allocatable :: type_string
 

--- a/src/les/les_model.f90
+++ b/src/les/les_model.f90
@@ -114,7 +114,7 @@ module les_model
      !! @param coef SEM coefficients.
      !! @param json A dictionary with parameters.
      module subroutine les_model_factory(object, type_name, dofmap, coef, json)
-       class(les_model_t), allocatable, target, intent(inout) :: object
+       class(les_model_t), allocatable, intent(inout) :: object
        character(len=*), intent(in) :: type_name
        type(dofmap_t), intent(in) :: dofmap
        type(coef_t), intent(in) :: coef

--- a/src/les/les_model_fctry.f90
+++ b/src/les/les_model_fctry.f90
@@ -53,7 +53,7 @@ contains
   !! @param coef SEM coefficients.
   !! @param json A dictionary with parameters.
   module subroutine les_model_factory(object, type_name, dofmap, coef, json)
-    class(les_model_t), allocatable, target, intent(inout) :: object
+    class(les_model_t), allocatable, intent(inout) :: object
     character(len=*), intent(in) :: type_name
     type(dofmap_t), intent(in) :: dofmap
     type(coef_t), intent(in) :: coef

--- a/src/wall_models/wall_model.f90
+++ b/src/wall_models/wall_model.f90
@@ -156,7 +156,7 @@ module wall_model
      !! @param json A dictionary with parameters.
      module subroutine wall_model_factory(object, coef, msk, facet, nu, &
           json)
-       class(wall_model_t), allocatable, target, intent(inout) :: object
+       class(wall_model_t), allocatable, intent(inout) :: object
        type(coef_t), intent(in) :: coef
        integer, intent(in) :: msk(:)
        integer, intent(in) :: facet(:)

--- a/src/wall_models/wall_model_fctry.f90
+++ b/src/wall_models/wall_model_fctry.f90
@@ -55,7 +55,7 @@ contains
   !! @param json A dictionary with parameters.
   module subroutine wall_model_factory(object, coef, msk, facet, nu, &
        json)
-    class(wall_model_t), allocatable, target, intent(inout) :: object
+    class(wall_model_t), allocatable, intent(inout) :: object
     type(coef_t), intent(in) :: coef
     integer, intent(in) :: msk(:)
     integer, intent(in) :: facet(:)


### PR DESCRIPTION
Work around this bug in NVHPC:
https://forums.developer.nvidia.com/t/submodule-matching-error-of-declaration/211278 by removing target attribute from dummy args to module subroutine