### PR TITLE
Move output last

### DIFF
--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -160,7 +160,6 @@ contains
        ! Execute all simulation components
        call neko_simcomps%compute(t, tstep)
 
-       call C%output_controller%execute(t, tstep)
 
        !> @todo Temporary fix until we have reworked the material properties
        rho = C%fluid%rho
@@ -182,6 +181,8 @@ contains
 
        call C%usr%user_check(t, tstep, C%fluid%u, C%fluid%v, C%fluid%w, &
                              C%fluid%p, C%fluid%c_Xh, C%params)
+
+       call C%output_controller%execute(t, tstep)
 
        call neko_log%end_section()
        end_time = MPI_WTIME()


### PR DESCRIPTION
Makes it so that one can modify a field in usercheck and this is reflected in the output at the same time step.

Will also enable more accurate user defined stats (that are not lagged by one time step if you modify things in usercheck).