### PR TITLE
Make the device module private

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -28,7 +28,7 @@ sem/dofmap.lo : sem/dofmap.f90 mesh/hex.lo mesh/quad.lo mesh/element.lo math/mat
 sem/coef.lo : sem/coef.f90 device/device.lo math/mxm_wrapper.lo sem/bcknd/device/device_coef.lo math/bcknd/device/device_math.lo mesh/mesh.lo math/math.lo sem/space.lo sem/dofmap.lo config/num_types.lo config/neko_config.lo gs/gs_ops.lo gs/gather_scatter.lo 
 sem/cpr.lo : sem/cpr.f90 sem/dofmap.lo common/log.lo math/mxm_wrapper.lo math/tensor.lo sem/coef.lo mesh/mesh.lo math/math.lo sem/space.lo field/field.lo config/num_types.lo config/neko_config.lo gs/gather_scatter.lo 
 common/time_interpolator.lo : common/time_interpolator.f90 math/fast3d.lo common/utils.lo math/math.lo math/bcknd/device/device_math.lo config/neko_config.lo field/field.lo config/num_types.lo 
-sem/interpolation.lo : sem/interpolation.f90 sem/space.lo math/bcknd/cpu/tensor_cpu.lo math/tensor.lo math/fast3d.lo device/device.lo config/num_types.lo config/neko_config.lo 
+sem/interpolation.lo : sem/interpolation.f90 common/utils.lo sem/space.lo math/bcknd/cpu/tensor_cpu.lo math/tensor.lo math/fast3d.lo device/device.lo config/num_types.lo config/neko_config.lo 
 sem/point_interpolator.lo : sem/point_interpolator.f90 config/neko_config.lo math/bcknd/device/device_math.lo device/device.lo common/utils.lo math/fast3d.lo math/math.lo mesh/point.lo config/num_types.lo sem/space.lo math/tensor.lo 
 sem/bcknd/device/device_coef.lo : sem/bcknd/device/device_coef.F90 common/utils.lo config/num_types.lo 
 gs/gs_bcknd.lo : gs/gs_bcknd.f90 config/num_types.lo 
@@ -135,7 +135,7 @@ io/fluid_stats_output.lo : io/fluid_stats_output.f90 math/matrix.lo io/output.lo
 io/mean_sqr_flow_output.lo : io/mean_sqr_flow_output.f90 io/output.lo config/num_types.lo fluid/mean_sqr_flow.lo 
 io/data_streamer.lo : io/data_streamer.F90 config/neko_config.lo comm/mpi_types.lo comm/comm.lo device/device.lo common/utils.lo sem/coef.lo field/field.lo config/num_types.lo 
 io/output_controller.lo : io/output_controller.f90 common/time_based_controller.lo config/num_types.lo common/profiler.lo common/utils.lo common/log.lo comm/comm.lo io/fld_file.lo io/output.lo 
-common/global_interpolation.lo : common/global_interpolation.F90 common/structs.lo comm/mpi_types.lo math/math.lo comm/comm.lo sem/local_interpolation.lo common/utils.lo common/log.lo mesh/mesh.lo sem/dofmap.lo sem/space.lo config/num_types.lo 
+common/global_interpolation.lo : common/global_interpolation.F90 common/structs.lo comm/mpi_types.lo math/math.lo comm/comm.lo device/device.lo sem/local_interpolation.lo common/utils.lo common/log.lo mesh/mesh.lo sem/dofmap.lo sem/space.lo config/num_types.lo config/neko_config.lo 
 common/profiler.lo : common/profiler.F90 common/runtime_statistics.lo common/craypat.lo device/hip/roctx.lo device/cuda/nvtx.lo device/device.lo config/neko_config.lo 
 common/craypat.lo : common/craypat.F90 
 bc/bc.lo : bc/bc.f90 io/file.lo field/field.lo common/utils.lo adt/tuple.lo adt/stack.lo mesh/facet_zone.lo mesh/mesh.lo sem/space.lo sem/coef.lo sem/dofmap.lo device/device.lo config/num_types.lo config/neko_config.lo 
@@ -146,8 +146,8 @@ bc/shear_stress.lo : bc/shear_stress.f90 common/json_utils.lo bc/neumann.lo bc/s
 bc/dong_outflow.lo : bc/dong_outflow.f90 common/json_utils.lo field/field_registry.lo bc/bcknd/device/device_dong_outflow.lo common/utils.lo sem/coef.lo sem/dofmap.lo field/field.lo bc/bc.lo config/num_types.lo device/device.lo bc/dirichlet.lo config/neko_config.lo 
 bc/zero_dirichlet.lo : bc/zero_dirichlet.f90 sem/coef.lo bc/bc.lo config/num_types.lo bc/bcknd/device/device_zero_dirichlet.lo 
 bc/inflow.lo : bc/inflow.f90 common/json_utils.lo sem/coef.lo bc/bc.lo config/num_types.lo bc/bcknd/device/device_inflow.lo 
-bc/field_dirichlet.lo : bc/field_dirichlet.f90 common/json_utils.lo sem/dofmap.lo math/bcknd/device/device_math.lo math/math.lo field/field_list.lo field/field.lo common/utils.lo device/device.lo bc/bc_list.lo bc/bc.lo bc/dirichlet.lo sem/coef.lo config/num_types.lo 
-bc/field_dirichlet_vector.lo : bc/field_dirichlet_vector.f90 bc/field_dirichlet.lo sem/dofmap.lo math/bcknd/device/device_math.lo math/math.lo field/field_list.lo field/field.lo common/utils.lo device/device.lo bc/bc_list.lo bc/bc.lo bc/dirichlet.lo sem/coef.lo config/num_types.lo 
+bc/field_dirichlet.lo : bc/field_dirichlet.f90 common/json_utils.lo sem/dofmap.lo math/bcknd/device/device_math.lo math/math.lo field/field_list.lo field/field.lo common/utils.lo bc/bc_list.lo bc/bc.lo bc/dirichlet.lo sem/coef.lo config/num_types.lo 
+bc/field_dirichlet_vector.lo : bc/field_dirichlet_vector.f90 bc/field_dirichlet.lo sem/dofmap.lo math/bcknd/device/device_math.lo math/math.lo field/field_list.lo field/field.lo common/utils.lo bc/bc_list.lo bc/bc.lo bc/dirichlet.lo sem/coef.lo config/num_types.lo 
 bc/usr_inflow.lo : bc/usr_inflow.f90 bc/bc.lo common/utils.lo bc/bcknd/device/device_inhom_dirichlet.lo device/device.lo bc/inflow.lo sem/coef.lo config/num_types.lo 
 bc/usr_scalar.lo : bc/usr_scalar.f90 common/utils.lo bc/bcknd/device/device_inhom_dirichlet.lo device/device.lo bc/bc.lo sem/coef.lo config/num_types.lo 
 bc/facet_normal.lo : bc/facet_normal.f90 common/utils.lo bc/bc.lo sem/coef.lo math/math.lo config/num_types.lo bc/bcknd/device/device_facet_normal.lo 
@@ -165,7 +165,7 @@ krylov/bcknd/cpu/cacg.lo : krylov/bcknd/cpu/cacg.f90 math/mxm_wrapper.lo comm/co
 krylov/bcknd/cpu/cheby.lo : krylov/bcknd/cpu/cheby.f90 comm/comm.lo math/math.lo bc/bc_list.lo gs/gather_scatter.lo sem/space.lo mesh/mesh.lo sem/coef.lo field/field.lo config/num_types.lo math/ax.lo krylov/precon.lo krylov/krylov.lo 
 krylov/bcknd/cpu/pipecg.lo : krylov/bcknd/cpu/pipecg.f90 comm/comm.lo math/math.lo bc/bc_list.lo gs/gather_scatter.lo sem/coef.lo field/field.lo config/num_types.lo math/ax.lo krylov/precon.lo krylov/krylov.lo 
 krylov/bcknd/cpu/bicgstab.lo : krylov/bcknd/cpu/bicgstab.f90 common/utils.lo math/math.lo bc/bc_list.lo gs/gather_scatter.lo sem/coef.lo field/field.lo math/ax.lo krylov/precon.lo krylov/krylov.lo config/num_types.lo 
-krylov/bcknd/cpu/gmres.lo : krylov/bcknd/cpu/gmres.f90 comm/comm.lo math/math.lo bc/bc_list.lo gs/gather_scatter.lo sem/coef.lo field/field.lo config/num_types.lo math/ax.lo krylov/precon.lo krylov/krylov.lo 
+krylov/bcknd/cpu/gmres.lo : krylov/bcknd/cpu/gmres.f90 comm/comm.lo config/neko_config.lo math/math.lo bc/bc_list.lo gs/gather_scatter.lo sem/coef.lo field/field.lo config/num_types.lo math/ax.lo krylov/precon.lo krylov/krylov.lo 
 krylov/bcknd/cpu/pc_jacobi.lo : krylov/bcknd/cpu/pc_jacobi.f90 gs/gather_scatter.lo sem/dofmap.lo config/num_types.lo sem/coef.lo krylov/precon.lo math/math.lo 
 krylov/bcknd/cpu/cg_coupled.lo : krylov/bcknd/cpu/cg_coupled.f90 common/utils.lo math/math.lo bc/bc_list.lo gs/gather_scatter.lo sem/coef.lo field/field.lo math/ax.lo krylov/precon.lo krylov/krylov.lo config/num_types.lo 
 krylov/bcknd/sx/cg_sx.lo : krylov/bcknd/sx/cg_sx.f90 math/math.lo bc/bc_list.lo gs/gather_scatter.lo sem/coef.lo field/field.lo math/ax.lo krylov/precon.lo krylov/krylov.lo config/num_types.lo 
@@ -174,10 +174,10 @@ krylov/bcknd/sx/gmres_sx.lo : krylov/bcknd/sx/gmres_sx.f90 comm/comm.lo math/mat
 krylov/bcknd/sx/pc_jacobi_sx.lo : krylov/bcknd/sx/pc_jacobi_sx.f90 gs/gather_scatter.lo config/num_types.lo sem/dofmap.lo sem/coef.lo krylov/precon.lo math/math.lo 
 krylov/bcknd/device/cg_device.lo : krylov/bcknd/device/cg_device.f90 math/bcknd/device/device_math.lo device/device.lo math/math.lo bc/bc_list.lo gs/gather_scatter.lo sem/coef.lo field/field.lo math/ax.lo krylov/precon.lo krylov/krylov.lo config/num_types.lo 
 krylov/bcknd/device/cheby_device.lo : krylov/bcknd/device/cheby_device.F90 device/device.lo math/bcknd/device/device_math.lo bc/bc_list.lo gs/gather_scatter.lo sem/space.lo mesh/mesh.lo sem/coef.lo field/field.lo config/num_types.lo math/ax.lo krylov/precon.lo krylov/krylov.lo 
-krylov/bcknd/device/pipecg_device.lo : krylov/bcknd/device/pipecg_device.F90 comm/comm.lo device/device.lo math/bcknd/device/device_math.lo math/math.lo bc/bc_list.lo gs/gather_scatter.lo sem/coef.lo field/field.lo config/num_types.lo math/ax.lo krylov/precon.lo krylov/krylov.lo 
-krylov/bcknd/device/fusedcg_device.lo : krylov/bcknd/device/fusedcg_device.F90 comm/comm.lo device/device.lo math/bcknd/device/device_math.lo math/math.lo bc/bc_list.lo gs/gather_scatter.lo sem/coef.lo field/field.lo config/num_types.lo math/ax.lo krylov/precon.lo krylov/krylov.lo 
-krylov/bcknd/device/fusedcg_cpld_device.lo : krylov/bcknd/device/fusedcg_cpld_device.F90 comm/comm.lo device/device.lo math/bcknd/device/device_math.lo math/math.lo bc/bc_list.lo gs/gather_scatter.lo sem/coef.lo field/field.lo config/num_types.lo math/ax.lo krylov/precon.lo krylov/krylov.lo 
-krylov/bcknd/device/gmres_device.lo : krylov/bcknd/device/gmres_device.F90 comm/comm.lo device/device.lo math/bcknd/device/device_math.lo math/math.lo krylov/bcknd/device/pc_identity_device.lo bc/bc_list.lo gs/gather_scatter.lo sem/coef.lo field/field.lo config/num_types.lo math/ax.lo krylov/precon.lo krylov/krylov.lo 
+krylov/bcknd/device/pipecg_device.lo : krylov/bcknd/device/pipecg_device.F90 comm/comm.lo common/utils.lo device/device.lo math/bcknd/device/device_math.lo math/math.lo bc/bc_list.lo gs/gather_scatter.lo sem/coef.lo field/field.lo config/num_types.lo math/ax.lo krylov/precon.lo krylov/krylov.lo 
+krylov/bcknd/device/fusedcg_device.lo : krylov/bcknd/device/fusedcg_device.F90 comm/comm.lo common/utils.lo device/device.lo math/bcknd/device/device_math.lo math/math.lo bc/bc_list.lo gs/gather_scatter.lo sem/coef.lo field/field.lo config/num_types.lo math/ax.lo krylov/precon.lo krylov/krylov.lo 
+krylov/bcknd/device/fusedcg_cpld_device.lo : krylov/bcknd/device/fusedcg_cpld_device.F90 comm/comm.lo common/utils.lo device/device.lo math/bcknd/device/device_math.lo math/math.lo bc/bc_list.lo gs/gather_scatter.lo sem/coef.lo field/field.lo config/num_types.lo math/ax.lo krylov/precon.lo krylov/krylov.lo 
+krylov/bcknd/device/gmres_device.lo : krylov/bcknd/device/gmres_device.F90 comm/comm.lo common/utils.lo device/device.lo math/bcknd/device/device_math.lo math/math.lo krylov/bcknd/device/pc_identity_device.lo bc/bc_list.lo gs/gather_scatter.lo sem/coef.lo field/field.lo config/num_types.lo math/ax.lo krylov/precon.lo krylov/krylov.lo config/neko_config.lo 
 krylov/bcknd/device/pc_jacobi_device.lo : krylov/bcknd/device/pc_jacobi_device.F90 gs/gather_scatter.lo device/device.lo math/bcknd/device/device_math.lo config/num_types.lo sem/dofmap.lo sem/coef.lo krylov/precon.lo 
 krylov/bcknd/device/pc_identity_device.lo : krylov/bcknd/device/pc_identity_device.f90 config/num_types.lo krylov/precon.lo math/bcknd/device/device_math.lo device/device.lo 
 time_schemes/time_scheme.lo : time_schemes/time_scheme.f90 config/num_types.lo config/neko_config.lo 
@@ -249,7 +249,7 @@ math/bcknd/sx/ax_helm_sx.lo : math/bcknd/sx/ax_helm_sx.f90 math/math.lo mesh/mes
 math/bcknd/xsmm/ax_helm_xsmm.lo : math/bcknd/xsmm/ax_helm_xsmm.F90 math/mxm_wrapper.lo mesh/mesh.lo sem/space.lo sem/coef.lo config/num_types.lo math/ax_helm.lo 
 math/bcknd/device/ax_helm_device.lo : math/bcknd/device/ax_helm_device.F90 device/device.lo math/bcknd/device/device_math.lo mesh/mesh.lo sem/space.lo sem/coef.lo config/num_types.lo math/ax_helm.lo 
 math/bcknd/device/ax_helm_full_device.lo : math/bcknd/device/ax_helm_full_device.F90 common/utils.lo device/device.lo math/bcknd/device/device_math.lo mesh/mesh.lo sem/space.lo sem/coef.lo config/num_types.lo math/ax_helm_full.lo 
-common/projection.lo : common/projection.f90 common/time_step_controller.lo common/utils.lo common/log.lo common/profiler.lo common/bcknd/device/device_projection.lo math/bcknd/device/device_math.lo device/device.lo config/neko_config.lo gs/gather_scatter.lo comm/comm.lo bc/bc_list.lo math/ax.lo sem/coef.lo math/math.lo config/num_types.lo 
+common/projection.lo : common/projection.f90 comm/comm.lo common/time_step_controller.lo common/utils.lo common/log.lo common/profiler.lo common/bcknd/device/device_projection.lo math/bcknd/device/device_math.lo device/device.lo config/neko_config.lo gs/gather_scatter.lo bc/bc_list.lo math/ax.lo sem/coef.lo math/math.lo config/num_types.lo 
 common/bcknd/device/device_projection.lo : common/bcknd/device/device_projection.F90 common/utils.lo config/num_types.lo 
 comm/parmetis.lo : comm/parmetis.F90 mesh/mesh.lo field/mesh_field.lo config/num_types.lo common/utils.lo mesh/point.lo comm/comm.lo 
 comm/redist.lo : comm/redist.f90 mesh/element.lo mesh/facet_zone.lo io/format/nmsh.lo mesh/mesh.lo comm/comm.lo mesh/curve.lo adt/stack.lo mesh/point.lo adt/htable.lo comm/mpi_types.lo field/mesh_field.lo 
@@ -263,7 +263,7 @@ device/hip/roctx.lo : device/hip/roctx.F90
 device/opencl_intf.lo : device/opencl_intf.F90 common/utils.lo config/num_types.lo 
 device/opencl/prgm_lib.lo : device/opencl/prgm_lib.F90 common/utils.lo device/opencl_intf.lo 
 device/dummy_device.lo : device/dummy_device.F90 
-device/device.lo : device/device.F90 device/opencl/prgm_lib.lo device/dummy_device.lo common/utils.lo adt/htable.lo device/hip_intf.lo device/cuda_intf.lo device/opencl_intf.lo config/num_types.lo 
+device/device.lo : device/device.F90 device/opencl/prgm_lib.lo common/utils.lo adt/htable.lo device/hip_intf.lo device/cuda_intf.lo device/opencl_intf.lo config/num_types.lo 
 math/field_math.lo : math/field_math.f90 math/bcknd/device/device_math.lo math/math.lo field/field.lo config/num_types.lo config/neko_config.lo 
 math/bcknd/device/device_math.lo : math/bcknd/device/device_math.F90 math/bcknd/device/opencl/opencl_math.lo math/bcknd/device/cuda/cuda_math.lo math/bcknd/device/hip/hip_math.lo comm/comm.lo common/utils.lo config/num_types.lo 
 math/bcknd/device/hip/hip_math.lo : math/bcknd/device/hip/hip_math.f90 config/num_types.lo 

--- a/src/bc/field_dirichlet.f90
+++ b/src/bc/field_dirichlet.f90
@@ -37,7 +37,6 @@ module field_dirichlet
   use dirichlet, only: dirichlet_t
   use bc, only: bc_t
   use bc_list, only : bc_list_t
-  use device, only: c_ptr, c_size_t
   use utils, only: split_string
   use field, only : field_t
   use field_list, only : field_list_t
@@ -48,6 +47,7 @@ module field_dirichlet
   use json_module, only : json_file
   use field_list, only : field_list_t
   use json_utils, only : json_get
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t    
   implicit none
   private
 

--- a/src/bc/field_dirichlet_vector.f90
+++ b/src/bc/field_dirichlet_vector.f90
@@ -37,7 +37,6 @@ module field_dirichlet_vector
   use dirichlet, only: dirichlet_t
   use bc, only: bc_t
   use bc_list, only : bc_list_t
-  use device, only: c_ptr, c_size_t
   use utils, only: split_string
   use field, only : field_t
   use field_list, only : field_list_t
@@ -48,6 +47,7 @@ module field_dirichlet_vector
   use utils, only: neko_error
   use json_module, only : json_file
   use field_list, only : field_list_t
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t    
   implicit none
   private
 

--- a/src/common/global_interpolation.F90
+++ b/src/common/global_interpolation.F90
@@ -36,20 +36,24 @@
 !! be found at https://github.com/Nek5000/gslib/blob/master/src/findpts.c
 !!
 module global_interpolation
-  use num_types, only: rp
-  use space, only: space_t
-  use dofmap, only: dofmap_t
-  use mesh, only: mesh_t
-  use logger, only: neko_log, LOG_SIZE
-  use utils, only: neko_error, neko_warning
-  use local_interpolation
-  use comm
-  use math, only: copy
+  use neko_config, only : NEKO_BCKND_DEVICE
+  use num_types, only : rp
+  use space, only : space_t
+  use dofmap, only : dofmap_t
+  use mesh, only : mesh_t
+  use logger, only : neko_log, LOG_SIZE
+  use utils, only : neko_error, neko_warning
+  use local_interpolation, only : local_interpolator_t
+  use device
+  use comm, only : NEKO_COMM, pe_size, pe_rank, MPI_Gather, &
+       MPI_DOUBLE_PRECISION, MPI_INTEGER, MPI_SUM, MPI_Reduce, MPI_Gatherv
+  use math, only : copy
   use neko_mpi_types
-  use structs, only: array_ptr_t
-  use, intrinsic :: iso_c_binding
+  use structs, only : array_ptr_t
+  use, intrinsic :: iso_c_binding  
   implicit none
   private
+  
   !> Implements global interpolation for arbitrary points in the domain.
   type, public :: global_interpolation_t
      !> X coordinates from which to interpolate.

--- a/src/common/gradient_jump_penalty.f90
+++ b/src/common/gradient_jump_penalty.f90
@@ -53,6 +53,7 @@ module gradient_jump_penalty
   use device
   use device_math
   use device_gradient_jump_penalty
+  use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR, c_associated
 
   implicit none
   private

--- a/src/common/projection.f90
+++ b/src/common/projection.f90
@@ -66,9 +66,9 @@ module projection
   use coefs, only : coef_t
   use ax_product, only : ax_t
   use bc_list, only : bc_list_t
-  use comm
   use gather_scatter, only : gs_t, GS_OP_ADD
-  use neko_config, only : NEKO_BCKND_DEVICE
+  use neko_config, only : NEKO_BCKND_DEVICE, NEKO_BLK_SIZE, &
+       NEKO_DEVICE_MPI, NEKO_BCKND_OPENCL
   use device, only : device_alloc, HOST_TO_DEVICE, device_memcpy, &
        device_get_ptr, device_free, device_map
   use device_math, only : device_glsc3, device_add2s2, device_cmult, &
@@ -78,10 +78,12 @@ module projection
   use profiler, only : profiler_start_region, profiler_end_region
   use logger, only : LOG_SIZE, neko_log
   use utils, only : neko_warning
-  use, intrinsic :: iso_c_binding
   use bc_list, only : bc_list_t
   use time_step_controller, only : time_step_controller_t
-
+  use comm, only : NEKO_COMM, pe_rank, MPI_Allreduce, MPI_IN_PLACE, &
+       MPI_SUM, MPI_REAL_PRECISION
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, &
+       c_sizeof, C_NULL_PTR, c_loc, c_associated
   implicit none
   private
 

--- a/src/device/cuda_intf.F90
+++ b/src/device/cuda_intf.F90
@@ -39,18 +39,6 @@ module cuda_intf
 
 #ifdef HAVE_CUDA
 
-  !> Global HIP command queue
-  type(c_ptr), bind(c) :: glb_cmd_queue = C_NULL_PTR
-
-  !> Aux HIP command queue
-  type(c_ptr), bind(c) :: aux_cmd_queue = C_NULL_PTR
-
-  !> High priority stream setting
-  integer :: STRM_HIGH_PRIO
-
-  !> Low priority stream setting
-  integer :: STRM_LOW_PRIO
-
   !> Enum @a cudaError
   enum, bind(c)
     enumerator :: cudaSuccess = 0
@@ -285,7 +273,12 @@ module cuda_intf
 
 contains
 
-  subroutine cuda_init
+  subroutine cuda_init(glb_cmd_queue, aux_cmd_queue, &
+       STRM_HIGH_PRIO, STRM_LOW_PRIO)
+    type(c_ptr), intent(inout) :: glb_cmd_queue
+    type(c_ptr), intent(inout) :: aux_cmd_queue
+    integer, intent(inout) :: STRM_HIGH_PRIO
+    integer, intent(inout) :: STRM_LOW_PRIO
     integer(c_int) :: device_id
     integer :: nthrds = 1
 
@@ -324,7 +317,10 @@ contains
     end if
   end subroutine cuda_init
 
-  subroutine cuda_finalize
+  subroutine cuda_finalize(glb_cmd_queue, aux_cmd_queue)
+    type(c_ptr), intent(inout) :: glb_cmd_queue
+    type(c_ptr), intent(inout) :: aux_cmd_queue
+    
     if (cudaStreamDestroy(glb_cmd_queue) .ne. cudaSuccess) then
        call neko_error('Error destroying main stream')
     end if

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -38,18 +38,6 @@ module hip_intf
 
 #ifdef HAVE_HIP
 
-  !> Global HIP command queue
-  type(c_ptr), bind(c) :: glb_cmd_queue = C_NULL_PTR
-
-  !> Aux HIP command queue
-  type(c_ptr), bind(c) :: aux_cmd_queue = C_NULL_PTR
-
-  !> High priority stream setting
-  integer :: STRM_HIGH_PRIO
-
-  !> Low priority stream setting
-  integer :: STRM_LOW_PRIO
-
   !> Enum @a hipError_t
   enum, bind(c)
     enumerator :: hipSuccess = 0
@@ -234,7 +222,12 @@ module hip_intf
 
 contains
 
-  subroutine hip_init
+  subroutine hip_init(glb_cmd_queue, aux_cmd_queue, &
+       STRM_HIGH_PRIO, STRM_LOW_PRIO)
+    type(c_ptr), intent(inout) :: glb_cmd_queue
+    type(c_ptr), intent(inout) :: aux_cmd_queue
+    integer, intent(inout) :: STRM_HIGH_PRIO
+    integer, intent(inout) :: STRM_LOW_PRIO
 
     if (hipDeviceGetStreamPriorityRange(STRM_LOW_PRIO, STRM_HIGH_PRIO) &
         .ne. hipSuccess) then
@@ -252,7 +245,10 @@ contains
     end if
   end subroutine hip_init
 
-  subroutine hip_finalize
+  subroutine hip_finalize(glb_cmd_queue, aux_cmd_queue)
+    type(c_ptr), intent(inout) :: glb_cmd_queue
+    type(c_ptr), intent(inout) :: aux_cmd_queue
+    
     if (hipStreamDestroy(glb_cmd_queue) .ne. hipSuccess) then
        call neko_error('Error destroying main stream')
     end if

--- a/src/device/opencl/prgm_lib.F90
+++ b/src/device/opencl/prgm_lib.F90
@@ -4,87 +4,90 @@ module opencl_prgm_lib
   use utils, only : neko_error
   use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR
   implicit none
+  private
 
 #ifdef HAVE_OPENCL
 
   !> Device math kernels
-  type(c_ptr), bind(c) :: math_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: math_program = C_NULL_PTR
 
   !> Device mathops kernels
-  type(c_ptr), bind(c) :: mathops_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: mathops_program = C_NULL_PTR
 
   !> Device Dirichlet kernels
-  type(c_ptr), bind(c) :: dirichlet_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: dirichlet_program = C_NULL_PTR
 
   !> Device Inflow kernels
-  type(c_ptr), bind(c) :: inflow_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: inflow_program = C_NULL_PTR
 
   !> Device zero dirichlet kernels
-  type(c_ptr), bind(c) :: zero_dirichlet_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: zero_dirichlet_program = C_NULL_PTR
 
   !> Device Symmetry kernels
-  type(c_ptr), bind(c) :: symmetry_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: symmetry_program = C_NULL_PTR
 
   !> Device Facet normal kernels
-  type(c_ptr), bind(c) :: facet_normal_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: facet_normal_program = C_NULL_PTR
 
   !> Device Blasius profile kernel
-  type(c_ptr), bind(c) :: inhom_dirichlet_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: inhom_dirichlet_program = C_NULL_PTR
 
   !> Device Derivative kernels
-  type(c_ptr), bind(c) :: dudxyz_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: dudxyz_program = C_NULL_PTR
 
   !> Device \f$ D^T X \f$ kernels
-  type(c_ptr), bind(c) :: cdtp_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: cdtp_program = C_NULL_PTR
 
   !> Device onvective kernels
-  type(c_ptr), bind(c) :: conv1_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: conv1_program = C_NULL_PTR
 
   !> Device CFL kernels
-  type(c_ptr), bind(c) :: cfl_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: cfl_program = C_NULL_PTR
 
   !> Device Velocity gradient kernels
-  type(c_ptr), bind(c) :: opgrad_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: opgrad_program = C_NULL_PTR
 
   !> Device Gather-Scatter kernels
-  type(c_ptr), bind(c) :: gs_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: gs_program = C_NULL_PTR
 
   !> Device Ax helm kernels
-  type(c_ptr), bind(c) :: ax_helm_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: ax_helm_program = C_NULL_PTR
 
   !> Device jacobi kernels
-  type(c_ptr), bind(c) :: jacobi_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: jacobi_program = C_NULL_PTR
 
   !> Device rhs_maker kernels
-  type(c_ptr), bind(c) :: rhs_maker_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: rhs_maker_program = C_NULL_PTR
 
   !> Device pnpn residual kernels
-  type(c_ptr), bind(c) :: pnpn_res_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: pnpn_res_program = C_NULL_PTR
 
   !> Device fdm kernels
-  type(c_ptr), bind(c) :: fdm_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: fdm_program = C_NULL_PTR
 
   !> Device tensor kernels
-  type(c_ptr), bind(c) :: tensor_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: tensor_program = C_NULL_PTR
 
   !> Device schwarz kernels
-  type(c_ptr), bind(c) :: schwarz_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: schwarz_program = C_NULL_PTR
 
   !> Device dong kernels
-  type(c_ptr), bind(c) :: dong_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: dong_program = C_NULL_PTR
 
   !> Device coef kernels
-  type(c_ptr), bind(c) :: coef_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: coef_program = C_NULL_PTR
 
   !> Device scalar residual kernels
-  type(c_ptr), bind(c) :: scalar_residual_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: scalar_residual_program = C_NULL_PTR
 
   !> Device lambda2 kernels
-  type(c_ptr), bind(c) :: lambda2_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: lambda2_program = C_NULL_PTR
 
   !> Device filter kernels
-  type(c_ptr), bind(c) :: filter_program = C_NULL_PTR
+  type(c_ptr), public, bind(c) :: filter_program = C_NULL_PTR
 
+  public :: opencl_prgm_lib_release
+  
 contains
 
   subroutine opencl_prgm_lib_release

--- a/src/field/field.f90
+++ b/src/field/field.f90
@@ -40,6 +40,7 @@ module field
   use mesh, only : mesh_t
   use space, only : space_t, operator(.ne.)
   use dofmap, only : dofmap_t
+  use, intrinsic :: iso_c_binding
   implicit none
   private
 

--- a/src/gs/bcknd/device/gs_device_mpi.F90
+++ b/src/gs/bcknd/device/gs_device_mpi.F90
@@ -40,7 +40,8 @@ module gs_device_mpi
   use htable, only : htable_i4_t
   use device
   use utils, only : neko_error
-  use, intrinsic :: iso_c_binding, only : c_sizeof, c_int32_t
+  use, intrinsic :: iso_c_binding, only : c_sizeof, c_int32_t, &
+       c_ptr, C_NULL_PTR, c_size_t, c_associated
   implicit none
   private
 

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -45,13 +45,14 @@ module gather_scatter
   use comm
   use dofmap, only : dofmap_t
   use field, only : field_t
-  use num_types, only : rp, dp, i2
+  use num_types, only : rp, dp, i2, i8
   use htable, only : htable_i8_t, htable_iter_i8_t
   use stack, only : stack_i4_t
   use utils, only : neko_error, linear_index
   use logger, only : neko_log, LOG_SIZE
   use profiler, only : profiler_start_region, profiler_end_region
   use device
+  use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR
   implicit none
   private
 

--- a/src/io/nmsh_file.f90
+++ b/src/io/nmsh_file.f90
@@ -48,7 +48,7 @@ module nmsh_file
        MPI_MODE_WRONLY, MPI_MODE_CREATE, MPI_MODE_RDONLY, MPI_INFO_NULL, &
        MPI_File_open, MPI_File_close, MPI_File_read_all, MPI_File_write_all, &
        MPI_File_write_at_all, MPI_File_read_at_all, MPI_INTEGER, MPI_SUM, &
-       MPI_Exscan, MPI_Barrier, MPI_Type_size
+       MPI_Exscan, MPI_Barrier, MPI_Type_size, MPI_Allreduce, MPI_File_sync
   use logger, only: neko_log, LOG_SIZE
   implicit none
 

--- a/src/krylov/bcknd/cpu/gmres.f90
+++ b/src/krylov/bcknd/cpu/gmres.f90
@@ -41,6 +41,7 @@ module gmres
   use gather_scatter, only : gs_t, GS_OP_ADD
   use bc_list, only : bc_list_t
   use math, only : glsc3, rzero, rone, copy, sub2, cmult2, abscmp
+  use neko_config, only : NEKO_BLK_SIZE
   use comm
   implicit none
   private

--- a/src/krylov/bcknd/device/cg_device.f90
+++ b/src/krylov/bcknd/device/cg_device.f90
@@ -43,7 +43,8 @@ module cg_device
   use math, only : abscmp
   use device
   use device_math, only : device_rzero, device_copy, device_glsc3, &
-                          device_add2s2, device_add2s1
+       device_add2s2, device_add2s1
+  use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR, c_associated
   implicit none
 
   !> Device based preconditioned conjugate gradient method

--- a/src/krylov/bcknd/device/cheby_device.F90
+++ b/src/krylov/bcknd/device/cheby_device.F90
@@ -45,6 +45,7 @@ module cheby_device
   use device_math, only : device_cmult2, device_sub2, &
        device_add2s1, device_add2s2, device_glsc3, device_copy
   use device
+  use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR, c_associated
   implicit none
   private
 

--- a/src/krylov/bcknd/device/fusedcg_cpld_device.F90
+++ b/src/krylov/bcknd/device/fusedcg_cpld_device.F90
@@ -43,7 +43,11 @@ module fusedcg_cpld_device
   use math, only : glsc3, rzero, copy, abscmp
   use device_math, only : device_rzero, device_copy, device_glsc3, device_glsc2
   use device
-  use comm
+  use utils, only : neko_error
+  use comm, only : NEKO_COMM, MPI_IN_PLACE, MPI_Allreduce, &
+       MPI_SUM, MPI_REAL_PRECISION, pe_size
+  use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR, &
+       c_associated, c_size_t, c_sizeof, c_int, c_loc
   implicit none
   private
 

--- a/src/krylov/bcknd/device/fusedcg_device.F90
+++ b/src/krylov/bcknd/device/fusedcg_device.F90
@@ -43,7 +43,11 @@ module fusedcg_device
   use math, only : glsc3, rzero, copy, abscmp
   use device_math, only : device_rzero, device_copy, device_glsc3
   use device
-  use comm
+  use utils, only : neko_error
+  use comm, only : NEKO_COMM, MPI_Allreduce, MPI_IN_PLACE, &
+       MPI_REAL_PRECISION, MPI_SUM, pe_size
+  use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR, &
+       c_associated, c_size_t, c_sizeof, c_int, c_loc
   implicit none
   private
 

--- a/src/krylov/bcknd/device/gmres_device.F90
+++ b/src/krylov/bcknd/device/gmres_device.F90
@@ -32,6 +32,7 @@
 !
 !> Defines various GMRES methods
 module gmres_device
+  use neko_config, only : NEKO_BCKND_OPENCL
   use krylov, only : ksp_t, ksp_monitor_t
   use precon, only : pc_t
   use ax_product, only : ax_t
@@ -47,8 +48,11 @@ module gmres_device
                           device_cmult2, device_add2s2_many, device_glsc3_many,&
                           device_sub2
   use device
-  use comm
-  use, intrinsic :: iso_c_binding
+  use utils, only : neko_error
+  use comm, only : NEKO_COMM, MPI_IN_PLACE, MPI_SUM, MPI_REAL_PRECISION, &
+       MPI_Allreduce, pe_size
+  use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR, c_loc, &
+       c_associated, c_int, c_size_t, c_sizeof
   implicit none
   private
 

--- a/src/krylov/bcknd/device/pc_jacobi_device.F90
+++ b/src/krylov/bcknd/device/pc_jacobi_device.F90
@@ -1,4 +1,4 @@
-! Copyright (c) 2021-2022, The Neko Authors
+! Copyright (c) 2021-2025, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -32,13 +32,14 @@
 !
 !> Jacobi preconditioner accelerator backend
 module device_jacobi
-  use precon
-  use coefs
-  use dofmap
-  use num_types
+  use precon, only : pc_t
+  use coefs, only : coef_t
+  use dofmap, only : dofmap_t
+  use num_types, only : rp
   use device_math
   use device
-  use gather_scatter
+  use gather_scatter, only : gs_t, GS_OP_ADD
+  use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR, c_associated
   implicit none
   private
 

--- a/src/krylov/bcknd/device/pipecg_device.F90
+++ b/src/krylov/bcknd/device/pipecg_device.F90
@@ -44,7 +44,12 @@ module pipecg_device
   use device_math, only : device_rzero, device_copy, &
        device_glsc3, device_vlsc3
   use device
-  use comm
+  use utils, only : neko_error
+  use comm, only : NEKO_COMM, pe_size, MPI_Iallreduce, MPI_Status, &
+       MPI_REAL_PRECISION, MPI_SUM, MPI_IN_PLACE, MPI_Request, &
+       MPI_Wait
+  use, intrinsic :: iso_c_binding, only :  c_ptr, C_NULL_PTR, &
+       c_associated, c_size_t, c_sizeof, c_int, c_loc
   implicit none
   private
 

--- a/src/krylov/pc_hsmg.f90
+++ b/src/krylov/pc_hsmg.f90
@@ -86,6 +86,7 @@ module hsmg
        krylov_solver_factory, krylov_solver_destroy
   use tree_amg_multigrid, only : tamg_solver_t
   use zero_dirichlet, only : zero_dirichlet_t
+  use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR, c_associated
   !$ use omp_lib
   implicit none
   private

--- a/src/math/matrix.f90
+++ b/src/math/matrix.f90
@@ -35,7 +35,7 @@ module matrix
   use neko_config, only: NEKO_BCKND_DEVICE
   use math, only: sub3, chsign, add3, cmult2, cadd2
   use num_types, only: rp
-  use device, only: device_map, device_free, c_ptr, C_NULL_PTR
+  use device, only: device_map, device_free
   use device_math, only: device_copy, device_cfill, device_cmult, &
        device_sub3, device_cmult2, device_add3, device_cadd2
   use utils, only: neko_error

--- a/src/math/operators.f90
+++ b/src/math/operators.f90
@@ -53,10 +53,12 @@ module operators
   use interpolation, only : interpolator_t
   use math, only : glsum, cmult, add2, add3s2, cadd, copy, col2, invcol2, &
                    invcol3, rzero
-  use device, only : c_ptr, device_get_ptr
-  use device_math, only : device_add2, device_cmult, device_copy, device_glsum, device_cadd
+  use device, only : device_get_ptr
+  use device_math, only : device_add2, device_cmult, device_copy, device_glsum, &
+       device_cadd
   use scratch_registry, only : neko_scratch_registry
   use comm
+  use, intrinsic :: iso_c_binding, only : c_ptr
   implicit none
   private
 

--- a/src/math/vector.f90
+++ b/src/math/vector.f90
@@ -35,7 +35,7 @@ module vector
   use neko_config, only: NEKO_BCKND_DEVICE
   use math, only: sub3, add3, cmult2, cadd2, cfill
   use num_types, only: rp
-  use device, only: device_map, device_free, c_ptr, C_NULL_PTR
+  use device, only: device_map, device_free
   use device_math, only: device_copy, device_cfill, device_cmult, &
        device_sub3, device_cmult2, device_add3, device_cadd2
   use utils, only: neko_error

--- a/src/mesh/point_zone.f90
+++ b/src/mesh/point_zone.f90
@@ -39,7 +39,7 @@ module point_zone
   use json_module, only: json_file
   use neko_config, only: NEKO_BCKND_DEVICE
   use device
-  use, intrinsic :: iso_c_binding, only: c_ptr, c_null_ptr
+  use, intrinsic :: iso_c_binding, only: c_ptr, c_null_ptr, c_associated
   implicit none
   private
 

--- a/src/sem/dofmap.f90
+++ b/src/sem/dofmap.f90
@@ -46,7 +46,7 @@ module dofmap
   use element, only : element_t
   use quad, only : quad_t
   use hex, only : hex_t
-  use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR
+  use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR, c_associated
   implicit none
   private
 

--- a/src/sem/interpolation.f90
+++ b/src/sem/interpolation.f90
@@ -39,6 +39,8 @@ module interpolation
   use tensor, only : tnsr3d
   use tensor_cpu, only : tnsr3d_cpu
   use space, only : space_t, operator(.eq.), GL, GLL
+  use utils, only : neko_error
+  use, intrinsic :: iso_c_binding
   implicit none
   private
 

--- a/src/sem/local_interpolation.f90
+++ b/src/sem/local_interpolation.f90
@@ -45,14 +45,16 @@ module local_interpolation
   use device
   use device_math, only: device_rzero
   use neko_config, only: NEKO_BCKND_DEVICE
+  use, intrinsic :: iso_c_binding
   implicit none
+  private
 
   !> Interpolation on a set of points with known rst coordinates in elements local
   !! to this process.
   !! Similar to point_interpolator, but prioritizes performance
   !! Only works with arrays of coordinates
   !! Performs interpolation with the configured NEKO_BCKND
-  type :: local_interpolator_t
+  type, public :: local_interpolator_t
      !> First space.
      type(space_t), pointer :: Xh => null()
      !> Number of points to interpolate on

--- a/src/source_terms/brinkman/elementwise_filter.f90
+++ b/src/source_terms/brinkman/elementwise_filter.f90
@@ -46,10 +46,9 @@ module elementwise_filter
   use matrix, only : matrix_t
   use mxm_wrapper, only : mxm
   use tensor, only : tnsr3d, trsp
-  use device, only : device_map, device_free, c_ptr, &
-                    C_NULL_PTR, device_memcpy, HOST_TO_DEVICE
+  use device, only : device_map, device_free, device_memcpy, HOST_TO_DEVICE
   use device_math, only : device_cfill
-  use, intrinsic :: iso_c_binding
+  use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR, c_associated
   implicit none
   private
 


### PR DESCRIPTION
This PR makes the `device` module private

In contrast to PR #1692, these changes fixes the errors with gfortran 13 described in #1686, and in contrast to #1692 it does not prodice an ICE with gfortran.



