### PR TITLE
Expose additional headers for external Neko consumers

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -708,6 +708,9 @@ EXTRA_DIST = \
 	comm/comm.h\
 	common/neko_log.h
 
+
+nobase_pkginclude_HEADERS = ${EXTRA_DIST}
+
 # Fortran deps. (updated with makedepf90 via target 'depend')
 include	.depends
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -708,7 +708,7 @@ EXTRA_DIST = \
 	comm/comm.h\
 	common/neko_log.h
 
-
+# Expose the listed headers in the package
 nobase_pkginclude_HEADERS = ${EXTRA_DIST}
 
 # Fortran deps. (updated with makedepf90 via target 'depend')


### PR DESCRIPTION
Enable external consumers of Neko to access more headers from the installed location.