### PR TITLE
Lift freeze fluid flag to top level

### DIFF
--- a/src/fluid/fluid_scheme_base.f90
+++ b/src/fluid/fluid_scheme_base.f90
@@ -103,6 +103,9 @@ module fluid_scheme_base
 
      !> Is mu varying in time? Currently only due to LES models.
      logical :: variable_material_properties = .false.
+     !> Is the fluid frozen at the moment
+     logical :: freeze = .false.
+
    contains
      !> Constructor
      procedure(fluid_scheme_base_init_intrf), pass(this), deferred :: init

--- a/src/fluid/fluid_scheme_incompressible.f90
+++ b/src/fluid/fluid_scheme_incompressible.f90
@@ -105,7 +105,6 @@ module fluid_scheme_incompressible
      type(fluid_stats_t) :: stats !< Fluid statistics
      type(mean_sqr_flow_t) :: mean_sqr !< Mean squared flow field
      logical :: forced_flow_rate = .false. !< Is the flow rate forced?
-     logical :: freeze = .false. !< Freeze velocity at initial condition?
 
      !> The turbulent kinematic viscosity field name
      character(len=:), allocatable :: nut_field_name


### PR DESCRIPTION
Move the freeze fluid flag to the top level for better accessibility and management within the fluid scheme modules.