### PR TITLE
Add linting and formatting scripts with README updates

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -57,7 +57,7 @@ jobs:
             if [[ ${file: -4} != ".f90" && ${file: -4} != ".F90" ]]; then
               continue
             fi
-            findent -Rr -i2 -d3 -f3 -s3 -c3 -w3 -t3 -j3 -k5 --ws_remred --indent_ampersand --openmp=0 < $file > $file.tmp
+            findent -Rr -i2 -d3 -f3 -s3 -c3 -w3 -t3 -j3 -k- --ws_remred --indent_ampersand --openmp=0 < $file > $file.tmp
             mv -f $file.tmp $file
           done
 
@@ -68,7 +68,7 @@ jobs:
             echo "" >&2
             echo "Please run the following commands to fix the formatting:" >&2
             echo "pip install findent" >&2
-            echo "findent -Rr -i2 -d3 -f3 -s3 -c3 -w3 -t3 -j3 -k5 --ws_remred --indent_ampersand --openmp=0 <file.f90 >file.f90.tmp" >&2
+            echo "findent -Rr -i2 -d3 -f3 -s3 -c3 -w3 -t3 -j3 -k- --ws_remred --indent_ampersand --openmp=0 <file.f90 >file.f90.tmp" >&2
             echo "mv file.f90.tmp file.f90" >&2
             git diff >&2
             exit 1

--- a/contrib/lint_format/format.sh
+++ b/contrib/lint_format/format.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Formatting helper script for Fortran files
+# This script uses the findent tool to format the Fortran files
+# The findent tool can be installed using the following command:
+# pip install findent
+
+# ---------------------------------------------------------------------------- #
+# Helper function
+
+function help() {
+    echo "Usage: format.sh [options] [files]"
+    echo "Format Fortran files in the repository."
+    echo "This tool will format the Fortran files using the findent tool."
+    echo "It can be used for specific files or all the modified files in the "
+    echo "repository. Relative paths will be relative to the Neko root directory."
+    echo ""
+    echo "Options:"
+    echo "  -h, --help                Print this help message"
+    echo "  -k, --indent_continuation Set the continuation indentation (default: 5)"
+    echo "      --target_branch       The branch to compare with (default: develop)"
+    echo ""
+    echo "Arguments:"
+    echo "  files                     List of files to format"
+    echo ""
+    echo "If no files are provided, format all the Fortran files in the repository which are modified."
+}
+
+# ---------------------------------------------------------------------------- #
+# Handle options and arguments
+
+# Set the root directory
+ROOT_DIR=$(realpath $(dirname $0)/../../)
+
+# Check if the findent tool is installed
+if ! command -v findent &>/dev/null; then
+    echo "The findent tool is not installed. Please install it using the following command:"
+    echo "pip install findent"
+    exit 1
+fi
+
+# List possible options
+OPTIONS=help,indent_continuation:,target_branch:
+OPT=h,k:
+
+# Assign default values to the options
+CONTINUATION="5"
+
+# Parse the inputs for options
+PARSED=$(getopt --options=$OPT --longoptions=$OPTIONS --name "$0" -- "$@")
+eval set -- "$PARSED"
+
+# Loop through the options and set the variables
+while true; do
+    case "$1" in
+    "-h" | "--help") help && exit ;;                                # Print help
+    "-k" | "--indent_continuation") CONTINUATION="$2" && shift 2 ;; # Continuation indentation
+    "--target_branch") TARGET_BRANCH="$2" && shift 2 ;;             # Target branch
+
+    # End of options
+    "--") shift && break ;;
+    esac
+done
+
+[ $CONTINUATION == "none" ] && CONTINUATION="-"
+
+# Set the options
+FLAGS="-Rr -i2 -d3 -f3 -s3 -c3 -w3 -t3 -j3 --ws_remred --indent_ampersand --openmp=0"
+FLAGS="$FLAGS -k$CONTINUATION"
+
+# If no files are provided, format all the Fortran files in the repository which are modified
+if [ $# -gt 0 ]; then
+    files=($@)
+else
+    echo "Formatting all the modified Fortran files in the repository."
+
+    git fetch origin $TARGET_BRANCH
+    files=($(git diff --name-only --diff-filter=d origin/$TARGET_BRANCH))
+fi
+
+# Prepend the root directory to the files if they are not absolute paths and
+# trim the leading ./ if present
+for i in ${!files[@]}; do
+    if [[ ${files[$i]} != /* ]]; then
+        files[$i]="$(realpath $ROOT_DIR/${files[$i]})"
+    fi
+done
+
+if [ ${#files[@]} -eq 0 ]; then
+    echo "No files to format"
+    exit 0
+fi
+
+for file in ${files[@]}; do
+    if [[ ${file: -4} != ".f90" && ${file: -4} != ".F90" ]]; then
+        continue
+    fi
+
+    printf "\t- $file\n"
+    findent $FLAGS <$file >$file.tmp
+    mv -f $file.tmp $file
+done

--- a/contrib/lint_format/format.sh
+++ b/contrib/lint_format/format.sh
@@ -44,6 +44,7 @@ OPT=h,k:
 
 # Assign default values to the options
 CONTINUATION="5"
+TARGET_BRANCH="develop"
 
 # Parse the inputs for options
 PARSED=$(getopt --options=$OPT --longoptions=$OPTIONS --name "$0" -- "$@")
@@ -73,7 +74,7 @@ if [ $# -gt 0 ]; then
 else
     echo "Formatting all the modified Fortran files in the repository."
 
-    git fetch origin $TARGET_BRANCH
+    git fetch origin $TARGET_BRANCH >/dev/null 2>&1
     files=($(git diff --name-only --diff-filter=d origin/$TARGET_BRANCH))
 fi
 

--- a/contrib/lint_format/lint.sh
+++ b/contrib/lint_format/lint.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# linting helper script for Fortran files
+# This script uses the flinter tool to lint the Fortran files
+# The linter tool can be installed using the following command:
+# pip install flinter nobvisual
+
+# ---------------------------------------------------------------------------- #
+# Helper function
+
+function help() {
+    echo "Usage: lint.sh [options] [files]"
+    echo "Lint Fortran files in the repository."
+    echo "This tool will lint the Fortran files using the flinter tool."
+    echo "It can be used for specific files or all the modified files in the "
+    echo "repository. Relative paths will be relative to the Neko root directory."
+    echo ""
+    echo "Options:"
+    echo "  -h, --help                Print this help message"
+    echo "      --target_branch       The branch to compare with (default: develop)"
+    echo ""
+    echo "Arguments:"
+    echo "  files                     List of files to lint"
+    echo ""
+    echo "If no files are provided, lint all the Fortran files in the repository which are modified."
+}
+
+# ---------------------------------------------------------------------------- #
+# Handle options and arguments
+
+# Set the root directory
+ROOT_DIR=$(realpath $(dirname $0)/../../)
+
+# Check if the flint tool is installed
+if ! command -v flint &>/dev/null; then
+    echo "The flint tool is not installed. Please install it using the following command:"
+    echo "pip install flint nobvisual"
+    exit 1
+fi
+
+# List possible options
+OPTIONS=help,target_branch:
+OPT=h
+
+# Default values for the options
+TARGET_BRANCH="develop"
+
+# Parse the inputs for options
+PARSED=$(getopt --options=$OPT --longoptions=$OPTIONS --name "$0" -- "$@")
+eval set -- "$PARSED"
+
+# Loop through the options and set the variables
+while true; do
+    case "$1" in
+    "-h" | "--help") help && exit ;;                    # Print help
+    "--target_branch") TARGET_BRANCH="$2" && shift 2 ;; # Target branch
+
+    # End of options
+    "--") shift && break ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------- #
+# Handle the files
+
+# If no files are provided, lint all the Fortran files in the repository which
+# are modified.
+if [ $# -gt 0 ]; then
+    files=($@)
+else
+    echo "Formatting all the modified Fortran files in the repository."
+
+    git fetch origin $TARGET_BRANCH >/dev/null 2>&1
+    files=($(git diff --name-only --diff-filter=d origin/$TARGET_BRANCH))
+fi
+
+# Prepend the root directory to the files if they are not absolute paths and
+# trim the leading ./ if present
+for i in ${!files[@]}; do
+    if [[ ${files[$i]} != /* ]]; then
+        files[$i]="$(realpath $ROOT_DIR/${files[$i]})"
+    fi
+done
+
+# ---------------------------------------------------------------------------- #
+# Lint the files
+
+failed_files=()
+printf "Linting files:\n"
+for file in ${files[@]}; do
+
+    # If the file is not a Fortran file, skip it.
+    if [[ ${file: -4} != ".f90" && ${file: -4} != ".F90" ]]; then
+        continue
+    fi
+
+    printf "\t- $file"
+    score=$(flint score -r $ROOT_DIR/flinter_rc.yml $(realpath $file) 2>/dev/null |
+        grep -oP '(?<=\>\|)[^\|\<]+(?=\|\<)')
+    printf ": $score\n"
+
+    if (($(echo "$score < 10" | bc -l))); then
+        failed_files+=($file)
+    fi
+done
+
+if [ ${#failed_files[@]} -eq 0 ]; then
+    echo "All files are linted successfully."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------- #
+# Print possible improvements
+
+printf "Files that can be improved:\n" | tee linter-report.txt
+for file in ${failed_files[@]}; do
+    printf "\t- $file\n" | tee -a linter-report.txt
+done
+
+if [ ${#failed_files[@]} -gt 0 ]; then
+    for file in ${failed_files[@]}; do
+        report=$(flint lint -r $ROOT_DIR/flinter_rc.yml $file)
+        if [ -z "$report" ]; then
+            report=$(flint stats -r $ROOT_DIR/flinter_rc.yml $file)
+        fi
+
+        printf "%.s-" {1..80} | tee -a linter-report.txt
+        printf "\n" | tee -a linter-report.txt
+        printf "Linting improvements for \n\t$file\n\n" | tee -a linter-report.txt
+        echo "$report" | tee -a linter-report.txt
+    done
+fi

--- a/contrib/lint_format/readme.md
+++ b/contrib/lint_format/readme.md
@@ -2,10 +2,26 @@
 
 This repository contains a set of tools to help you lint and format your code.
 
-## Linters
+## Linter
 
+The [linter](lint.sh) script will help you lint your code. It uses the `flint`
+tool to check your code based on the recommended style guide.
 
-## Formatters
+To use the linter, run the following command:
+
+```sh
+./lint.sh <path>
+```
+
+Where `<path>` is the path to the file or directory you want to lint. If you
+don't provide a path, the script will lint all modified fortran files in the
+repository.
+
+The linter will provide a list of suggested improvements to your code. You can
+also see the list of improvements in the report (`flinter-report.txt`) generated
+by the linter.
+
+## Formatter
 
 The [formatter](format.sh) script will help you format your code. It uses the
 `findent` tool to format your code based on the recommended style guide.

--- a/contrib/lint_format/readme.md
+++ b/contrib/lint_format/readme.md
@@ -1,0 +1,23 @@
+# Linting and Formatting tools
+
+This repository contains a set of tools to help you lint and format your code.
+
+## Linters
+
+
+## Formatters
+
+The [formatter](format.sh) script will help you format your code. It uses the
+`findent` tool to format your code based on the recommended style guide.
+
+To use the formatter, run the following command:
+
+```sh
+./format.sh <path>
+```
+
+Where `<path>` is the path to the file or directory you want to format. If you
+don't provide a path, the script will format all modified fortran files in the
+repository.
+
+Additional settings can be found by running `./format.sh --help`.


### PR DESCRIPTION
Introduce a linting script for Fortran files and a formatter script. Update the README to provide usage instructions for both tools.

Additionally we stop forcing people to format continuation lines to 5 spaces