### PR TITLE
make the default of extrapolation in les to be false

### DIFF
--- a/doc/pages/user-guide/simcomps.md
+++ b/doc/pages/user-guide/simcomps.md
@@ -297,10 +297,11 @@ keywords:
   to different fields. For example, one for the scalar and one to the fluid.
 - `extrapolation`: Whether or not extrapolate the velocity to
   compute the eddy viscosity.
-  - `true`: the default option, extrapolate the velocity as the same order as
+  - `true`: extrapolate the velocity as the same order as
   the time scheme.
-  - `false`: disable the extrapolation. In this case, the estimation of the eddy
-  viscosity is of first order, while circumvent the risk of unstable extrapolation.
+  - `false`: the default option, disable the extrapolation. 
+  In this case, the estimation of the eddy viscosity is of first order, while 
+  circumvent the risk of unstable extrapolation.
 
  ~~~~~~~~~~~~~~~{.json}
  {

--- a/src/les/dynamic_smagorinsky.f90
+++ b/src/les/dynamic_smagorinsky.f90
@@ -94,7 +94,7 @@ contains
 
       call json_get_or_default(json, "nut_field", nut_name, "nut")
       call json_get_or_default(json, "delta_type", delta_type, "pointwise")
-      call json_get_or_default(json, "extrapolation", if_ext, .true.)
+      call json_get_or_default(json, "extrapolation", if_ext, .false.)
 
       call this%free()
       call this%init_base(fluid, nut_name, delta_type, if_ext)

--- a/src/les/dynamic_smagorinsky.f90
+++ b/src/les/dynamic_smagorinsky.f90
@@ -193,7 +193,7 @@ contains
 
     if (filter_1d%nx .le. 2) then
        call neko_error("Dynamic Smagorinsky model error: test filter is not &
-            &defined for the current polynomial order")
+       &defined for the current polynomial order")
     end if
     if (mod(filter_1d%nx,2) .eq. 0) then ! number of grid spacing is odd
        ! cutoff at polynomial order int((filter_1d%nx)/2)

--- a/src/les/sigma.f90
+++ b/src/les/sigma.f90
@@ -82,7 +82,7 @@ contains
     call json_get_or_default(json, "delta_type", delta_type, "pointwise")
     ! Based on  C = 1.35 as default values
     call json_get_or_default(json, "c", c, 1.35_rp)
-    call json_get_or_default(json, "extrapolation", if_ext, .true.)
+    call json_get_or_default(json, "extrapolation", if_ext, .false.)
 
     call neko_log%section('LES model')
     write(log_buf, '(A)') 'Model : Sigma'

--- a/src/les/smagorinsky.f90
+++ b/src/les/smagorinsky.f90
@@ -81,7 +81,7 @@ contains
     call json_get_or_default(json, "nut_field", nut_name, "nut")
     call json_get_or_default(json, "delta_type", delta_type, "pointwise")
     call json_get_or_default(json, "c_s", c_s, 0.17_rp)
-    call json_get_or_default(json, "extrapolation", if_ext, .true.)
+    call json_get_or_default(json, "extrapolation", if_ext, .false.)
 
     call neko_log%section('LES model')
     write(log_buf, '(A)') 'Model : Smagorinsky'

--- a/src/les/vreman.f90
+++ b/src/les/vreman.f90
@@ -82,7 +82,7 @@ contains
     call json_get_or_default(json, "delta_type", delta_type, "pointwise")
     ! Based on the Smagorinsky Cs = 0.17.
     call json_get_or_default(json, "c", c, 0.07_rp)
-    call json_get_or_default(json, "extrapolation", if_ext, .true.)
+    call json_get_or_default(json, "extrapolation", if_ext, .false.)
 
     call neko_log%section('LES model')
     write(log_buf, '(A)') 'Model : Vreman'

--- a/src/les/wale.f90
+++ b/src/les/wale.f90
@@ -81,7 +81,7 @@ contains
     call json_get_or_default(json, "nut_field", nut_name, "nut")
     call json_get_or_default(json, "delta_type", delta_type, "pointwise")
     call json_get_or_default(json, "c_w", c_w, 0.55_rp)
-    call json_get_or_default(json, "extrapolation", if_ext, .true.)
+    call json_get_or_default(json, "extrapolation", if_ext, .false.)
 
     call neko_log%section('LES model')
     write(log_buf, '(A)') 'Model : Wale'


### PR DESCRIPTION
According to my personal experience, the extrapolation tends to be unstable in a lot of cases in the current LES setting, thus it's safe to set the default choice to be false. The point is a less accurate result is better than an unstable result.