### PR TITLE
Enhance option parsing for macOS compatibility

### DIFF
--- a/contrib/lint_format/format.sh
+++ b/contrib/lint_format/format.sh
@@ -52,7 +52,8 @@ if [ $(uname) == "Darwin" ]; then
     if command -v gnu-getopt >/dev/null 2>&1; then
         PARSED=$(gnu-getopt --options=$OPT --longoptions=$OPTIONS --name "$0" -- "$@")
     else
-        echo "Warning: macOS uses BSD getopt, long options are not supported." >&2
+        echo "GNU-getopt not found." >&2
+        echo "Falling back to BSD getopt, long options are not supported." >&2
         PARSED=$(getopt $OPT "$@")
     fi
 else

--- a/contrib/lint_format/format.sh
+++ b/contrib/lint_format/format.sh
@@ -47,7 +47,18 @@ CONTINUATION="5"
 TARGET_BRANCH="develop"
 
 # Parse the inputs for options
-PARSED=$(getopt --options=$OPT --longoptions=$OPTIONS --name "$0" -- "$@")
+if [ $(uname) == "Darwin" ]; then
+    # Use gnu-getopt on macOS
+    if command -v gnu-getopt >/dev/null 2>&1; then
+        PARSED=$(gnu-getopt --options=$OPT --longoptions=$OPTIONS --name "$0" -- "$@")
+    else
+        echo "Warning: macOS uses BSD getopt, long options are not supported." >&2
+        PARSED=$(getopt $OPT "$@")
+    fi
+else
+    # Use getopt on Linux
+    PARSED=$(getopt --options=$OPT --longoptions=$OPTIONS --name "$0" -- "$@")
+fi
 eval set -- "$PARSED"
 
 # Loop through the options and set the variables
@@ -59,6 +70,7 @@ while true; do
 
     # End of options
     "--") shift && break ;;
+    *) echo "Unknown option: $1" >&2 && help && exit 1 ;; # Unknown option
     esac
 done
 

--- a/contrib/lint_format/lint.sh
+++ b/contrib/lint_format/lint.sh
@@ -50,7 +50,8 @@ if [ $(uname) == "Darwin" ]; then
     if command -v gnu-getopt >/dev/null 2>&1; then
         PARSED=$(gnu-getopt --options=$OPT --longoptions=$OPTIONS --name "$0" -- "$@")
     else
-        echo "Warning: macOS uses BSD getopt, long options are not supported." >&2
+        echo "GNU-getopt not found." >&2
+        echo "Falling back to BSD getopt, long options are not supported." >&2
         PARSED=$(getopt $OPT "$@")
     fi
 else

--- a/contrib/lint_format/lint.sh
+++ b/contrib/lint_format/lint.sh
@@ -67,6 +67,7 @@ while true; do
 
     # End of options
     "--") shift && break ;;
+    *) echo "Unknown option: $1" >&2 && help && exit 1 ;; # Unknown option
     esac
 done
 

--- a/contrib/lint_format/lint.sh
+++ b/contrib/lint_format/lint.sh
@@ -45,7 +45,18 @@ OPT=h
 TARGET_BRANCH="develop"
 
 # Parse the inputs for options
-PARSED=$(getopt --options=$OPT --longoptions=$OPTIONS --name "$0" -- "$@")
+if [ $(uname) == "Darwin" ]; then
+    # Use gnu-getopt on macOS
+    if command -v gnu-getopt >/dev/null 2>&1; then
+        PARSED=$(gnu-getopt --options=$OPT --longoptions=$OPTIONS --name "$0" -- "$@")
+    else
+        echo "Warning: macOS uses BSD getopt, long options are not supported." >&2
+        PARSED=$(getopt $OPT "$@")
+    fi
+else
+    # Use getopt on Linux
+    PARSED=$(getopt --options=$OPT --longoptions=$OPTIONS --name "$0" -- "$@")
+fi
 eval set -- "$PARSED"
 
 # Loop through the options and set the variables


### PR DESCRIPTION
Improve option parsing in scripts to support long options on macOS using gnu-getopt, with a fallback to BSD getopt. Additionally, implement reporting for unknown options.