### PR TITLE
Add user_startup routine, make case public in neko_simcomps

### DIFF
--- a/doc/pages/user-guide/user-file.md
+++ b/doc/pages/user-guide/user-file.md
@@ -215,12 +215,9 @@ example](https://github.com/ExtremeFLOW/neko/blob/564686b127ff75a362a06126c6b23e
     integer, intent(in) :: tstep
     real(kind=rp), intent(inout) :: rho, mu, cp, lambda
     type(json_file), intent(inout) :: params
-    real(kind=rp) :: Re
 
-    call json_get(params, "case.fluid.Ra", Ra)
-    call json_get(params, "case.scalar.Pr", Pr)
+    ! Re and Pr computed in `user_startup`
 
-    Re = sqrt(Ra / Pr)
     mu = 1.0_rp / Re
     lambda = mu / Pr
     rho = 1.0_rp

--- a/doc/pages/user-guide/user-file.md
+++ b/doc/pages/user-guide/user-file.md
@@ -78,28 +78,50 @@ executable `bin/neko` in your local neko installation folder.
 The following user functions, if defined in the user file, will always be
 executed, regardless of what is set in the case file:
 
+- [user_startup](@ref user-file_init-and-final): For early access to the case
+  file, its manipulation or initializing simple user parameter variables.
 - [user_init_modules](@ref user-file_init-and-final): For initializing user
   variables and objects
 - [user_finalize_modules](@ref user-file_init-and-final): For finalizing, e.g
   freeing variables and terminating processes
-- [user_check](@ref user-file_user-check): Executed at the end of every time step,
-  for e.g. computing and/or outputting user defined quantities.
-- [material_properties](@ref user-file_mat-prop): For computing and setting material
-  properties such as `rho`, `mu`, `cp` and `lambda`.
-- [user_mesh_setup](@ref user-file_user-mesh-setup): For applying a deformation to
-  the mesh element nodes, before the simulation time loop.
-- [scalar_user_bc](@ref user-file_scalar-bc): For applying boundary conditions to
-  the scalar, on all zones that are not already specified with uniform dirichlet
-  values e.g. `d=1`. For more information on the scalar, see the [relevant section of the case file](@ref case-file_scalar).
+- [user_check](@ref user-file_user-check): Executed at the end of every time
+  step, for e.g. computing and/or outputting user defined quantities.
+- [material_properties](@ref user-file_mat-prop): For computing and setting
+  material properties such as `rho`, `mu`, `cp` and `lambda`.
+- [user_mesh_setup](@ref user-file_user-mesh-setup): For applying a deformation
+  to the mesh element nodes, before the simulation time loop.
+- [scalar_user_bc](@ref user-file_scalar-bc): For applying boundary conditions
+  to the scalar, on all zones that are not already specified with uniform
+  dirichlet values e.g. `d=1`. For more information on the scalar, see the
+  [relevant section of the case file](@ref case-file_scalar).
 
 ### Initializing and finalizing {#user-file_init-and-final}
 
-The two subroutines `user_init_modules` and `user_finalize_modules` may be used
-to initialize/finalize any user defined variables, external objects, or
-processes. They are respectively executed right before/after the simulation time
-loop.
+Threeo subroutines `user_startup`, `user_init_modules` and
+`user_finalize_modules` may be used to initialize/finalize any user defined
+variables, external objects, or processes.  The `user_startup` routine is called
+immediately after the case file is read in, meaning that no important objects
+are initialized yet (e.g. the mesh, fluid, etc.). The `user_init_modules` and
+`user_finalize_modules` are respectively executed right before/after the
+simulation time loop.
+
+In most cases, one can use `user_init_modules` routine and not the
+`user_startup`. The latter is only necessary when you want to either manipulate
+the case file programmatically before it is used in the simulation, or define
+some variables that will be used in the constructors of some of the types.
+An example of the latter is defining some material property constants that
+can be used in the user `material_properties` routine, which is run by the
+constructor of the `case%fluid` object.
+
 
 ```fortran
+  ! Manipulate the case file and define simple user variables
+  subroutine startup(params)
+    type(json_file), intent(inout) :: params
+
+    ! insert your initialization code here
+
+  end subroutine startup
 
   ! Initialize user variables or external objects
   subroutine initialize(t, u, v, w, p, coef, params)
@@ -125,9 +147,9 @@ loop.
   end subroutine initialize
 ```
 
-In the example above, the subroutines `initialize` and `finalize` contain the
-actual implementations. They must also be interfaced to the internal procedures
-`user_init_modules` and `user_finalize_modules` in `user_setup`:
+In the example above, the subroutines `startup`, `initialize` and `finalize`
+contain the actual implementations. They must also be interfaced to the internal
+procedures `user_init_modules` and `user_finalize_modules` in `user_setup`:
 
 ```fortran
 
@@ -135,6 +157,7 @@ actual implementations. They must also be interfaced to the internal procedures
   subroutine user_setup(u)
     type(user_t), intent(inout) :: u
 
+    u%user_startup => startup
     u%user_init_modules => initialize
     u%user_finalize_modules => finalize
 
@@ -142,7 +165,7 @@ actual implementations. They must also be interfaced to the internal procedures
 
 ```
 
-@note `user_init_modules` and `user_finalize_modules` are independent of each
+@note All three routines are independent of each
 other. Using one does not require the use of the other.
 
 ### Computing at every time step {#user-file_user-check}

--- a/doc/pages/user-guide/user-file.md
+++ b/doc/pages/user-guide/user-file.md
@@ -97,7 +97,7 @@ executed, regardless of what is set in the case file:
 
 ### Initializing and finalizing {#user-file_init-and-final}
 
-Threeo subroutines `user_startup`, `user_init_modules` and
+Three subroutines `user_startup`, `user_init_modules` and
 `user_finalize_modules` may be used to initialize/finalize any user defined
 variables, external objects, or processes.  The `user_startup` routine is called
 immediately after the case file is read in, meaning that no important objects

--- a/examples/rayleigh_benard/rayleigh.f90
+++ b/examples/rayleigh_benard/rayleigh.f90
@@ -14,7 +14,15 @@ contains
     u%fluid_user_f_vector => forcing
     u%scalar_user_bc => scalar_bc
     u%material_properties => set_material_properties
+    u%user_startup => startup
   end subroutine user_setup
+
+  subroutine startup(params)
+    type(json_file), intent(inout) :: params
+
+    call json_get(params, "case.fluid.Ra", Ra)
+    call json_get(params, "case.scalar.Pr", Pr)
+  end subroutine startup
 
   subroutine set_material_properties(t, tstep, rho, mu, cp, lambda, params)
     real(kind=rp), intent(in) :: t
@@ -22,9 +30,6 @@ contains
     real(kind=rp), intent(inout) :: rho, mu, cp, lambda
     type(json_file), intent(inout) :: params
     real(kind=rp) :: Re
-
-    call json_get(params, "case.fluid.Ra", Ra)
-    call json_get(params, "case.scalar.Pr", Pr)
 
     Re = 1.0_rp / Pr
 

--- a/examples/rayleigh_benard/rayleigh.f90
+++ b/examples/rayleigh_benard/rayleigh.f90
@@ -80,18 +80,18 @@ contains
                 rand = cos(real(e+s%msh%offset_el,rp)*real(i*j*k,rp))
                 z = s%dof%z(i,j,k,e)
                 s%x(i,j,k,e) = 1-z + 0.0001* rand*&
-                                     sin(4*pi/4.5*s%dof%x(i,j,k,e)) &
-                * sin(4*pi/4.5*s%dof%y(i,j,k,e))
+                     sin(4*pi/4.5*s%dof%x(i,j,k,e)) &
+                     * sin(4*pi/4.5*s%dof%y(i,j,k,e))
 
-            end do
+             end do
           end do
        end do
     end do
 
     if ((NEKO_BCKND_DEVICE .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
-       .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+         .or. (NEKO_BCKND_OPENCL .eq. 1)) then
        call device_memcpy(s%x, s%x_d, s%dof%size(), &
-                          HOST_TO_DEVICE, sync=.false.)
+            HOST_TO_DEVICE, sync=.false.)
     end if
 
 
@@ -112,7 +112,7 @@ contains
     ta2pr = ta2*Pr
 
     if ((NEKO_BCKND_CUDA .eq. 1) .or. (NEKO_BCKND_HIP .eq. 1) &
-       .or. (NEKO_BCKND_OPENCL .eq. 1)) then
+         .or. (NEKO_BCKND_OPENCL .eq. 1)) then
        call device_cmult2(f%u_d,v%x_d,Ta2Pr,f%dm%size())
        call device_cmult2(f%v_d,u%x_d,Ta2Pr,f%dm%size())
        call device_cmult2(f%w_d,s%x_d,rapr,f%dm%size())

--- a/examples/rayleigh_benard_cylinder/rayleigh.f90
+++ b/examples/rayleigh_benard_cylinder/rayleigh.f90
@@ -88,14 +88,14 @@ contains
                 r = sqrt(s%dof%x(i,j,k,e)**2+s%dof%y(i,j,k,e)**2)
                 z = s%dof%z(i,j,k,e)
                 s%x(i,j,k,e) = 1-z + 0.0001*rand*s%dof%x(i,j,k,e)*&
-                                                    sin(3*pi*r/0.05_rp)*sin(10*pi*z)
+                     sin(3*pi*r/0.05_rp)*sin(10*pi*z)
              end do
           end do
        end do
     end do
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_memcpy(s%x, s%x_d, s%dof%size(), &
-                          HOST_TO_DEVICE, sync=.false.)
+            HOST_TO_DEVICE, sync=.false.)
     end if
 
   end subroutine set_initial_conditions_for_s

--- a/examples/rayleigh_benard_cylinder/rayleigh.f90
+++ b/examples/rayleigh_benard_cylinder/rayleigh.f90
@@ -16,20 +16,23 @@ contains
     u%scalar_user_ic => set_initial_conditions_for_s
     u%scalar_user_bc => set_scalar_boundary_conditions
     u%material_properties => set_material_properties
+    u%user_startup => startup
   end subroutine user_setup
+
+  subroutine startup(params)
+    type(json_file), intent(inout) :: params
+
+    call json_get(params, "case.fluid.Ra", Ra)
+    call json_get(params, "case.scalar.Pr", Pr)
+    Re = sqrt(Ra / Pr)
+  end subroutine startup
 
   subroutine set_material_properties(t, tstep, rho, mu, cp, lambda, params)
     real(kind=rp), intent(in) :: t
     integer, intent(in) :: tstep
     real(kind=rp), intent(inout) :: rho, mu, cp, lambda
     type(json_file), intent(inout) :: params
-    real(kind=rp) :: Re
 
-    call json_get(params, "case.fluid.Ra", Ra)
-    call json_get(params, "case.scalar.Pr", Pr)
-
-
-    Re = sqrt(Ra / Pr)
     mu = 1.0_rp / Re
     lambda = mu / Pr
     rho = 1.0_rp

--- a/src/case.f90
+++ b/src/case.f90
@@ -268,10 +268,10 @@ contains
     !
     ! Setup initial conditions
     !
-    call json_get(this%params, 'case.fluid.initial_condition.type',&
+    call json_get(this%params, 'case.fluid.initial_condition.type', &
          string_val)
     call json_extract_object(this%params, 'case.fluid.initial_condition', &
-       json_subdict)
+         json_subdict)
 
     call neko_log%section("Fluid initial condition ")
 
@@ -300,7 +300,7 @@ contains
        call json_get(this%params, 'case.scalar.initial_condition.type', &
             string_val)
        call json_extract_object(this%params, 'case.scalar.initial_condition', &
-          json_subdict)
+            json_subdict)
 
        call neko_log%section("Scalar initial condition ")
 

--- a/src/case.f90
+++ b/src/case.f90
@@ -148,6 +148,12 @@ contains
     integer :: output_dir_len
     integer :: precision
 
+    !
+    ! Setup user defined functions
+    !
+    call this%usr%init()
+
+    ! Run user startup routine
     call this%usr%user_startup(this%params)
 
     !
@@ -204,10 +210,7 @@ contains
     !
     call neko_point_zone_registry%init(this%params, this%msh)
 
-    !
-    ! Setup user defined functions
-    !
-    call this%usr%init()
+    ! Run user mesh motion routine
     call this%usr%user_mesh_setup(this%msh)
 
     !

--- a/src/case.f90
+++ b/src/case.f90
@@ -148,6 +148,8 @@ contains
     integer :: output_dir_len
     integer :: precision
 
+    call this%usr%user_startup(this%params)
+
     !
     ! Load mesh
     !

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -228,11 +228,17 @@ module user_intf
      !! (much more powerful than pointwise in terms of what can be done).
      procedure(field_dirichlet_update), nopass, pointer :: &
           user_dirichlet_update => null()
-     !> Routine to set material properties
+     !> Routine to set material properties.
      procedure(user_material_properties), nopass, pointer :: &
           material_properties => null()
    contains
-     !> Constructor.
+     !> Constructor that points non-associated routines to dummy ones.
+     !! Calling a dummy routine causes an error in most cases, but sometimes
+     !! the dummy routine just does nothing. E.g., the dummmy `user_startup`
+     !! just does nothing. The association of the actual routines defined by
+     !! the user happens in the `user_setup` routine inside the user file.
+     !! A call to this routine is injected into the neko executable by
+     !! `makeneko`.
      procedure, pass(this) :: init => user_intf_init
   end type user_t
 
@@ -395,7 +401,6 @@ contains
   !> Dummy user startup
   subroutine dummy_user_startup(params)
     type(json_file), intent(inout) :: params
-    call neko_error('Dummy user defined start-up routine')
   end subroutine dummy_user_startup
 
   !> Dummy user initial condition

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -487,8 +487,8 @@ contains
     integer, intent(in) :: ie
     real(kind=rp), intent(in) :: t
     integer, intent(in) :: tstep
-    call neko_warning('Dummy scalar user bc set, applied on all" // &
-         " non-labeled zones')
+    call neko_warning('Dummy scalar user bc set, applied on all' // &
+         ' non-labeled zones')
   end subroutine dummy_scalar_user_bc
 
   !> Dummy user mesh apply

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -487,8 +487,8 @@ contains
     integer, intent(in) :: ie
     real(kind=rp), intent(in) :: t
     integer, intent(in) :: tstep
-    call neko_warning('Dummy scalar user bc set, applied on all non-labeled &
-         & zones')
+    call neko_warning('Dummy scalar user bc set, applied on all" // &
+         " non-labeled zones')
   end subroutine dummy_scalar_user_bc
 
   !> Dummy user mesh apply

--- a/src/common/user_intf.f90
+++ b/src/common/user_intf.f90
@@ -54,6 +54,14 @@ module user_intf
   implicit none
   private
 
+  !> Abstract interface for a user start-up routine
+  abstract interface
+     subroutine user_startup_intrf(params)
+       import json_file
+       type(json_file), intent(inout) :: params
+     end subroutine user_startup_intrf
+  end interface
+
   !> Abstract interface for user defined initial conditions
   abstract interface
      subroutine useric(u, v, w, p, params)
@@ -170,152 +178,196 @@ module user_intf
      end subroutine user_material_properties
   end interface
 
+  !> A type collecting all the overridable user routines.
   type, public :: user_t
-     !> Logical to indicate if the code have been extended by the user.
+     !> Run as soon as the case file is read, with nothing else initialized.
+     !! Use to manipulate the case file, and define custom parameters.
+     procedure(user_startup_intrf), nopass, pointer :: &
+          user_startup => null()
+     !> Run after the entire case is initialized and restarted, but before the
+     !! time loop. Good place to create auxillary fields, etc.
+     procedure(user_initialize_modules), nopass, pointer :: &
+          user_init_modules => null()
+     !> Compute user initial conditions for the incompressible fluid.
      procedure(useric), nopass, pointer :: fluid_user_ic => null()
+     !> Compute user initial conditions for the compressible fluid.
+     procedure(useric_compressible), nopass, pointer :: &
+          fluid_compressible_user_ic => null()
+     !> Compute user initial conditions for the scalar.
      procedure(useric_scalar), nopass, pointer :: scalar_user_ic => null()
-     procedure(useric_compressible), nopass, pointer :: fluid_compressible_user_ic => null()
-     procedure(user_initialize_modules), nopass, pointer :: user_init_modules => null()
-     procedure(user_simcomp_init), nopass, pointer :: init_user_simcomp => null()
+     !> Constructor for the user simcomp. Ran in the constructor of
+     !! neko_simcomps.
+     procedure(user_simcomp_init), nopass, pointer :: &
+          init_user_simcomp => null()
+     !> Run right after reading the mesh and allows to manipulate it.
      procedure(usermsh), nopass, pointer :: user_mesh_setup => null()
+     !> Run at the end of each time-step in the time loop, right before field
+     !! output to disk.
      procedure(usercheck), nopass, pointer :: user_check => null()
-     procedure(user_final_modules), nopass, pointer :: user_finalize_modules => null()
-     procedure(fluid_source_compute_pointwise), nopass, pointer :: fluid_user_f => null()
-     procedure(fluid_source_compute_vector), nopass, pointer :: fluid_user_f_vector => null()
-     procedure(scalar_source_compute_pointwise), nopass, pointer :: scalar_user_f => null()
-     procedure(scalar_source_compute_vector), nopass, pointer :: scalar_user_f_vector => null()
+     !> Runs in the end of the simulation, after the last output. Mean as a
+     !! place to run `free()` on user-allocated objects.
+     procedure(user_final_modules), nopass, pointer :: &
+          user_finalize_modules => null()
+     !> User forcing for the fluid, pointwise interface.
+     procedure(fluid_source_compute_pointwise), nopass, pointer :: &
+          fluid_user_f => null()
+     !> User forcing for the fluid, field (vector) interface.
+     procedure(fluid_source_compute_vector), nopass, pointer :: &
+          fluid_user_f_vector => null()
+     !> User forcing for the scalar, pointwise interface.
+     procedure(scalar_source_compute_pointwise), nopass, pointer :: &
+          scalar_user_f => null()
+     !> User forcing for the scalar, field (vector) interface.
+     procedure(scalar_source_compute_vector), nopass, pointer :: &
+          scalar_user_f_vector => null()
+     !> User boundary condition for the fluid, pointwise interface.
      procedure(usr_inflow_eval), nopass, pointer :: fluid_user_if => null()
-     procedure(field_dirichlet_update), nopass, pointer :: user_dirichlet_update => null()
+     !> User boundary condition for the scalar, pointwise interface.
      procedure(usr_scalar_bc_eval), nopass, pointer :: scalar_user_bc => null()
+     !> User boundary condition for the fluid or the scalar, field interface
+     !! (much more powerful than pointwise in terms of what can be done).
+     procedure(field_dirichlet_update), nopass, pointer :: &
+          user_dirichlet_update => null()
      !> Routine to set material properties
-     procedure(user_material_properties), nopass, pointer :: material_properties => null()
+     procedure(user_material_properties), nopass, pointer :: &
+          material_properties => null()
    contains
-     procedure, pass(u) :: init => user_intf_init
+     !> Constructor.
+     procedure, pass(this) :: init => user_intf_init
   end type user_t
 
-  public :: useric, useric_scalar, useric_compressible, user_initialize_modules, &
-       usermsh, dummy_user_material_properties, user_material_properties, &
-       user_simcomp_init, simulation_component_user_settings
+  public :: useric, useric_scalar, useric_compressible, &
+       user_initialize_modules, usermsh, dummy_user_material_properties, &
+       user_material_properties, user_simcomp_init, &
+       simulation_component_user_settings, user_startup_intrf
 contains
 
-  !> User interface initialization
-  subroutine user_intf_init(u)
-    class(user_t), intent(inout) :: u
+  !> Constructor.
+  subroutine user_intf_init(this)
+    class(user_t), intent(inout) :: this
     logical :: user_extended = .false.
     character(len=256), dimension(14) :: extensions
     integer :: i, n
 
     n = 0
-    if (.not. associated(u%fluid_user_ic)) then
-       u%fluid_user_ic => dummy_user_ic
+    if (.not. associated(this%user_startup)) then
+       this%user_startup => dummy_user_startup
+    else
+       user_extended = .true.
+       n = n + 1
+       write(extensions(n), '(A)') '- Startup'
+    end if
+
+    if (.not. associated(this%fluid_user_ic)) then
+       this%fluid_user_ic => dummy_user_ic
     else
        user_extended = .true.
        n = n + 1
        write(extensions(n), '(A)') '- Fluid initial condition'
     end if
 
-    if (.not. associated(u%scalar_user_ic)) then
-       u%scalar_user_ic => dummy_user_ic_scalar
+    if (.not. associated(this%scalar_user_ic)) then
+       this%scalar_user_ic => dummy_user_ic_scalar
     else
        user_extended = .true.
        n = n + 1
        write(extensions(n), '(A)') '- Scalar initial condition'
     end if
 
-    if (.not. associated(u%fluid_compressible_user_ic)) then
-       u%fluid_compressible_user_ic => dummy_user_ic_compressible
+    if (.not. associated(this%fluid_compressible_user_ic)) then
+       this%fluid_compressible_user_ic => dummy_user_ic_compressible
     else
        user_extended = .true.
        n = n + 1
        write(extensions(n), '(A)') '- Compressible fluid initial condition'
     end if
 
-    if (.not. associated(u%fluid_user_f)) then
-       u%fluid_user_f => dummy_user_f
+    if (.not. associated(this%fluid_user_f)) then
+       this%fluid_user_f => dummy_user_f
     else
        user_extended = .true.
        n = n + 1
        write(extensions(n), '(A)') '- Fluid source term'
     end if
 
-    if (.not. associated(u%fluid_user_f_vector)) then
-       u%fluid_user_f_vector => dummy_user_f_vector
+    if (.not. associated(this%fluid_user_f_vector)) then
+       this%fluid_user_f_vector => dummy_user_f_vector
     else
        user_extended = .true.
        n = n + 1
        write(extensions(n), '(A)') '- Fluid source term vector'
     end if
 
-    if (.not. associated(u%scalar_user_f)) then
-       u%scalar_user_f => dummy_scalar_user_f
+    if (.not. associated(this%scalar_user_f)) then
+       this%scalar_user_f => dummy_scalar_user_f
     else
        user_extended = .true.
        n = n + 1
        write(extensions(n), '(A)') '- Scalar source term'
     end if
 
-    if (.not. associated(u%scalar_user_f_vector)) then
-       u%scalar_user_f_vector => dummy_user_scalar_f_vector
+    if (.not. associated(this%scalar_user_f_vector)) then
+       this%scalar_user_f_vector => dummy_user_scalar_f_vector
     else
        user_extended = .true.
        n = n + 1
        write(extensions(n), '(A)') '- Scalar source term vector'
     end if
 
-    if (.not. associated(u%scalar_user_bc)) then
-       u%scalar_user_bc => dummy_scalar_user_bc
+    if (.not. associated(this%scalar_user_bc)) then
+       this%scalar_user_bc => dummy_scalar_user_bc
     else
        user_extended = .true.
        n = n + 1
        write(extensions(n), '(A)') '- Scalar boundary condition'
     end if
 
-    if (.not. associated(u%user_dirichlet_update)) then
-       u%user_dirichlet_update => dirichlet_do_nothing
+    if (.not. associated(this%user_dirichlet_update)) then
+       this%user_dirichlet_update => dirichlet_do_nothing
     else
        user_extended = .true.
        n = n + 1
        write(extensions(n), '(A)') '- Dirichlet boundary condition'
     end if
 
-    if (.not. associated(u%user_mesh_setup)) then
-       u%user_mesh_setup => dummy_user_mesh_setup
+    if (.not. associated(this%user_mesh_setup)) then
+       this%user_mesh_setup => dummy_user_mesh_setup
     else
        user_extended = .true.
        n = n + 1
        write(extensions(n), '(A)') '- Mesh setup'
     end if
 
-    if (.not. associated(u%user_check)) then
-       u%user_check => dummy_user_check
+    if (.not. associated(this%user_check)) then
+       this%user_check => dummy_user_check
     else
        user_extended = .true.
        n = n + 1
        write(extensions(n), '(A)') '- User check'
     end if
 
-    if (.not. associated(u%user_init_modules)) then
-       u%user_init_modules => dummy_user_init_no_modules
+    if (.not. associated(this%user_init_modules)) then
+       this%user_init_modules => dummy_user_init_no_modules
     else
        user_extended = .true.
        n = n + 1
        write(extensions(n), '(A)') '- Initialize modules'
     end if
 
-    if (.not. associated(u%init_user_simcomp)) then
-       u%init_user_simcomp => dummy_user_init_no_simcomp
+    if (.not. associated(this%init_user_simcomp)) then
+       this%init_user_simcomp => dummy_user_init_no_simcomp
     end if
 
-    if (.not. associated(u%user_finalize_modules)) then
-       u%user_finalize_modules => dummy_user_final_no_modules
+    if (.not. associated(this%user_finalize_modules)) then
+       this%user_finalize_modules => dummy_user_final_no_modules
     else
        user_extended = .true.
        n = n + 1
        write(extensions(n), '(A)') '- Finalize modules'
     end if
 
-    if (.not. associated(u%material_properties)) then
-       u%material_properties => dummy_user_material_properties
+    if (.not. associated(this%material_properties)) then
+       this%material_properties => dummy_user_material_properties
     else
        user_extended = .true.
        n = n + 1
@@ -339,6 +391,12 @@ contains
   ! Below is the dummy user interface
   ! when running in pure turboNEKO mode
   !
+
+  !> Dummy user startup
+  subroutine dummy_user_startup(params)
+    type(json_file), intent(inout) :: params
+    call neko_error('Dummy user defined start-up routine')
+  end subroutine dummy_user_startup
 
   !> Dummy user initial condition
   subroutine dummy_user_ic(u, v, w, p, params)
@@ -409,7 +467,8 @@ contains
   end subroutine dummy_scalar_user_f
 
   !> Dummy user boundary condition for scalar
-  subroutine dummy_scalar_user_bc(s, x, y, z, nx, ny, nz, ix, iy, iz, ie, t, tstep)
+  subroutine dummy_scalar_user_bc(s, x, y, z, nx, ny, nz, ix, iy, iz, ie, t, &
+       tstep)
     real(kind=rp), intent(inout) :: s
     real(kind=rp), intent(in) :: x
     real(kind=rp), intent(in) :: y
@@ -423,7 +482,8 @@ contains
     integer, intent(in) :: ie
     real(kind=rp), intent(in) :: t
     integer, intent(in) :: tstep
-    call neko_warning('Dummy scalar user bc set, applied on all non-labeled zones')
+    call neko_warning('Dummy scalar user bc set, applied on all non-labeled &
+         & zones')
   end subroutine dummy_scalar_user_bc
 
   !> Dummy user mesh apply

--- a/src/scalar/scalar_ic.f90
+++ b/src/scalar/scalar_ic.f90
@@ -169,7 +169,7 @@ contains
     n = s%dof%size()
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_memcpy(s%x, s%x_d, n, &
-                          HOST_TO_DEVICE, sync = .false.)
+            HOST_TO_DEVICE, sync = .false.)
     end if
 
     ! Ensure continuity across elements for initial conditions
@@ -309,11 +309,11 @@ contains
 
           if (sample_mesh_idx .eq. -1) &
                call neko_error("Invalid file name for the initial condition. &
-&The file format must be e.g. 'mean0.f00001'")
+               &The file format must be e.g. 'mean0.f00001'")
 
           write (log_buf, '(A,ES12.6)') "Tolerance     : ", tolerance
           call neko_log%message(log_buf)
-          write (log_buf, '(A,A)')     "Mesh file     : ", &
+          write (log_buf, '(A,A)') "Mesh file     : ", &
                trim(mesh_file_name)
           call neko_log%message(log_buf)
 
@@ -342,10 +342,10 @@ contains
 
     if (mesh_mismatch .and. .not. interpolate) then
        call neko_error("The fld file must match the current mesh! &
-&Use 'interpolate': 'true' to enable interpolation.")
+            &Use 'interpolate': 'true' to enable interpolation.")
     else if (.not. mesh_mismatch .and. interpolate) then
        call neko_log%warning("You have activated interpolation but you might &
-&still be using the same mesh.")
+            &still be using the same mesh.")
     end if
 
 
@@ -356,11 +356,11 @@ contains
        type is (fld_file_t)
           if (.not. ft%dp_precision) then
              call neko_warning("The coordinates read from the field file are &
-&in single precision.")
+                  &in single precision.")
              call neko_log%message("It is recommended to use a mesh in double &
-&precision for better interpolation results.")
+                  &precision for better interpolation results.")
              call neko_log%message("If the interpolation does not work, you&
-&can try to increase the tolerance.")
+                  &can try to increase the tolerance.")
           end if
        class default
        end select

--- a/src/scalar/scalar_ic.f90
+++ b/src/scalar/scalar_ic.f90
@@ -273,15 +273,14 @@ contains
     call neko_log%message("File name     : " // trim(file_name))
     write (log_buf, '(A,L1)') "Interpolation : ", interpolate
     call neko_log%message(log_buf)
-    if (interpolate) then
-    end if
 
     ! Extract sample index from the file name
     sample_idx = extract_fld_file_index(file_name, -1)
 
-    if (sample_idx .eq. -1) &
-         call neko_error("Invalid file name for the initial condition. The&
-      & file format must be e.g. 'mean0.f00001'")
+    if (sample_idx .eq. -1) then
+       call neko_error("Invalid file name for the initial condition. The " // &
+            "file format must be e.g. 'mean0.f00001'")
+    end if
 
     ! Change from "field0.f000*" to "field0.fld" for the fld reader
     call filename_chsuffix(file_name, file_name, 'fld')
@@ -300,9 +299,10 @@ contains
           ! Extract sample index from the mesh file name
           sample_mesh_idx = extract_fld_file_index(mesh_file_name, -1)
 
-          if (sample_mesh_idx .eq. -1) &
-               call neko_error("Invalid file name for the initial condition. &
-            &The file format must be e.g. 'mean0.f00001'")
+          if (sample_mesh_idx .eq. -1) then
+             call neko_error("Invalid file name for the initial condition." // &
+                  " The file format must be e.g. 'mean0.f00001'")
+          end if
 
           write (log_buf, '(A,ES12.6)') "Tolerance     : ", tolerance
           call neko_log%message(log_buf)
@@ -334,11 +334,11 @@ contains
          fld_data%gdim .ne. s%msh%gdim)
 
     if (mesh_mismatch .and. .not. interpolate) then
-       call neko_error("The fld file must match the current mesh! &
-         &Use 'interpolate': 'true' to enable interpolation.")
+       call neko_error("The fld file must match the current mesh! " // &
+            "Use 'interpolate': 'true' to enable interpolation.")
     else if (.not. mesh_mismatch .and. interpolate) then
-       call neko_log%warning("You have activated interpolation but you might &
-         &still be using the same mesh.")
+       call neko_log%warning("You have activated interpolation but you " // &
+            "might still be using the same mesh.")
     end if
 
 
@@ -348,12 +348,12 @@ contains
        select type (ft => f%file_type)
        type is (fld_file_t)
           if (.not. ft%dp_precision) then
-             call neko_warning("The coordinates read from the field file are &
-               &in single precision.")
-             call neko_log%message("It is recommended to use a mesh in double &
-               &precision for better interpolation results.")
-             call neko_log%message("If the interpolation does not work, you&
-               &can try to increase the tolerance.")
+             call neko_warning("The coordinates read from the field file " // &
+                  "are in single precision.")
+             call neko_log%message("It is recommended to use a mesh in " // &
+                  "double precision for better interpolation results.")
+             call neko_log%message("If the interpolation does not work, " // &
+                  "you can try to increase the tolerance.")
           end if
        class default
        end select

--- a/src/simulation_components/simcomp_executor.f90
+++ b/src/simulation_components/simcomp_executor.f90
@@ -282,8 +282,8 @@ contains
           end if
        end do
        if (order_found .and. .not. previous_found) then
-          call neko_error("Simulation component order must be contiguous &
-               &starting at 1.")
+          call neko_error("Simulation component order must be contiguous " // &
+               "starting at 1.")
        end if
        previous_found = order_found
     end do

--- a/src/simulation_components/simcomp_executor.f90
+++ b/src/simulation_components/simcomp_executor.f90
@@ -56,7 +56,7 @@ module simcomp_executor
      !> Number of simcomps
      integer, private :: n_simcomps
      !> The case
-     type(case_t), pointer, private :: case
+     type(case_t), pointer :: case
      !> Flag to indicate if the simcomp executor has been finalized.
      logical, private :: finalized = .false.
    contains


### PR DESCRIPTION
The PR contains some improvements for user-file lovers.

- I make the neko_simcomps%case object public again, so that the user file is in "god mode" via it.
- I add docstrings to the user file .f90 and do a bit of refactoring and reformatting.
- A new user routine is added, called `user_startup`. This is run right at the beginning of the case init and only gets the case file JSON as input. The purpose is to either hack into the params before they are passed to constructors, or define user-defined variables of built-in type (constants in particular). A case in point is the material property constants in the rayleigh and RBC examples. I guess this will be a welcome addition. What prompted me to add this is that in the PR with scalar improvements, the material_properties routine no longer received the full case params, so doing things as before in the examples above did not work. 