### PR TITLE
Atomic min max GS operator

### DIFF
--- a/src/gs/bcknd/device/cuda/gs.cu
+++ b/src/gs/bcknd/device/cuda/gs.cu
@@ -154,6 +154,28 @@ extern "C" {
                                           dof_d + offset, n);
       }
       break;
+    case GS_OP_MIN:
+      if (stream == NULL) {
+        gs_unpack_min_kernel<real>
+          <<<nblcks, nthrds>>>(u_d, buf_d + offset, dof_d + offset, n);
+      }
+      else {
+        gs_unpack_min_kernel<real>
+          <<<nblcks, nthrds, 0, stream>>>(u_d, buf_d + offset,
+                                          dof_d + offset, n);
+      }
+      break;
+    case GS_OP_MAX:
+      if (stream == NULL) {
+        gs_unpack_max_kernel<real>
+          <<<nblcks, nthrds>>>(u_d, buf_d + offset, dof_d + offset, n);
+      }
+      else {
+        gs_unpack_max_kernel<real>
+          <<<nblcks, nthrds, 0, stream>>>(u_d, buf_d + offset,
+                                          dof_d + offset, n);
+      }
+      break;
     default:
       printf("%s: unknown gs op %d\n", __FILE__, op);
       abort();

--- a/src/gs/bcknd/device/cuda/gs_kernels.h
+++ b/src/gs/bcknd/device/cuda/gs_kernels.h
@@ -287,19 +287,31 @@ __global__ void gs_unpack_add_kernel(T * __restrict__ u,
   }
 }
 
-__device__ float atomicMinFloat(float* address, float val) {
+template<typename T>
+__device__ T atomicMinFloat(T* address, T val);
+
+template<>
+__device__ float atomicMinFloat<float>(float* address, float val) {
     int* address_as_int = (int*)address;
     int val_as_int = __float_as_int(val);
 
-    // Adjust the float representation to preserve ordering
     if (val_as_int < 0) val_as_int = 0x80000000 - val_as_int;
-
     int old = atomicMin(address_as_int, val_as_int);
-
-    // Adjust back the float representation
     if (old < 0) old = 0x80000000 - old;
 
     return __int_as_float(old);
+}
+
+template<>
+__device__ double atomicMinFloat<double>(double* address, double val) {
+    unsigned long long* address_as_ull = (unsigned long long*)address;
+    unsigned long long val_as_ull = __double_as_longlong(val);
+
+    if (val_as_ull < 0) val_as_ull = 0x8000000000000000ULL - val_as_ull;
+    unsigned long long old = atomicMin(address_as_ull, val_as_ull);
+    if (old < 0) old = 0x8000000000000000ULL - old;
+
+    return __longlong_as_double(old);
 }
 
 template< typename T >
@@ -325,13 +337,16 @@ __global__ void gs_unpack_min_kernel(T * __restrict__ u,
   }
 }
 
-__device__ float atomicMaxFloat_CAS(float* address, float val) {
+template<typename T>
+__device__ T atomicMaxFloat_CAS(T* address, T val);
+
+template<>
+__device__ float atomicMaxFloat_CAS<float>(float* address, float val) {
     int* address_as_int = (int*)address;
     int old = *address_as_int;
     int assumed;
     int val_as_int = __float_as_int(val);
 
-    // Adjust for IEEE 754 ordering
     if (val_as_int < 0) 
         val_as_int = 0x80000000 - val_as_int;
 
@@ -341,26 +356,59 @@ __device__ float atomicMaxFloat_CAS(float* address, float val) {
                        max(val_as_int, assumed));
     } while (assumed != old);
 
-    // Convert back to float representation
     if (old < 0) 
         old = 0x80000000 - old;
 
     return __int_as_float(old);
 }
 
-__device__ float atomicMaxFloat(float* address, float val) {
+template<>
+__device__ double atomicMaxFloat_CAS<double>(double* address, double val) {
+    unsigned long long* address_as_ull = (unsigned long long*)address;
+    unsigned long long old = *address_as_ull;
+    unsigned long long assumed;
+    unsigned long long val_as_ull = __double_as_longlong(val);
+
+    if (val_as_ull < 0) 
+        val_as_ull = 0x8000000000000000ULL - val_as_ull;
+
+    do {
+        assumed = old;
+        old = atomicCAS(address_as_ull, assumed,
+                       max(val_as_ull, assumed));
+    } while (assumed != old);
+
+    if (old < 0) 
+        old = 0x8000000000000000ULL - old;
+
+    return __longlong_as_double(old);
+}
+
+template<typename T>
+__device__ T atomicMaxFloat(T* address, T val);
+
+template<>
+__device__ float atomicMaxFloat<float>(float* address, float val) {
     int* address_as_int = (int*)address;
     int val_as_int = __float_as_int(val);
 
-    // Adjust the float representation to preserve ordering
     if (val_as_int < 0) val_as_int = 0x80000000 - val_as_int;
-
     int old = atomicMax(address_as_int, val_as_int);
-
-    // Adjust back the float representation
     if (old < 0) old = 0x80000000 - old;
 
     return __int_as_float(old);
+}
+
+template<>
+__device__ double atomicMaxFloat<double>(double* address, double val) {
+    unsigned long long* address_as_ull = (unsigned long long*)address;
+    unsigned long long val_as_ull = __double_as_longlong(val);
+
+    if (val_as_ull < 0) val_as_ull = 0x8000000000000000ULL - val_as_ull;
+    unsigned long long old = atomicMax(address_as_ull, val_as_ull);
+    if (old < 0) old = 0x8000000000000000ULL - old;
+
+    return __longlong_as_double(old);
 }
 
 template< typename T >

--- a/src/gs/bcknd/device/cuda/gs_kernels.h
+++ b/src/gs/bcknd/device/cuda/gs_kernels.h
@@ -303,9 +303,9 @@ template<>
 __device__ double atomicMinFloat<double>(double* address, double val) {
     double old;
     old = !signbit(val) ? __longlong_as_double(atomicMin((unsigned long long*)address, 
-                                              __double_as_longlong(val))) :
+                            (unsigned long long)__double_as_longlong(val))) :
           __longlong_as_double(atomicMax((unsigned long long*)address, 
-                                       __double_as_longlong(val)));
+                            (unsigned long long)__double_as_longlong(val)));
     
     return old;
 }
@@ -348,9 +348,9 @@ template<>
 __device__ double atomicMaxFloat<double>(double* address, double val) {
     double old;
     old = !signbit(val) ? __longlong_as_double(atomicMax((unsigned long long*)address, 
-                                              __double_as_longlong(val))) :
+                              (unsigned long long)__double_as_longlong(val))) :
           __longlong_as_double(atomicMin((unsigned long long*)address, 
-                                       __double_as_longlong(val)));
+                              (unsigned long long)__double_as_longlong(val)));
     return old;
 }
 

--- a/src/gs/bcknd/device/cuda/gs_kernels.h
+++ b/src/gs/bcknd/device/cuda/gs_kernels.h
@@ -307,9 +307,15 @@ __device__ double atomicMinFloat<double>(double* address, double val) {
     unsigned long long* address_as_ull = (unsigned long long*)address;
     unsigned long long val_as_ull = __double_as_longlong(val);
 
-    if (val_as_ull < 0) val_as_ull = 0x8000000000000000ULL - val_as_ull;
+    // Check MSB instead of comparing with 0
+    if (val_as_ull & 0x8000000000000000ULL) 
+        val_as_ull = 0x8000000000000000ULL - val_as_ull;
+        
     unsigned long long old = atomicMin(address_as_ull, val_as_ull);
-    if (old < 0) old = 0x8000000000000000ULL - old;
+    
+    // Check MSB for old value
+    if (old & 0x8000000000000000ULL) 
+        old = 0x8000000000000000ULL - old;
 
     return __longlong_as_double(old);
 }
@@ -369,7 +375,7 @@ __device__ double atomicMaxFloat_CAS<double>(double* address, double val) {
     unsigned long long assumed;
     unsigned long long val_as_ull = __double_as_longlong(val);
 
-    if (val_as_ull < 0) 
+    if (val_as_ull & 0x8000000000000000ULL) 
         val_as_ull = 0x8000000000000000ULL - val_as_ull;
 
     do {
@@ -378,7 +384,7 @@ __device__ double atomicMaxFloat_CAS<double>(double* address, double val) {
                        max(val_as_ull, assumed));
     } while (assumed != old);
 
-    if (old < 0) 
+    if (old & 0x8000000000000000ULL) 
         old = 0x8000000000000000ULL - old;
 
     return __longlong_as_double(old);
@@ -404,9 +410,11 @@ __device__ double atomicMaxFloat<double>(double* address, double val) {
     unsigned long long* address_as_ull = (unsigned long long*)address;
     unsigned long long val_as_ull = __double_as_longlong(val);
 
-    if (val_as_ull < 0) val_as_ull = 0x8000000000000000ULL - val_as_ull;
+    if (val_as_ull & 0x8000000000000000ULL)
+      val_as_ull = 0x8000000000000000ULL - val_as_ull;
     unsigned long long old = atomicMax(address_as_ull, val_as_ull);
-    if (old < 0) old = 0x8000000000000000ULL - old;
+    if (old & 0x8000000000000000ULL)
+      old = 0x8000000000000000ULL - old;
 
     return __longlong_as_double(old);
 }

--- a/src/gs/bcknd/device/cuda/gs_kernels.h
+++ b/src/gs/bcknd/device/cuda/gs_kernels.h
@@ -302,11 +302,12 @@ __device__ float atomicMinFloat<float>(float* address, float val) {
 template<>
 __device__ double atomicMinFloat<double>(double* address, double val) {
     double old;
+#if __CUDA_ARCH__ >= 600
     old = !signbit(val) ? __longlong_as_double(atomicMin((unsigned long long*)address, 
-                            (unsigned long long)__double_as_longlong(val))) :
+                                            __double_as_longlong(val))) :
           __longlong_as_double(atomicMax((unsigned long long*)address, 
-                            (unsigned long long)__double_as_longlong(val)));
-    
+                                            __double_as_longlong(val)));
+#endif
     return old;
 }
 
@@ -347,10 +348,12 @@ __device__ float atomicMaxFloat<float>(float* address, float val) {
 template<>
 __device__ double atomicMaxFloat<double>(double* address, double val) {
     double old;
+#if __CUDA_ARCH__ >= 600
     old = !signbit(val) ? __longlong_as_double(atomicMax((unsigned long long*)address, 
-                              (unsigned long long)__double_as_longlong(val))) :
+                                                __double_as_longlong(val))) :
           __longlong_as_double(atomicMin((unsigned long long*)address, 
-                              (unsigned long long)__double_as_longlong(val)));
+                                                __double_as_longlong(val)));
+#endif
     return old;
 }
 

--- a/src/gs/bcknd/device/cuda/gs_kernels.h
+++ b/src/gs/bcknd/device/cuda/gs_kernels.h
@@ -328,8 +328,8 @@ __global__ void gs_unpack_min_kernel(T * __restrict__ u,
     // Use atomicMin for shared nodal points
     atomicMinFloat(&u[-idx-1], val);
   } else {
-    // Directly compute min for non-shared nodal points
-    atomicMinFloat(&u[idx-1], val);
+    // Directly compute min for nodal points on edges
+    u[idx-1] = min(u[idx-1], val);
   }
 }
 
@@ -372,8 +372,8 @@ __global__ void gs_unpack_max_kernel(T * __restrict__ u,
     // Use atomicMax for shared nodal points
     atomicMaxFloat(&u[-idx-1], val);
   } else {
-    // Directly compute max for non-shared nodal points
-    atomicMaxFloat(&u[idx-1], val);
+    // Directly compute min for nodal points on edges
+    u[idx-1] = max(u[idx-1], val);
   }
 }
 

--- a/src/gs/bcknd/device/cuda/gs_kernels.h
+++ b/src/gs/bcknd/device/cuda/gs_kernels.h
@@ -325,6 +325,29 @@ __global__ void gs_unpack_min_kernel(T * __restrict__ u,
   }
 }
 
+__device__ float atomicMaxFloat_CAS(float* address, float val) {
+    int* address_as_int = (int*)address;
+    int old = *address_as_int;
+    int assumed;
+    int val_as_int = __float_as_int(val);
+
+    // Adjust for IEEE 754 ordering
+    if (val_as_int < 0) 
+        val_as_int = 0x80000000 - val_as_int;
+
+    do {
+        assumed = old;
+        old = atomicCAS(address_as_int, assumed, 
+                       max(val_as_int, assumed));
+    } while (assumed != old);
+
+    // Convert back to float representation
+    if (old < 0) 
+        old = 0x80000000 - old;
+
+    return __int_as_float(old);
+}
+
 __device__ float atomicMaxFloat(float* address, float val) {
     int* address_as_int = (int*)address;
     int val_as_int = __float_as_int(val);
@@ -356,10 +379,10 @@ __global__ void gs_unpack_max_kernel(T * __restrict__ u,
 
   if (idx < 0) {
     // Use atomicMax for shared nodal points
-    atomicMaxFloat(&u[-idx-1], val);
+    atomicMaxFloat_CAS(&u[-idx-1], val);
   } else {
     // Directly compute max for non-shared nodal points
-    atomicMaxFloat(&u[idx-1], val);
+    atomicMaxFloat_CAS(&u[idx-1], val);
   }
 }
 

--- a/src/gs/bcknd/device/hip/gs.hip
+++ b/src/gs/bcknd/device/hip/gs.hip
@@ -165,6 +165,34 @@ extern "C" {
 
       }
       break;
+    case GS_OP_MIN:
+      if (stream == NULL) {
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_unpack_min_kernel<real>),
+                           nblcks, nthrds, 0, 0,
+                           u_d, buf_d + offset,
+                           dof_d + offset, n);
+      }
+      else {
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_unpack_min_kernel<real>),
+                           nblcks, nthrds, 0, stream,
+                           u_d, buf_d + offset,
+                           dof_d + offset, n);
+      }
+      break;
+    case GS_OP_MAX:
+      if (stream == NULL) {
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_unpack_max_kernel<real>),
+                           nblcks, nthrds, 0, 0,
+                           u_d, buf_d + offset,
+                           dof_d + offset, n);
+      }
+      else {
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_unpack_max_kernel<real>),
+                           nblcks, nthrds, 0, stream,
+                           u_d, buf_d + offset,
+                           dof_d + offset, n);
+      }
+      break;
     default:
       printf("%s: unknown gs op %d\n", __FILE__, op);
       abort();

--- a/src/gs/bcknd/device/hip/gs_kernels.h
+++ b/src/gs/bcknd/device/hip/gs_kernels.h
@@ -341,6 +341,8 @@ __global__ void gs_unpack_min_kernel(T * __restrict__ u,
   }
 }
 
+
+// atomicMaxFloat_CAS for comparision, will remove later
 template<typename T>
 __device__ T atomicMaxFloat_CAS(T* address, T val);
 
@@ -433,10 +435,10 @@ __global__ void gs_unpack_max_kernel(T * __restrict__ u,
 
   if (idx < 0) {
     // Use atomicMax for shared nodal points
-    atomicMaxFloat_CAS(&u[-idx-1], val);
+    atomicMaxFloat(&u[-idx-1], val);
   } else {
     // Directly compute max for non-shared nodal points
-    atomicMaxFloat_CAS(&u[idx-1], val);
+    atomicMaxFloat(&u[idx-1], val);
   }
 }
 

--- a/src/gs/bcknd/device/hip/gs_kernels.h
+++ b/src/gs/bcknd/device/hip/gs_kernels.h
@@ -301,9 +301,9 @@ template<>
 __device__ double atomicMinFloat<double>(double* address, double val) {
     double old;
     old = !signbit(val) ? __longlong_as_double(atomicMin((unsigned long long*)address, 
-                                              __double_as_longlong(val))) :
+                            (unsigned long long)__double_as_longlong(val))) :
           __longlong_as_double(atomicMax((unsigned long long*)address, 
-                                       __double_as_longlong(val)));
+                            (unsigned long long)__double_as_longlong(val)));
     
     return old;
 }
@@ -346,9 +346,9 @@ template<>
 __device__ double atomicMaxFloat<double>(double* address, double val) {
     double old;
     old = !signbit(val) ? __longlong_as_double(atomicMax((unsigned long long*)address, 
-                                              __double_as_longlong(val))) :
+                              (unsigned long long)__double_as_longlong(val))) :
           __longlong_as_double(atomicMin((unsigned long long*)address, 
-                                       __double_as_longlong(val)));
+                              (unsigned long long)__double_as_longlong(val)));
     return old;
 }
 

--- a/src/gs/bcknd/device/hip/gs_kernels.h
+++ b/src/gs/bcknd/device/hip/gs_kernels.h
@@ -290,32 +290,22 @@ __device__ T atomicMinFloat(T* address, T val);
 
 template<>
 __device__ float atomicMinFloat<float>(float* address, float val) {
-    int* address_as_int = (int*)address;
-    int val_as_int = __float_as_int(val);
+    float old;
+    old = !signbit(val) ? __int_as_float(atomicMin((int*)address, __float_as_int(val))) :
+        __uint_as_float(atomicMax((unsigned int*)address, __float_as_uint(val)));
 
-    if (val_as_int < 0) val_as_int = 0x80000000 - val_as_int;
-    int old = atomicMin(address_as_int, val_as_int);
-    if (old < 0) old = 0x80000000 - old;
-
-    return __int_as_float(old);
+    return old;
 }
 
 template<>
 __device__ double atomicMinFloat<double>(double* address, double val) {
-    unsigned long long* address_as_ull = (unsigned long long*)address;
-    unsigned long long val_as_ull = __double_as_longlong(val);
-
-    // Check MSB instead of comparing with 0
-    if (val_as_ull & 0x8000000000000000ULL) 
-        val_as_ull = 0x8000000000000000ULL - val_as_ull;
-        
-    unsigned long long old = atomicMin(address_as_ull, val_as_ull);
+    double old;
+    old = !signbit(val) ? __longlong_as_double(atomicMin((unsigned long long*)address, 
+                                              __double_as_longlong(val))) :
+          __longlong_as_double(atomicMax((unsigned long long*)address, 
+                                       __double_as_longlong(val)));
     
-    // Check MSB for old value
-    if (old & 0x8000000000000000ULL) 
-        old = 0x8000000000000000ULL - old;
-
-    return __longlong_as_double(old);
+    return old;
 }
 
 template< typename T >
@@ -341,82 +331,25 @@ __global__ void gs_unpack_min_kernel(T * __restrict__ u,
   }
 }
 
-
-// atomicMaxFloat_CAS for comparision, will remove later
-template<typename T>
-__device__ T atomicMaxFloat_CAS(T* address, T val);
-
-template<>
-__device__ float atomicMaxFloat_CAS<float>(float* address, float val) {
-    int* address_as_int = (int*)address;
-    int old = *address_as_int;
-    int assumed;
-    int val_as_int = __float_as_int(val);
-
-    if (val_as_int < 0) 
-        val_as_int = 0x80000000 - val_as_int;
-
-    do {
-        assumed = old;
-        old = atomicCAS(address_as_int, assumed, 
-                       max(val_as_int, assumed));
-    } while (assumed != old);
-
-    if (old < 0) 
-        old = 0x80000000 - old;
-
-    return __int_as_float(old);
-}
-
-template<>
-__device__ double atomicMaxFloat_CAS<double>(double* address, double val) {
-    unsigned long long* address_as_ull = (unsigned long long*)address;
-    unsigned long long old = *address_as_ull;
-    unsigned long long assumed;
-    unsigned long long val_as_ull = __double_as_longlong(val);
-
-    if (val_as_ull & 0x8000000000000000ULL) 
-        val_as_ull = 0x8000000000000000ULL - val_as_ull;
-
-    do {
-        assumed = old;
-        old = atomicCAS(address_as_ull, assumed,
-                       max(val_as_ull, assumed));
-    } while (assumed != old);
-
-    if (old & 0x8000000000000000ULL) 
-        old = 0x8000000000000000ULL - old;
-
-    return __longlong_as_double(old);
-}
-
 template<typename T>
 __device__ T atomicMaxFloat(T* address, T val);
 
 template<>
 __device__ float atomicMaxFloat<float>(float* address, float val) {
-    int* address_as_int = (int*)address;
-    int val_as_int = __float_as_int(val);
-
-    if (val_as_int < 0) val_as_int = 0x80000000 - val_as_int;
-    int old = atomicMax(address_as_int, val_as_int);
-    if (old < 0) old = 0x80000000 - old;
-
-    return __int_as_float(old);
+    float old;
+    old = !signbit(val) ? __int_as_float(atomicMax((int*)address, __float_as_int(val))) :
+        __uint_as_float(atomicMin((unsigned int*)address, __float_as_uint(val)));
+    return old;
 }
 
 template<>
 __device__ double atomicMaxFloat<double>(double* address, double val) {
-    unsigned long long* address_as_ull = (unsigned long long*)address;
-    unsigned long long val_as_ull = __double_as_longlong(val);
-
-    if (val_as_ull & 0x8000000000000000ULL)
-      val_as_ull = 0x8000000000000000ULL - val_as_ull;
-    unsigned long long old = atomicMax(address_as_ull, val_as_ull);
-    if (old & 0x8000000000000000ULL)
-      old = 0x8000000000000000ULL - old;
-
-    return __longlong_as_double(old);
+    double old;
+    old = !signbit(val) ? __longlong_as_double(atomicMax((unsigned long long*)address, 
+                                              __double_as_longlong(val))) :
+          __longlong_as_double(atomicMin((unsigned long long*)address, 
+                                       __double_as_longlong(val)));
+    return old;
 }
 
 template< typename T >

--- a/src/gs/bcknd/device/hip/gs_kernels.h
+++ b/src/gs/bcknd/device/hip/gs_kernels.h
@@ -285,19 +285,31 @@ __global__ void gs_unpack_add_kernel(T * __restrict__ u,
   }
 }
 
-__device__ float atomicMinFloat(float* address, float val) {
+template<typename T>
+__device__ T atomicMinFloat(T* address, T val);
+
+template<>
+__device__ float atomicMinFloat<float>(float* address, float val) {
     int* address_as_int = (int*)address;
     int val_as_int = __float_as_int(val);
 
-    // Adjust the float representation to preserve ordering
     if (val_as_int < 0) val_as_int = 0x80000000 - val_as_int;
-
     int old = atomicMin(address_as_int, val_as_int);
-
-    // Adjust back the float representation
     if (old < 0) old = 0x80000000 - old;
 
     return __int_as_float(old);
+}
+
+template<>
+__device__ double atomicMinFloat<double>(double* address, double val) {
+    unsigned long long* address_as_ull = (unsigned long long*)address;
+    unsigned long long val_as_ull = __double_as_longlong(val);
+
+    if (val_as_ull < 0) val_as_ull = 0x8000000000000000ULL - val_as_ull;
+    unsigned long long old = atomicMin(address_as_ull, val_as_ull);
+    if (old < 0) old = 0x8000000000000000ULL - old;
+
+    return __longlong_as_double(old);
 }
 
 template< typename T >
@@ -346,19 +358,31 @@ __device__ float atomicMaxFloat_CAS(float* address, float val) {
     return __int_as_float(old);
 }
 
-__device__ float atomicMaxFloat(float* address, float val) {
+template<typename T>
+__device__ T atomicMaxFloat(T* address, T val);
+
+template<>
+__device__ float atomicMaxFloat<float>(float* address, float val) {
     int* address_as_int = (int*)address;
     int val_as_int = __float_as_int(val);
 
-    // Adjust the float representation to preserve ordering
     if (val_as_int < 0) val_as_int = 0x80000000 - val_as_int;
-
     int old = atomicMax(address_as_int, val_as_int);
-
-    // Adjust back the float representation
     if (old < 0) old = 0x80000000 - old;
 
     return __int_as_float(old);
+}
+
+template<>
+__device__ double atomicMaxFloat<double>(double* address, double val) {
+    unsigned long long* address_as_ull = (unsigned long long*)address;
+    unsigned long long val_as_ull = __double_as_longlong(val);
+
+    if (val_as_ull < 0) val_as_ull = 0x8000000000000000ULL - val_as_ull;
+    unsigned long long old = atomicMax(address_as_ull, val_as_ull);
+    if (old < 0) old = 0x8000000000000000ULL - old;
+
+    return __longlong_as_double(old);
 }
 
 template< typename T >
@@ -377,10 +401,10 @@ __global__ void gs_unpack_max_kernel(T * __restrict__ u,
 
   if (idx < 0) {
     // Use atomicMax for shared nodal points
-    atomicMaxFloat_CAS(&u[-idx-1], val);
+    atomicMaxFloat(&u[-idx-1], val);
   } else {
     // Directly compute max for non-shared nodal points
-    atomicMaxFloat_CAS(&u[idx-1], val);
+    atomicMaxFloat(&u[idx-1], val);
   }
 }
 

--- a/src/gs/bcknd/device/hip/gs_kernels.h
+++ b/src/gs/bcknd/device/hip/gs_kernels.h
@@ -305,9 +305,15 @@ __device__ double atomicMinFloat<double>(double* address, double val) {
     unsigned long long* address_as_ull = (unsigned long long*)address;
     unsigned long long val_as_ull = __double_as_longlong(val);
 
-    if (val_as_ull < 0) val_as_ull = 0x8000000000000000ULL - val_as_ull;
+    // Check MSB instead of comparing with 0
+    if (val_as_ull & 0x8000000000000000ULL) 
+        val_as_ull = 0x8000000000000000ULL - val_as_ull;
+        
     unsigned long long old = atomicMin(address_as_ull, val_as_ull);
-    if (old < 0) old = 0x8000000000000000ULL - old;
+    
+    // Check MSB for old value
+    if (old & 0x8000000000000000ULL) 
+        old = 0x8000000000000000ULL - old;
 
     return __longlong_as_double(old);
 }
@@ -367,7 +373,7 @@ __device__ double atomicMaxFloat_CAS<double>(double* address, double val) {
     unsigned long long assumed;
     unsigned long long val_as_ull = __double_as_longlong(val);
 
-    if (val_as_ull < 0) 
+    if (val_as_ull & 0x8000000000000000ULL) 
         val_as_ull = 0x8000000000000000ULL - val_as_ull;
 
     do {
@@ -376,7 +382,7 @@ __device__ double atomicMaxFloat_CAS<double>(double* address, double val) {
                        max(val_as_ull, assumed));
     } while (assumed != old);
 
-    if (old < 0) 
+    if (old & 0x8000000000000000ULL) 
         old = 0x8000000000000000ULL - old;
 
     return __longlong_as_double(old);
@@ -402,9 +408,11 @@ __device__ double atomicMaxFloat<double>(double* address, double val) {
     unsigned long long* address_as_ull = (unsigned long long*)address;
     unsigned long long val_as_ull = __double_as_longlong(val);
 
-    if (val_as_ull < 0) val_as_ull = 0x8000000000000000ULL - val_as_ull;
+    if (val_as_ull & 0x8000000000000000ULL)
+      val_as_ull = 0x8000000000000000ULL - val_as_ull;
     unsigned long long old = atomicMax(address_as_ull, val_as_ull);
-    if (old < 0) old = 0x8000000000000000ULL - old;
+    if (old & 0x8000000000000000ULL)
+      old = 0x8000000000000000ULL - old;
 
     return __longlong_as_double(old);
 }

--- a/src/gs/bcknd/device/hip/gs_kernels.h
+++ b/src/gs/bcknd/device/hip/gs_kernels.h
@@ -326,8 +326,8 @@ __global__ void gs_unpack_min_kernel(T * __restrict__ u,
     // Use atomicMin for shared nodal points
     atomicMinFloat(&u[-idx-1], val);
   } else {
-    // Directly compute min for non-shared nodal points
-    atomicMinFloat(&u[idx-1], val);
+    // Directly compute min for nodal points on edges
+    u[idx-1] = min(u[idx-1], val);
   }
 }
 
@@ -370,8 +370,8 @@ __global__ void gs_unpack_max_kernel(T * __restrict__ u,
     // Use atomicMax for shared nodal points
     atomicMaxFloat(&u[-idx-1], val);
   } else {
-    // Directly compute max for non-shared nodal points
-    atomicMaxFloat(&u[idx-1], val);
+    // Directly compute min for nodal points on edges
+    u[idx-1] = max(u[idx-1], val);
   }
 }
 

--- a/src/gs/bcknd/device/hip/gs_kernels.h
+++ b/src/gs/bcknd/device/hip/gs_kernels.h
@@ -285,4 +285,80 @@ __global__ void gs_unpack_add_kernel(T * __restrict__ u,
   }
 }
 
+__device__ float atomicMinFloat(float* address, float val) {
+    int* address_as_int = (int*)address;
+    int val_as_int = __float_as_int(val);
+
+    // Adjust the float representation to preserve ordering
+    if (val_as_int < 0) val_as_int = 0x80000000 - val_as_int;
+
+    int old = atomicMin(address_as_int, val_as_int);
+
+    // Adjust back the float representation
+    if (old < 0) old = 0x80000000 - old;
+
+    return __int_as_float(old);
+}
+
+template< typename T >
+__global__ void gs_unpack_min_kernel(T * __restrict__ u,
+                                     const T * __restrict__ buf,
+                                     const int32_t * __restrict__ dof,
+                                     const int n) {
+
+  const int j = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (j >= n)
+    return;
+
+  const int32_t idx = dof[j];
+  const T val = buf[j];
+
+  if (idx < 0) {
+    // Use atomicMin for shared nodal points
+    atomicMinFloat(&u[-idx-1], val);
+  } else {
+    // Directly compute min for non-shared nodal points
+    atomicMinFloat(&u[idx-1], val);
+  }
+}
+
+__device__ float atomicMaxFloat(float* address, float val) {
+    int* address_as_int = (int*)address;
+    int val_as_int = __float_as_int(val);
+
+    // Adjust the float representation to preserve ordering
+    if (val_as_int < 0) val_as_int = 0x80000000 - val_as_int;
+
+    int old = atomicMax(address_as_int, val_as_int);
+
+    // Adjust back the float representation
+    if (old < 0) old = 0x80000000 - old;
+
+    return __int_as_float(old);
+}
+
+template< typename T >
+__global__ void gs_unpack_max_kernel(T * __restrict__ u,
+                                     const T * __restrict__ buf,
+                                     const int32_t * __restrict__ dof,
+                                     const int n) {
+
+  const int j = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (j >= n)
+    return;
+
+  const int32_t idx = dof[j];
+  const T val = buf[j];
+
+  if (idx < 0) {
+    // Use atomicMax for shared nodal points
+    atomicMaxFloat(&u[-idx-1], val);
+  } else {
+    // Directly compute max for non-shared nodal points
+    atomicMaxFloat(&u[idx-1], val);
+  }
+}
+
 #endif // __GS_GS_KERNELS__

--- a/src/gs/bcknd/device/hip/gs_kernels.h
+++ b/src/gs/bcknd/device/hip/gs_kernels.h
@@ -301,10 +301,9 @@ template<>
 __device__ double atomicMinFloat<double>(double* address, double val) {
     double old;
     old = !signbit(val) ? __longlong_as_double(atomicMin((unsigned long long*)address, 
-                            (unsigned long long)__double_as_longlong(val))) :
+                                            __double_as_longlong(val))) :
           __longlong_as_double(atomicMax((unsigned long long*)address, 
-                            (unsigned long long)__double_as_longlong(val)));
-    
+                                            __double_as_longlong(val)));
     return old;
 }
 
@@ -346,9 +345,9 @@ template<>
 __device__ double atomicMaxFloat<double>(double* address, double val) {
     double old;
     old = !signbit(val) ? __longlong_as_double(atomicMax((unsigned long long*)address, 
-                              (unsigned long long)__double_as_longlong(val))) :
+                                                __double_as_longlong(val))) :
           __longlong_as_double(atomicMin((unsigned long long*)address, 
-                              (unsigned long long)__double_as_longlong(val)));
+                                                __double_as_longlong(val)));
     return old;
 }
 

--- a/tests/unit/gather_scatter/gather_scatter_parallel.pf
+++ b/tests/unit/gather_scatter/gather_scatter_parallel.pf
@@ -81,6 +81,8 @@ contains
     call gs_h%init(d)
     call x%init(m, Xh, "x")   
     n = Xh%lx * Xh%ly * Xh%lz * m%nelv
+
+    !> Test GS_OP_ADD
     call rone(x%x, n)
     call add2(x%x,real(d%dof,rp), n/2)
 
@@ -101,6 +103,54 @@ contains
       @assertEqual(x%x(lx,j,i,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
       enddo
     enddo 
+
+    !> Test GS_OP_MIN
+    call rone(x%x, n)
+    ! Multiply by dof create different values from both sides
+    call col2(x%x,real(d%dof,rp), n/2)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), HOST_TO_DEVICE, sync=.false.)
+    end if
+
+    call gs_h%op(x%x, n, GS_OP_MIN)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), DEVICE_TO_HOST, sync=.true.)
+    end if
+
+    ! Checks if values match at shared face between elements
+    do i = 1,lx
+      do j = 1,lx
+      @assertEqual(x%x(lx,j,i,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
+      enddo
+    enddo
+
+    !> Test GS_OP_MAX
+    call rone(x%x, n)
+    ! Multiply by dof create different values from both sides
+    call col2(x%x,real(d%dof,rp), n/2)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), HOST_TO_DEVICE, sync=.false.)
+    end if
+
+    call gs_h%op(x%x, n, GS_OP_MAX)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), DEVICE_TO_HOST, sync=.true.)
+    end if
+
+    ! Checks if values match at shared face between elements
+    do i = 1,lx
+      do j = 1,lx
+      @assertEqual(x%x(lx,j,i,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
+      enddo
+    enddo
 
     call device_finalize
     
@@ -170,6 +220,8 @@ contains
     call gs_h%init(d)
     call x%init(m, Xh, "x")   
     n = Xh%lx * Xh%ly * Xh%lz * m%nelv
+
+    !> Test GS_OP_ADD
     call rone(x%x, n)
     call add2(x%x,real(d%dof,rp), n/2)
 
@@ -189,7 +241,51 @@ contains
       do j = 1,lx
       @assertEqual(x%x(lx+1-i,j,lx,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
       enddo
-    enddo 
+    enddo
+
+    !> Test GS_OP_MIN
+    call rone(x%x, n)
+    call col2(x%x,real(d%dof,rp), n/2)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), HOST_TO_DEVICE, sync=.false.)
+    end if
+    
+    call gs_h%op(x%x, n, GS_OP_MIN)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), DEVICE_TO_HOST, sync=.true.)
+    end if
+    
+    do i = 1,lx
+      do j = 1,lx
+      @assertEqual(x%x(lx+1-i,j,lx,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
+      enddo
+    enddo
+
+    !> Test GS_OP_MAX
+    call rone(x%x, n)
+    call col2(x%x,real(d%dof,rp), n/2)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), HOST_TO_DEVICE, sync=.false.)
+    end if
+    
+    call gs_h%op(x%x, n, GS_OP_MAX)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), DEVICE_TO_HOST, sync=.true.)
+    end if
+    
+    do i = 1,lx
+      do j = 1,lx
+      @assertEqual(x%x(lx+1-i,j,lx,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
+      enddo
+    enddo
 
     call device_finalize
     
@@ -258,6 +354,8 @@ contains
     call gs_h%init(d)
     call x%init(m, Xh, "x")   
     n = Xh%lx * Xh%ly * Xh%lz * m%nelv
+
+    !> Test GS_OP_ADD
     call rone(x%x, n)
     call add2(x%x,real(d%dof,rp), n/2)
 
@@ -277,7 +375,51 @@ contains
       do j = 1,lx
       @assertEqual(x%x(1,lx+1-j,lx+1-i,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
       enddo
-    enddo 
+    enddo
+
+    !> Test GS_OP_MIN
+    call rone(x%x, n)
+    call col2(x%x,real(d%dof,rp), n/2)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), HOST_TO_DEVICE, sync=.false.)
+    end if
+    
+    call gs_h%op(x%x, n, GS_OP_MIN)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), DEVICE_TO_HOST, sync=.true.)
+    end if
+    
+    do i = 1,lx
+      do j = 1,lx
+      @assertEqual(x%x(1,lx+1-j,lx+1-i,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
+      enddo
+    enddo
+
+    !> Test GS_OP_MAX
+    call rone(x%x, n)
+    call col2(x%x,real(d%dof,rp), n/2)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), HOST_TO_DEVICE, sync=.false.)
+    end if
+    
+    call gs_h%op(x%x, n, GS_OP_MAX)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), DEVICE_TO_HOST, sync=.true.)
+    end if
+    
+    do i = 1,lx
+      do j = 1,lx
+      @assertEqual(x%x(1,lx+1-j,lx+1-i,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
+      enddo
+    enddo
 
     call device_finalize
     
@@ -346,6 +488,8 @@ contains
     call gs_h%init(d)
     call x%init(m, Xh, "x")   
     n = Xh%lx * Xh%ly * Xh%lz * m%nelv
+
+    !> Test GS_OP_ADD
     call rone(x%x, n)
     call add2(x%x,real(d%dof,rp), n/2)
 
@@ -365,6 +509,50 @@ contains
       do j = 1,lx
       @assertEqual(x%x(1,j,lx+1-i,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
       enddo
+    enddo
+
+    !> Test GS_OP_MIN
+    call rone(x%x, n)
+    call col2(x%x,real(d%dof,rp), n/2)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), HOST_TO_DEVICE, sync=.false.)
+    end if
+    
+    call gs_h%op(x%x, n, GS_OP_MIN)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), DEVICE_TO_HOST, sync=.true.)
+    end if
+
+    do i = 1,lx
+      do j = 1,lx
+      @assertEqual(x%x(1,j,lx+1-i,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
+      enddo
+    enddo
+
+   !> Test GS_OP_MAX
+   call rone(x%x, n)
+   call col2(x%x,real(d%dof,rp), n/2)
+
+   if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+        (NEKO_BCKND_OPENCL .eq. 1)) then
+      call device_memcpy(x%x, x%x_d, size(x%x), HOST_TO_DEVICE, sync=.false.)
+   end if
+   
+   call gs_h%op(x%x, n, GS_OP_MAX)
+
+   if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+        (NEKO_BCKND_OPENCL .eq. 1)) then
+      call device_memcpy(x%x, x%x_d, size(x%x), DEVICE_TO_HOST, sync=.true.)
+   end if
+
+   do i = 1,lx
+     do j = 1,lx
+     @assertEqual(x%x(1,j,lx+1-i,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
+     enddo
    enddo
 
    call device_finalize
@@ -434,6 +622,8 @@ contains
     call gs_h%init(d)
     call x%init(m, Xh, "x")   
     n = Xh%lx * Xh%ly * Xh%lz * m%nelv
+
+    !> Test GS_OP_ADD
     call rone(x%x, n)    
     call add2(x%x,real(d%dof,rp), n/2)
 
@@ -453,6 +643,50 @@ contains
       do j = 1,lx
       @assertEqual(x%x(i,j,1,1), x%x(1,j,i,2), tolerance=epsilon(1.0_rp))
       enddo
+    enddo
+
+   !> Test GS_OP_MIN
+   call rone(x%x, n)
+   call col2(x%x,real(d%dof,rp), n/2)
+
+   if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+        (NEKO_BCKND_OPENCL .eq. 1)) then
+      call device_memcpy(x%x, x%x_d, size(x%x), HOST_TO_DEVICE, sync=.false.)
+   end if
+   
+   call gs_h%op(x%x, n, GS_OP_MIN)
+
+   if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+        (NEKO_BCKND_OPENCL .eq. 1)) then
+      call device_memcpy(x%x, x%x_d, size(x%x), DEVICE_TO_HOST, sync=.true.)
+   end if
+   
+   do i = 1,lx
+     do j = 1,lx
+     @assertEqual(x%x(i,j,1,1), x%x(1,j,i,2), tolerance=epsilon(1.0_rp))
+     enddo
+   enddo
+
+   !> Test GS_OP_MAX
+   call rone(x%x, n)
+   call col2(x%x,real(d%dof,rp), n/2)
+
+   if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+        (NEKO_BCKND_OPENCL .eq. 1)) then
+      call device_memcpy(x%x, x%x_d, size(x%x), HOST_TO_DEVICE, sync=.false.)
+   end if
+   
+   call gs_h%op(x%x, n, GS_OP_MAX)
+
+   if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+        (NEKO_BCKND_OPENCL .eq. 1)) then
+      call device_memcpy(x%x, x%x_d, size(x%x), DEVICE_TO_HOST, sync=.true.)
+   end if
+   
+   do i = 1,lx
+     do j = 1,lx
+     @assertEqual(x%x(i,j,1,1), x%x(1,j,i,2), tolerance=epsilon(1.0_rp))
+     enddo
    enddo
 
    call device_finalize
@@ -522,6 +756,8 @@ contains
     call gs_h%init(d)
     call x%init(m, Xh, "x")   
     n = Xh%lx * Xh%ly * Xh%lz * m%nelv
+
+    !> Test GS_OP_ADD
     call rone(x%x, n)
     call add2(x%x,real(d%dof,rp), n/2)
 
@@ -541,7 +777,51 @@ contains
       do j = 1,lx
       @assertEqual(x%x(lx+1-j,lx,i,1), x%x(1,j,i,2), tolerance=epsilon(1.0_rp))
       enddo
-    enddo 
+    enddo
+
+    !> Test GS_OP_MIN
+    call rone(x%x, n)
+    call col2(x%x,real(d%dof,rp), n/2)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), HOST_TO_DEVICE, sync=.false.)
+    end if
+    
+    call gs_h%op(x%x, n, GS_OP_MIN)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), DEVICE_TO_HOST, sync=.true.)
+    end if
+    
+    do i = 1,lx
+      do j = 1,lx
+      @assertEqual(x%x(lx+1-j,lx,i,1), x%x(1,j,i,2), tolerance=epsilon(1.0_rp))
+      enddo
+    enddo
+
+    !> Test GS_OP_MAX
+    call rone(x%x, n)
+    call col2(x%x,real(d%dof,rp), n/2)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), HOST_TO_DEVICE, sync=.false.)
+    end if
+    
+    call gs_h%op(x%x, n, GS_OP_MAX)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), DEVICE_TO_HOST, sync=.true.)
+    end if
+    
+    do i = 1,lx
+      do j = 1,lx
+      @assertEqual(x%x(lx+1-j,lx,i,1), x%x(1,j,i,2), tolerance=epsilon(1.0_rp))
+      enddo
+    enddo
 
     call device_finalize
     
@@ -610,6 +890,8 @@ contains
     call gs_h%init(d)
     call x%init(m, Xh, "x")   
     n = Xh%lx * Xh%ly * Xh%lz * m%nelv
+
+    !> Test GS_OP_ADD
     call rone(x%x, n)
     call add2(x%x,real(d%dof,rp), n/2)
 
@@ -629,7 +911,51 @@ contains
       do j = 1,lx
       @assertEqual(x%x(j,1,i,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
       enddo
-    enddo 
+    enddo
+
+    !> Test GS_OP_MIN
+    call rone(x%x, n)
+    call col2(x%x,real(d%dof,rp), n/2)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), HOST_TO_DEVICE, sync=.false.)
+    end if
+    
+    call gs_h%op(x%x, n, GS_OP_MIN)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), DEVICE_TO_HOST, sync=.true.)
+    end if
+    
+    do i = 1,lx
+      do j = 1,lx
+      @assertEqual(x%x(j,1,i,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
+      enddo
+    enddo
+
+    !> Test GS_OP_MAX
+    call rone(x%x, n)
+    call col2(x%x,real(d%dof,rp), n/2)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), HOST_TO_DEVICE, sync=.false.)
+    end if
+    
+    call gs_h%op(x%x, n, GS_OP_MAX)
+
+    if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
+         (NEKO_BCKND_OPENCL .eq. 1)) then
+       call device_memcpy(x%x, x%x_d, size(x%x), DEVICE_TO_HOST, sync=.true.)
+    end if
+    
+    do i = 1,lx
+      do j = 1,lx
+      @assertEqual(x%x(j,1,i,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
+      enddo
+    enddo
 
     call device_finalize
     


### PR DESCRIPTION
## Changes
- Supports `GS_OP_MIN`, `GS_OP_MAX` for `gs op` using CUDA and HIP
- Add unit tests for the added operators, in `tests/unit/gather_scatter`
- Add benchmark tests to `tests/bench/gs`
## Benchmark results
By running `tests/bench/gs`.
### HIP, `rocm/6.2.0`
```
 -------------Mesh-------------
 Reading a binary Neko file box.nmsh
 gdim = 3, nelements =     27000
 Reading elements
 Reading BC/zone data
 Reading deformation data
 Mesh read, setting up connectivity
 Done setting up mesh and connectivity
 Mesh and connectivity setup (excluding read) time (s): 93.528476

 --------Gather-Scatter--------
 Comm         :   Device MPI
 Avg. internal:      2646000
 Avg. external:            0
 Backend      :          hip
 
GS_OP_ADD mean:   0.4491E-03, stddev:   0.3858E-05
 
GS_OP_MIN mean:   0.4492E-03, stddev:   0.3962E-05
 
GS_OP_MAX mean:   0.4490E-03, stddev:   0.4021E-05
```
### CUDA
```
 -------------Mesh-------------
 Reading a binary Neko file box.nmsh
 gdim = 3, nelements =     27000
 Reading elements
 Reading BC/zone data
 Reading deformation data
 Mesh read, setting up connectivity
 Done setting up mesh and connectivity
 Mesh and connectivity setup (excluding read) time (s): 69.145985

 --------Gather-Scatter--------
 Comm         :          MPI
 Avg. internal:      2646000
 Avg. external:            0
 Backend      :         cuda

GS_OP_ADD mean:   0.7639E-04, stddev:   0.7434E-05

GS_OP_MIN mean:   0.7630E-04, stddev:   0.7027E-05

GS_OP_MAX mean:   0.7629E-04, stddev:   0.6781E-05
```