### PR TITLE
add start_time for probes

### DIFF
--- a/doc/pages/user-guide/simcomps.md
+++ b/doc/pages/user-guide/simcomps.md
@@ -89,11 +89,18 @@ and s1 if neko is run with one scalar. To output in a different `fld` series, us
 
 ### probes {#simcomp_probes}
 Probes selected solution fields at a list of points. This list of points can be
-generated in a variety of ways, but the most common is to use the `csv` type.
+generated in a variety of ways, but the most common is to use the `csv` type. 
 
-#### Supported types:
+Mandatory fields for this simcomp are:
+- `fields`: a list of fields to probe. Should be a list of field names that exist in the registry. Example: `"fields": ["u", "v", "p", "s"]`.
+- `output_file`: Name of the file in which to output the probed fields. Must be `.csv`.
 
- - `file`: Reads a list of points from a CSV file. The name of the file is
+It is also possible to set a `start_time` before which the probes will not be 
+executed (same behavior as the statistics).
+
+#### Supported types
+
+- `file`: Reads a list of points from a CSV file. The name of the file is
    provided with the `file_name` keyword. The CSV file should have the
    following format:
    ~~~~~~~~~~~~~~~{.csv}
@@ -154,7 +161,8 @@ generated in a variety of ways, but the most common is to use the `csv` type.
   0.0, -1.0, 0.0
   ~~~~~~~~~~~~~~~
 
- #### Example usage:
+ #### Example usage
+ 
  ~~~~~~~~~~~~~~~{.json}
  {
    "type": "probes",

--- a/src/simulation_components/probes.F90
+++ b/src/simulation_components/probes.F90
@@ -60,6 +60,8 @@ module probes
   private
 
   type, public, extends(simulation_component_t) :: probes_t
+     !> Time after which to start collecting probes
+     real(kind=rp) :: start_time
      !> Number of output fields
      integer :: n_fields = 0
      type(global_interpolation_t) :: global_interp
@@ -144,6 +146,7 @@ contains
     call json%info('fields', n_children = this%n_fields)
     call json_get(json, 'fields', this%which_fields)
     call json_get(json, 'output_file', output_file)
+    call json_get_or_default(json, 'start_time', this%start_time, -1.0_rp)
 
     call this%sampled_fields%init(this%n_fields)
     do i = 1, this%n_fields
@@ -637,6 +640,9 @@ contains
     class(probes_t), intent(inout) :: this
     type(time_state_t), intent(in) :: time
     integer :: i, ierr
+
+    !> Do not execute if we are below the start_time
+    if (time%t .lt. this%start_time) return
 
     !> Check controller to determine if we must write
     do i = 1, this%n_fields

--- a/src/simulation_components/probes.F90
+++ b/src/simulation_components/probes.F90
@@ -60,7 +60,7 @@ module probes
   private
 
   type, public, extends(simulation_component_t) :: probes_t
-     !> Time after which to start collecting probes
+     !> Time after which to start collecting probes.
      real(kind=rp) :: start_time
      !> Number of output fields
      integer :: n_fields = 0


### PR DESCRIPTION
As the title says, adds a `start_time` to the probes. It is basically the same behavior as the statistics, with the intent to skip any transient behaviors in the beginning of a simulation, and start collecting probes after the given `start_time`.

It would be cool to have this stuff at the simcomp level but I am not feeling brave enough to mess with the time controllers right now... 

I propose to merge this if we are happy to get the functionality, and think bigger picture later :)  