### PR TITLE
Update PkgConfig CFlags

### DIFF
--- a/neko.pc.in
+++ b/neko.pc.in
@@ -4,10 +4,10 @@ libdir=@libdir@
 includedir=${prefix}/include
 includedir_pkg=${prefix}/include/neko
 compiler=@FC@
- 
+
 Name: NEKO
 Version: @PACKAGE_VERSION@
 Description:
-Requires: 
+Requires:
 Libs: -L${libdir} -lneko @LDFLAGS@ @LIBS@
-Cflags: @FCFLAGS@ -I${includedir} -I${includedir_pkg} 
+Cflags: -I${includedir} -I${includedir_pkg}


### PR DESCRIPTION
We currently force any dependent program to use the identical list of compiler flags used to compile Neko.

This is probably not really what we intended so they are removed from the package here in order to improve portability