### PR TITLE
Check for boundary_conditions entry when labled zones present

### DIFF
--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -1034,9 +1034,7 @@ contains
        ! Check that there are no labeled zones, i.e. all are periodic.
        do i = 1, size(this%msh%labeled_zones)
           if (this%msh%labeled_zones(i)%size .gt. 0) then
-             write(error_unit, '(A, A, I0)') "*** ERROR ***: ", &
-                  "No boundary_conditions entry in the case file!"
-             error stop
+             call neko_error("No boundary_conditions entry in the case file!")
           end if
        end do
 

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -908,7 +908,7 @@ contains
                 write(error_unit, '(A, A, I0, A, A, I0, A)') "*** ERROR ***: ",&
                      "Zone index ", zone_indices(j), &
                      " is invalid as this zone has 0 size, meaning it ", &
-                     "does not in the mesh. Check fluid boundary condition ", &
+                     "is not in the mesh. Check fluid boundary condition ", &
                      i, "."
                 error stop
              end if
@@ -1030,6 +1030,16 @@ contains
           end if
 
        end do
+    else
+       ! Check that there are no labeled zones, i.e. all are periodic.
+       do i = 1, size(this%msh%labeled_zones)
+          if (this%msh%labeled_zones(i)%size .gt. 0) then
+             write(error_unit, '(A, A, I0)') "*** ERROR ***: ", &
+                  "No boundary_conditions entry in the case file!"
+             error stop
+          end if
+       end do
+
     end if
 
     call this%bc_prs_surface%finalize()

--- a/tests/reframe/src/minihemi.case.template
+++ b/tests/reframe/src/minihemi.case.template
@@ -27,6 +27,27 @@
             "delta": 0.6,
             "freestream_velocity": [1.0, 0.0, 0.0]
         },
+        "boundary_conditions": [
+        {
+            "type": "symmetry",
+            "zone_indices": [1]
+        },
+        {
+            "type": "no_slip",
+            "zone_indices": [2]
+        },
+        {
+            "type": "outflow",
+            "zone_indices": [3]
+        },
+        {
+            "type": "blasius_profile",
+            "zone_indices": [4],
+            "approximation": "sin",
+            "delta": 0.6,
+            "freestream_velocity": [1.0, 0.0, 0.0]
+        }
+        ],
         "velocity_solver": {
             "type": "cg",
             "preconditioner": "jacobi",

--- a/tests/reframe/src/rayleigh.case.template
+++ b/tests/reframe/src/rayleigh.case.template
@@ -38,13 +38,11 @@
             "absolute_tolerance": 1e-6,
             "max_iterations": 800
         },
-        "boundary_types": [
-            "",
-            "",
-            "",
-            "",
-            "w",
-            "w"
+        "boundary_conditions": [
+            {
+                "type": "no_slip",
+                "zone_indices": [5, 6]
+            }
         ],
         "output_control": "never",
         "output_value": 0
@@ -62,13 +60,17 @@
         "initial_condition": {
             "type": "user"
         },
-        "boundary_types": [
-            "",
-            "",
-            "",
-            "",
-            "d=1",
-            "d=0"
+        "boundary_conditions": [
+            {
+                "type": "dirichlet",
+                "value": 1,
+                "zone_indices": [5]
+            },
+            {
+                "type": "dirichlet",
+                "value": 0,
+                "zone_indices": [6]
+            }
         ]
     }
 }


### PR DESCRIPTION
Fixes issue #1766 

I guess we only have two options now: labels or periodic zones. If there are labled zones, boundary conditions must be provided.

So, this checks that there are no labeled zones in the mesh if the boundary_conditions keyword is not provided, and then throws an error.