### PR TITLE
Override CMake policy for JSON-Fortran compatibility with Intel compiler

### DIFF
--- a/.github/actions/setup_json-fortran/action.yml
+++ b/.github/actions/setup_json-fortran/action.yml
@@ -129,6 +129,7 @@ runs:
         cmake -B $WORKING_DIR/build -S $WORKING_DIR \
           --install-prefix=$INSTALL_DIR \
           -DUSE_GNU_INSTALL_CONVENTION=ON \
+          -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
           -DSKIP_DOC_GEN=ON ${{ inputs.configure-options }}
 
     - name: Build


### PR DESCRIPTION
Override the CMake policy to support deprecated versions of JSON-Fortran due to compatibility issues with the Intel compiler.