### PR TITLE
Add option to write a field with zone ids to mesh_checker

### DIFF
--- a/contrib/mesh_checker/mesh_checker.f90
+++ b/contrib/mesh_checker/mesh_checker.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018-2023, The Neko Authors
+! Copyright (c) 2024-2025, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -42,12 +42,22 @@ program mesh_checker
   character(len=LOG_SIZE) :: log_buf
   integer :: total_size, inlet_size, wall_size, periodic_size
   integer :: outlet_size, symmetry_size, outlet_normal_size
+  type(dirichlet_t) :: bdry_mask
+  type(field_t) :: bdry_field
+  type(file_t) :: bdry_file
+  type(space_t) :: Xh
+  type(gs_t) :: gs
+  type(coef_t) :: coef
+  type(dofmap_t) :: dofmap
+  logical :: write_zone_ids
 
   argc = command_argument_count()
 
   if (argc .lt. 1) then
      if (pe_rank .eq. 0) then
-        write(*,*) 'Usage: ./mesh_checker mesh.nmsh'
+        write(*,*) 'Usage: ./mesh_checker mesh.nmsh [--write_zone_ids]'
+        write(*,*) '--write-zone-ids : write a field file with boundaries &
+        & marked by zone ID.'
      end if
      stop
   end if
@@ -56,6 +66,17 @@ program mesh_checker
 
   call get_command_argument(1, inputchar)
   read(inputchar, *) mesh_fname
+
+  write_zone_ids = .false.
+
+  ! Check for optional boolean flag
+  do i = 2, argc
+     call get_command_argument(i, inputchar)
+     if (trim(inputchar) == "--write_zone_ids") then
+         write_zone_ids = .true.
+     end if
+  end do
+
 
   mesh_file = file_t(trim(mesh_fname))
 
@@ -89,28 +110,58 @@ program mesh_checker
       write(*,*) 'Number of built-in inlet faces:         ', inlet_size
       write(*,*) 'Number of built-in wall faces:          ', wall_size
       write(*,*) 'Number of built-in outlet faces:        ', outlet_size
-      write(*,*) 'Number of built-in outlet-normal faces: ', outlet_normal_size 
-      write(*,*) 'Number of built-in symmetry faces:      ', symmetry_size 
+      write(*,*) 'Number of built-in outlet-normal faces: ', outlet_normal_size
+      write(*,*) 'Number of built-in symmetry faces:      ', symmetry_size
       write(*,*) 'Number of periodic faces:               ', periodic_size
       write(*,*) ''
       if (total_size .gt. 0) then
          write(*,*) 'WARNING: Your mesh contains non-periodic "built-in" zones,&
-              & which are deprecated. Your mesh must have been created natively& 
+              & which are deprecated. Your mesh must have been created natively&
               & by Nek5000, e.g. with genbox.'
       end if
       write(*,*) 'Labeled zones: '
   end if
 
-      do i = 1, size(msh%labeled_zones) 
+      do i = 1, size(msh%labeled_zones)
 
          call MPI_Allreduce(msh%labeled_zones(i)%size, total_size, 1, &
               MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
          if (total_size .gt. 0 .and. pe_rank .eq. 0) then
             write(*,'(A,I2,A,I0,A)') '    Zone ', i, ': ', total_size, &
                  ' faces'
-            
+
          end if
       end do
+
+
+  if (write_zone_ids) then
+     if (pe_rank .eq. 0) write(*,*) 'Writing zone ids to zoneids0.f00000'
+     call Xh%init(1, 2, 2, 2)
+     call dofmap%init(msh, Xh)
+     call gs%init(dofmap)
+     call coef%init(gs)
+
+     call bdry_field%init(dofmap)
+
+
+     do i = 1, size(msh%labeled_zones)
+          call bdry_mask%init_from_components(coef, real(i, kind=rp))
+          call bdry_mask%mark_zone(msh%labeled_zones(i))
+          call bdry_mask%finalize()
+          call bdry_mask%apply_scalar(bdry_field%x, dofmap%size())
+          call bdry_mask%free()
+     end do
+
+     bdry_file = file_t('zone_ids.fld')
+     call bdry_file%write(bdry_field)
+
+     call Xh%free()
+     call gs%free()
+     call dofmap%free()
+     call bdry_field%free()
+     call msh%free()
+     call bdry_mask%free()
+  end if
 
   if (pe_rank .eq. 0) write(*,*) 'Done'
   call neko_finalize

--- a/contrib/mesh_checker/mesh_checker.f90
+++ b/contrib/mesh_checker/mesh_checker.f90
@@ -57,7 +57,7 @@ program mesh_checker
      if (pe_rank .eq. 0) then
         write(*,*) 'Usage: ./mesh_checker mesh.nmsh [--write_zone_indices]'
         write(*,*) '--write_zone_indices : write a field file with boundaries &
-        & marked by zone index.'
+             & marked by zone index.'
      end if
      stop
   end if
@@ -72,7 +72,7 @@ program mesh_checker
   do i = 2, argc
      call get_command_argument(i, inputchar)
      if (trim(inputchar) == "--write_zone_indices") then
-         write_zone_ids = .true.
+        write_zone_ids = .true.
      end if
   end do
 
@@ -97,39 +97,39 @@ program mesh_checker
        + symmetry_size
 
   if (pe_rank .eq. 0) then
-      write(*,*) ''
-      write(*,*) '--------------Size-------------'
-      write(*,*) 'Number of elements: ', msh%glb_nelv
-      write(*,*) 'Number of points:   ', msh%glb_mpts
-      write(*,*) 'Number of faces:    ', msh%glb_mfcs
-      write(*,*) 'Number of edges:    ', msh%glb_meds
-      write(*,*) ''
-      write(*,*) '--------------Zones------------'
-      write(*,*) 'Number of built-in inlet faces:         ', inlet_size
-      write(*,*) 'Number of built-in wall faces:          ', wall_size
-      write(*,*) 'Number of built-in outlet faces:        ', outlet_size
-      write(*,*) 'Number of built-in outlet-normal faces: ', outlet_normal_size
-      write(*,*) 'Number of built-in symmetry faces:      ', symmetry_size
-      write(*,*) 'Number of periodic faces:               ', periodic_size
-      write(*,*) ''
-      if (total_size .gt. 0) then
-         write(*,*) 'WARNING: Your mesh contains non-periodic "built-in" zones,&
-              & which are deprecated. Your mesh must have been created natively&
-              & by Nek5000, e.g. with genbox.'
-      end if
-      write(*,*) 'Labeled zones: '
+     write(*,*) ''
+     write(*,*) '--------------Size-------------'
+     write(*,*) 'Number of elements: ', msh%glb_nelv
+     write(*,*) 'Number of points:   ', msh%glb_mpts
+     write(*,*) 'Number of faces:    ', msh%glb_mfcs
+     write(*,*) 'Number of edges:    ', msh%glb_meds
+     write(*,*) ''
+     write(*,*) '--------------Zones------------'
+     write(*,*) 'Number of built-in inlet faces:         ', inlet_size
+     write(*,*) 'Number of built-in wall faces:          ', wall_size
+     write(*,*) 'Number of built-in outlet faces:        ', outlet_size
+     write(*,*) 'Number of built-in outlet-normal faces: ', outlet_normal_size
+     write(*,*) 'Number of built-in symmetry faces:      ', symmetry_size
+     write(*,*) 'Number of periodic faces:               ', periodic_size
+     write(*,*) ''
+     if (total_size .gt. 0) then
+        write(*,*) 'WARNING: Your mesh contains non-periodic "built-in" zones,&
+             & which are deprecated. Your mesh must have been created natively&
+             & by Nek5000, e.g. with genbox.'
+     end if
+     write(*,*) 'Labeled zones: '
   end if
 
-      do i = 1, size(msh%labeled_zones)
+  do i = 1, size(msh%labeled_zones)
 
-         call MPI_Allreduce(msh%labeled_zones(i)%size, total_size, 1, &
-              MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
-         if (total_size .gt. 0 .and. pe_rank .eq. 0) then
-            write(*,'(A,I2,A,I0,A)') '    Zone ', i, ': ', total_size, &
-                 ' faces'
+     call MPI_Allreduce(msh%labeled_zones(i)%size, total_size, 1, &
+          MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
+     if (total_size .gt. 0 .and. pe_rank .eq. 0) then
+        write(*,'(A,I2,A,I0,A)') '    Zone ', i, ': ', total_size, &
+             ' faces'
 
-         end if
-      end do
+     end if
+  end do
 
   if (write_zone_ids) then
      if (pe_rank .eq. 0) write(*,*) 'Writing zone ids to zone_indices0.f00000'
@@ -141,11 +141,11 @@ program mesh_checker
      call bdry_field%init(dofmap)
 
      do i = 1, size(msh%labeled_zones)
-          call bdry_mask%init_from_components(coef, real(i, kind=rp))
-          call bdry_mask%mark_zone(msh%labeled_zones(i))
-          call bdry_mask%finalize()
-          call bdry_mask%apply_scalar(bdry_field%x, dofmap%size())
-          call bdry_mask%free()
+        call bdry_mask%init_from_components(coef, real(i, kind=rp))
+        call bdry_mask%mark_zone(msh%labeled_zones(i))
+        call bdry_mask%finalize()
+        call bdry_mask%apply_scalar(bdry_field%x, dofmap%size())
+        call bdry_mask%free()
      end do
 
      bdry_file = file_t('zone_indices.fld')

--- a/contrib/mesh_checker/mesh_checker.f90
+++ b/contrib/mesh_checker/mesh_checker.f90
@@ -76,7 +76,6 @@ program mesh_checker
      end if
   end do
 
-
   mesh_file = file_t(trim(mesh_fname))
 
   call mesh_file%read(msh)
@@ -132,7 +131,6 @@ program mesh_checker
          end if
       end do
 
-
   if (write_zone_ids) then
      if (pe_rank .eq. 0) write(*,*) 'Writing zone ids to zone_ids0.f00000'
      call Xh%init(1, 2, 2, 2)
@@ -141,7 +139,6 @@ program mesh_checker
      call coef%init(gs)
 
      call bdry_field%init(dofmap)
-
 
      do i = 1, size(msh%labeled_zones)
           call bdry_mask%init_from_components(coef, real(i, kind=rp))

--- a/contrib/mesh_checker/mesh_checker.f90
+++ b/contrib/mesh_checker/mesh_checker.f90
@@ -69,7 +69,6 @@ program mesh_checker
 
   write_zone_ids = .false.
 
-  ! Check for optional boolean flag
   do i = 2, argc
      call get_command_argument(i, inputchar)
      if (trim(inputchar) == "--write_zone_ids") then
@@ -135,7 +134,7 @@ program mesh_checker
 
 
   if (write_zone_ids) then
-     if (pe_rank .eq. 0) write(*,*) 'Writing zone ids to zoneids0.f00000'
+     if (pe_rank .eq. 0) write(*,*) 'Writing zone ids to zone_ids0.f00000'
      call Xh%init(1, 2, 2, 2)
      call dofmap%init(msh, Xh)
      call gs%init(dofmap)

--- a/contrib/mesh_checker/mesh_checker.f90
+++ b/contrib/mesh_checker/mesh_checker.f90
@@ -55,9 +55,9 @@ program mesh_checker
 
   if (argc .lt. 1) then
      if (pe_rank .eq. 0) then
-        write(*,*) 'Usage: ./mesh_checker mesh.nmsh [--write_zone_ids]'
-        write(*,*) '--write-zone-ids : write a field file with boundaries &
-        & marked by zone ID.'
+        write(*,*) 'Usage: ./mesh_checker mesh.nmsh [--write_zone_indices]'
+        write(*,*) '--write_zone_indices : write a field file with boundaries &
+        & marked by zone index.'
      end if
      stop
   end if
@@ -71,7 +71,7 @@ program mesh_checker
 
   do i = 2, argc
      call get_command_argument(i, inputchar)
-     if (trim(inputchar) == "--write_zone_ids") then
+     if (trim(inputchar) == "--write_zone_indices") then
          write_zone_ids = .true.
      end if
   end do
@@ -132,7 +132,7 @@ program mesh_checker
       end do
 
   if (write_zone_ids) then
-     if (pe_rank .eq. 0) write(*,*) 'Writing zone ids to zone_ids0.f00000'
+     if (pe_rank .eq. 0) write(*,*) 'Writing zone ids to zone_indices0.f00000'
      call Xh%init(1, 2, 2, 2)
      call dofmap%init(msh, Xh)
      call gs%init(dofmap)
@@ -148,7 +148,7 @@ program mesh_checker
           call bdry_mask%free()
      end do
 
-     bdry_file = file_t('zone_ids.fld')
+     bdry_file = file_t('zone_indices.fld')
      call bdry_file%write(bdry_field)
 
      call Xh%free()

--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -167,6 +167,11 @@ you have two zones, which should be no-slip walls, you can either create two
 `no_slip` conditions, one for each zone, or just create a single condition and
 apply it to both.
 
+The indices your boundaries have is determined by the mesh. To check them, you
+can use the `mesh_checker` utility with the optional `--write_zone_ids`
+argument. This will output a `zone_ids0.f00000` file that you can inspect in
+Paraview, and the boundaries will be marked by their index value.
+
 Recall that periodic conditions are built into the mesh, since they are
 topological in nature. This means that you must not specify any conditions for
 the corresponding zones. For example, in the `turb_pipe` example, which is a

--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -168,8 +168,8 @@ you have two zones, which should be no-slip walls, you can either create two
 apply it to both.
 
 The indices your boundaries have is determined by the mesh. To check them, you
-can use the `mesh_checker` utility with the optional `--write_zone_ids`
-argument. This will output a `zone_ids0.f00000` file that you can inspect in
+can use the `mesh_checker` utility with the optional `--write_zone_indices`
+argument. This will output a `zone_indices0.f00000` file that you can inspect in
 Paraview, and the boundaries will be marked by their index value.
 
 Recall that periodic conditions are built into the mesh, since they are


### PR DESCRIPTION
Should be very handy for setting the zone_id for boundary conditions.