### PR TITLE
Counter is not always a proper number

### DIFF
--- a/src/io/generic_file.f90
+++ b/src/io/generic_file.f90
@@ -37,7 +37,7 @@ module generic_file
   !> A generic file handler.
   type, abstract :: generic_file_t
      character(len=1024) :: fname
-     integer :: counter
+     integer :: counter = 0
      integer :: start_counter = 0
      !> File format is serial
      logical :: serial = .false.


### PR DESCRIPTION
Maybe should look more into this, but fixes it for me at least. I think I access the get_counter before the file is initialized.