### PR TITLE
Remove built-in zones from the code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,14 @@ postprocess_fluid_stats
 map_to_equidistant_1d
 calc_lift_from_field
 libneko*.so
+ 
+# ! But unignore directories with the same name as binaries
+!contrib/rea2nbin
+!contrib/genmeshbox
+!contrib/prepart
+!contrib/average_field_in_space
+!contrib/average_fields_in_time
+!contrib/postprocess_fluid_stats
+!contrib/map_to_equidistant_1d
+!contrib/calc_lift_from_field
 

--- a/contrib/mesh_checker/mesh_checker.f90
+++ b/contrib/mesh_checker/mesh_checker.f90
@@ -57,7 +57,7 @@ program mesh_checker
      if (pe_rank .eq. 0) then
         write(*,*) 'Usage: ./mesh_checker mesh.nmsh [--write_zone_indices]'
         write(*,*) '--write_zone_indices : write a field file with boundaries &
-             & marked by zone index.'
+        & marked by zone index.'
      end if
      stop
   end if

--- a/contrib/mesh_checker/mesh_checker.f90
+++ b/contrib/mesh_checker/mesh_checker.f90
@@ -80,21 +80,8 @@ program mesh_checker
 
   call mesh_file%read(msh)
 
-  call MPI_Allreduce(msh%inlet%size, inlet_size, 1, &
-       MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
-  call MPI_Allreduce(msh%wall%size, wall_size, 1, &
-       MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
-  call MPI_Allreduce(msh%outlet%size, outlet_size, 1, &
-       MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
-  call MPI_Allreduce(msh%outlet_normal%size, outlet_normal_size, 1, &
-       MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
-  call MPI_Allreduce(msh%sympln%size, symmetry_size, 1, &
-       MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
   call MPI_Allreduce(msh%periodic%size, periodic_size, 1, &
        MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
-
-  total_size = inlet_size + wall_size + outlet_size + outlet_normal_size &
-       + symmetry_size
 
   if (pe_rank .eq. 0) then
      write(*,*) ''
@@ -105,18 +92,8 @@ program mesh_checker
      write(*,*) 'Number of edges:    ', msh%glb_meds
      write(*,*) ''
      write(*,*) '--------------Zones------------'
-     write(*,*) 'Number of built-in inlet faces:         ', inlet_size
-     write(*,*) 'Number of built-in wall faces:          ', wall_size
-     write(*,*) 'Number of built-in outlet faces:        ', outlet_size
-     write(*,*) 'Number of built-in outlet-normal faces: ', outlet_normal_size
-     write(*,*) 'Number of built-in symmetry faces:      ', symmetry_size
-     write(*,*) 'Number of periodic faces:               ', periodic_size
+     write(*,'(A, I0)') 'Number of periodic faces: ', periodic_size
      write(*,*) ''
-     if (total_size .gt. 0) then
-        write(*,*) 'WARNING: Your mesh contains non-periodic "built-in" zones,&
-             & which are deprecated. Your mesh must have been created natively&
-             & by Nek5000, e.g. with genbox.'
-     end if
      write(*,*) 'Labeled zones: '
   end if
 

--- a/contrib/prepart/prepart.f90
+++ b/contrib/prepart/prepart.f90
@@ -67,14 +67,14 @@ program prepart
      idx_cntr(rank) = idx_cntr(rank) + 1
      idx_map(i) = idx
      call new_msh%add_element(idx, idx, &
-                              msh%elements(i)%e%pts(1)%p, &
-                              msh%elements(i)%e%pts(2)%p, &
-                              msh%elements(i)%e%pts(3)%p, &
-                              msh%elements(i)%e%pts(4)%p, &
-                              msh%elements(i)%e%pts(5)%p, &
-                              msh%elements(i)%e%pts(6)%p, &
-                              msh%elements(i)%e%pts(7)%p, &
-                              msh%elements(i)%e%pts(8)%p)
+          msh%elements(i)%e%pts(1)%p, &
+          msh%elements(i)%e%pts(2)%p, &
+          msh%elements(i)%e%pts(3)%p, &
+          msh%elements(i)%e%pts(4)%p, &
+          msh%elements(i)%e%pts(5)%p, &
+          msh%elements(i)%e%pts(6)%p, &
+          msh%elements(i)%e%pts(7)%p, &
+          msh%elements(i)%e%pts(8)%p)
 
   end do
 
@@ -97,7 +97,7 @@ program prepart
         idx = idx_map(msh%labeled_zones(j)%facet_el(i)%x(2))
         label = j ! adhere to standards...
         call new_msh%mark_labeled_facet(msh%labeled_zones(j)%facet_el(i)%x(1), &
-                                        idx, label)
+             idx, label)
      end do
   end do
 
@@ -111,7 +111,7 @@ program prepart
   do i = 1, msh%curve%size
      idx = idx_map(msh%curve%curve_el(i)%el_idx)
      call new_msh%mark_curve_element(idx, msh%curve%curve_el(i)%curve_data, &
-                                     msh%curve%curve_el(i)%curve_type)
+          msh%curve%curve_el(i)%curve_type)
   end do
 
   call new_msh%finalize()

--- a/contrib/prepart/prepart.f90
+++ b/contrib/prepart/prepart.f90
@@ -16,7 +16,7 @@ program prepart
      stop
   end if
 
-  call neko_init
+  call neko_init()
 
   call get_command_argument(1, fname)
   call get_command_argument(2, nprtschr)

--- a/contrib/prepart/prepart.f90
+++ b/contrib/prepart/prepart.f90
@@ -119,8 +119,8 @@ program prepart
   deallocate(idx_map)
   call msh%free()
 
-  output_ = trim(fname(1:scan(trim(fname), &
-       '.', back=.true.) - 1))//'_'//trim(nprtschr)//'.nmsh'
+  output_ = trim(fname(1:scan(trim(fname), '.', back = .true.) - 1)) // &
+       '_' // trim(nprtschr) // '.nmsh'
 
   new_msh_file = file_t(output_)
   call new_msh_file%write(new_msh)

--- a/contrib/prepart/prepart.f90
+++ b/contrib/prepart/prepart.f90
@@ -16,7 +16,7 @@ program prepart
      stop
   end if
 
-  call neko_init 
+  call neko_init
 
   call get_command_argument(1, fname)
   call get_command_argument(2, nprtschr)
@@ -60,9 +60,9 @@ program prepart
   !
 
   new_msh%lgenc = .false.
-  call new_msh%init(msh%gdim, msh%nelv)  
+  call new_msh%init(msh%gdim, msh%nelv)
   do i = 1, msh%nelv
-     rank = parts%data(i)     
+     rank = parts%data(i)
      idx = idx_cntr(rank) + new_el(rank)
      idx_cntr(rank) = idx_cntr(rank) + 1
      idx_map(i) = idx
@@ -83,32 +83,7 @@ program prepart
 
   !
   ! Add zones
-  ! 
-  do i = 1, msh%wall%size
-     idx = idx_map(msh%wall%facet_el(i)%x(2))
-     call new_msh%mark_wall_facet(msh%wall%facet_el(i)%x(1), idx)
-  end do
-
-  do i = 1, msh%inlet%size
-     idx = idx_map(msh%inlet%facet_el(i)%x(2))
-     call new_msh%mark_inlet_facet(msh%inlet%facet_el(i)%x(1), idx)
-  end do
-
-  do i = 1, msh%outlet%size
-     idx = idx_map(msh%outlet%facet_el(i)%x(2))
-     call new_msh%mark_outlet_facet(msh%outlet%facet_el(i)%x(1), idx)
-  end do
-
-  do i = 1, msh%outlet_normal%size
-     idx = idx_map(msh%outlet_normal%facet_el(i)%x(2))
-     call new_msh%mark_outlet_normal_facet(msh%outlet_normal%facet_el(i)%x(1), &
-                                           idx)
-  end do
-
-  do i = 1, msh%sympln%size
-     idx = idx_map(msh%sympln%facet_el(i)%x(2))
-     call new_msh%mark_sympln_facet(msh%sympln%facet_el(i)%x(1), idx)
-  end do
+  !
 
   do i = 1, msh%periodic%size
      idx = idx_map(msh%periodic%facet_el(i)%x(2))
@@ -125,7 +100,7 @@ program prepart
                                         idx, label)
      end do
   end do
-  
+
   do i = 1, msh%periodic%size
      idx = idx_map(msh%periodic%facet_el(i)%x(2))
      p_idx = idx_map(msh%periodic%p_facet_el(i)%x(2))
@@ -138,14 +113,14 @@ program prepart
      call new_msh%mark_curve_element(idx, msh%curve%curve_el(i)%curve_data, &
                                      msh%curve%curve_el(i)%curve_type)
   end do
-  
+
   call new_msh%finalize()
-  
+
   deallocate(idx_map)
   call msh%free()
 
   output_ = trim(fname(1:scan(trim(fname), &
-       '.', back=.true.) - 1))//'_'//trim(nprtschr)//'.nmsh' 
+       '.', back=.true.) - 1))//'_'//trim(nprtschr)//'.nmsh'
 
   new_msh_file = file_t(output_)
   call new_msh_file%write(new_msh)

--- a/src/comm/redist.f90
+++ b/src/comm/redist.f90
@@ -53,8 +53,8 @@ contains
 
   !> Redistribute a mesh @a msh according to new partitions
   subroutine redist_mesh(msh, parts)
-    type(mesh_t), intent(inout), target :: msh    !< Mesh
-    type(mesh_fld_t), intent(in) :: parts         !< Partitions
+    type(mesh_t), intent(inout), target :: msh !< Mesh
+    type(mesh_fld_t), intent(in) :: parts !< Partitions
     type(stack_nh_t), allocatable :: new_mesh_dist(:)
     type(stack_nz_t), allocatable :: new_zone_dist(:)
     type(stack_nc_t), allocatable :: new_curve_dist(:)
@@ -167,8 +167,8 @@ contains
        select type (nzd_array => new_zone_dist(dst)%data)
        type is (nmsh_zone_t)
           call MPI_Sendrecv(nzd_array, &
-            new_zone_dist(dst)%size(), MPI_NMSH_ZONE, dst, 1, recv_buf_zone,&
-            max_recv(2), MPI_NMSH_ZONE, src, 1, NEKO_COMM, status, ierr)
+               new_zone_dist(dst)%size(), MPI_NMSH_ZONE, dst, 1, recv_buf_zone,&
+               max_recv(2), MPI_NMSH_ZONE, src, 1, NEKO_COMM, status, ierr)
        end select
        call MPI_Get_count(status, MPI_NMSH_ZONE, recv_size, ierr)
 
@@ -225,7 +225,7 @@ contains
 
              ! Old glb to new glb
              tmp = msh%elements(i)%e%id()
-             call glb_map%set(np(i)%el_idx,  tmp)
+             call glb_map%set(np(i)%el_idx, tmp)
           else
              call neko_error('Global element id already defined')
           end if
@@ -288,7 +288,7 @@ contains
        call MPI_Get_count(status, MPI_INTEGER, recv_size, ierr)
 
        do j = 1, recv_size, 2
-          call glb_map%set(recv_buf_idx(j),  recv_buf_idx(j+1))
+          call glb_map%set(recv_buf_idx(j), recv_buf_idx(j+1))
        end do
     end do
     deallocate(recv_buf_idx)
@@ -373,7 +373,7 @@ contains
     select type(zp => z)
     type is (facet_zone_periodic_t)
        do i = 1, zp%size
-          zone_el =  zp%facet_el(i)%x(2)
+          zone_el = zp%facet_el(i)%x(2)
           nmsh_zone%e = msh%elements(zp%facet_el(i)%x(2))%e%id()
           nmsh_zone%f = zp%facet_el(i)%x(1)
           nmsh_zone%p_e = zp%p_facet_el(i)%x(2)
@@ -384,7 +384,7 @@ contains
        end do
     type is (facet_zone_t)
        do i = 1, zp%size
-          zone_el =  zp%facet_el(i)%x(2)
+          zone_el = zp%facet_el(i)%x(2)
           nmsh_zone%e = msh%elements(zp%facet_el(i)%x(2))%e%id()
           nmsh_zone%f = zp%facet_el(i)%x(1)
           nmsh_zone%p_f = lbl ! Labels are encoded in the periodic facet...

--- a/src/comm/redist.f90
+++ b/src/comm/redist.f90
@@ -87,12 +87,7 @@ contains
        call new_zone_dist(i)%init()
     end do
 
-    call redist_zone(msh, msh%wall, 1, parts, new_zone_dist)
-    call redist_zone(msh, msh%inlet, 2, parts, new_zone_dist)
-    call redist_zone(msh, msh%outlet, 3, parts, new_zone_dist)
-    call redist_zone(msh, msh%sympln, 4, parts, new_zone_dist)
     call redist_zone(msh, msh%periodic, 5, parts, new_zone_dist)
-    call redist_zone(msh, msh%outlet_normal, 6, parts, new_zone_dist)
 
     do j = 1, NEKO_MSH_MAX_ZLBLS
        label = j
@@ -310,23 +305,13 @@ contains
              call neko_error('Missing element after redistribution')
           end if
           select case(zp(i)%type)
-          case(1)
-             call msh%mark_wall_facet(zp(i)%f, new_el_idx)
-          case(2)
-             call msh%mark_inlet_facet(zp(i)%f, new_el_idx)
-          case(3)
-             call msh%mark_outlet_facet(zp(i)%f, new_el_idx)
-          case(4)
-             call msh%mark_sympln_facet(zp(i)%f, new_el_idx)
           case(5)
              if (glb_map%get(zp(i)%p_e, new_pel_idx) .gt. 0) then
                 call neko_error('Missing periodic element after redistribution')
              end if
-             
+
              call msh%mark_periodic_facet(zp(i)%f, new_el_idx, &
                   zp(i)%p_f, zp(i)%p_e, zp(i)%glb_pt_ids)
-          case(6)
-             call msh%mark_outlet_normal_facet(zp(i)%f, new_el_idx)
           case(7)
              call msh%mark_labeled_facet(zp(i)%f, new_el_idx, zp(i)%p_f)
           end select
@@ -340,7 +325,7 @@ contains
              if (glb_map%get(zp(i)%p_e, new_pel_idx) .gt. 0) then
                 call neko_error('Missing periodic element after redistribution')
              end if
-             
+
              call msh%apply_periodic_facet(zp(i)%f, new_el_idx, &
                   zp(i)%p_f, zp(i)%p_e, zp(i)%glb_pt_ids)
           end select
@@ -348,7 +333,7 @@ contains
     end select
     call new_zone_dist(pe_rank)%free()
 
-       
+
     !
     ! Add curve element information for new mesh distribution
     !
@@ -362,7 +347,7 @@ contains
        end do
     end select
     call new_curve_dist(pe_rank)%free()
-           
+
 
     call msh%finalize()
 

--- a/src/io/nmsh_file.f90
+++ b/src/io/nmsh_file.f90
@@ -457,8 +457,8 @@ contains
     integer :: ncurves, ncurves_glb, ncurves_offset
     integer :: el_idx, el_idx_glb
     class(element_t), pointer :: ep
-    integer(i4), dimension(8), parameter :: vcyc_to_sym = [1, 2, 4, 3, 5, &
-         & 6, 8, 7] ! cyclic to symmetric vertex mapping
+    integer(i4), dimension(8), parameter :: vcyc_to_sym = &
+         [1, 2, 4, 3, 5, 6, 8, 7] ! cyclic to symmetric vertex mapping
 
     select type (data)
     type is (mesh_t)
@@ -528,7 +528,7 @@ contains
        call neko_error('Invalid dimension of mesh')
     end if
 
-    nzones =  msh%periodic%size
+    nzones = msh%periodic%size
     do i = 1, NEKO_MSH_MAX_ZLBLS
        nzones = nzones + msh%labeled_zones(i)%size
     end do

--- a/src/io/nmsh_file.f90
+++ b/src/io/nmsh_file.f90
@@ -188,20 +188,10 @@ contains
              el_idx_glb = nmsh_zone(i)%e
              if (msh%htel%get(el_idx_glb, el_idx) .eq. 0) then
                 select case (nmsh_zone(i)%type)
-                case (1)
-                   call msh%mark_wall_facet(nmsh_zone(i)%f, el_idx)
-                case (2)
-                   call msh%mark_inlet_facet(nmsh_zone(i)%f, el_idx)
-                case (3)
-                   call msh%mark_outlet_facet(nmsh_zone(i)%f, el_idx)
-                case (4)
-                   call msh%mark_sympln_facet(nmsh_zone(i)%f, el_idx)
                 case (5)
                    call msh%mark_periodic_facet(nmsh_zone(i)%f, el_idx, &
                         nmsh_zone(i)%p_f, nmsh_zone(i)%p_e, &
                         nmsh_zone(i)%glb_pt_ids)
-                case (6)
-                   call msh%mark_outlet_normal_facet(nmsh_zone(i)%f, el_idx)
                 case (7)
                    call msh%mark_labeled_facet(nmsh_zone(i)%f, el_idx, &
                         nmsh_zone(i)%p_f)
@@ -356,14 +346,6 @@ contains
           el_idx_glb = nmsh_zone(i)%e
           if (msh%htel%get(el_idx_glb, el_idx) .eq. 0) then
              select case (nmsh_zone(i)%type)
-             case (1)
-                call msh%mark_wall_facet(nmsh_zone(i)%f, el_idx)
-             case (2)
-                call msh%mark_inlet_facet(nmsh_zone(i)%f, el_idx)
-             case (3)
-                call msh%mark_outlet_facet(nmsh_zone(i)%f, el_idx)
-             case (4)
-                call msh%mark_sympln_facet(nmsh_zone(i)%f, el_idx)
              case (5)
                 nmsh_zone(i)%glb_pt_ids(3) = nmsh_zone(i)%glb_pt_ids(1) + &
                      msh%glb_nelv * 8
@@ -383,8 +365,6 @@ contains
                 nmsh_zone(i)%glb_pt_ids = ids
                 call msh%mark_periodic_facet(nmsh_zone(i)%f, el_idx, &
                      nmsh_zone(i)%p_f, nmsh_zone(i)%p_e, ids)
-             case (6)
-                call msh%mark_outlet_normal_facet(nmsh_zone(i)%f, el_idx)
              case (7)
                 call msh%mark_labeled_facet(nmsh_zone(i)%f, el_idx, &
                      nmsh_zone(i)%p_f)
@@ -525,7 +505,7 @@ contains
           ep => msh%elements(i)%e
           nmsh_hex(i)%el_idx = ep%id()
           do j = 1, 8
-             nmsh_hex(i)%v(j)%v_idx = ep%pts(vcyc_to_sym(j))%p%id()             
+             nmsh_hex(i)%v(j)%v_idx = ep%pts(vcyc_to_sym(j))%p%id()
              nmsh_hex(i)%v(j)%v_xyz = ep%pts(vcyc_to_sym(j))%p%x
           end do
        end do
@@ -548,8 +528,7 @@ contains
        call neko_error('Invalid dimension of mesh')
     end if
 
-    nzones = msh%wall%size + msh%inlet%size + msh%outlet%size + &
-         msh%sympln%size + msh%periodic%size + msh%outlet_normal%size
+    nzones =  msh%periodic%size
     do i = 1, NEKO_MSH_MAX_ZLBLS
        nzones = nzones + msh%labeled_zones(i)%size
     end do
@@ -572,34 +551,6 @@ contains
           nmsh_zone(:)%type = 0
 
           j = 1
-          do i = 1, msh%wall%size
-             nmsh_zone(j)%e = msh%elements(msh%wall%facet_el(i)%x(2))%e%id() 
-             nmsh_zone(j)%f = msh%wall%facet_el(i)%x(1)
-             nmsh_zone(j)%type = 1
-             j = j + 1
-          end do
-
-          do i = 1, msh%inlet%size
-             nmsh_zone(j)%e = msh%elements(msh%inlet%facet_el(i)%x(2))%e%id()
-             nmsh_zone(j)%f = msh%inlet%facet_el(i)%x(1)
-             nmsh_zone(j)%type = 2
-             j = j + 1
-          end do
-
-          do i = 1, msh%outlet%size
-             nmsh_zone(j)%e = msh%elements(msh%outlet%facet_el(i)%x(2))%e%id()
-             nmsh_zone(j)%f = msh%outlet%facet_el(i)%x(1)
-             nmsh_zone(j)%type = 3
-             j = j + 1
-          end do
-
-          do i = 1, msh%sympln%size
-             nmsh_zone(j)%e = msh%elements(msh%sympln%facet_el(i)%x(2))%e%id()
-             nmsh_zone(j)%f = msh%sympln%facet_el(i)%x(1)
-             nmsh_zone(j)%type = 4
-             j = j + 1
-          end do
-
           do i = 1, msh%periodic%size
              nmsh_zone(j)%e = msh%elements(msh%periodic%facet_el(i)%x(2))%e%id()
              nmsh_zone(j)%f = msh%periodic%facet_el(i)%x(1)
@@ -607,14 +558,6 @@ contains
              nmsh_zone(j)%p_f = msh%periodic%p_facet_el(i)%x(1)
              nmsh_zone(j)%glb_pt_ids = msh%periodic%p_ids(i)%x
              nmsh_zone(j)%type = 5
-             j = j + 1
-          end do
-
-          do i = 1, msh%outlet_normal%size
-             nmsh_zone(j)%e = &
-                  msh%elements(msh%outlet_normal%facet_el(i)%x(2))%e%id()
-             nmsh_zone(j)%f = msh%outlet_normal%facet_el(i)%x(1)
-             nmsh_zone(j)%type = 6
              j = j + 1
           end do
 
@@ -646,7 +589,7 @@ contains
 
     ncurves_offset = 0
     call MPI_Exscan(ncurves, ncurves_offset, 1, &
-         MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)    
+         MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
 
     mpi_offset = mpi_el_offset + int(MPI_INTEGER_SIZE, i8) + &
          int(nzones_glb, i8)*int(nmsh_zone_size, i8)

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -521,7 +521,7 @@ contains
                 call this%elements(i)%e%facet_id(edge, j)
 
                 ! Assume that all facets are on the exterior
-                facet_data%x = (/ 0, 0/)
+                facet_data%x = [0, 0]
 
                 !check it this face has shown up earlier
                 if (fmp%get(edge, facet_data) .eq. 0) then
@@ -565,7 +565,7 @@ contains
                    if (facet_data%x(1) .eq. el_glb_idx ) then
                       this%facet_neigh(j, i) = facet_data%x(2)
                       call this%elements(i)%e%facet_id(face_comp, &
-                           j+(2*mod(j,2)-1))
+                           j + (2*mod(j, 2) - 1))
                       if (face_comp .eq. face) then
                          facet_data%x(2) = el_glb_idx
                          this%facet_neigh(j, i) = facet_data%x(1)

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -61,33 +61,33 @@ module mesh
      class(element_t), allocatable :: e
   end type mesh_element_t
 
-  type, public ::  mesh_t
-     integer :: nelv            !< Number of elements
-     integer :: npts            !< Number of points per element
-     integer :: gdim            !< Geometric dimension
-     integer :: mpts            !< Number of (unique) points in the mesh
-     integer :: mfcs            !< Number of (unique) faces in the mesh
-     integer :: meds            !< Number of (unique) edges in the mesh
+  type, public :: mesh_t
+     integer :: nelv !< Number of elements
+     integer :: npts !< Number of points per element
+     integer :: gdim !< Geometric dimension
+     integer :: mpts !< Number of (unique) points in the mesh
+     integer :: mfcs !< Number of (unique) faces in the mesh
+     integer :: meds !< Number of (unique) edges in the mesh
 
-     integer :: glb_nelv        !< Global number of elements
-     integer :: glb_mpts        !< Global number of unique points
-     integer :: glb_mfcs        !< Global number of unique faces
-     integer :: glb_meds        !< Global number of unique edges
+     integer :: glb_nelv !< Global number of elements
+     integer :: glb_mpts !< Global number of unique points
+     integer :: glb_mfcs !< Global number of unique faces
+     integer :: glb_meds !< Global number of unique edges
 
-     integer :: offset_el       !< Element offset
-     integer :: max_pts_id      !< Max local point id
+     integer :: offset_el !< Element offset
+     integer :: max_pts_id !< Max local point id
 
      type(point_t), allocatable :: points(:) !< list of points
      type(mesh_element_t), allocatable :: elements(:) !< List of elements
      logical, allocatable :: dfrmd_el(:) !< List of elements
 
-     type(htable_i4_t) :: htp   !< Table of unique points (global->local)
+     type(htable_i4_t) :: htp !< Table of unique points (global->local)
      type(htable_i4t4_t) :: htf !< Table of unique faces (facet->local id)
      type(htable_i4t2_t) :: hte !< Table of unique edges (edge->local id)
-     type(htable_i4_t) :: htel  !< Table of unique elements (global->local)
+     type(htable_i4_t) :: htel !< Table of unique elements (global->local)
 
 
-     integer, allocatable :: facet_neigh(:,:)  !< Facet to neigh. element table
+     integer, allocatable :: facet_neigh(:,:) !< Facet to neigh. element table
 
      !> Facet to element's id tuple and the mapping of the
      !! points between lower id element and higher
@@ -95,24 +95,24 @@ module mesh
      class(htable_t), allocatable :: facet_map
      type(stack_i4_t), allocatable :: point_neigh(:) !< Point to neigh. table
 
-     type(distdata_t) :: ddata            !< Mesh distributed data
-     logical, allocatable :: neigh(:)     !< Neighbouring ranks
+     type(distdata_t) :: ddata !< Mesh distributed data
+     logical, allocatable :: neigh(:) !< Neighbouring ranks
      integer, allocatable :: neigh_order(:) !< Neighbour order
 
      integer(2), allocatable :: facet_type(:,:) !< Facet type
 
      type(facet_zone_t), allocatable :: labeled_zones(:) !< Zones with labeled facets
-     type(facet_zone_periodic_t) :: periodic             !< Zones with periodic facets
-     type(curve_t) :: curve                        !< Set of curved elements
+     type(facet_zone_periodic_t) :: periodic !< Zones with periodic facets
+     type(curve_t) :: curve !< Set of curved elements
 
-     logical :: lconn = .false.                !< valid connectivity
-     logical :: ldist = .false.                !< valid distributed data
-     logical :: lnumr = .false.                !< valid numbering
-     logical :: lgenc = .true.                 !< generate connectivity
+     logical :: lconn = .false. !< valid connectivity
+     logical :: ldist = .false. !< valid distributed data
+     logical :: lnumr = .false. !< valid numbering
+     logical :: lgenc = .true. !< generate connectivity
 
      !> enables user to specify a deformation
      !! that is applied to all x,y,z coordinates generated with this mesh
-     procedure(mesh_deform), pass(msh), pointer  :: apply_deform => null()
+     procedure(mesh_deform), pass(msh), pointer :: apply_deform => null()
    contains
      procedure, private, pass(this) :: init_nelv => mesh_init_nelv
      procedure, private, pass(this) :: init_dist => mesh_init_dist
@@ -174,8 +174,8 @@ contains
   !> Initialise a mesh @a this with @a nelv elements
   subroutine mesh_init_nelv(this, gdim, nelv)
     class(mesh_t), intent(inout) :: this !< Mesh
-    integer, intent(in) :: gdim          !< Geometric dimension
-    integer, intent(in) :: nelv          !< Local number of elements
+    integer, intent(in) :: gdim !< Geometric dimension
+    integer, intent(in) :: nelv !< Local number of elements
     integer :: ierr
     character(len=LOG_SIZE) :: log_buf
 
@@ -202,8 +202,8 @@ contains
 
   !> Initialise a mesh @a this based on a distribution @a dist
   subroutine mesh_init_dist(this, gdim, dist)
-    class(mesh_t), intent(inout) :: this    !< Mesh
-    integer, intent(in) :: gdim             !< Geometric dimension
+    class(mesh_t), intent(inout) :: this !< Mesh
+    integer, intent(in) :: gdim !< Geometric dimension
     type(linear_dist_t), intent(in) :: dist !< Data distribution
     character(len=LOG_SIZE) :: log_buf
 
@@ -465,8 +465,8 @@ contains
              !should stack have inout on what we push? would be neat with in
              id = ep%id()
              call this%point_neigh(p_local_idx)%push(id)
-         end do
-         do i = 1, NEKO_HEX_NFCS
+          end do
+          do i = 1, NEKO_HEX_NFCS
              call ep%facet_id(f, i)
              call this%add_face(f)
           end do
@@ -521,7 +521,7 @@ contains
                 call this%elements(i)%e%facet_id(edge, j)
 
                 ! Assume that all facets are on the exterior
-                facet_data%x = (/  0, 0/)
+                facet_data%x = (/ 0, 0/)
 
                 !check it this face has shown up earlier
                 if (fmp%get(edge, facet_data) .eq. 0) then
@@ -565,7 +565,7 @@ contains
                    if (facet_data%x(1) .eq. el_glb_idx ) then
                       this%facet_neigh(j, i) = facet_data%x(2)
                       call this%elements(i)%e%facet_id(face_comp, &
-                                                      j+(2*mod(j,2)-1))
+                           j+(2*mod(j,2)-1))
                       if (face_comp .eq. face) then
                          facet_data%x(2) = el_glb_idx
                          this%facet_neigh(j, i) = facet_data%x(1)
@@ -653,7 +653,7 @@ contains
   subroutine mesh_generate_external_facet_conn(this)
     type(mesh_t), intent(inout) :: this
     type(tuple_i4_t) :: edge, edge2
-    type(tuple4_i4_t) :: face,  face2
+    type(tuple4_i4_t) :: face, face2
     type(tuple_i4_t) :: facet_data
     type(stack_i4_t) :: buffer
     type(MPI_Status) :: status
@@ -678,7 +678,7 @@ contains
     do i = 1, this%nelv
        el_glb_idx = i + this%offset_el
        do j = 1, n_sides
-          facet = j             ! Adhere to standards...
+          facet = j ! Adhere to standards...
           if (this%facet_neigh(j, i) .eq. 0) then
              if (n_nodes .eq. 2) then
                 call this%elements(i)%e%facet_id(edge, j)
@@ -922,7 +922,7 @@ contains
 
     num_edge_glb = 2* this%meds
     call MPI_Allreduce(MPI_IN_PLACE, num_edge_glb, 1, &
-         MPI_INTEGER, MPI_SUM, NEKO_COMM,  ierr)
+         MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
 
     glb_max = int(num_edge_glb, i8)
 
@@ -1048,9 +1048,9 @@ contains
           call distdata_set_local_to_global_edge(this%ddata, id, shared_offset)
 
           ! Add new number to send data as [old_glb_id new_glb_id] for each edge
-          call send_buff%push(glb_ptr)    ! Old glb_id integer*8
+          call send_buff%push(glb_ptr) ! Old glb_id integer*8
           glb_id = int(shared_offset, i8) ! Waste some space here...
-          call send_buff%push(glb_id)     ! New glb_id integer*4
+          call send_buff%push(glb_id) ! New glb_id integer*4
 
           shared_offset = shared_offset + 1
        else
@@ -1105,7 +1105,7 @@ contains
                 if (glb_to_loc%get(recv_buff(j), id) .eq. 0) then
                    n_glb_id = int(recv_buff(j + 1 ), 4)
                    call distdata_set_local_to_global_edge(this%ddata, id, &
-                                                          n_glb_id)
+                        n_glb_id)
                 else
                    call neko_error('Invalid edge id')
                 end if
@@ -1241,7 +1241,7 @@ contains
 
     if (this%gdim .eq. 2) then
 
-       if (owned_facets .gt. 32)  then
+       if (owned_facets .gt. 32) then
           call send_buff%init(owned_facets)
        else
           call send_buff%init()
@@ -1251,7 +1251,7 @@ contains
        do i = 1, edge_owner%size()
           if (this%hte%get(ed(i), id) .eq. 0) then
              call distdata_set_local_to_global_facet(this%ddata, id, &
-                                                     shared_offset)
+                  shared_offset)
 
              ! Add new number to send buffer
              ! [edge id1 ... edge idn new_glb_id]
@@ -1266,7 +1266,7 @@ contains
 
     else
 
-       if (owned_facets .gt. 32)  then
+       if (owned_facets .gt. 32) then
           call send_buff%init(owned_facets)
        else
           call send_buff%init()
@@ -1276,7 +1276,7 @@ contains
        do i = 1, face_owner%size()
           if (this%htf%get(fd(i), id) .eq. 0) then
              call distdata_set_local_to_global_facet(this%ddata, id, &
-                                                     shared_offset)
+                  shared_offset)
 
              ! Add new number to send buffer
              ! [face id1 ... face idn new_glb_id]
@@ -1578,18 +1578,20 @@ contains
     integer :: pe
     integer :: org_ids(4), pids(4)
     type(point_t), pointer :: pi
-    integer, dimension(4, 6) :: face_nodes = reshape((/1,5,7,3,&
-                                                       2,6,8,4,&
-                                                       1,2,6,5,&
-                                                       3,4,8,7,&
-                                                       1,2,4,3,&
-                                                       5,6,8,7/),&
-                                                       (/4,6/))
-    integer, dimension(2, 4) :: edge_nodes = reshape((/1,3,&
-                                                       2,4,&
-                                                       1,2,&
-                                                       3,4 /),&
-                                                       (/2,4/))
+    integer, dimension(4, 6) :: face_nodes = &
+         reshape((/1,5,7,3,&
+         2,6,8,4,&
+         1,2,6,5,&
+         3,4,8,7,&
+         1,2,4,3,&
+         5,6,8,7/),&
+         (/4,6/))
+    integer, dimension(2, 4) :: edge_nodes = &
+         reshape((/1,3,&
+         2,4,&
+         1,2,&
+         3,4 /),&
+         (/2,4/))
 
     do i = 1, this%periodic%size
        e = this%periodic%facet_el(i)%x(2)
@@ -1632,17 +1634,17 @@ contains
     type(tuple4_i4_t) :: ft
     type(tuple_i4_t) :: et
     integer, dimension(4, 6) :: face_nodes = reshape((/1,5,7,3,&
-                                                       2,6,8,4,&
-                                                       1,2,6,5,&
-                                                       3,4,8,7,&
-                                                       1,2,4,3,&
-                                                       5,6,8,7/),&
-                                                       (/4,6/))
+         2,6,8,4,&
+         1,2,6,5,&
+         3,4,8,7,&
+         1,2,4,3,&
+         5,6,8,7/),&
+         (/4,6/))
     integer, dimension(2, 4) :: edge_nodes = reshape((/1,3,&
-                                                       2,4,&
-                                                       1,2,&
-                                                       3,4 /),&
-                                                      (/2,4/))
+         2,4,&
+         1,2,&
+         3,4 /),&
+         (/2,4/))
 
     select type(ele => this%elements(e)%e)
     type is(hex_t)
@@ -1651,7 +1653,7 @@ contains
           L = 0d0
           do i = 1, 4
              L = L + ele%pts(face_nodes(i,f))%p%x(1:3) - &
-               elp%pts(face_nodes(i,pf))%p%x(1:3)
+                  elp%pts(face_nodes(i,pf))%p%x(1:3)
           end do
           L = L/4
           do i = 1, 4
@@ -1680,7 +1682,7 @@ contains
           L = 0d0
           do i = 1, 2
              L = L + ele%pts(edge_nodes(i,f))%p%x(1:3) - &
-               elp%pts(edge_nodes(i,pf))%p%x(1:3)
+                  elp%pts(edge_nodes(i,pf))%p%x(1:3)
           end do
           L = L/2
           do i = 1, 2
@@ -1714,12 +1716,12 @@ contains
     type(tuple4_i4_t) :: ft
     type(tuple_i4_t) :: et
     integer, dimension(4, 6) :: face_nodes = reshape((/1,5,7,3,&
-                                                       2,6,8,4,&
-                                                       1,2,6,5,&
-                                                       3,4,8,7,&
-                                                       1,2,4,3,&
-                                                       5,6,8,7/),&
-                                                       (/4,6/))
+         2,6,8,4,&
+         1,2,6,5,&
+         3,4,8,7,&
+         1,2,4,3,&
+         5,6,8,7/),&
+         (/4,6/))
     select type(ele => this%elements(e)%e)
     type is(hex_t)
        do i = 1, 4
@@ -1813,7 +1815,7 @@ contains
   !! @todo Consider moving this to distdata
   function mesh_have_point_glb_idx(this, index) result(local_id)
     class(mesh_t), intent(inout) :: this
-    integer, intent(inout) :: index  !< Global index
+    integer, intent(inout) :: index !< Global index
     integer :: local_id
 
     if (this%htp%get(index, local_id) .eq. 1) then

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -1578,14 +1578,14 @@ contains
     integer :: pe
     integer :: org_ids(4), pids(4)
     type(point_t), pointer :: pi
-    integer, dimension(4, 6) :: face_nodes = &
-         reshape((/1,5,7,3,&
-         2,6,8,4,&
-         1,2,6,5,&
-         3,4,8,7,&
-         1,2,4,3,&
-         5,6,8,7/),&
-         (/4,6/))
+    integer, dimension(4, 6) :: face_nodes = reshape([ &
+         1,5,7,3, &
+         2,6,8,4, &
+         1,2,6,5, &
+         3,4,8,7, &
+         1,2,4,3, &
+         5,6,8,7],&
+         [4,6])
     integer, dimension(2, 4) :: edge_nodes = &
          reshape((/1,3,&
          2,4,&

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -1633,18 +1633,20 @@ contains
     integer :: i, j, id, p_local_idx, match
     type(tuple4_i4_t) :: ft
     type(tuple_i4_t) :: et
-    integer, dimension(4, 6) :: face_nodes = reshape((/1,5,7,3,&
+    integer, dimension(4, 6) :: face_nodes = reshape([&
+         1,5,7,3,&
          2,6,8,4,&
          1,2,6,5,&
          3,4,8,7,&
          1,2,4,3,&
-         5,6,8,7/),&
-         (/4,6/))
-    integer, dimension(2, 4) :: edge_nodes = reshape((/1,3,&
+         5,6,8,7],&
+         ([4,6]))
+    integer, dimension(2, 4) :: edge_nodes = reshape([&
+         1,3,&
          2,4,&
          1,2,&
-         3,4 /),&
-         (/2,4/))
+         3,4 ],&
+         ([2,4]))
 
     select type(ele => this%elements(e)%e)
     type is(hex_t)
@@ -1715,13 +1717,14 @@ contains
     integer :: i, id, p_local_idx
     type(tuple4_i4_t) :: ft
     type(tuple_i4_t) :: et
-    integer, dimension(4, 6) :: face_nodes = reshape((/1,5,7,3,&
+    integer, dimension(4, 6) :: face_nodes = reshape([&
+         1,5,7,3,&
          2,6,8,4,&
          1,2,6,5,&
          3,4,8,7,&
          1,2,4,3,&
-         5,6,8,7/),&
-         (/4,6/))
+         5,6,8,7],&
+         [4,6])
     select type(ele => this%elements(e)%e)
     type is(hex_t)
        do i = 1, 4

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -1586,12 +1586,12 @@ contains
          1,2,4,3, &
          5,6,8,7],&
          [4,6])
-    integer, dimension(2, 4) :: edge_nodes = &
-         reshape((/1,3,&
-         2,4,&
-         1,2,&
-         3,4 /),&
-         (/2,4/))
+    integer, dimension(2, 4) :: edge_nodes = reshape([ &
+         1,3, &
+         2,4, &
+         1,2, &
+         3,4],&
+         [2,4])
 
     do i = 1, this%periodic%size
        e = this%periodic%facet_el(i)%x(2)

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -1640,13 +1640,13 @@ contains
          3,4,8,7,&
          1,2,4,3,&
          5,6,8,7],&
-         ([4,6]))
+         [4,6])
     integer, dimension(2, 4) :: edge_nodes = reshape([&
          1,3,&
          2,4,&
          1,2,&
          3,4 ],&
-         ([2,4]))
+         [2,4])
 
     select type(ele => this%elements(e)%e)
     type is(hex_t)


### PR DESCRIPTION
I think we are ready, as our tooling does not allow them to appear (rea2nbin creates labled zones from built-in ones).

I retain the (now strange) numbering that periodic zones are marked with 5 and labeled zones with 7 in the mesh file. Changing this would cause too much disruption for existing meshes, so we can save that for when and if we decide to revamp the nmsh format.