### PR TITLE
Constructors for simulation_component_t without JSON dep

### DIFF
--- a/doc/examples/simulation_components/user_simcomp.f90
+++ b/doc/examples/simulation_components/user_simcomp.f90
@@ -47,8 +47,8 @@ module simcomp_example
      ! Constructor from json, wrapping the actual constructor.
      procedure, pass(this) :: init => simcomp_test_init_from_json
      ! Actual constructor.
-     procedure, pass(this) :: init_from_attributes => &
-       simcomp_test_init_from_attributes
+     procedure, pass(this) :: init_from_components => &
+          simcomp_test_init_from_components
      ! Destructor.
      procedure, pass(this) :: free => simcomp_test_free
      ! Compute the simcomp_test field.
@@ -63,17 +63,17 @@ contains
     type(json_file), intent(inout) :: json
     class(case_t), intent(inout), target :: case
 
-    call this%init_from_attributes()
+    call this%init_from_components()
     call this%init_base(json, case)
 
   end subroutine simcomp_test_init_from_json
 
   ! Actual constructor.
-  subroutine simcomp_test_init_from_attributes(this)
+  subroutine simcomp_test_init_from_components(this)
     class(user_simcomp_t), intent(inout) :: this
 
     write(*,*) "Initializing simcomp_test field"
-  end subroutine simcomp_test_init_from_attributes
+  end subroutine simcomp_test_init_from_components
 
   ! Destructor.
   subroutine simcomp_test_free(this)

--- a/src/neko.f90
+++ b/src/neko.f90
@@ -126,6 +126,8 @@ module neko
   use json_utils, only : json_get, json_get_or_default, json_extract_item
   use bc_list, only : bc_list_t
   use les_model, only : les_model_t
+  use field_writer, only : field_writer_t
+  use time_based_controller, only : time_based_controller_t
   use, intrinsic :: iso_fortran_env
   !$ use omp_lib
   implicit none

--- a/src/simulation_components/derivative.f90
+++ b/src/simulation_components/derivative.f90
@@ -69,8 +69,8 @@ module derivative
      !> Constructor from json, wrapping the actual constructor.
      procedure, pass(this) :: init => derivative_init_from_json
      !> Actual constructor.
-     procedure, pass(this) :: init_from_attributes => &
-          derivative_init_from_attributes
+     procedure, pass(this) :: init_from_components => &
+          derivative_init_from_components
      !> Destructor.
      procedure, pass(this) :: free => derivative_free
      !> Compute the derivative field.
@@ -99,11 +99,11 @@ contains
     call this%init_base(json, case)
     call this%writer%init(json, case)
 
-    call derivative_init_from_attributes(this, fieldname, direction)
+    call derivative_init_from_components(this, fieldname, direction)
   end subroutine derivative_init_from_json
 
   !> Actual constructor.
-  subroutine derivative_init_from_attributes(this, fieldname, direction)
+  subroutine derivative_init_from_components(this, fieldname, direction)
     class(derivative_t), intent(inout) :: this
     character(len=*) :: fieldname
     character(len=*) :: direction
@@ -128,7 +128,7 @@ contains
     else
        call neko_error("The direction of the derivative must be x, y or z")
     end if
-  end subroutine derivative_init_from_attributes
+  end subroutine derivative_init_from_components
 
   !> Destructor.
   subroutine derivative_free(this)

--- a/src/simulation_components/field_writer.f90
+++ b/src/simulation_components/field_writer.f90
@@ -54,8 +54,8 @@ module field_writer
      !> Constructor from json, wrapping the actual constructor.
      procedure, pass(this) :: init => field_writer_init_from_json
      !> Actual constructor.
-     procedure, pass(this) :: init_from_attributes => &
-          field_writer_init_from_attributes
+     procedure, pass(this) :: init_from_components => &
+          field_writer_init_from_components
      !> Destructor.
      procedure, pass(this) :: free => field_writer_free
      !> Here to compy with the interface, does nothing.
@@ -83,15 +83,15 @@ contains
        if (json%valid_path("output_precision")) then
           call json_get(json, "output_precision", precision)
           if (precision == "double") then
-             call field_writer_init_from_attributes(this, fields, filename, dp)
+             call field_writer_init_from_components(this, fields, filename, dp)
           else
-             call field_writer_init_from_attributes(this, fields, filename, sp)
+             call field_writer_init_from_components(this, fields, filename, sp)
           end if
        else
-          call field_writer_init_from_attributes(this, fields, filename)
+          call field_writer_init_from_components(this, fields, filename)
        end if
     else
-       call field_writer_init_from_attributes(this, fields)
+       call field_writer_init_from_components(this, fields)
     end if
   end subroutine field_writer_init_from_json
 
@@ -101,7 +101,7 @@ contains
   !! provided, fields are added to the main output file.
   !! @param precision The real precision of the output data. Optional, defaults
   !! to single precision.
-  subroutine field_writer_init_from_attributes(this, fields, filename, precision)
+  subroutine field_writer_init_from_components(this, fields, filename, precision)
     class(field_writer_t), intent(inout) :: this
     character(len=20), allocatable, intent(in) :: fields(:)
     character(len=*), intent(in), optional :: filename
@@ -137,7 +137,7 @@ contains
        end do
     end if
 
-  end subroutine field_writer_init_from_attributes
+  end subroutine field_writer_init_from_components
 
   !> Destructor.
   subroutine field_writer_free(this)

--- a/src/simulation_components/field_writer.f90
+++ b/src/simulation_components/field_writer.f90
@@ -139,11 +139,11 @@ contains
   !! @param case The simulation case object.
   !! @param order The execution oder priority of the simcomp.
   !! @param preprocess_controller Control mode for preprocessing.
-  !! @param preprocess_controller Value parameter for preprocessing.
+  !! @param preprocess_value Value parameter for preprocessing.
   !! @param compute_controller Control mode for computing.
-  !! @param compute_controller Value parameter for computing.
+  !! @param compute_value Value parameter for computing.
   !! @param output_controller Control mode for output.
-  !! @param output_controller Value parameter for output.
+  !! @param output_value Value parameter for output.
   !! @param fields Array of field names to be sampled.
   !! @param filename The name of the file save the fields to. Optional, if not
   !! provided, fields are added to the main output file.

--- a/src/simulation_components/field_writer.f90
+++ b/src/simulation_components/field_writer.f90
@@ -42,6 +42,7 @@ module field_writer
   use case, only : case_t
   use fld_file_output, only : fld_file_output_t
   use json_utils, only : json_get
+  use time_based_controller, only : time_based_controller_t
   implicit none
   private
 
@@ -53,9 +54,15 @@ module field_writer
    contains
      !> Constructor from json, wrapping the actual constructor.
      procedure, pass(this) :: init => field_writer_init_from_json
-     !> Actual constructor.
-     procedure, pass(this) :: init_from_components => &
-          field_writer_init_from_components
+     !> Constructor from components, passing time_based_controllers.
+     generic :: init_from_components => &
+          init_from_controllers, init_from_controllers_properties
+     procedure, pass(this) :: init_from_controllers => &
+          field_writer_init_from_controllers
+     !> Constructor from components, passing the properties of 
+     !! time_based_controllers.
+     procedure, pass(this) :: init_from_controllers_properties => &
+          field_writer_init_from_controllers_properties
      !> Common part of both constructors.
      procedure, private, pass(this) :: init_common => field_writer_init_common
      !> Destructor.
@@ -97,50 +104,73 @@ contains
     end if
   end subroutine field_writer_init_from_json
 
-  !> Actual constructor.
+  !> Constructor from components, passing controllers.
+  !! @param case The simulation case object.
+  !! @param order The execution oder priority of the simcomp.
+  !! @param preprocess_controller The controller for running preprocessing.
+  !! @param compute_controller The controller for running compute.
+  !! @param output_controller The controller for producing output.
   !! @param fields Array of field names to be sampled.
   !! @param filename The name of the file save the fields to. Optional, if not
   !! provided, fields are added to the main output file.
   !! @param precision The real precision of the output data. Optional, defaults
   !! to single precision.
-  subroutine field_writer_init_from_components(this, fields, filename, &
-       precision)
+  subroutine field_writer_init_from_controllers(this, case, order, &
+       preprocess_controller, compute_controller, output_controller, &
+       fields, filename, precision)
     class(field_writer_t), intent(inout) :: this
-    character(len=20), allocatable, intent(in) :: fields(:)
+    class(case_t), intent(inout), target :: case
+    integer :: order
+    type(time_based_controller_t), intent(in) :: preprocess_controller
+    type(time_based_controller_t), intent(in) :: compute_controller
+    type(time_based_controller_t), intent(in) :: output_controller
+    character(len=20), intent(in) :: fields(:)
     character(len=*), intent(in), optional :: filename
     integer, intent(in), optional :: precision
-    character(len=20) :: fieldi
-    integer :: i
 
-    ! Register fields if they don't exist.
-    do i=1, size(fields)
-       fieldi = trim(fields(i))
-       call neko_field_registry%add_field(this%case%fluid%dm_Xh, fieldi,&
-            ignore_existing=.true.)
-    end do
+    call this%init_base_from_components(case, order, preprocess_controller, &
+    compute_controller, output_controller)
+    call this%init_common(fields, filename, precision)
 
-    if (present(filename)) then
-       if (present(precision)) then
-          call this%output%init(precision, filename, size(fields))
-       else
-          call this%output%init(sp, filename, size(fields))
-       end if
-       do i=1, size(fields)
-          fieldi = trim(fields(i))
-          call this%output%fields%assign(i, neko_field_registry%get_field(fieldi))
-       end do
+  end subroutine field_writer_init_from_controllers
 
-       call this%case%output_controller%add(this%output, &
-            this%output_controller%control_value, &
-            this%output_controller%control_mode)
-    else
-       do i=1, size(fields)
-          fieldi = trim(fields(i))
-          call this%case%f_out%fluid%append(neko_field_registry%get_field(fieldi))
-       end do
-    end if
+  !> Constructor from components, passing properties o the 
+  !! time_based_controller` components in the base type.
+  !! @param case The simulation case object.
+  !! @param order The execution oder priority of the simcomp.
+  !! @param preprocess_controller Control mode for preprocessing.
+  !! @param preprocess_controller Value parameter for preprocessing.
+  !! @param compute_controller Control mode for computing.
+  !! @param compute_controller Value parameter for computing.
+  !! @param output_controller Control mode for output.
+  !! @param output_controller Value parameter for output.
+  !! @param fields Array of field names to be sampled.
+  !! @param filename The name of the file save the fields to. Optional, if not
+  !! provided, fields are added to the main output file.
+  !! @param precision The real precision of the output data. Optional, defaults
+  !! to single precision.
+  subroutine field_writer_init_from_controllers_properties(this, &
+       case, order, preprocess_control, preprocess_value, compute_control, &
+       compute_value, output_control, output_value, fields, filename, precision)
+    class(field_writer_t), intent(inout) :: this
+    class(case_t), intent(inout), target :: case
+    integer :: order
+    character(len=*), intent(in) :: preprocess_control
+    real(kind=rp), intent(in) :: preprocess_value
+    character(len=*), intent(in) :: compute_control
+    real(kind=rp), intent(in) :: compute_value
+    character(len=*), intent(in) :: output_control
+    real(kind=rp), intent(in) :: output_value
+    character(len=20), intent(in) :: fields(:)
+    character(len=*), intent(in), optional :: filename
+    integer, intent(in), optional :: precision
 
-  end subroutine field_writer_init_from_components
+    call this%init_base_from_components(case, order, preprocess_control, &
+         preprocess_value, compute_control, compute_value, output_control, &
+       output_value)
+    call this%init_common(fields, filename, precision)
+
+  end subroutine field_writer_init_from_controllers_properties
 
   !> Common part of both constructors.
   !! @param fields Array of field names to be sampled.
@@ -150,7 +180,7 @@ contains
   !! to single precision.
   subroutine field_writer_init_common(this, fields, filename, precision)
     class(field_writer_t), intent(inout) :: this
-    character(len=20), allocatable, intent(in) :: fields(:)
+    character(len=20), intent(in) :: fields(:)
     character(len=*), intent(in), optional :: filename
     integer, intent(in), optional :: precision
     character(len=20) :: fieldi

--- a/src/simulation_components/fluid_stats_simcomp.f90
+++ b/src/simulation_components/fluid_stats_simcomp.f90
@@ -74,8 +74,8 @@ module fluid_stats_simcomp
      !> Constructor from json, wrapping the actual constructor.
      procedure, pass(this) :: init => fluid_stats_simcomp_init_from_json
      !> Actual constructor.
-     procedure, pass(this) :: init_from_attributes => &
-          fluid_stats_simcomp_init_from_attributes
+     procedure, pass(this) :: init_from_components => &
+          fluid_stats_simcomp_init_from_components
      !> Destructor.
      procedure, pass(this) :: free => fluid_stats_simcomp_free
      !> Does sampling for statistics.
@@ -120,10 +120,10 @@ contains
 
     if (json%valid_path("output_filename")) then
        call json_get(json, "output_filename", filename)
-       call fluid_stats_simcomp_init_from_attributes(this, u, v, w, p, coef, &
+       call fluid_stats_simcomp_init_from_components(this, u, v, w, p, coef, &
             start_time, hom_dir, stat_set,filename)
     else
-       call fluid_stats_simcomp_init_from_attributes(this, u, v, w, p, coef, &
+       call fluid_stats_simcomp_init_from_components(this, u, v, w, p, coef, &
             start_time, hom_dir, stat_set)
     end if
 
@@ -137,7 +137,7 @@ contains
   !! @param start_time time to start sampling stats
   !! @param hom_dir directions to average in
   !! @param stat_set Set of statistics to compute (basic/full)
-  subroutine fluid_stats_simcomp_init_from_attributes(this, u, v, w, p, coef, &
+  subroutine fluid_stats_simcomp_init_from_components(this, u, v, w, p, coef, &
        start_time, hom_dir, stat_set, fname)
     class(fluid_stats_simcomp_t), intent(inout) :: this
     character(len=*), intent(in) :: hom_dir
@@ -181,7 +181,7 @@ contains
 
     call neko_log%end_section()
 
-  end subroutine fluid_stats_simcomp_init_from_attributes
+  end subroutine fluid_stats_simcomp_init_from_components
 
   !> Destructor.
   subroutine fluid_stats_simcomp_free(this)

--- a/src/simulation_components/force_torque.f90
+++ b/src/simulation_components/force_torque.f90
@@ -92,8 +92,8 @@ module force_torque
      !> Constructor from json, wrapping the actual constructor.
      procedure, pass(this) :: init => force_torque_init_from_json
      !> Actual constructor.
-     procedure, pass(this) :: init_from_attributes => &
-          force_torque_init_from_attributes
+     procedure, pass(this) :: init_from_components => &
+          force_torque_init_from_components
      !> Destructor.
      procedure, pass(this) :: free => force_torque_free
      !> Compute the force_torque field.
@@ -123,13 +123,13 @@ contains
     call json_get_or_default(json, 'scale', scale, 1.0_rp)
     call json_get_or_default(json, 'long_print', long_print, .false.)
     call json_get(json, 'center', center)
-    call force_torque_init_from_attributes(this, zone_id, zone_name, &
+    call force_torque_init_from_components(this, zone_id, zone_name, &
          center, scale, case%fluid%c_xh, &
          long_print)
   end subroutine force_torque_init_from_json
 
   !> Actual constructor.
-  subroutine force_torque_init_from_attributes(this, zone_id, zone_name, &
+  subroutine force_torque_init_from_components(this, zone_id, zone_name, &
        center, scale, coef, long_print)
     class(force_torque_t), intent(inout) :: this
     real(kind=rp), intent(in) :: center(3)
@@ -227,7 +227,7 @@ contains
             .true.)
     end if
 
-  end subroutine force_torque_init_from_attributes
+  end subroutine force_torque_init_from_components
 
   !> Destructor.
   subroutine force_torque_free(this)

--- a/src/simulation_components/lambda2.f90
+++ b/src/simulation_components/lambda2.f90
@@ -70,8 +70,8 @@ module lambda2
      !> Constructor from json.
      procedure, pass(this) :: init => lambda2_init_from_json
      !> Actual constructor.
-     procedure, pass(this) :: init_from_attributes => &
-          lambda2_init_from_attributes
+     procedure, pass(this) :: init_from_components => &
+          lambda2_init_from_components
      !> Destructor.
      procedure, pass(this) :: free => lambda2_free
      !> Compute the lambda2 field
@@ -100,11 +100,11 @@ contains
     w => neko_field_registry%get_field("w")
     lambda2 => neko_field_registry%get_field("lambda2")
 
-    call lambda2_init_from_attributes(this, u, v, w, lambda2)
+    call lambda2_init_from_components(this, u, v, w, lambda2)
   end subroutine lambda2_init_from_json
 
   !> Actual constructor.
-  subroutine lambda2_init_from_attributes(this, u, v, w, lambda2)
+  subroutine lambda2_init_from_components(this, u, v, w, lambda2)
     class(lambda2_t), intent(inout) :: this
     type(field_t), pointer, intent(inout) :: u, v, w, lambda2
 
@@ -113,7 +113,7 @@ contains
     this%w => w
     this%lambda2 => lambda2
 
-  end subroutine lambda2_init_from_attributes
+  end subroutine lambda2_init_from_components
 
   !> Destructor.
   subroutine lambda2_free(this)

--- a/src/simulation_components/probes.F90
+++ b/src/simulation_components/probes.F90
@@ -91,8 +91,8 @@ module probes
      !> Initialize from json
      procedure, pass(this) :: init => probes_init_from_json
      ! Actual constructor
-     procedure, pass(this) :: init_from_attributes => &
-          probes_init_from_attributes
+     procedure, pass(this) :: init_from_components => &
+          probes_init_from_components
      !> Destructor
      procedure, pass(this) :: free => probes_free
      !> Setup offset for I/O when using sequential write/read from rank 0
@@ -202,7 +202,7 @@ contains
          MPI_INTEGER, MPI_SUM, NEKO_COMM, ierr)
 
     call probes_show(this)
-    call this%init_from_attributes(case%fluid%dm_Xh, output_file)
+    call this%init_from_components(case%fluid%dm_Xh, output_file)
 
   end subroutine probes_init_from_json
 
@@ -452,7 +452,7 @@ contains
   !> Initialize without json things
   !! @param dof Dofmap to probe
   !! @output_file Name of output file, current must be CSV
-  subroutine probes_init_from_attributes(this, dof, output_file)
+  subroutine probes_init_from_components(this, dof, output_file)
     class(probes_t), intent(inout) :: this
     type(dofmap_t), intent(in) :: dof
     character(len=:), allocatable, intent(inout) :: output_file
@@ -524,7 +524,7 @@ contains
        call neko_error("Invalid data. Expected csv_file_t.")
     end select
 
-  end subroutine probes_init_from_attributes
+  end subroutine probes_init_from_components
 
   !> Destructor
   subroutine probes_free(this)

--- a/src/simulation_components/simulation_component.f90
+++ b/src/simulation_components/simulation_component.f90
@@ -179,11 +179,11 @@ contains
   !! @param case The simulation case object.
   !! @param order The execution oder priority of the simcomp.
   !! @param preprocess_controller Control mode for preprocessing.
-  !! @param preprocess_controller Value parameter for preprocessing.
+  !! @param preprocess_value Value parameter for preprocessing.
   !! @param compute_controller Control mode for computing.
-  !! @param compute_controller Value parameter for computing.
+  !! @param compute_value Value parameter for computing.
   !! @param output_controller Control mode for output.
-  !! @param output_controller Value parameter for output.
+  !! @param output_value Value parameter for output.
   subroutine simulation_component_init_base_from_controllers_properties(this, &
        case, order, preprocess_control, preprocess_value, compute_control, &
        compute_value, output_control, output_value)
@@ -234,7 +234,7 @@ contains
   !> Parse JSON to determine the properties of the `time_based_controllers`.
   !! @param json The JSON dictionary of the simcomp.
   !! @param case_params The entire case configuration JSON.
-  !! @param preprocess_controller Control mode for preprocessing.
+  !! @param preprocess_value Control mode for preprocessing.
   !! @param preprocess_controller Value parameter for preprocessing.
   !! @param compute_controller Control mode for computing.
   !! @param compute_controller Value parameter for computing.

--- a/src/simulation_components/simulation_component.f90
+++ b/src/simulation_components/simulation_component.f90
@@ -62,15 +62,15 @@ module simulation_component
      procedure, pass(this) :: init_base => simulation_component_init_base
      !> Constructor for the simulation_component_t (base) class from components.
      generic :: init_base_from_components => &
-          simulation_component_init_base_from_controllers_properties, &
-          simulation_component_init_base_from_controllers
-     !> Constructor for the simulation_component_t (base) class from 
+          init_base_from_controllers_properties, &
+          init_base_from_controllers
+     !> Constructor for the simulation_component_t (base) class from
      !! time_based_controllers, essentially directly from all components (we
-     !! reserve that name for the generic binding).
+     !! reserve the `_from_components` name for the generic binding).
      procedure, pass(this) :: init_base_from_controllers => &
           simulation_component_init_base_from_controllers
-     !> Constructor for the simulation_component_t (base) class from 
-     !! properties of time_based_controllers, so that the latter are
+     !> Constructor for the simulation_component_t (base) class from
+     !! properties of time_based_controllers, so the latter are
      !! constructed.
      procedure, pass(this) :: init_base_from_controllers_properties => &
           simulation_component_init_base_from_controllers_properties
@@ -162,19 +162,20 @@ contains
     real(kind=rp) :: preprocess_value, compute_value, output_value
     integer :: order
 
-      call this%parse_json(json, case%params, preprocess_control, &
+    call this%parse_json(json, case%params, preprocess_control, &
          preprocess_value, compute_control, compute_value, output_control, &
          output_value)
 
     call json_get_or_default(json, "order", order, -1)
 
     call this%init_base_from_components(case, order, &
-       preprocess_control, preprocess_value, compute_control, compute_value, &
-       output_control, output_value)
+         preprocess_control, preprocess_value, compute_control, compute_value, &
+         output_control, output_value)
 
   end subroutine simulation_component_init_base
 
-  !> Constructor for the `simulation_component_t` (base) class from components.
+  !> Constructor for the `simulation_component_t` (base) class via the
+  !! properties of the `time_based_controller` components.
   !! @param case The simulation case object.
   !! @param order The execution oder priority of the simcomp.
   !! @param preprocess_controller Control mode for preprocessing.
@@ -184,10 +185,8 @@ contains
   !! @param output_controller Control mode for output.
   !! @param output_controller Value parameter for output.
   subroutine simulation_component_init_base_from_controllers_properties(this, &
-       case, order, &
-       preprocess_control, preprocess_value, &
-       compute_control, compute_value, &
-       output_control, output_value)
+       case, order, preprocess_control, preprocess_value, compute_control, &
+       compute_value, output_control, output_value)
     class(simulation_component_t), intent(inout) :: this
     class(case_t), intent(inout), target :: case
     integer :: order
@@ -214,7 +213,7 @@ contains
   !! @param case The simulation case object.
   !! @param order The execution oder priority of the simcomp.
   !! @param preprocess_controller The controller for running preprocessing.
-  !! @param compute_controller The controller for running compute. 
+  !! @param compute_controller The controller for running compute.
   !! @param output_controller The controller for producing output.
   subroutine simulation_component_init_base_from_controllers(this, case, order, &
        preprocess_controller, compute_controller, output_controller)
@@ -246,7 +245,7 @@ contains
        output_control, output_value)
     class(simulation_component_t), intent(inout) :: this
     type(json_file), intent(inout) :: json
-    type(json_file), intent(inout) :: case_params 
+    type(json_file), intent(inout) :: case_params
     character(len=:), allocatable, intent(inout) :: preprocess_control
     real(kind=rp), intent(out) :: preprocess_value
     character(len=:), allocatable, intent(inout) :: compute_control

--- a/src/simulation_components/simulation_component.f90
+++ b/src/simulation_components/simulation_component.f90
@@ -71,7 +71,7 @@ module simulation_component
           simulation_component_init_base_from_controllers
      !> Constructor for the simulation_component_t (base) class from
      !! properties of time_based_controllers, so the latter are
-     !! constructed.
+     !! constructed instead of assigned.
      procedure, pass(this) :: init_base_from_controllers_properties => &
           simulation_component_init_base_from_controllers_properties
      !> Destructor for the simulation_component_t (base) class.

--- a/src/simulation_components/spectral_error.f90
+++ b/src/simulation_components/spectral_error.f90
@@ -129,13 +129,13 @@ contains
     call this%init_base(json, case)
     call this%writer%init(json, case)
 
-    call spectral_error_init_from_attributes(this, case%fluid%c_Xh)
+    call spectral_error_init_from_components(this, case%fluid%c_Xh)
 
   end subroutine spectral_error_init
 
   !> Actual constructor.
   !! @param coef type with all geometrical variables.
-  subroutine spectral_error_init_from_attributes(this, coef)
+  subroutine spectral_error_init_from_components(this, coef)
     class(spectral_error_t), intent(inout) :: this
     type(coef_t), intent(in) :: coef
     integer :: il, jl, aa
@@ -182,7 +182,7 @@ contains
       endif
     end associate
 
-  end subroutine spectral_error_init_from_attributes
+  end subroutine spectral_error_init_from_components
 
   !> Destructor
   subroutine spectral_error_free(this)

--- a/src/simulation_components/vorticity.f90
+++ b/src/simulation_components/vorticity.f90
@@ -78,8 +78,8 @@ module vorticity
      !> Constructor from json, wrapping the actual constructor.
      procedure, pass(this) :: init => vorticity_init_from_json
      !> Actual constructor.
-     procedure, pass(this) :: init_from_attributes => &
-          vorticity_init_from_attributes
+     procedure, pass(this) :: init_from_components => &
+          vorticity_init_from_components
      !> Destructor.
      procedure, pass(this) :: free => vorticity_free
      !> Compute the vorticity field.
@@ -106,11 +106,11 @@ contains
     call this%init_base(json, case)
     call this%writer%init(json, case)
 
-    call vorticity_init_from_attributes(this)
+    call vorticity_init_from_components(this)
   end subroutine vorticity_init_from_json
 
   !> Actual constructor.
-  subroutine vorticity_init_from_attributes(this)
+  subroutine vorticity_init_from_components(this)
     class(vorticity_t), intent(inout) :: this
 
     this%u => neko_field_registry%get_field_by_name("u")
@@ -124,7 +124,7 @@ contains
     call this%temp1%init(this%u%dof)
     call this%temp2%init(this%u%dof)
 
-  end subroutine vorticity_init_from_attributes
+  end subroutine vorticity_init_from_components
 
   !> Destructor.
   subroutine vorticity_free(this)

--- a/src/simulation_components/weak_grad.f90
+++ b/src/simulation_components/weak_grad.f90
@@ -66,8 +66,8 @@ module weak_grad
      !> Constructor from json, wrapping the actual constructor.
      procedure, pass(this) :: init => weak_grad_init_from_json
      !> Actual constructor.
-     procedure, pass(this) :: init_from_attributes => &
-          weak_grad_init_from_attributes
+     procedure, pass(this) :: init_from_components => &
+          weak_grad_init_from_components
      !> Destructor.
      procedure, pass(this) :: free => weak_grad_free
      !> Compute the weak_grad field.
@@ -97,11 +97,11 @@ contains
     call this%init_base(json, case)
     call this%writer%init(json, case)
 
-    call weak_grad_init_from_attributes(this, fieldname)
+    call weak_grad_init_from_components(this, fieldname)
   end subroutine weak_grad_init_from_json
 
   !> Actual constructor.
-  subroutine weak_grad_init_from_attributes(this, fieldname)
+  subroutine weak_grad_init_from_components(this, fieldname)
     class(weak_grad_t), intent(inout) :: this
     character(len=*) :: fieldname
 
@@ -115,7 +115,7 @@ contains
          "weak_grad_" // fieldname // "_z")
 
 
-  end subroutine weak_grad_init_from_attributes
+  end subroutine weak_grad_init_from_components
 
   !> Destructor.
   subroutine weak_grad_free(this)

--- a/src/source_terms/brinkman/PDE_filter.f90
+++ b/src/source_terms/brinkman/PDE_filter.f90
@@ -102,8 +102,8 @@ module PDE_filter
      !> Constructor from json.
      procedure, pass(this) :: init => PDE_filter_init_from_json
      !> Actual constructor.
-     procedure, pass(this) :: init_from_attributes => &
-          PDE_filter_init_from_attributes
+     procedure, pass(this) :: init_from_components => &
+          PDE_filter_init_from_components
      !> Destructor.
      procedure, pass(this) :: free => PDE_filter_free
      !> Apply the filter
@@ -132,12 +132,12 @@ contains
          this%precon_type_filt, 'jacobi')
 
     call this%init_base(json, coef)
-    call PDE_filter_init_from_attributes(this, coef)
+    call PDE_filter_init_from_components(this, coef)
 
   end subroutine PDE_filter_init_from_json
 
   !> Actual constructor.
-  subroutine PDE_filter_init_from_attributes(this, coef)
+  subroutine PDE_filter_init_from_components(this, coef)
     class(PDE_filter_t), intent(inout) :: this
     type(coef_t), intent(in) :: coef
     integer :: n
@@ -160,7 +160,7 @@ contains
          this%coef%gs_h, &
          this%bclst_filt, this%precon_type_filt)
 
-  end subroutine PDE_filter_init_from_attributes
+  end subroutine PDE_filter_init_from_components
 
   !> Destructor.
   subroutine PDE_filter_free(this)

--- a/src/source_terms/brinkman/elementwise_filter.f90
+++ b/src/source_terms/brinkman/elementwise_filter.f90
@@ -71,8 +71,8 @@ module elementwise_filter
      !> Constructor.
      procedure, pass(this) :: init => elementwise_filter_init_from_json
      !> Actual constructor.
-     procedure, pass(this) :: init_from_attributes => &
-          elementwise_filter_init_from_attributes
+     procedure, pass(this) :: init_from_components => &
+          elementwise_filter_init_from_components
      !> Destructor.
      procedure, pass(this) :: free => elementwise_filter_free
      !> Set up 1D filter inside an element.
@@ -95,19 +95,19 @@ contains
     ! Filter assumes lx = ly = lz
     call this%init_base(json, coef)
 
-    call this%init_from_attributes(coef%dof%xh%lx, this%filter_type)
+    call this%init_from_components(coef%dof%xh%lx, this%filter_type)
 
   end subroutine elementwise_filter_init_from_json
   !> Actual Constructor.
   !! @param nx number of points in an elements in one direction.
   !! @param filter_type possible options: "Boyd", "nonBoyd"
-  subroutine elementwise_filter_init_from_attributes(this, nx, filter_type)
+  subroutine elementwise_filter_init_from_components(this, nx, filter_type)
     class(elementwise_filter_t), intent(inout) :: this
     character(len=*) :: filter_type
     integer :: nx
-    
+
     this%nx = nx
-    this%nt = nx ! initialize as if nothing is filtered yet 
+    this%nt = nx ! initialize as if nothing is filtered yet
 
     allocate(this%fh(nx, nx))
     allocate(this%fht(nx, nx))
@@ -123,8 +123,8 @@ contains
        call device_cfill(this%fh_d, 0.0_rp, this%nx * this%nx)
        call device_cfill(this%fht_d, 0.0_rp, this%nx * this%nx)
     end if
-    
-  end subroutine elementwise_filter_init_from_attributes
+
+  end subroutine elementwise_filter_init_from_components
 
   !> Destructor.
   subroutine elementwise_filter_free(this)
@@ -163,12 +163,12 @@ contains
     class(elementwise_filter_t), intent(inout) :: this
 
     call build_1d_cpu(this%fh, this%fht, this%trnsfr, &
-                               this%nx, this%filter_type)
+         this%nx, this%filter_type)
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_memcpy(this%fh, this%fh_d, &
-                          this%nx * this%nx, HOST_TO_DEVICE, sync = .false.)
+            this%nx * this%nx, HOST_TO_DEVICE, sync = .false.)
        call device_memcpy(this%fht, this%fht_d, &
-                          this%nx * this%nx, HOST_TO_DEVICE, sync = .false.)
+            this%nx * this%nx, HOST_TO_DEVICE, sync = .false.)
     end if
 
   end subroutine build_1d
@@ -181,7 +181,7 @@ contains
 
     ! F_out = fh x fh x fh x F_in
     call tnsr3d(F_out%x, this%nx, F_in%x, this%nx, this%fh, this%fht, this%fht, &
-                this%coef%msh%nelv)
+         this%coef%msh%nelv)
 
   end subroutine elementwise_field_filter_3d
 
@@ -207,7 +207,7 @@ contains
 
     call zwgll(zpts, rmult, nx)
 
-    n  = nx-1
+    n = nx-1
     do j = 1, nx
        z = zpts(j)
        call legendre_poly(Lj, z, n)
@@ -234,10 +234,10 @@ contains
        diag(i,i) = trnsfr(i)
     end do
 
-    call mxm  (diag, nx, pht%x, nx, fh, nx)       !          -1
-    call mxm  (phi%x, nx, fh, nx, pht%x, nx)      !     V D V
+    call mxm (diag, nx, pht%x, nx, fh, nx) !          -1
+    call mxm (phi%x, nx, fh, nx, pht%x, nx) !     V D V
 
-    call copy      (fh, pht%x, nx*nx)
+    call copy (fh, pht%x, nx*nx)
     call trsp (fht, nx, fh, nx)
 
   end subroutine build_1d_cpu

--- a/tests/unit/time_based_controller/test_time_based_controller.pf
+++ b/tests/unit/time_based_controller/test_time_based_controller.pf
@@ -46,6 +46,8 @@ subroutine test_assign()
   @assertEqual(ctrl1%frequency, ctrl2%frequency, tolerance=1e-6_rp)
   @assertEqual(ctrl1%nsteps, ctrl2%nsteps)
   @assertEqual(ctrl1%nexecutions, ctrl2%nexecutions)
+  @assertEqual(ctrl1%control_value, ctrl2%control_value)
+  @assertEqual(ctrl1%control_mode, ctrl2%control_mode)
 
 end subroutine test_assign
 


### PR DESCRIPTION
Depends on #1819 

This PR addresses an architectural issue with simcomps: the constructor of the base type depends on JSON. So there really is no way to init a simcomp from components. Even though we have some constructors from components in simcomps, they don't fully work properly, because `init_base` is always run in the json-based constuctor.

Here, I add two additional constructors to the base simcomp type, which are based on components. A `generic` called (predictably) `init_from_components` binds them together.

The individual simcomps need to make use of this. So far in this PR, I just modify the `field_writer` simcomp, but this change needs to later propagate to the other simcomps, and be adopted in new ones. When done, we will be able to init simcomps without json inside neko, the user file, or 3rd-party libraries like Tim's.