### PR TITLE
Stop indenting case lines in select statements

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -52,14 +52,12 @@ jobs:
       # ---------------------------------------------------------------------- #
 
       - name: Format sources
-        env:
-          FINDENT_FLAGS: "-Rr -i2 -d3 -f3 -s3 -w3 -t3 -j3 -k5 --ws_remred --indent_ampersand --openmp=0"
         run: |
           for file in ${{ steps.get-changed-files.outputs.changed-files }}; do
             if [[ ${file: -4} != ".f90" && ${file: -4} != ".F90" ]]; then
               continue
             fi
-            findent < $file > $file.tmp
+            findent -Rr -i2 -d3 -f3 -s3 -c3 -w3 -t3 -j3 -k5 --ws_remred --indent_ampersand --openmp=0 < $file > $file.tmp
             mv -f $file.tmp $file
           done
 
@@ -70,7 +68,7 @@ jobs:
             echo "" >&2
             echo "Please run the following commands to fix the formatting:" >&2
             echo "pip install findent" >&2
-            echo "findent -Rr -i2 -d3 -f3 -s3 -w3 -t3 -j3 -k5 --ws_remred --indent_ampersand --openmp=0 <file.f90 >file.f90.tmp" >&2
+            echo "findent -Rr -i2 -d3 -f3 -s3 -c3 -w3 -t3 -j3 -k5 --ws_remred --indent_ampersand --openmp=0 <file.f90 >file.f90.tmp" >&2
             echo "mv file.f90.tmp file.f90" >&2
             git diff >&2
             exit 1

--- a/doc/pages/developer-guide/code-style.md
+++ b/doc/pages/developer-guide/code-style.md
@@ -8,11 +8,14 @@ indentation level of 2, except for the extra indentation within `do` `if`,
 `type`, `interface`, where the indentation level is 3, continuation statements,
 which should be indented by 5 and a 0 indentation is
 used for `module` or `contains` (except for `contains` inside a derived type,
-where a single indentation level is used).
+where a single indentation level is used). It should be noted that no
+indentation should be applied to the `case` statements contained in a 
+`select case` block.
 
 These are the default rules in Emacs' Fortran mode, an example is given below,
 additional information on the Emacs' Fortran mode can be found at
-[https://emacsdocs.org](https://emacsdocs.org/docs/emacs/Fortran).
+[https://emacsdocs.org](https://emacsdocs.org/docs/emacs/Fortran) and the full
+formatting script for emacs can be found at the [Emacs' GitHub](https://github.com/emacs-mirror/emacs/blob/master/lisp/progmodes/f90.el).
 
 ~~~~~~~~~~~~~~~{.f90}
 module example
@@ -40,6 +43,13 @@ contains
        ... This statement is very long &
             continues on the next line
     end if
+    
+    select case (x)
+    case (1)
+       ...
+    case (2)
+       ...
+    end select
 
   end subroutine foo
 


### PR DESCRIPTION
Adjust formatting rules to ensure no indentation is applied to case statements within select case blocks. Update the findent command to reflect these changes in the formatting process.