### PR TITLE
Update smagorinsky_cpu.f90

### DIFF
--- a/src/les/bcknd/cpu/smagorinsky_cpu.f90
+++ b/src/les/bcknd/cpu/smagorinsky_cpu.f90
@@ -65,7 +65,7 @@ contains
     type(field_t), intent(in) :: delta
     real(kind=rp), intent(in) :: c_s
     type(field_t), pointer :: u, v, w
-    ! double of the strain rate tensor
+    ! strain rate tensor
     type(field_t), pointer :: s11, s22, s33, s12, s13, s23
     real(kind=rp) :: s_abs
     integer :: temp_indices(6)


### PR DESCRIPTION
As I can see s11, s22 ... are the components of the strain rate tensor basing on the classical definition: $$\frac{1}{2}(\frac{\partial u_i}{\partial x_j}+\frac{\partial u_j}{\partial x_i})$$. Thus, it is not double of the strain rate tensor (as considered in the Lilly paper for example) and the former comment was misleading.