### PR TITLE
Enable custom type injection to factories and a plugin architecture

### DIFF
--- a/NEKO_PLUGINS/my_model2/modules.txt
+++ b/NEKO_PLUGINS/my_model2/modules.txt
@@ -1,0 +1,1 @@
+my_model2

--- a/NEKO_PLUGINS/my_model2/my_model2.f90
+++ b/NEKO_PLUGINS/my_model2/my_model2.f90
@@ -1,0 +1,121 @@
+module my_model2
+  use num_types, only : rp
+  use les_model, only : les_model_t, register_les_model, les_model_allocate
+  use field, only : field_t
+  use fluid_scheme_base, only : fluid_scheme_base_t
+  use json_utils, only : json_get_or_default
+  use json_module, only : json_file
+  use field_registry, only : neko_field_registry
+  use logger, only : LOG_SIZE, neko_log
+  use field_math, only : field_cfill
+
+  implicit none
+
+  !> Implements a dummy user model
+  type, public, extends(les_model_t) :: my_model2_t
+     !> Model constant, defaults to 0.07.
+     real(kind=rp) :: c
+   contains
+     !> Constructor from JSON.
+     procedure, pass(this) :: init => my_model2_init
+     !> Constructor from components.
+     procedure, pass(this) :: init_from_components => &
+          my_model2_init_from_components
+     !> Destructor.
+     procedure, pass(this) :: free => my_model2_free
+     !> Compute eddy viscosity.
+     procedure, pass(this) :: compute => my_model2_compute
+  end type my_model2_t
+
+contains
+  !> Constructor.
+  !! @param fluid The fluid_scheme_base_t object.
+  !! @param json A dictionary with parameters.
+  subroutine my_model2_init(this, fluid, json)
+    class(my_model2_t), intent(inout) :: this
+    class(fluid_scheme_base_t), intent(inout), target :: fluid
+    type(json_file), intent(inout) :: json
+    character(len=:), allocatable :: nut_name
+    real(kind=rp) :: c
+    character(len=:), allocatable :: delta_type
+    logical :: if_ext
+    character(len=LOG_SIZE) :: log_buf
+
+    call json_get_or_default(json, "nut_field", nut_name, "nut")
+    call json_get_or_default(json, "delta_type", delta_type, "pointwise")
+    call json_get_or_default(json, "extrapolation", if_ext, .true.)
+
+    call neko_log%section('LES model')
+    write(log_buf, '(A)') 'Model : CUSTOM MODEL 2 TEST'
+    call neko_log%message(log_buf)
+    call neko_log%end_section()
+
+    call my_model2_init_from_components(this, fluid, c, nut_name, &
+         delta_type, if_ext)
+  end subroutine my_model2_init
+
+  !> Constructor from components.
+  !! @param fluid The fluid_scheme_base_t object.
+  !! @param c The model constant.
+  !! @param nut_name The name of the SGS viscosity field.
+  !! @param delta_type The type of filter size.
+  !! @param if_ext Whether trapolate the velocity.
+  subroutine my_model2_init_from_components(this, fluid, c, nut_name, &
+       delta_type, if_ext)
+    class(my_model2_t), intent(inout) :: this
+    class(fluid_scheme_base_t), intent(inout), target :: fluid
+    real(kind=rp) :: c
+    character(len=*), intent(in) :: nut_name
+    character(len=*), intent(in) :: delta_type
+    logical, intent(in) :: if_ext
+
+    call this%free()
+
+    call this%init_base(fluid, nut_name, delta_type, if_ext)
+    this%c = c
+
+  end subroutine my_model2_init_from_components
+
+  !> Destructor for the les_model_t (base) class.
+  subroutine my_model2_free(this)
+    class(my_model2_t), intent(inout) :: this
+
+    call this%free_base()
+  end subroutine my_model2_free
+
+  !> Compute eddy viscosity.
+  !! @param t The time value.
+  !! @param tstep The current time-step.
+  subroutine my_model2_compute(this, t, tstep)
+    class(my_model2_t), intent(inout) :: this
+    real(kind=rp), intent(in) :: t
+    integer, intent(in) :: tstep
+
+    write(*,*) "Executing custom SGS model 2!!"
+    ! Just a value to test
+    call field_cfill(this%nut, 5e-3_rp)
+
+  end subroutine my_model2_compute
+
+  !> The allocator for my_model2_t
+  subroutine custom_allocator(obj)
+    class(les_model_t), allocatable, intent(inout) :: obj
+
+    allocate(my_model2_t::obj)
+  end subroutine custom_allocator
+
+  !> module name + register_types routine
+  !! Can register all the custom types from the module here!
+  subroutine my_model2_register_types()
+    procedure(les_model_allocate), pointer :: allocator_ptr
+
+    allocator_ptr => custom_allocator  ! Assign procedure pointer
+
+    write(*,*) "Registering the my_model2_t SGS model"
+    call register_les_model("my_model2", allocator_ptr)
+    write(*,*) "Done"
+
+  end subroutine my_model2_register_types
+
+
+end module my_model2

--- a/examples/tgv/plugins.txt
+++ b/examples/tgv/plugins.txt
@@ -1,0 +1,1 @@
+my_model2

--- a/examples/tgv/test_module.f90
+++ b/examples/tgv/test_module.f90
@@ -1,0 +1,105 @@
+module test_module
+  use num_types, only : rp
+  use les_model, only : les_model_t
+  use field, only : field_t
+  use fluid_scheme_base, only : fluid_scheme_base_t
+  use json_utils, only : json_get_or_default
+  use json_module, only : json_file
+  use field_registry, only : neko_field_registry
+  use logger, only : LOG_SIZE, neko_log
+  use field_math, only : field_cfill
+
+!  use les_model_fctry, only : les_model_allocate
+
+  implicit none
+
+  !> Implements a dummy user model
+  type, public, extends(les_model_t) :: my_model_t
+     !> Model constant, defaults to 0.07.
+     real(kind=rp) :: c
+   contains
+     !> Constructor from JSON.
+     procedure, pass(this) :: init => my_model_init
+     !> Constructor from components.
+     procedure, pass(this) :: init_from_components => &
+          my_model_init_from_components
+     !> Destructor.
+     procedure, pass(this) :: free => my_model_free
+     !> Compute eddy viscosity.
+     procedure, pass(this) :: compute => my_model_compute
+  end type my_model_t
+
+contains
+  !> Constructor.
+  !! @param fluid The fluid_scheme_base_t object.
+  !! @param json A dictionary with parameters.
+  subroutine my_model_init(this, fluid, json)
+    class(my_model_t), intent(inout) :: this
+    class(fluid_scheme_base_t), intent(inout), target :: fluid
+    type(json_file), intent(inout) :: json
+    character(len=:), allocatable :: nut_name
+    real(kind=rp) :: c
+    character(len=:), allocatable :: delta_type
+    logical :: if_ext
+    character(len=LOG_SIZE) :: log_buf
+
+    call json_get_or_default(json, "nut_field", nut_name, "nut")
+    call json_get_or_default(json, "delta_type", delta_type, "pointwise")
+    call json_get_or_default(json, "extrapolation", if_ext, .true.)
+
+    call neko_log%section('LES model')
+    write(log_buf, '(A)') 'Model : CUSTOM MODEL TEST'
+    call neko_log%message(log_buf)
+    call neko_log%end_section()
+
+    call my_model_init_from_components(this, fluid, c, nut_name, &
+         delta_type, if_ext)
+  end subroutine my_model_init
+
+  !> Constructor from components.
+  !! @param fluid The fluid_scheme_base_t object.
+  !! @param c The model constant.
+  !! @param nut_name The name of the SGS viscosity field.
+  !! @param delta_type The type of filter size.
+  !! @param if_ext Whether trapolate the velocity.
+  subroutine my_model_init_from_components(this, fluid, c, nut_name, &
+       delta_type, if_ext)
+    class(my_model_t), intent(inout) :: this
+    class(fluid_scheme_base_t), intent(inout), target :: fluid
+    real(kind=rp) :: c
+    character(len=*), intent(in) :: nut_name
+    character(len=*), intent(in) :: delta_type
+    logical, intent(in) :: if_ext
+
+    call this%free()
+
+    call this%init_base(fluid, nut_name, delta_type, if_ext)
+    this%c = c
+
+  end subroutine my_model_init_from_components
+
+  !> Destructor for the les_model_t (base) class.
+  subroutine my_model_free(this)
+    class(my_model_t), intent(inout) :: this
+
+    call this%free_base()
+  end subroutine my_model_free
+
+  !> Compute eddy viscosity.
+  !! @param t The time value.
+  !! @param tstep The current time-step.
+  subroutine my_model_compute(this, t, tstep)
+    class(my_model_t), intent(inout) :: this
+    real(kind=rp), intent(in) :: t
+    integer, intent(in) :: tstep
+
+    ! Just a value to test
+    call field_cfill(this%nut, 1e-3_rp)
+
+  end subroutine my_model_compute
+
+  subroutine test_module_register_types()
+    print *, "Registering MySolver types!"
+  end subroutine test_module_register_types
+
+end module test_module

--- a/examples/tgv/tgv.case
+++ b/examples/tgv/tgv.case
@@ -18,11 +18,12 @@
   "fluid": {
     "scheme": "pnpn",
     "Re": 360,
+    "nut_field" : "nut",
     "initial_condition": {
       "type": "user"
     },
     "velocity_solver": {
-      "type": "cg",
+      "type": "coupledcg",
       "preconditioner": "jacobi",
       "projection_space_size": 0,
       "absolute_tolerance": 1e-7,
@@ -44,6 +45,11 @@
       "type": "vorticity",
       "compute_control": "tsteps",
       "compute_value": 50
+    },
+    {
+      "type": "les_model",
+      "model" : "smagorinsky",
+      "nut_field": "nut"
     }
   ]
   }

--- a/examples/tgv/tgv.case
+++ b/examples/tgv/tgv.case
@@ -48,7 +48,8 @@
     },
     {
       "type": "les_model",
-      "model" : "my_model",
+      //"model" : "my_model",
+      "model" : "my_model2",
       "nut_field": "nut",
       "output_control": "global",
       "output_filename": "les"

--- a/examples/tgv/tgv.case
+++ b/examples/tgv/tgv.case
@@ -8,7 +8,7 @@
   "output_at_end": true,
   "load_balance": false,
   "job_timelimit": "00:00:00",
-  "end_time": 3.0,
+  "end_time": 2e-2,
   "timestep": 1e-2,
   "numerics": {
     "time_order": 3,
@@ -48,8 +48,10 @@
     },
     {
       "type": "les_model",
-      "model" : "smagorinsky",
-      "nut_field": "nut"
+      "model" : "my_model",
+      "nut_field": "nut",
+      "output_control": "global",
+      "output_filename": "les"
     }
   ]
   }

--- a/makeneko.in
+++ b/makeneko.in
@@ -7,46 +7,94 @@ includedir_pkg=${prefix}/include/neko
 FC=@FC@
 FCFLAGS='@FCFLAGS@'
 
-printf "\n%s\n" 'N E K O build tool, Version @PACKAGE_VERSION@'
-printf "%s\n" '@NEKO_BUILD_INFO@'
+NEKO_PLUGINS=${NEKO_PLUGINS}
 
-
-if [ -z "$1" ]
-  then
-      echo "No user file provided"
-      exit 1
+# Ensure user provides at least one .f90 file
+if [ $# -eq 0 ]; then
+    echo "Usage: makeneko <file1.f90> <file2.f90>"
+    exit 1
 fi
-printf '\n%s' "Building user NEKO ..."
-rm -f usr_driver.f90
 
-# Find all user-defined modules (excluding 'user')
-user_modules=$(grep -hE '^[[:space:]]*module[[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*' *.f90 | \
+# Collect user-provided .f90 files (excluding usr_driver.f90)
+USER_FILES=""
+for file in "$@"; do
+    if [ "$file" != "plugins.txt" ] && [ "$file" != "usr_driver.f90" ]; then
+        USER_FILES="$USER_FILES $file"
+    fi
+done
+
+# Read plugins list if provided as an argument
+PLUGINS_FILE="plugins.txt"
+PLUGINS=""
+if [ -f "$PLUGINS_FILE" ]; then
+    PLUGINS=$(grep -v '^[[:space:]]*$' "$PLUGINS_FILE" | grep -v '^#')  # Ignore empty lines and comments
+fi
+
+PLUGIN_FILES=""
+PLUGIN_MODULES=""
+
+# Process each plugin
+for PLUGIN in $PLUGINS; do
+    PLUGIN_DIR="$NEKO_PLUGINS/$PLUGIN"
+    MODULES_FILE="$PLUGIN_DIR/modules.txt"
+
+    if [ ! -d "$PLUGIN_DIR" ]; then
+        echo "Warning: Plugin '$PLUGIN' not found in $NEKO_PLUGINS"
+        continue
+    fi
+
+    # Collect .f90 files from the plugin directory
+    for FILE in "$PLUGIN_DIR"/*.f90; do
+        PLUGIN_FILES="$PLUGIN_FILES $FILE"
+    done
+
+    # Read module names from modules.txt
+    if [ -f "$MODULES_FILE" ]; then
+        MODULES=$(grep -v '^[[:space:]]*$' "$MODULES_FILE" | grep -v '^#')  # Ignore empty lines and comments
+        PLUGIN_MODULES="$PLUGIN_MODULES $MODULES"
+    else
+        echo "Warning: Plugin '$PLUGIN' has no modules.txt file ($MODULES_FILE)"
+    fi
+done
+
+# Extract module names from user-provided .f90 files
+USER_MODULES=$(grep -hE '^[[:space:]]*module[[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*' $USER_FILES 2>/dev/null | \
                grep -vE '^[[:space:]]*!' | \
-               grep -vE 'module procedure' | \
-               awk '{if ($2 != "user") print $2}' | sort -u)
+               grep -vE 'module procedure|module[[:space:]]+user' | \
+               awk '{print $2}' | sort -u)
 
-
-cat >> usr_driver.f90 << _ACEOF
+# Create usr_driver.f90
+cat > usr_driver.f90 << _ACEOF
 program usrneko
   use neko
   use user
 _ACEOF
 
-# Automatically import user modules
-for mod in $user_modules; do
-  echo "  use $mod, only: ${mod}_register_types" >> usr_driver.f90
+# Insert `use` statements for local user .f90 files
+for mod in $USER_MODULES; do
+  echo "  use $mod" >> usr_driver.f90
+done
+
+# Insert `use` statements for plugins
+for mod in $PLUGIN_MODULES; do
+  echo "  use $mod" >> usr_driver.f90
 done
 
 cat >> usr_driver.f90 << _ACEOF
 
   type(case_t), target :: C
 
-  ! Call register_types() for all modules
+  ! Register all user-defined types
   call user_setup(C%usr)
 _ACEOF
 
-# Generate calls to renamed `register_types` routines
-for mod in $user_modules; do
+# Register types from local user .f90 files
+for mod in $USER_MODULES; do
+  echo "  call ${mod}_register_types()" >> usr_driver.f90
+done
+
+# Register types from plugins
+for mod in $PLUGIN_MODULES; do
   echo "  call ${mod}_register_types()" >> usr_driver.f90
 done
 
@@ -58,9 +106,8 @@ cat >> usr_driver.f90 << _ACEOF
 end program usrneko
 _ACEOF
 
-$FC $FCFLAGS -I$includedir_pkg -L$libdir $@ usr_driver.f90\
-    -lneko @LDFLAGS@ @LIBS@ -o neko
+# Compile everything
+$FC $FCFLAGS -I$includedir_pkg -L$libdir $USER_FILES $PLUGIN_FILES usr_driver.f90 -lneko @LDFLAGS@ @LIBS@ -o neko
 
 rm -f usr_driver.f90
-
-printf "%s\n" ' done!'
+echo "User NEKO build complete!"

--- a/makeneko.in
+++ b/makeneko.in
@@ -18,17 +18,38 @@ if [ -z "$1" ]
 fi
 printf '\n%s' "Building user NEKO ..."
 rm -f usr_driver.f90
+
+# Find all user-defined modules (excluding 'user')
+user_modules=$(grep -hoP 'module \K\w+' *.f90 | grep -v '^user$' | sort -u)
+
 cat >> usr_driver.f90 << _ACEOF
 program usrneko
   use neko
   use user
+_ACEOF
+
+# Automatically import user modules
+for mod in $user_modules; do
+  echo "  use $mod, only: ${mod}_register_types" >> usr_driver.f90
+done
+
+cat >> usr_driver.f90 << _ACEOF
+
   type(case_t), target :: C
-  
+
+  ! Call register_types() for all modules
   call user_setup(C%usr)
+_ACEOF
+
+# Generate calls to renamed `register_types` routines
+for mod in $user_modules; do
+  echo "  call ${mod}_register_types()" >> usr_driver.f90
+done
+
+cat >> usr_driver.f90 << _ACEOF
   call neko_init(C)
   call neko_solve(C)
   call neko_finalize(C)
-
 
 end program usrneko
 _ACEOF

--- a/makeneko.in
+++ b/makeneko.in
@@ -20,7 +20,11 @@ printf '\n%s' "Building user NEKO ..."
 rm -f usr_driver.f90
 
 # Find all user-defined modules (excluding 'user')
-user_modules=$(grep -hoP 'module \K\w+' *.f90 | grep -v '^user$' | sort -u)
+user_modules=$(grep -hE '^[[:space:]]*module[[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*' *.f90 | \
+               grep -vE '^[[:space:]]*!' | \
+               grep -vE 'module procedure' | \
+               awk '{if ($2 != "user") print $2}' | sort -u)
+
 
 cat >> usr_driver.f90 << _ACEOF
 program usrneko

--- a/src/.depends
+++ b/src/.depends
@@ -326,7 +326,7 @@ source_terms/bcknd/device/cuda/cuda_filters.lo : source_terms/bcknd/device/cuda/
 source_terms/bcknd/device/hip/hip_filters.lo : source_terms/bcknd/device/hip/hip_filters.f90 config/num_types.lo 
 source_terms/bcknd/device/opencl/opencl_filters.lo : source_terms/bcknd/device/opencl/opencl_filters.f90 config/num_types.lo 
 les/les_model.lo : les/les_model.f90 comm/comm.lo common/utils.lo math/bcknd/device/device_math.lo math/math.lo device/device.lo config/neko_config.lo gs/gs_ops.lo sem/coef.lo sem/dofmap.lo field/field_registry.lo field/field_series.lo field/field.lo common/rhs_maker.lo time_schemes/time_scheme_controller.lo fluid/fluid_pnpn.lo fluid/fluid_scheme_base.lo config/num_types.lo 
-les/les_model_fctry.lo : les/les_model_fctry.f90 les/sigma.lo les/dynamic_smagorinsky.lo les/smagorinsky.lo les/vreman.lo les/les_model.lo 
+les/les_model_fctry.lo : les/les_model_fctry.f90 fluid/fluid_scheme_base.lo les/sigma.lo les/dynamic_smagorinsky.lo les/smagorinsky.lo les/vreman.lo les/les_model.lo 
 les/vreman.lo : les/vreman.f90 common/log.lo field/field_registry.lo les/bcknd/device/vreman_device.lo les/bcknd/cpu/vreman_cpu.lo config/neko_config.lo common/json_utils.lo fluid/fluid_scheme_base.lo field/field.lo les/les_model.lo config/num_types.lo 
 les/bcknd/cpu/vreman_cpu.lo : les/bcknd/cpu/vreman_cpu.f90 gs/gs_ops.lo sem/coef.lo math/operators.lo field/field.lo field/field_registry.lo field/scratch_registry.lo math/math.lo field/field_list.lo config/num_types.lo 
 les/bcknd/device/vreman_device.lo : les/bcknd/device/vreman_device.f90 les/bcknd/device/device_vreman_nut.lo math/bcknd/device/device_math.lo gs/gs_ops.lo sem/coef.lo math/operators.lo field/field.lo field/field_registry.lo field/scratch_registry.lo math/math.lo config/num_types.lo 

--- a/src/les/les_model.f90
+++ b/src/les/les_model.f90
@@ -129,25 +129,67 @@ module les_model
   end interface
 
   interface
-     !> LES model factory. Both constructs and initializes the object.
+     !> LES model allocator.
+     !! @param object The object to be allocated.
+     !! @param type_name The name of the LES model.
+     module subroutine les_model_allocator(object, type_name)
+       class(les_model_t), allocatable, intent(inout) :: object
+       character(len=*), intent(in) :: type_name
+     end subroutine les_model_allocator
+  end interface
+
+  interface
+     !> LES model factory. Both allocates and initializes the object.
      !! @param object The object to be allocated.
      !! @param type_name The name of the LES model.
      !! @param fluid The fluid scheme base type pointer.
      !! @param dofmap SEM map of degrees of freedom.
      !! @param coef SEM coefficients.
      !! @param json A dictionary with parameters.
-     module subroutine les_model_factory(object, type_name, fluid, dofmap, &
-          coef, json)
+     module subroutine les_model_factory(object, type_name, fluid, json)
        class(les_model_t), allocatable, intent(inout) :: object
        character(len=*), intent(in) :: type_name
-       class(fluid_scheme_base_t), intent(in) :: fluid
-       type(dofmap_t), intent(in) :: dofmap
-       type(coef_t), intent(in) :: coef
+       class(fluid_scheme_base_t), intent(inout) :: fluid
        type(json_file), intent(inout) :: json
      end subroutine les_model_factory
   end interface
 
-  public :: les_model_factory
+  !
+  ! Machinery for injecting user-defined types
+  !
+
+  interface
+     !> Called in user modules to add an allocator for custom types.
+     module subroutine register_les_model(type_name, allocator)
+       character(len=*), intent(in) :: type_name
+       procedure(les_model_allocate), pointer, intent(in) :: allocator
+     end subroutine register_les_model
+  end interface
+
+  ! Interface for an object allocator. Implemented in the user modules.
+  abstract interface
+     subroutine les_model_allocate(obj)
+        import les_model_t
+        class(les_model_t), allocatable, intent(inout) :: obj
+     end subroutine les_model_allocate
+  end interface
+
+  ! A name-allocator pair for user-defined types. A helper type to define a
+  ! registry of custom allocators.
+  type allocator_entry
+     character(len=20) :: type_name
+     procedure(les_model_allocate), pointer, nopass :: allocator
+  end type allocator_entry
+
+  ! Registry of LES model allocators for user-defined types
+  type(allocator_entry), allocatable :: les_model_registry(:)
+
+  ! The size of the `les_model_registry`
+  integer :: les_model_registry_size = 0
+
+  public :: les_model_factory, les_model_allocator,  register_les_model, &
+       les_model_allocate
+
 
 contains
   !> Constructor for the les_model_t (base) class.

--- a/src/les/les_model.f90
+++ b/src/les/les_model.f90
@@ -132,12 +132,15 @@ module les_model
      !> LES model factory. Both constructs and initializes the object.
      !! @param object The object to be allocated.
      !! @param type_name The name of the LES model.
+     !! @param fluid The fluid scheme base type pointer.
      !! @param dofmap SEM map of degrees of freedom.
      !! @param coef SEM coefficients.
      !! @param json A dictionary with parameters.
-     module subroutine les_model_factory(object, type_name, dofmap, coef, json)
+     module subroutine les_model_factory(object, type_name, fluid, dofmap, &
+          coef, json)
        class(les_model_t), allocatable, intent(inout) :: object
        character(len=*), intent(in) :: type_name
+       class(fluid_scheme_base_t), intent(in) :: fluid
        type(dofmap_t), intent(in) :: dofmap
        type(coef_t), intent(in) :: coef
        type(json_file), intent(inout) :: json

--- a/src/neko.f90
+++ b/src/neko.f90
@@ -123,6 +123,7 @@ module neko
   use json_module, only : json_file
   use json_utils, only : json_get, json_get_or_default, json_extract_item
   use bc_list, only : bc_list_t
+  use les_model, only : les_model_t
   use, intrinsic :: iso_fortran_env
   !$ use omp_lib
   implicit none

--- a/src/simulation_components/les_simcomp.f90
+++ b/src/simulation_components/les_simcomp.f90
@@ -97,10 +97,7 @@ contains
 
     call json_get(json, "model", name)
 
-    call les_model_factory(this%les_model, name, case%fluid, case%fluid%dm_Xh,&
-         case%fluid%c_Xh, json)
-    call this%les_model%init(case%fluid, json)
-
+    call les_model_factory(this%les_model, name, case%fluid, json)
   end subroutine les_simcomp_init_from_json
 
   !> Destructor.

--- a/src/simulation_components/les_simcomp.f90
+++ b/src/simulation_components/les_simcomp.f90
@@ -97,7 +97,7 @@ contains
 
     call json_get(json, "model", name)
 
-    call les_model_factory(this%les_model, name, case%fluid%dm_Xh,&
+    call les_model_factory(this%les_model, name, case%fluid, case%fluid%dm_Xh,&
          case%fluid%c_Xh, json)
     call this%les_model%init(case%fluid, json)
 


### PR DESCRIPTION
I think I finally had a breakthrough in extending neko factories to user-defined types. In this demonstrator, I show how it works and also propose a prototype of a plugin architecture. Here, everything is shown using LES models as an example.

## Injecting types

The main idea is as follows.
* For built-in types the factories work exactly as before, with if-else statements.
* For user types, we introduce an registry of (name, allocator) pairs, here `les_model_registry`. An allocator is a simple subroutine that takes a pointer to a base type and allocates it to a custom derived type. Inside the factory, if the type_name is not among the KNOWN_TYPES (i.e. the built-in ones) it starts searching in this registry instead.
* The user is provided a `register_les_model` subroutine, which adds a (typename, allocator) a pair to the registry.
* **The tricky part** is, of course, performing this registration, i.e. calling the user routine that calls register_les_model ahead of time, before the factories are used in the code. This is where we have to rely on a convention.
We say that a user module called `my_module` should always add a `my_module_register_types` subroutine, in which the calls to `register_...` routines defined by the extendable types happen. We then modify `makeneko` to grep the .f90 files to figure out the module names and automatically inject `use` statements and calls to the `....register` routines. So we end up with something like.

```fortran
program usrneko
  use neko
  use user
  use test_module !!! Injected

  type(case_t), target :: C

  ! Register all user-defined types
  call user_setup(C%usr)
  ! Injection, custom type is now in the les_model_registry and ready to be allocated by the 
  ! factory
  call test_module_register_types() factory
  call neko_init(C)
  call neko_solve(C)
  call neko_finalize(C)

end program usrneko
```

and on the side of the custom module we have

```fortran
  !> The allocator for my_model_t
  subroutine custom_allocator(obj)
    class(les_model_t), allocatable, intent(inout) :: obj

    allocate(my_model_t::obj)
  end subroutine custom_allocator

  !> module name + register_types routine
  !! Can register all the custom types from the module here!
  subroutine test_module_register_types()
    procedure(les_model_allocate), pointer :: allocator_ptr

    allocator_ptr => custom_allocator  ! Assign procedure pointer

    write(*,*) "Registering the my_model_t SGS model"
    call register_les_model("my_model", allocator_ptr)
    write(*,*) "Done"

  end subroutine test_module_register_types
```

If a module does not inject any types, the routine is still used, but it should just be empty. I think this is ok for the huge benefit this provides.

## Plugins
Once I was there, it was easy to extend this to a primitive plugin architecture. 

* We define a NEKO_PLUGINS env var, where each folder will contain some .f90 and a *modules.txt*. The latter contains a list of all type-injecting modules inside the plugin.
* In the case directory we add a plugins.txt, with a list of plugins, just directory names inside NEKO_PLUGINS.
* Based on this, makeneko grabs all the .f90s from the requested plugins, and then does the type registration routine injection in exactly the same way as for the .f90s in the case directory. 

In the PR I just added a NEKO_PLUGINS right to src to have it somewhere, and there is an SGS model inside. 

I originally thought of going one step forward and have a way of compiling pluings into libraries, but I realized there are too many factors to consider and I suck at this stuff. Also, custom GPU code is not considered here and we should discuss this. But even as is, this is a huge step forward and I am very keen on getting this in in some form soon. The plugins and the local .f90 can be treated as separate tracks later, one a natural continuation of the other.

Feel free to play with the provided SGS model example in `tgv`! 


