### PR TITLE
Fix cray broken intents due to #1607

### DIFF
--- a/src/fluid/fluid_scheme.f90
+++ b/src/fluid/fluid_scheme.f90
@@ -1017,7 +1017,7 @@ contains
     type(coef_t), target, intent(in) :: coef
     type(dofmap_t), target, intent(in) :: dof
     type(gs_t), target, intent(inout) :: gs
-    type(bc_list_t), target, intent(in) :: bclst
+    type(bc_list_t), target, intent(inout) :: bclst
     character(len=*) :: pctype
 
     call precon_factory(pc, pctype)

--- a/src/fluid/fluid_stats.f90
+++ b/src/fluid/fluid_stats.f90
@@ -718,12 +718,12 @@ contains
   subroutine fluid_stats_post_process(this, mean, reynolds, pressure_flatness,&
        pressure_skewness, skewness_tensor, mean_vel_grad, dissipation_tensor)
     class(fluid_stats_t) :: this
-    type(field_list_t), intent(in), optional :: mean
-    type(field_list_t), intent(in), optional :: reynolds
+    type(field_list_t), intent(inout), optional :: mean
+    type(field_list_t), intent(inout), optional :: reynolds
     type(field_list_t), intent(in), optional :: pressure_skewness
     type(field_list_t), intent(in), optional :: pressure_flatness
     type(field_list_t), intent(in), optional :: skewness_tensor
-    type(field_list_t), intent(in), optional :: mean_vel_grad
+    type(field_list_t), intent(inout), optional :: mean_vel_grad
     type(field_list_t), intent(in), optional :: dissipation_tensor
     integer :: n
 

--- a/src/krylov/pc_hsmg.f90
+++ b/src/krylov/pc_hsmg.f90
@@ -141,7 +141,7 @@ contains
     type(coef_t), intent(in), target :: coef
     type(dofmap_t), intent(in), target :: dof
     type(gs_t), intent(inout), target :: gs_h
-    type(bc_list_t), intent(in), target :: bclst
+    type(bc_list_t), intent(inout), target :: bclst
     character(len=*), optional :: crs_pctype
     integer :: n, i
     integer :: lx_crs, lx_mid

--- a/src/scalar/scalar_scheme.f90
+++ b/src/scalar/scalar_scheme.f90
@@ -617,7 +617,7 @@ contains
     type(coef_t), target, intent(in) :: coef
     type(dofmap_t), target, intent(in) :: dof
     type(gs_t), target, intent(inout) :: gs
-    type(bc_list_t), target, intent(in) :: bclst
+    type(bc_list_t), target, intent(inout) :: bclst
     character(len=*) :: pctype
 
     call precon_factory(pc, pctype)


### PR DESCRIPTION
## Context
- Some intents were set incorrectly in #1607 but were not detected on local build, and github builds
- After #1607, neko doesn't build on Dardel `cce/16.0.1`
## Changes
- Correct the wrong intents
- Make sure neko builds on Dardel