### PR TITLE
Increase field width in logs to prevent overflow

### DIFF
--- a/contrib/genmeshbox/genmeshbox.f90
+++ b/contrib/genmeshbox/genmeshbox.f90
@@ -107,11 +107,11 @@ program genmeshbox
         if (.not. file_exists) then
 
            open(unit=10, file=trim(log_fname), status = 'new', action = 'write')
-           write (10, '(A,2(F10.6," "),I4,L2)') "xmin, xmax, Nel, periodic:", &
+           write (10, '(A,2(F12.6," "),I4,L2)') "xmin, xmax, Nel, periodic:", &
                 x0, x1, nelx, period_x
-           write (10, '(A,2(F10.6," "),I4,L2)') "ymin, ymax, Nel, periodic:", &
+           write (10, '(A,2(F12.6," "),I4,L2)') "ymin, ymax, Nel, periodic:", &
                 y0, y1, nely, period_y
-           write (10, '(A,2(F10.6," "),I4,L2)') "zmin, zmax, Nel, periodic:", &
+           write (10, '(A,2(F12.6," "),I4,L2)') "zmin, zmax, Nel, periodic:", &
                 z0, z1, nelz, period_z
            close(10)
            exit

--- a/src/io/output_controller.f90
+++ b/src/io/output_controller.f90
@@ -284,7 +284,7 @@ contains
 
     sample_time = sample_end_time - sample_start_time
     if (write_output) then
-       write(log_buf, '(A16,1x,F10.6,A,F9.6)') 'Writing at time:', t, &
+       write(log_buf, '(A16,1x,F12.6,A,F9.6)') 'Writing at time:', t, &
             ' Output time (s): ', sample_time
        call neko_log%message(log_buf)
        call neko_log%end_section()


### PR DESCRIPTION
Increase field width from F10.6 to F12.6 to prevent overflow in genmeshbox and statistics logs in atmospheric cases.