### PR TITLE
Fix wall model boundary condition constructor

### DIFF
--- a/src/bc/shear_stress.f90
+++ b/src/bc/shear_stress.f90
@@ -87,7 +87,7 @@ contains
   subroutine shear_stress_apply_scalar(this, x, n, t, tstep, strong)
     class(shear_stress_t), intent(inout) :: this
     integer, intent(in) :: n
-    real(kind=rp), intent(inout),  dimension(n) :: x
+    real(kind=rp), intent(inout), dimension(n) :: x
     real(kind=rp), intent(in), optional :: t
     integer, intent(in), optional :: tstep
     logical, intent(in), optional :: strong
@@ -104,9 +104,9 @@ contains
   subroutine shear_stress_apply_vector(this, x, y, z, n, t, tstep, strong)
     class(shear_stress_t), intent(inout) :: this
     integer, intent(in) :: n
-    real(kind=rp), intent(inout),  dimension(n) :: x
-    real(kind=rp), intent(inout),  dimension(n) :: y
-    real(kind=rp), intent(inout),  dimension(n) :: z
+    real(kind=rp), intent(inout), dimension(n) :: x
+    real(kind=rp), intent(inout), dimension(n) :: y
+    real(kind=rp), intent(inout), dimension(n) :: z
     real(kind=rp), intent(in), optional :: t
     integer, intent(in), optional :: tstep
     logical, intent(in), optional :: strong

--- a/src/bc/shear_stress.f90
+++ b/src/bc/shear_stress.f90
@@ -64,13 +64,20 @@ module shear_stress
      procedure, pass(this) :: apply_vector => shear_stress_apply_vector
      procedure, pass(this) :: apply_scalar_dev => shear_stress_apply_scalar_dev
      procedure, pass(this) :: apply_vector_dev => shear_stress_apply_vector_dev
+     !> Constructor.
      procedure, pass(this) :: init => shear_stress_init
+     !> Constructor from components.
+     procedure, pass(this) :: init_from_components => &
+          shear_stress_init_from_components
      procedure, pass(this) :: set_stress_scalar => &
           shear_stress_set_stress_scalar
      procedure, pass(this) :: set_stress_array => &
           shear_stress_set_stress_array
+     !> Set the shear stress to apply.
      generic :: set_stress => set_stress_scalar, set_stress_array
+     !> Destructor.
      procedure, pass(this) :: free => shear_stress_free
+     !> Finalize the construction.
      procedure, pass(this) :: finalize => shear_stress_finalize
   end type shear_stress_t
 
@@ -153,17 +160,28 @@ contains
     class(shear_stress_t), target, intent(inout) :: this
     type(coef_t), intent(in) :: coef
     type(json_file), intent(inout) ::json
-    real(kind=rp), allocatable :: x(:)
+    real(kind=rp), allocatable :: value(:)
 
-    call this%init_base(coef)
-    this%strong = .false.
+    call json_get(json, 'value', value)
 
-    call json_get(json, 'value', x)
-
-    if (size(x) .ne. 3) then
+    if (size(value) .ne. 3) then
        call neko_error ("The shear stress vector provided for the shear stress &
             & boundary condition should have 3 components.")
     end if
+
+    call this%init_from_components(coef, value)
+  end subroutine shear_stress_init
+
+  !> Constructor from components.
+  !! @param[in] coef The SEM coefficients.
+  !! @param[in] value The value of the shear stress to apply.
+  subroutine shear_stress_init_from_components(this, coef, value)
+    class(shear_stress_t), target, intent(inout) :: this
+    type(coef_t), intent(in) :: coef
+    real(kind=rp), intent(in) :: value(3)
+
+    call this%init_base(coef)
+    this%strong = .false.
 
     call this%symmetry%free()
     call this%symmetry%init_from_components(this%coef)
@@ -172,11 +190,11 @@ contains
     call this%neumann_y%free()
     call this%neumann_z%free()
 
-    call this%neumann_x%init_from_components(this%coef, x(1))
-    call this%neumann_y%init_from_components(this%coef, x(2))
-    call this%neumann_z%init_from_components(this%coef, x(3))
+    call this%neumann_x%init_from_components(this%coef, value(1))
+    call this%neumann_y%init_from_components(this%coef, value(2))
+    call this%neumann_z%init_from_components(this%coef, value(3))
 
-  end subroutine shear_stress_init
+  end subroutine shear_stress_init_from_components
 
   subroutine shear_stress_finalize(this)
     class(shear_stress_t), target, intent(inout) :: this

--- a/src/bc/wall_model_bc.f90
+++ b/src/bc/wall_model_bc.f90
@@ -174,8 +174,9 @@ contains
     class(wall_model_bc_t), target, intent(inout) :: this
     type(coef_t), intent(in) :: coef
     type(json_file), intent(inout) :: json
+    real(kind=rp) :: value(3) = [0, 0, 0]
 
-    call this%shear_stress_t%init(coef, json)
+    call this%shear_stress_t%init_from_components(coef, value)
     call json_get(json, "nu", this%nu)
     this%params_ = json
 

--- a/src/bc/wall_model_bc.f90
+++ b/src/bc/wall_model_bc.f90
@@ -33,44 +33,44 @@
 !> Defines the `wall_model_bc_t` type.
 !! Maintainer: Timofey Mukha.
 module wall_model_bc
-    use num_types, only : rp
-    use bc, only : bc_t
-    use, intrinsic :: iso_c_binding, only : c_ptr
-    use utils, only : neko_error, nonlinear_index
-    use json_utils, only : json_get
-    use coefs, only : coef_t
-    use wall_model, only : wall_model_t, wall_model_factory
-    use rough_log_law, only : rough_log_law_t
-    use spalding, only : spalding_t
-    use shear_stress, only : shear_stress_t
-    use json_module, only : json_file
-    implicit none
-    private
+  use num_types, only : rp
+  use bc, only : bc_t
+  use, intrinsic :: iso_c_binding, only : c_ptr
+  use utils, only : neko_error, nonlinear_index
+  use json_utils, only : json_get
+  use coefs, only : coef_t
+  use wall_model, only : wall_model_t, wall_model_factory
+  use rough_log_law, only : rough_log_law_t
+  use spalding, only : spalding_t
+  use shear_stress, only : shear_stress_t
+  use json_module, only : json_file
+  implicit none
+  private
 
-    !> A shear stress boundary condition, computing the stress values using a
-    !! wall model.
-    !! @warning Only works with axis-aligned boundaries.
-    type, public, extends(shear_stress_t) :: wall_model_bc_t
-       !> The wall model to compute the stress.
-       class(wall_model_t), allocatable :: wall_model
-       !> The kinematic viscosity.
-       real(kind=rp) :: nu
-       !> Parameter dictionary for the wall model
-       type(json_file) params_
-     contains
-       !> Constructor.
-       procedure, pass(this) :: init => wall_model_bc_init
-       !> Destructor.
-       procedure, pass(this) :: free => wall_model_bc_free
-       !> Finalize by building mask arrays and init'ing the wall model.
-       procedure, pass(this) :: finalize => wall_model_bc_finalize
-       procedure, pass(this) :: apply_scalar => wall_model_bc_apply_scalar
-       procedure, pass(this) :: apply_vector => wall_model_bc_apply_vector
-       procedure, pass(this) :: apply_scalar_dev => &
-            wall_model_bc_apply_scalar_dev
-       procedure, pass(this) :: apply_vector_dev => &
-            wall_model_bc_apply_vector_dev
-    end type wall_model_bc_t
+  !> A shear stress boundary condition, computing the stress values using a
+  !! wall model.
+  !! @warning Only works with axis-aligned boundaries.
+  type, public, extends(shear_stress_t) :: wall_model_bc_t
+     !> The wall model to compute the stress.
+     class(wall_model_t), allocatable :: wall_model
+     !> The kinematic viscosity.
+     real(kind=rp) :: nu
+     !> Parameter dictionary for the wall model
+     type(json_file) params_
+   contains
+     !> Constructor.
+     procedure, pass(this) :: init => wall_model_bc_init
+     !> Destructor.
+     procedure, pass(this) :: free => wall_model_bc_free
+     !> Finalize by building mask arrays and init'ing the wall model.
+     procedure, pass(this) :: finalize => wall_model_bc_finalize
+     procedure, pass(this) :: apply_scalar => wall_model_bc_apply_scalar
+     procedure, pass(this) :: apply_vector => wall_model_bc_apply_vector
+     procedure, pass(this) :: apply_scalar_dev => &
+          wall_model_bc_apply_scalar_dev
+     procedure, pass(this) :: apply_vector_dev => &
+          wall_model_bc_apply_vector_dev
+  end type wall_model_bc_t
 
 contains
 
@@ -78,7 +78,7 @@ contains
   subroutine wall_model_bc_apply_scalar(this, x, n, t, tstep, strong)
     class(wall_model_bc_t), intent(inout) :: this
     integer, intent(in) :: n
-    real(kind=rp), intent(inout),  dimension(n) :: x
+    real(kind=rp), intent(inout), dimension(n) :: x
     real(kind=rp), intent(in), optional :: t
     integer, intent(in), optional :: tstep
     logical, intent(in), optional :: strong
@@ -97,9 +97,9 @@ contains
   subroutine wall_model_bc_apply_vector(this, x, y, z, n, t, tstep, strong)
     class(wall_model_bc_t), intent(inout) :: this
     integer, intent(in) :: n
-    real(kind=rp), intent(inout),  dimension(n) :: x
-    real(kind=rp), intent(inout),  dimension(n) :: y
-    real(kind=rp), intent(inout),  dimension(n) :: z
+    real(kind=rp), intent(inout), dimension(n) :: x
+    real(kind=rp), intent(inout), dimension(n) :: y
+    real(kind=rp), intent(inout), dimension(n) :: z
     real(kind=rp), intent(in), optional :: t
     integer, intent(in), optional :: tstep
     logical, intent(in), optional :: strong
@@ -115,22 +115,22 @@ contains
 
        ! Populate the 3D wall stress field for post-processing.
        do i = 1, this%msk(0)
-         magtau = sqrt(this%wall_model%tau_x(i)**2 + &
-                       this%wall_model%tau_y(i)**2 + &
-                       this%wall_model%tau_z(i)**2)
+          magtau = sqrt(this%wall_model%tau_x(i)**2 + &
+               this%wall_model%tau_y(i)**2 + &
+               this%wall_model%tau_z(i)**2)
 
-         ! Mark sampling nodes with a -1 for debugging
-         this%wall_model%tau_field%x(this%wall_model%ind_r(i), &
-                                     this%wall_model%ind_s(i), &
-                                     this%wall_model%ind_t(i), &
-                                     this%wall_model%ind_e(i)) = -1.0_rp
-         this%wall_model%tau_field%x(this%msk(i),1,1,1) = magtau
+          ! Mark sampling nodes with a -1 for debugging
+          this%wall_model%tau_field%x(this%wall_model%ind_r(i), &
+               this%wall_model%ind_s(i), &
+               this%wall_model%ind_t(i), &
+               this%wall_model%ind_e(i)) = -1.0_rp
+          this%wall_model%tau_field%x(this%msk(i),1,1,1) = magtau
        end do
 
        ! Set the computed stress for application by the underlying Neumann
        ! boundary conditions.
        call this%set_stress(this%wall_model%tau_x, this%wall_model%tau_y, &
-           this%wall_model%tau_z)
+            this%wall_model%tau_z)
     end if
 
     ! Either add the stress to the RHS or apply the non-penetration condition


### PR DESCRIPTION
The constructor was broken, because it was trying to init shear_stress_t from JSON, which failed when trying to locate the `value` keyword.

I add an init_from_components to shear_stress_t and use in the wall_model_bc_t constructor to fix things.