### PR TITLE
Add option for fluid statistics filename

### DIFF
--- a/doc/pages/user-guide/statistics-guide.md
+++ b/doc/pages/user-guide/statistics-guide.md
@@ -35,10 +35,12 @@ Statistics are enable in the the case file as a simcomp with the added argument 
 | `avg_direction`        | Directions to compute spatial average.                         | x,y,z,xy,xz,yz  |  No spatial average           |
 | `set_of_stats`        | What set of stats to compute.                         | basic, full  |  full         |
 | `compute_value` | Interval, in timesteps or simulationtime, depending on compute\_control, for sampling the flow fields for statistics. | Positive real or int  | Not set (but recommended with every 50 timesteps or so  |
+| `output_filename`        | Userspecified filename to store output in                         | filename.fld  |  fluid_statsX*        |
 
-In addition to the usual controls for the output, which then outputs the averages computes from the last time the statistics were written to file.
+\*The name of the written statistics file will by default be `fluid_statsX_0.f0000X,..., fluid_statsX_0.f0000Y` where X is the number of the first outputted statistic of the current run.
 
-For example, if one wants to compute only the basic statistics and sample the fields every 4 time steps and compute and output batches every 20 time units and have an initial transient of 60 time units the following would work:
+
+In addition, one can specify the usual controles for the output, which then outputs the averages computes from the last time the statistics were written to file. For example, if one wants to compute only the basic statistics and sample the fields every 4 time steps and compute and output batches every 20 time units and have an initial transient of 60 time units the following would work:
 
 ~~~~~~~~~~~~~~~{.json}
 "simulation_components": 
@@ -59,7 +61,7 @@ For example, if one wants to compute only the basic statistics and sample the fi
 @attention For simulations requiring restarts, it is recommended to run each 
 restart in a different output directory as a precaution to avoid potential overwritings of files.
 
-Preferably set the initial transient to a multiple of output_value as otherwise the first output will be slightly shorter than the rest. The code related to fluid statistics are located in fluid_stats and fluid_stats_simcomp. The name of the outputted statistics will by default be `fluid_statsX_0.f0000X,..., fluid_statsX_0.f0000Y` where X is the number of the first outputted statistic of the current run.
+Preferably set the initial transient to a multiple of output_value as otherwise the first output will be slightly shorter than the rest. The code related to fluid statistics are located in fluid_stats and fluid_stats_simcomp. 
 
 The argument "avg_direction" is optional and if ignored we output 3d fields. The statistics are saved in a fld file according to the following in 2D and 3D. Observe that in 2D the mean Z-velocity is stored in a last scalar field. All other fields are kept the same. This is due to a limitation of the fld file format.
 

--- a/doc/pages/user-guide/statistics-guide.md
+++ b/doc/pages/user-guide/statistics-guide.md
@@ -35,12 +35,11 @@ Statistics are enable in the the case file as a simcomp with the added argument 
 | `avg_direction`        | Directions to compute spatial average.                         | x,y,z,xy,xz,yz  |  No spatial average           |
 | `set_of_stats`        | What set of stats to compute.                         | basic, full  |  full         |
 | `compute_value` | Interval, in timesteps or simulationtime, depending on compute\_control, for sampling the flow fields for statistics. | Positive real or int  | Not set (but recommended with every 50 timesteps or so  |
-| `output_filename`        | Userspecified filename to store output in                         | filename.fld  |  fluid_statsX*        |
+| `output_filename`        | Userspecified filename to store output in.                       | filename.fld  |  fluid_statsX*        |
 
 \*The name of the written statistics file will by default be `fluid_statsX_0.f0000X,..., fluid_statsX_0.f0000Y` where X is the number of the first outputted statistic of the current run.
 
-
-In addition, one can specify the usual controles for the output, which then outputs the averages computes from the last time the statistics were written to file. For example, if one wants to compute only the basic statistics and sample the fields every 4 time steps and compute and output batches every 20 time units and have an initial transient of 60 time units the following would work:
+In addition, one can specify the usual controls for the output, which then outputs the averages computes from the last time the statistics were written to file. For example, if one wants to compute only the basic statistics and sample the fields every 4 time steps and compute and output batches every 20 time units and have an initial transient of 60 time units the following would work:
 
 ~~~~~~~~~~~~~~~{.json}
 "simulation_components": 

--- a/src/simulation_components/fluid_stats_simcomp.f90
+++ b/src/simulation_components/fluid_stats_simcomp.f90
@@ -67,6 +67,8 @@ module fluid_stats_simcomp
      !> Time value at which the sampling of statistics is initiated.
      real(kind=rp) :: start_time
      real(kind=rp) :: time
+     logical :: default_fname = .true.
+
    contains
      !> Constructor from json, wrapping the actual constructor.
      procedure, pass(this) :: init => fluid_stats_simcomp_init_from_json
@@ -93,7 +95,6 @@ contains
     type(json_file), intent(inout) :: json
     class(case_t), intent(inout), target :: case
     character(len=:), allocatable :: filename
-    character(len=:), allocatable :: precision
     character(len=20), allocatable :: fields(:)
     character(len=:), allocatable :: hom_dir
     character(len=:), allocatable :: stat_set
@@ -109,13 +110,21 @@ contains
     call json_get_or_default(json, 'set_of_stats', &
          stat_set, 'full')
 
+
     u => neko_field_registry%get_field("u")
     v => neko_field_registry%get_field("v")
     w => neko_field_registry%get_field("w")
     p => neko_field_registry%get_field("p")
     coef => case%fluid%c_Xh
-    call fluid_stats_simcomp_init_from_attributes(this, u, v, w, p, coef, &
-         start_time, hom_dir, stat_set)
+
+    if (json%valid_path("output_filename")) then
+       call json_get(json, "output_filename", filename)
+       call fluid_stats_simcomp_init_from_attributes(this, u, v, w, p, coef, &
+            start_time, hom_dir, stat_set,filename)
+    else
+       call fluid_stats_simcomp_init_from_attributes(this, u, v, w, p, coef, &
+            start_time, hom_dir, stat_set)
+    end if
 
   end subroutine fluid_stats_simcomp_init_from_json
 
@@ -128,15 +137,16 @@ contains
   !! @param hom_dir directions to average in
   !! @param stat_set Set of statistics to compute (basic/full)
   subroutine fluid_stats_simcomp_init_from_attributes(this, u, v, w, p, coef, &
-       start_time, hom_dir, stat_set)
+       start_time, hom_dir, stat_set, fname)
     class(fluid_stats_simcomp_t), intent(inout) :: this
     character(len=*), intent(in) :: hom_dir
     character(len=*), intent(in) :: stat_set
     real(kind=rp), intent(in) :: start_time
     type(field_t), intent(inout) :: u, v, w, p !>Should really be intent in I think
     type(coef_t), intent(in) :: coef
+    character(len=*), intent(in), optional :: fname
+    character(len=NEKO_FNAME_LEN) :: stats_fname
     character(len=LOG_SIZE) :: log_buf
-    character(len=NEKO_FNAME_LEN) :: fname
     character(len=5) :: prefix
 
     call neko_log%section('Fluid stats')
@@ -156,8 +166,15 @@ contains
     call this%stats_output%init(this%stats, this%start_time, &
          hom_dir = hom_dir, path = this%case%output_directory)
     write (prefix, '(I5)') this%stats_output%file_%get_counter()
-    fname = "fluid_stats"//trim(adjustl(prefix))//"_.fld"
-    call this%stats_output%init_base(fname)
+    if (present(fname)) then
+       this%default_fname = .false.
+       stats_fname = fname
+    else
+       stats_fname = "fluid_stats"//trim(adjustl(prefix))//"_.fld"
+       this%default_fname = .true.
+    end if
+
+    call this%stats_output%init_base(stats_fname)
 
     call this%case%output_controller%add(this%stats_output, &
          this%output_controller%control_value, &
@@ -180,10 +197,11 @@ contains
     character(len=NEKO_FNAME_LEN) :: fname
     character(len=5) :: prefix
     if (t .gt. this%time) this%time = t
-
-    write (prefix, '(I5)') this%stats_output%file_%get_counter()
-    fname = "fluid_stats"//trim(adjustl(prefix))//"_.fld"
-    call this%stats_output%init_base(fname)
+    if (this%default_fname) then
+       write (prefix, '(I5)') this%stats_output%file_%get_counter()
+       fname = "fluid_stats"//trim(adjustl(prefix))//"_.fld"
+       call this%stats_output%init_base(fname)
+    end if
   end subroutine fluid_stats_simcomp_restart
 
   !> fluid_stats, called depending on compute_control and compute_value


### PR DESCRIPTION
There was a suggestion to have the option to be able to get the same behavior as before for the stats.

With this it is possible to replicate the original behavior if one wants to by setting the filename to "fluid_stats.fld".

One can also set some other name if they want to.

Maybe we should add this keyword to the top of the simulation components at some point as well. 