### PR TITLE
Fix a few typos and a broken link

### DIFF
--- a/doc/pages/developer-guide/code-style.md
+++ b/doc/pages/developer-guide/code-style.md
@@ -66,7 +66,7 @@ rules. The linting rules are enforced by the
 
 Please note, newer versions of flint fails to execute for some of our large files (htable.f90 and stack.f90).
 
-One way to install flint is thorugh pip:
+One way to install flint is through pip:
 ```sh
 pip install nobvisual==0.2.0 flinter==0.4.0
 ```
@@ -116,8 +116,8 @@ However, there are some exceptions to these rules:
 - Spaces after the comma in a list of arguments or array indices may be omitted
   for single letter variable names and 2 digit numbers. For example, `foo(a,b)`
   and `foo(a,10)` are allowed, but `foo(a,bb)` and `foo(a,100)` are not.
-- Spaces after the comma is not required in format specifiers.
-- Spaces around the `=` operator is not required in type declarations.
+- Spaces after the comma are not required in format specifiers.
+- Spaces around the `=` operator are not required in type declarations.
 
 ## Tools
 
@@ -126,7 +126,7 @@ In order to simplify compliance to the indentation rules the
 rules by assigning the following options. The documentation of `findent` provide
 details for emacs, vim and gedit. For VSCode, the [Modern
 Fortran](https://marketplace.visualstudio.com/items?itemName=fortran-lang.linter-gfortran)
-extension provide an integration.
+extension provides an integration.
 
 ```sh
 findent -Rr -i2 -d3 -f3 -s3 -w3 -t3 -j3 -k5 --ws_remred --openmp=0 < input.f90 > formatted.f90

--- a/doc/pages/developer-guide/testing.md
+++ b/doc/pages/developer-guide/testing.md
@@ -10,7 +10,7 @@ git clone https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git -b v4.4.2
 
 cd pFUnit && mkdir b && cd b && cmake -DCMAKE_INSTALL_PREFIX=/pfunit_install_path .. && make -j$(nproc) && make install
 ```
-You will now have a dirctory called PFUNIT-4.4 in your intall path.
+You will now have a directory called PFUNIT-4.4 in your install path.
 
 ## Configuring Neko
 To use pFUnit with Neko, we need to specify its location during the `configure` phase of the build.
@@ -46,11 +46,11 @@ The instructions will differ somewhat depending on whether you test uses MPI or 
    If your test does not use MPI, you can copy from e.g. `hex`, otherwise take it from `field`. As usual, the `Makefile.in` will turn into a `Makefile` during the `configure` phase of the build.
 4. The `Makefile.in` looks very much like the `Makefile` examples in the documentation of pFUnit.
    1. The `check` target should be changed to the name of your test.
-      If yor test does not use MPI, name it the same as the name of the folder  + `_test`. If you need MPI, then don't use `test`, but rather something else, like `_suite`.
+      If your test does not use MPI, name it the same as the name of the folder  + `_test`. If you need MPI, then don't use `test`, but rather something else, like `_suite`.
    2. The lines defining `_TESTS`, `_OTHER_LIBRARIES`, and the other pFUnit stuff should be prefixed with the name selected above. Similarly with the `eval` statement.
    3. In the `clean` target, also put the same name as in `check`.
 5. If you use MPI, you now need to create a runner script.
-   Copy `field/field_test` tp start with, which looks like this
+   Copy `field/field_test` to start with, which looks like this
    ```bash
    #!/bin/sh
    if which mpirun >/dev/null; then

--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -5,7 +5,7 @@
 The case file defines all the parameters of a simulation.
 The format of the file is JSON, making it easy to read and write case files
 using the majority of the popular programming languages.
-JSON is heirarchical and, and consists of parameter blocks enclosed in curly
+JSON is hierarchical and, and consists of parameter blocks enclosed in curly
 braces.
 These blocks are referred to as objects.
 The case file makes use objects to separate the configuration of different parts
@@ -31,8 +31,8 @@ The current high-level structure of the case file is shown below.
     }
 }
 ~~~~~~~~~~~~~~~
-The `version` keywords is reserved to track changes in the format of the file.
-The the subsections below we list all the configuration options for each of the high-level objects.
+The `version` keyword is reserved to track changes in the format of the file.
+The subsections below we list all the configuration options for each of the high-level objects.
 Some parameters will have default values, and are therefore optional.
 
 ## Output frequency control
@@ -41,7 +41,7 @@ outputs.
 It is described already now in order to clarify the meaning of several
 parameters found in the tables below.
 
-The frequency is controlled by two paramters, ending with `_control` and
+The frequency is controlled by two parameters, ending with `_control` and
 `_value`, respectively.
 The latter name is perhaps not ideal, but it is somewhat difficult to come up
 with a good one, suggestions are welcome.
@@ -74,8 +74,8 @@ but also defines several parameters that pertain to the simulation as a whole.
 | `checkpoint_value`         | The frequency of sampling in terms of `checkpoint_control`.                                           | Positive real or integer                        | -             |
 | `checkpoint_format`        | The file format of checkpoints                                                                        | `chkp` or `hdf5`                                | `chkp`        |
 | `restart_file`             | checkpoint to use for a restart from previous data                                                    | Strings ending with `.chkp`                     | -             |
-| `restart_mesh_file`        | If the restart file is on a different mesh, specifiy the .nmsh file used to generate it here          | Strings enging with `.nmsh`                     | -             |
-| `mesh2mesh_tolerance`      | Tolerance for the restart when restarting from another mesh                                           | Postive reals                                   | 1e-6          |
+| `restart_mesh_file`        | If the restart file is on a different mesh, specify the .nmsh file used to generate it here          | Strings ending with `.nmsh`                     | -             |
+| `mesh2mesh_tolerance`      | Tolerance for the restart when restarting from another mesh                                           | Positive reals                                   | 1e-6          |
 | `timestep`                 | Time-step size                                                                                        | Positive reals                                  | -             |
 | `variable_timestep`        | Whether to use variable dt                                                                            | `true` or `false`                               | `false`       |
 | `max_timestep`             | Maximum time-step size when variable time step is activated                                           | Positive reals                                  | -             |
@@ -113,8 +113,8 @@ Used to define the properties of the numerical discretization.
 
 | Name                         | Description                                                                                                   | Admissible values          | Default value                   |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------- | -------------------------- | ------------------------------- |
-| `polynomial_order`           | The oder of the polynomial basis.                                                                             | Integers, typically 5 to 9 | -                               |
-| `time_order`                 | The order of the time integration scheme. Refer to the `time_scheme_controller` type documention for details. | 1,2, 3                     | -                               |
+| `polynomial_order`           | The order of the polynomial basis.                                                                             | Integers, typically 5 to 9 | -                               |
+| `time_order`                 | The order of the time integration scheme. Refer to the `time_scheme_controller` type documentation for details. | 1, 2, 3                     | -                               |
 | `dealias`                    | Whether to apply dealiasing to advection terms.                                                               | `true` or `false`          | `false`                         |
 | `dealiased_polynomial order` | The polynomial order in the higher-order space used in the dealising.                                         | Integer                    | `3/2(polynomial_order + 1) - 1` |
 
@@ -591,7 +591,7 @@ concisely directly in the table.
 | `flow_rate_force.value`                 | Bulk velocity or volumetric flow rate.                                                            | Positive real                                    | -             |
 | `flow_rate_force.use_averaged_flow`     | Whether bulk velocity or volumetric flow rate is given by the `value` parameter.                  | `true` or `false`                                | -             |
 | `freeze`                                | Whether to fix the velocity field at initial conditions.                                          | `true` or `false`                                | `false`       |
-| `advection`                             | Whether to compute the advetion term.                                                             | `true` or `false`                                | `true`        |
+| `advection`                             | Whether to compute the advection term.                                                             | `true` or `false`                                | `true`        |
 
 ## Scalar {#case-file_scalar}
 The scalar object allows to add a scalar transport equation to the solution.
@@ -658,7 +658,7 @@ of using source terms for the scalar can be found in the `scalar_mms` example.
 | ------------------------- | -------------------------------------------------------- | ------------------------------- | ------------- |
 | `enabled`                 | Whether to enable the scalar computation.                | `true` or `false`               | `true`        |
 | `Pe`                      | The Peclet number.                                       | Positive real                   | -             |
-| `cp`                      | Specific heat cpacity.                                   | Positive real                   | -             |
+| `cp`                      | Specific heat capacity.                                  | Positive real                   | -             |
 | `lambda`                  | Thermal conductivity.                                    | Positive real                   | -             |
 | `nut_field`               | Name of the turbulent kinematic viscosity field.         | String                          | Empty string  |
 | `Pr_t`                    | Turbulent Prandtl number                                 | Positive real                   | -             |
@@ -714,4 +714,4 @@ currently supports 50 regions, with id 1..25 being reserved for internal use.
 | Name                | Description                                                          | Admissible values | Default value |
 | ------------------- | -------------------------------------------------------------------- | ----------------- | ------------- |
 | `enabled`           | Whether to enable gathering of runtime statistics                    | `true` or `false` | `false`       |
-| `output_profile`    | Wheter to output all gathered profiling data as a CSV file           | `true` or `false` | `false`       |
+| `output_profile`    | Whether to output all gathered profiling data as a CSV file          | `true` or `false` | `false`       |

--- a/doc/pages/user-guide/installation.md
+++ b/doc/pages/user-guide/installation.md
@@ -77,12 +77,11 @@ checking for fgslib_gs_setup in -lgs... yes
 The following steps is an example on how to build and install ParMETIS
 
 ``` shell
-$ wget http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-4.0.3.tar.gz
-$ tar xzf parmetis-4.0.3.tar.gz && cd parmetis-4.0.3 && make config prefix=/parmetis_install_path
-$ make -j$(nproc) && make install
+$ export PARMETIS_INSTALL=/usr/local/parmetis
+$ wget https://github.com/mfem/tpls/raw/refs/heads/gh-pages/parmetis-4.0.3.tar.gz
+$ tar xzf parmetis-4.0.3.tar.gz && cd parmetis-4.0.3 && make config prefix=${PARMETIS_INSTALL} && make install
+$ cd metis && make config prefix=${PARMETIS_INSTALL} && make install && cd ../..
 ```
-@note ParMETIS might not install `metis.h`, check if it is found in `/parmetis_install_path/include`.  If this is not the case, repeat the same `make config prefix=/parmetis_install_path` and `make install` commands from the `metis` subfolder.
-
 
 #### Bulding PFunit (optional)
 

--- a/doc/pages/user-guide/io.md
+++ b/doc/pages/user-guide/io.md
@@ -4,7 +4,7 @@
 
 ## Mesh
 
-Neko has it's own mesh format, `.nmsh`. All meshes should be 3D and consist of
+Neko has its own mesh format, `.nmsh`. All meshes should be 3D and consist of
 hexahedral elements. A 2D or 1D case can be mimicked by having a single element
 across selected axes and applying periodic boundary conditions.
 
@@ -24,7 +24,7 @@ convenience.
 
 It should be noted, that the `.re2` format allows to store boundary conditions.
 This is relevant for users that have old Nek5000 cases, who wish to convert them
-to Neko. Boundary condition is converted and used by Neko, and for these
+to Neko. Boundary conditions are converted and used by Neko, and for these
 boundaries one does not need to provide information in the `boundary_types`
 keyword in the case file. This is why in some of the examples, `boundary_types`
 is only filled for some of the boundaries. However, since this feature
@@ -35,9 +35,9 @@ encoded into the mesh file, and this will remain so in the future.
 ## Three-dimensional field output
 Neko stores the 3D fields with results in the `.fld` format, which is the same
 as in Nek5000. The advantage of adopting this format, is that there is a reader
-in Paraview and Visit, which can be used to visualize them. Note that the latest
+in Paraview and VisIt, which can be used to visualize them. Note that the latest
 version of Paraview actually has two reader for `.fld`. For now, Neko has only
-been tested with the older reader, which uses Visit under the hood.  A file with
+been tested with the older reader, which uses VisIt under the hood.  A file with
 the `.nek5000` extension is used as the entry point for the readers and stores
 some metadata. Users may also find the Python package `pymech` useful for
 working with `.fld`s. Note that only the first output `.fld` file stores the


### PR DESCRIPTION
## Changes
- I found some typos in the documentation, which I fixed them as I read through the documentation.
- The URL to `parmetis-4.0.3.tar.gz` is broken. I replaced it with a link from the MFEM repo.