### PR TITLE
Don't allocate unecessary zero sized arrays

### DIFF
--- a/src/common/projection.f90
+++ b/src/common/projection.f90
@@ -120,7 +120,8 @@ contains
   subroutine projection_init(this, n, L, activ_step)
     class(projection_t), target, intent(inout) :: this
     integer, intent(in) :: n
-    integer, optional, intent(in) :: L, activ_step
+    integer, intent(in) :: L
+    integer, optional, intent(in) :: activ_step
     integer :: i
     integer(c_size_t) :: ptr_size
     type(c_ptr) :: ptr
@@ -128,11 +129,7 @@ contains
 
     call this%free()
 
-    if (present(L)) then
-       this%L = L
-    else
-       this%L = 20
-    end if
+    this%L = L
 
     if (present(activ_step)) then
        this%activ_step = activ_step

--- a/src/common/projection.f90
+++ b/src/common/projection.f90
@@ -162,6 +162,7 @@ contains
 
        call device_map(this%xbar, this%xbar_d, n)
        call device_alloc(this%alpha_d, int(c_sizeof(dummy)*this%L, c_size_t))
+
        call device_rzero(this%xbar_d, n)
        call device_rzero(this%alpha_d, this%L)
 

--- a/src/common/projection.f90
+++ b/src/common/projection.f90
@@ -142,6 +142,12 @@ contains
 
     this%m = 0
 
+    ! Return if the space is 0, to avoid allocating zero sized
+    ! arrays, which are not supported for all backends
+    if (this%L .le. 0) then
+       return
+    end if
+
     allocate(this%xx(n, this%L))
     allocate(this%bb(n, this%L))
     allocate(this%xbar(n))
@@ -156,7 +162,6 @@ contains
 
        call device_map(this%xbar, this%xbar_d, n)
        call device_alloc(this%alpha_d, int(c_sizeof(dummy)*this%L, c_size_t))
-
        call device_rzero(this%xbar_d, n)
        call device_rzero(this%alpha_d, this%L)
 


### PR DESCRIPTION

We should avoid allocating zero sized arrays, especially on devices, which might not support it

