### PR TITLE
Change nmsh to use glb el index, allowing for parallel writes

### DIFF
--- a/contrib/genmeshbox/genmeshbox.f90
+++ b/contrib/genmeshbox/genmeshbox.f90
@@ -210,7 +210,7 @@ program genmeshbox
                  end do
               end do
            end do
-           call msh%add_element(i, p(1,1,1), p(2,1,1),p(1,2,1),p(2,2,1),&
+           call msh%add_element(i, i, p(1,1,1), p(2,1,1),p(1,2,1),p(2,2,1),&
                 p(1,1,2), p(2,1,2), p(1,2,2), p(2,2,2))
            i = i + 1
         end do

--- a/contrib/prepart/prepart.f90
+++ b/contrib/prepart/prepart.f90
@@ -66,7 +66,7 @@ program prepart
      idx = idx_cntr(rank) + new_el(rank)
      idx_cntr(rank) = idx_cntr(rank) + 1
      idx_map(i) = idx
-     call new_msh%add_element(idx, &
+     call new_msh%add_element(idx, idx, &
                               msh%elements(i)%e%pts(1)%p, &
                               msh%elements(i)%e%pts(2)%p, &
                               msh%elements(i)%e%pts(3)%p, &

--- a/src/case.f90
+++ b/src/case.f90
@@ -170,6 +170,13 @@ contains
        call neko_log%section('Load Balancing')
        call parmetis_partmeshkway(this%msh, parts)
        call redist_mesh(this%msh, parts)
+       
+       ! store the balanced mesh (for e.g. restarts)
+       string_val = trim(string_val(1:scan(trim(string_val), &
+            '.', back=.true.) - 1))//'_lb.nmsh'
+       msh_file = file_t(string_val)
+       call msh_file%write(this%msh)
+
        call neko_log%end_section()
     end if
 

--- a/src/comm/redist.f90
+++ b/src/comm/redist.f90
@@ -220,7 +220,7 @@ contains
           do j = 1, 8
              p(j) = point_t(np(i)%v(j)%v_xyz, np(i)%v(j)%v_idx)
           end do
-          call msh%add_element(i, &
+          call msh%add_element(i, np(i)%el_idx, &
                p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8))
 
           if (el_map%get(np(i)%el_idx, tmp) .gt. 0) then
@@ -324,7 +324,7 @@ contains
              end if
              
              call msh%mark_periodic_facet(zp(i)%f, new_el_idx, &
-                  zp(i)%p_f, new_pel_idx, zp(i)%glb_pt_ids)
+                  zp(i)%p_f, zp(i)%p_e, zp(i)%glb_pt_ids)
           case(6)
              call msh%mark_outlet_normal_facet(zp(i)%f, new_el_idx)
           case(7)
@@ -342,7 +342,7 @@ contains
              end if
              
              call msh%apply_periodic_facet(zp(i)%f, new_el_idx, &
-                  zp(i)%p_f, new_pel_idx, zp(i)%glb_pt_ids)
+                  zp(i)%p_f, zp(i)%p_e, zp(i)%glb_pt_ids)
           end select
        end do
     end select
@@ -389,7 +389,7 @@ contains
     type is (facet_zone_periodic_t)
        do i = 1, zp%size
           zone_el =  zp%facet_el(i)%x(2)
-          nmsh_zone%e = zp%facet_el(i)%x(2) + msh%offset_el
+          nmsh_zone%e = msh%elements(zp%facet_el(i)%x(2))%e%id()
           nmsh_zone%f = zp%facet_el(i)%x(1)
           nmsh_zone%p_e = zp%p_facet_el(i)%x(2)
           nmsh_zone%p_f = zp%p_facet_el(i)%x(1)
@@ -400,7 +400,7 @@ contains
     type is (facet_zone_t)
        do i = 1, zp%size
           zone_el =  zp%facet_el(i)%x(2)
-          nmsh_zone%e = zp%facet_el(i)%x(2) + msh%offset_el
+          nmsh_zone%e = msh%elements(zp%facet_el(i)%x(2))%e%id()
           nmsh_zone%f = zp%facet_el(i)%x(1)
           nmsh_zone%p_f = lbl ! Labels are encoded in the periodic facet...
           nmsh_zone%type = type
@@ -420,7 +420,7 @@ contains
 
     do i = 1, c%size
        curve_el = c%curve_el(i)%el_idx
-       nmsh_curve%e = curve_el + msh%offset_el
+       nmsh_curve%e = msh%elements(curve_el)%e%id()
        nmsh_curve%curve_data = c%curve_el(i)%curve_data
        nmsh_curve%type = c%curve_el(i)%curve_type
        call new_dist(parts%data(curve_el))%push(nmsh_curve)

--- a/src/io/re2_file.f90
+++ b/src/io/re2_file.f90
@@ -349,7 +349,7 @@ contains
                 if(mod(i,nelv/10) .eq. 0) write(*,*) i, 'elements read'
              end if
              ! swap vertices to keep symmetric vertex numbering in neko
-             call msh%add_element(i, p(1), p(2), p(4), p(3))
+             call msh%add_element(i, i, p(1), p(2), p(4), p(3))
           end do
           deallocate(re2v1_data_xy)
        else
@@ -366,7 +366,7 @@ contains
                 if(mod(i,nelv/10) .eq. 0) write(*,*) i, 'elements read'
              end if
              ! swap vertices to keep symmetric vertex numbering in neko
-             call msh%add_element(i, p(1), p(2), p(4), p(3))
+             call msh%add_element(i, i, p(1), p(2), p(4), p(3))
           end do
           deallocate(re2v2_data_xy)
        end if
@@ -387,7 +387,7 @@ contains
                 if(mod(i,nelv/100) .eq. 0) write(*,*) i, 'elements read'
              end if
              ! swap vertices to keep symmetric vertex numbering in neko
-             call msh%add_element(i, &
+             call msh%add_element(i, i, &
                   p(1), p(2), p(4), p(3), p(5), p(6), p(8), p(7))
           end do
           deallocate(re2v1_data_xyz)
@@ -406,7 +406,7 @@ contains
                 if(mod(i,nelv/100) .eq. 0) write(*,*) i, 'elements read'
              end if
              ! swap vertices to keep symmetric vertex numbering in neko
-             call msh%add_element(i, &
+             call msh%add_element(i, i, &
                   p(1), p(2), p(4), p(3), p(5), p(6), p(8), p(7))
           end do
           deallocate(re2v2_data_xyz)

--- a/src/io/rea_file.f90
+++ b/src/io/rea_file.f90
@@ -206,7 +206,7 @@ contains
                    call rea_file_add_point(htp, p(j), pt_idx)
                 end do
                 ! swap vertices to keep symmetric vertex numbering in neko
-                call msh%add_element(el_idx, p(1), p(2), p(4), p(3))
+                call msh%add_element(el_idx, el_idx, p(1), p(2), p(4), p(3))
              end if
           else if (ndim .eq. 3) then
              read(9, *) (xc(j),j=1,4)
@@ -221,7 +221,7 @@ contains
                    call rea_file_add_point(htp, p(j), pt_idx)
                 end do
                 ! swap vertices to keep symmetric vertex numbering in neko
-                call msh%add_element(el_idx, &
+                call msh%add_element(el_idx, el_idx, &
                      p(1), p(2), p(4), p(3), p(5), p(6), p(8), p(7))
              end if
           end if

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -84,6 +84,8 @@ module mesh
      type(htable_i4_t) :: htp   !< Table of unique points (global->local)
      type(htable_i4t4_t) :: htf !< Table of unique faces (facet->local id)
      type(htable_i4t2_t) :: hte !< Table of unique edges (edge->local id)
+     type(htable_i4_t) :: htel  !< Table of unique elements (global->local)
+
 
      integer, allocatable :: facet_neigh(:,:)  !< Facet to neigh. element table
 
@@ -294,6 +296,7 @@ contains
     this%facet_type = 0
 
     call this%htp%init(this%npts*this%nelv, i)
+    call this%htel%init(this%nelv, i)
 
     call this%wall%init(this%nelv)
     call this%inlet%init(this%nelv)
@@ -328,6 +331,7 @@ contains
     call this%htp%free()
     call this%htf%free()
     call this%hte%free()
+    call this%htel%free()
     call distdata_free(this%ddata)
     call this%curve%free()
 
@@ -1395,12 +1399,11 @@ contains
 
 
   !> Add a quadrilateral element to the mesh @a this
-  subroutine mesh_add_quad(this, el, p1, p2, p3, p4)
+  subroutine mesh_add_quad(this, el, el_glb, p1, p2, p3, p4)
     class(mesh_t), target, intent(inout) :: this
-    integer, value :: el
+    integer, value :: el, el_glb
     type(point_t), target, intent(inout) :: p1, p2, p3, p4
-    class(element_t), pointer :: ep
-    integer :: p(4), el_glb_idx
+    integer :: p(4)
     type(tuple_i4_t) :: e
 
     ! Connectivity invalidated if a new element is added
@@ -1414,12 +1417,9 @@ contains
     call this%add_point(p3, p(3))
     call this%add_point(p4, p(4))
 
-    ep => this%elements(el)%e
-    el_glb_idx = el + this%offset_el
-
-    select type(ep)
+    select type (ep => this%elements(el)%e)
     type is (quad_t)
-       call ep%init(el_glb_idx, &
+       call ep%init(el_glb, &
             this%points(p(1)), this%points(p(2)), &
             this%points(p(3)), this%points(p(4)))
 
@@ -1431,12 +1431,11 @@ contains
   end subroutine mesh_add_quad
 
   !> Add a hexahedral element to the mesh @a this
-  subroutine mesh_add_hex(this, el, p1, p2, p3, p4, p5, p6, p7, p8)
+  subroutine mesh_add_hex(this, el, el_glb, p1, p2, p3, p4, p5, p6, p7, p8)
     class(mesh_t), target, intent(inout) :: this
-    integer, value :: el
+    integer, value :: el, el_glb
     type(point_t), target, intent(inout) :: p1, p2, p3, p4, p5, p6, p7, p8
-    class(element_t), pointer :: ep
-    integer :: p(8), el_glb_idx
+    integer :: p(8)
     type(tuple4_i4_t) :: f
     type(tuple_i4_t) :: e
 
@@ -1455,11 +1454,12 @@ contains
     call this%add_point(p7, p(7))
     call this%add_point(p8, p(8))
 
-    ep => this%elements(el)%e
-    el_glb_idx = el + this%offset_el
-    select type(ep)
+    ! Global to local mapping
+    call this%htel%set(el_glb, el)
+
+    select type (ep => this%elements(el)%e)
     type is (hex_t)
-       call ep%init(el_glb_idx, &
+       call ep%init(el_glb, &
             this%points(p(1)), this%points(p(2)), &
             this%points(p(3)), this%points(p(4)), &
             this%points(p(5)), this%points(p(6)), &

--- a/tests/unit/dofmap/dofmap_parallel.pf
+++ b/tests/unit/dofmap/dofmap_parallel.pf
@@ -62,10 +62,10 @@ contains
 
     call m%init(gdim, dist)
 
-    call m%add_element(1, p(1), p(2), p(3), p(4), &
+    call m%add_element(1, 1, p(1), p(2), p(3), p(4), &
          p(7), p(8), p(10), p(9))
 
-    call m%add_element(2, p(2), p(5), p(4), p(6), &
+    call m%add_element(2, 2, p(2), p(5), p(4), p(6), &
          p(8), p(11), p(9), p(12))
 
     call Xh%init(GLL, 2, 2, 2)
@@ -131,10 +131,10 @@ contains
     call m%init(gdim, dist)
     Call Xh%init(GLL, lx,lx,lx)
 
-    call m%add_element(1, p(1), p(2), p(4), p(3), &
+    call m%add_element(1, 1, p(1), p(2), p(4), p(3), &
          p(5), p(6), p(8), p(7))
 
-    call m%add_element(2, p(2), p(9), p(3), p(10), &
+    call m%add_element(2, 2, p(2), p(9), p(3), p(10), &
          p(6), p(11), p(7), p(12))
     
     call m%generate_conn() 
@@ -206,9 +206,9 @@ contains
     Call Xh%init(GLL, lx,lx,lx)
 
 
-    call m%add_element(1, p(5), p(1), p(8), p(4), &
+    call m%add_element(1, 1, p(5), p(1), p(8), p(4), &
          p(6), p(2), p(7), p(3))
-    call m%add_element(2, p(2), p(9), p(3), p(10), &
+    call m%add_element(2, 2, p(2), p(9), p(3), p(10), &
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
@@ -279,9 +279,9 @@ contains
     Call Xh%init(GLL, lx,lx,lx)
 
 
-    call m%add_element(1, p(7), p(8), p(6), p(5), &
+    call m%add_element(1, 1, p(7), p(8), p(6), p(5), &
          p(3), p(4), p(2), p(1))
-    call m%add_element(2, p(2), p(9), p(3), p(10), &
+    call m%add_element(2, 2, p(2), p(9), p(3), p(10), &
          p(6), p(11), p(7), p(12))
     call m%generate_conn()
     call d%init(m, Xh)
@@ -351,9 +351,9 @@ contains
     Call Xh%init(GLL, lx,lx,lx)
 
 
-    call m%add_element(1, p(6), p(5), p(7), p(8), &
+    call m%add_element(1, 1, p(6), p(5), p(7), p(8), &
          p(2), p(1), p(3), p(4))
-    call m%add_element(2, p(2), p(9), p(3), p(10), &
+    call m%add_element(2, 2, p(2), p(9), p(3), p(10), &
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
@@ -424,9 +424,9 @@ contains
     Call Xh%init(GLL, lx,lx,lx)
 
 
-    call m%add_element(1, p(2), p(6), p(3), p(7), &
+    call m%add_element(1, 1, p(2), p(6), p(3), p(7), &
          p(1), p(5), p(4), p(8))
-    call m%add_element(2, p(2), p(9), p(3), p(10), &
+    call m%add_element(2, 2, p(2), p(9), p(3), p(10), &
          p(6), p(11), p(7), p(12))
     call m%generate_conn()
 
@@ -498,9 +498,9 @@ contains
     Call Xh%init(GLL, lx,lx,lx)
 
 
-    call m%add_element(1, p(4), p(1), p(3), p(2), &
+    call m%add_element(1, 1, p(4), p(1), p(3), p(2), &
          p(8), p(5), p(7), p(6))
-    call m%add_element(2, p(2), p(9), p(3), p(10), &
+    call m%add_element(2, 2, p(2), p(9), p(3), p(10), &
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
@@ -571,9 +571,9 @@ contains
     Call Xh%init(GLL, lx,lx,lx)
 
 
-    call m%add_element(1, p(2), p(3), p(1), p(4), &
+    call m%add_element(1, 1, p(2), p(3), p(1), p(4), &
          p(6), p(7), p(5), p(8))
-    call m%add_element(2, p(2), p(9), p(3), p(10), &
+    call m%add_element(2, 2, p(2), p(9), p(3), p(10), &
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()

--- a/tests/unit/field/field_parallel.pf
+++ b/tests/unit/field/field_parallel.pf
@@ -68,10 +68,10 @@ contains
     call p(12)%set_id(12)
   
     call msh%init(3, 2)
-    call msh%add_element(1, p(1), p(2), p(4), p(3), &
+    call msh%add_element(1, 1, p(1), p(2), p(4), p(3), &
          p(7), p(8), p(9), p(10))
     
-    call msh%add_element(2, p(2), p(5), p(6), p(4), &
+    call msh%add_element(2, 2, p(2), p(5), p(6), p(4), &
          p(8), p(11), p(12), p(9))
     call msh%generate_conn()
     

--- a/tests/unit/gather_scatter/gather_scatter_parallel.pf
+++ b/tests/unit/gather_scatter/gather_scatter_parallel.pf
@@ -69,10 +69,10 @@ contains
     call m%init(gdim, dist)
     Call Xh%init(GLL, lx,lx,lx)
 
-    call m%add_element(1, p(1), p(2), p(4), p(3), &
+    call m%add_element(1, 1, p(1), p(2), p(4), p(3), &
          p(5), p(6), p(8), p(7))
 
-    call m%add_element(2, p(2), p(9), p(3), p(10), &
+    call m%add_element(2, 2, p(2), p(9), p(3), p(10), &
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
@@ -160,9 +160,9 @@ contains
     Call Xh%init(GLL, lx,lx,lx)
 
 
-    call m%add_element(1, p(5), p(1), p(8), p(4), &
+    call m%add_element(1, 1, p(5), p(1), p(8), p(4), &
          p(6), p(2), p(7), p(3))
-    call m%add_element(2, p(2), p(9), p(3), p(10), &
+    call m%add_element(2, 2, p(2), p(9), p(3), p(10), &
          p(6), p(11), p(7), p(12))
     call m%generate_conn()
 
@@ -248,9 +248,9 @@ contains
     Call Xh%init(GLL, lx,lx,lx)
 
 
-    call m%add_element(1, p(7), p(8), p(6), p(5), &
+    call m%add_element(1, 1, p(7), p(8), p(6), p(5), &
          p(3), p(4), p(2), p(1))
-    call m%add_element(2, p(2), p(9), p(3), p(10), &
+    call m%add_element(2, 2, p(2), p(9), p(3), p(10), &
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
@@ -336,9 +336,9 @@ contains
     Call Xh%init(GLL, lx,lx,lx)
 
 
-    call m%add_element(1, p(6), p(5), p(7), p(8), &
+    call m%add_element(1, 1, p(6), p(5), p(7), p(8), &
          p(2), p(1), p(3), p(4))
-    call m%add_element(2, p(2), p(9), p(3), p(10), &
+    call m%add_element(2, 2, p(2), p(9), p(3), p(10), &
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
@@ -424,9 +424,9 @@ contains
     Call Xh%init(GLL, lx,lx,lx)
 
 
-    call m%add_element(1, p(2), p(6), p(3), p(7), &
+    call m%add_element(1, 1, p(2), p(6), p(3), p(7), &
          p(1), p(5), p(4), p(8))
-    call m%add_element(2, p(2), p(9), p(3), p(10), &
+    call m%add_element(2, 2, p(2), p(9), p(3), p(10), &
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
@@ -512,9 +512,9 @@ contains
     Call Xh%init(GLL, lx,lx,lx)
 
 
-    call m%add_element(1, p(4), p(1), p(3), p(2), &
+    call m%add_element(1, 1, p(4), p(1), p(3), p(2), &
          p(8), p(5), p(7), p(6))
-    call m%add_element(2, p(2), p(9), p(3), p(10), &
+    call m%add_element(2, 2, p(2), p(9), p(3), p(10), &
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()
@@ -600,9 +600,9 @@ contains
     Call Xh%init(GLL, lx,lx,lx)
 
 
-    call m%add_element(1, p(2), p(3), p(1), p(4), &
+    call m%add_element(1, 1, p(2), p(3), p(1), p(4), &
          p(6), p(7), p(5), p(8))
-    call m%add_element(2, p(2), p(9), p(3), p(10), &
+    call m%add_element(2, 2, p(2), p(9), p(3), p(10), &
          p(6), p(11), p(7), p(12))
 
     call m%generate_conn()

--- a/tests/unit/mean_field/mean_field_parallel.pf
+++ b/tests/unit/mean_field/mean_field_parallel.pf
@@ -68,10 +68,10 @@ contains
     call p(12)%set_id(12)
   
     call msh%init(3, 2)
-    call msh%add_element(1, p(1), p(2), p(4), p(3), &
+    call msh%add_element(1, 1, p(1), p(2), p(4), p(3), &
          p(7), p(8), p(9), p(10))
     
-    call msh%add_element(2, p(2), p(5), p(6), p(4), &
+    call msh%add_element(2, 2, p(2), p(5), p(6), p(4), &
          p(8), p(11), p(12), p(9))
     call msh%generate_conn()
     

--- a/tests/unit/mean_sqr_field/mean_sqr_field_parallel.pf
+++ b/tests/unit/mean_sqr_field/mean_sqr_field_parallel.pf
@@ -69,10 +69,10 @@ contains
     call p(12)%set_id(12)
   
     call msh%init(3, 2)
-    call msh%add_element(1, p(1), p(2), p(4), p(3), &
+    call msh%add_element(1, 1, p(1), p(2), p(4), p(3), &
          p(7), p(8), p(9), p(10))
     
-    call msh%add_element(2, p(2), p(5), p(6), p(4), &
+    call msh%add_element(2, 2, p(2), p(5), p(6), p(4), &
          p(8), p(11), p(12), p(9))
     call msh%generate_conn()
     

--- a/tests/unit/mesh/mesh_parallel.pf
+++ b/tests/unit/mesh/mesh_parallel.pf
@@ -102,9 +102,9 @@ contains
     call m%init(gdim, dist)
     if (this%getNumProcesses() .eq. 1) then
 
-       call m%add_element(1, p(1), p(2), p(3), p(4))
+       call m%add_element(1, 1, p(1), p(2), p(3), p(4))
 
-       call m%add_element(2, p(2), p(5), p(4), p(6))
+       call m%add_element(2, 2, p(2), p(5), p(4), p(6))
 
        @assertEqual(6, m%htp%num_entries())
 
@@ -127,7 +127,7 @@ contains
     else   
        if (this%getProcessRank() .eq. 0) then
 
-          call m%add_element(1, p(1), p(2), p(3), p(4))
+          call m%add_element(1, 1, p(1), p(2), p(3), p(4))
 
           @assertEqual(4, m%htp%num_entries())
 
@@ -141,7 +141,7 @@ contains
 
        else
 
-          call m%add_element(1, p(2), p(5), p(4), p(6))
+          call m%add_element(1, 1, p(2), p(5), p(4), p(6))
 
           @assertEqual(4, m%htp%num_entries())
 
@@ -202,11 +202,11 @@ contains
     call m%init(gdim, dist)
     if (this%getNumProcesses() .eq. 1) then
 
-       call m%add_element(1, p(1), p(2), p(3), p(4), &
+       call m%add_element(1, 1, p(1), p(2), p(3), p(4), &
             p(7), p(8), p(10), p(9))
 
 
-       call m%add_element(2, p(2), p(5), p(4), p(6), &
+       call m%add_element(2, 2, p(2), p(5), p(4), p(6), &
             p(8), p(11), p(9), p(12))
 
        @assertEqual(12, m%htp%num_entries())
@@ -238,7 +238,7 @@ contains
     else   
        if (this%getProcessRank() .eq. 0) then
 
-          call m%add_element(1, p(1), p(2), p(3), p(4), &
+          call m%add_element(1, 1, p(1), p(2), p(3), p(4), &
                p(7), p(8), p(10), p(9))
 
           @assertEqual(8, m%htp%num_entries())
@@ -257,7 +257,7 @@ contains
 
        else
 
-          call m%add_element(1, p(2), p(5), p(4), p(6), &
+          call m%add_element(1, 1, p(2), p(5), p(4), p(6), &
                p(8), p(11), p(9), p(12))
 
           @assertEqual(8, m%htp%num_entries())
@@ -312,9 +312,9 @@ contains
     call m%init(gdim, dist)
     if (this%getNumProcesses() .eq. 1) then
 
-       call m%add_element(1, p(1), p(2), p(3), p(4))
+       call m%add_element(1, 1, p(1), p(2), p(3), p(4))
 
-       call m%add_element(2, p(2), p(5), p(4), p(6))
+       call m%add_element(2, 2, p(2), p(5), p(4), p(6))
 
        call m%generate_conn()
 
@@ -347,7 +347,7 @@ contains
     else   
        if (this%getProcessRank() .eq. 0) then
 
-          call m%add_element(1, p(1), p(2), p(3), p(4))
+          call m%add_element(1, 1, p(1), p(2), p(3), p(4))
 
           call m%generate_conn()
 
@@ -371,7 +371,7 @@ contains
        
        else
 
-          call m%add_element(1, p(2), p(5), p(4), p(6))
+          call m%add_element(1, 1, p(2), p(5), p(4), p(6))
 
           call m%generate_conn()
 
@@ -444,11 +444,11 @@ contains
     call m%init(gdim, dist)
     if (this%getNumProcesses() .eq. 1) then
 
-       call m%add_element(1, p(1), p(2), p(3), p(4), &
+       call m%add_element(1, 1, p(1), p(2), p(3), p(4), &
             p(7), p(8), p(10), p(9))
 
 
-       call m%add_element(2, p(2), p(5), p(4), p(6), &
+       call m%add_element(2, 2, p(2), p(5), p(4), p(6), &
             p(8), p(11), p(9), p(12))
 
        call m%generate_conn()
@@ -521,7 +521,7 @@ contains
     else   
        if (this%getProcessRank() .eq. 0) then
 
-          call m%add_element(1, p(1), p(2), p(3), p(4), &
+          call m%add_element(1, 1, p(1), p(2), p(3), p(4), &
                p(7), p(8), p(10), p(9))
 
           call m%generate_conn()
@@ -563,7 +563,7 @@ contains
 
        else
 
-          call m%add_element(1, p(2), p(5), p(4), p(6), &
+          call m%add_element(1, 1, p(2), p(5), p(4), p(6), &
                p(8), p(11), p(9), p(12))
 
           call m%generate_conn()

--- a/tests/unit/point_interpolation/point_interpolation_parallel.pf
+++ b/tests/unit/point_interpolation/point_interpolation_parallel.pf
@@ -102,7 +102,7 @@ contains
     call create_points(p)
 
     call msh%init(3, dist)
-    call msh%add_element(1, p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8))
+    call msh%add_element(1, 1, p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8))
 
     call msh%generate_conn()
     call Xh%init(GLL, lx, lx, lx)
@@ -142,7 +142,7 @@ contains
     dist = linear_dist_t(1, pe_rank, pe_size, NEKO_COMM)
     call create_points(p)
     call msh%init(3, dist)
-    call msh%add_element(1, p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8))
+    call msh%add_element(1, 1, p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8))
     call msh%generate_conn()
     call Xh%init(GLL, lx, lx, lx)
     call dof%init(msh, Xh)
@@ -206,7 +206,7 @@ contains
     dist = linear_dist_t(1, pe_rank, pe_size, NEKO_COMM)
     call create_points(p)
     call msh%init(3, dist)
-    call msh%add_element(1, p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8))
+    call msh%add_element(1, 1, p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8))
     call msh%generate_conn()
     call Xh%init(GLL, lx, lx, lx)
     call dof%init(msh, Xh)

--- a/tests/unit/scratch_registry/test_scratch_registry.pf
+++ b/tests/unit/scratch_registry/test_scratch_registry.pf
@@ -43,7 +43,7 @@ contains
     call p(12)%set_id(12)
     
     call msh%init(3, 1)
-    call msh%add_element(1, p(1), p(2), p(4), p(3), &
+    call msh%add_element(1, 1, p(1), p(2), p(4), p(3), &
          p(7), p(8), p(9), p(10))
     pe_rank = 1
     pe_size = 1


### PR DESCRIPTION
This PR changes the nmsh/mesh handling of element indices, from local to global index. The global index is also retained during load balancing and redistribution (i.e vertex indices).

These changes introduces the possibility to write a mesh in parallel to a nmsh, e.g.  write out a mesh after load balancing, such that a restart could be performed (without scrambled data...) 

__Note__: No breaking changes, old meshes are still compatible 

_Todo_:
* `contrib/prepart ` needs some modifications before it can be used for "offline" load balancing in parallel 