### PR TITLE
Make both comp. and comm. gs backends selectable

### DIFF
--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -118,11 +118,13 @@ contains
 
     gs%dofmap => dofmap
 
+    use_device_mpi = .false.
     if (present(comm_bcknd)) then
        comm_bcknd_ = comm_bcknd
     else
        if (NEKO_DEVICE_MPI) then
           comm_bcknd_ = GS_COMM_MPIGPU
+          use_device_mpi = .true.
        else
           comm_bcknd_ = GS_COMM_MPI
        end if


### PR DESCRIPTION
Adds the functionality of selecting either of the comp. and comm. backends for gather-scatter operations at runtime, e.g:

* Launch a host MPI backend on GPUs
`call gs%init(dof, comm_bcknd=GS_COMM_MPI)`

* Launch pure host MPI (despite Neko backend)
`call gs%init(dof, bcknd=GS_BCKND_CPU, comm_bcknd=GS_COMM_MPI)`