### PR TITLE
Add masked_scatter_copy and masked_gather_copy for OpenCL

### DIFF
--- a/src/math/bcknd/device/cuda/cuda_math.f90
+++ b/src/math/bcknd/device/cuda/cuda_math.f90
@@ -64,14 +64,6 @@ module cuda_math
        integer(c_int) :: n, m
      end subroutine cuda_masked_scatter_copy
 
-
-     subroutine cuda_masked_scatter_copy(a_d, b_d, mask_d, n, m) &
-          bind(c, name = 'cuda_masked_scatter_copy')
-       use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d, mask_d
-       integer(c_int) :: n, m
-     end subroutine cuda_masked_scatter_copy
-
      subroutine cuda_masked_atomic_reduction(a_d, b_d, mask_d, n, m) &
           bind(c, name = 'cuda_masked_atomic_reduction')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int

--- a/src/math/bcknd/device/cuda/cuda_math.f90
+++ b/src/math/bcknd/device/cuda/cuda_math.f90
@@ -57,6 +57,13 @@ module cuda_math
        integer(c_int) :: n, m
      end subroutine cuda_masked_red_copy
 
+     subroutine cuda_masked_scatter_copy(a_d, b_d, mask_d, n, m) &
+          bind(c, name = 'cuda_masked_scatter_copy')
+       use, intrinsic :: iso_c_binding, only: c_int, c_ptr
+       type(c_ptr), value :: a_d, b_d, mask_d
+       integer(c_int) :: n, m
+     end subroutine cuda_masked_scatter_copy
+
      subroutine cuda_masked_atomic_reduction(a_d, b_d, mask_d, n, m) &
           bind(c, name = 'cuda_masked_atomic_reduction')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int

--- a/src/math/bcknd/device/cuda/math.cu
+++ b/src/math/bcknd/device/cuda/math.cu
@@ -76,8 +76,8 @@ extern "C" {
 
   }
 
-  /** Fortran wrapper for masked copy
-   * Copy a vector \f$ a(mask) = b(mask) \f$
+  /** Fortran wrapper for masked reduced copy
+   * Copy a vector \f$ a = b(mask) \f$
    */
   void cuda_masked_red_copy(void *a, void *b, void *mask, int *n, int *m) {
 
@@ -88,6 +88,19 @@ extern "C" {
       (cudaStream_t) glb_cmd_queue>>>((real *) a, (real*) b,(int*) mask, *n, *m);
     CUDA_CHECK(cudaGetLastError());
 
+  }
+
+  /** Fortran wrapper for masked scatter copy
+   * Copy a vector \f$ a(mask) = b \f$
+   */
+  void cuda_masked_scatter_copy(void *a, void *b, void *mask, int *n, int *m) {
+
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks(((*m)+1024 - 1)/ 1024, 1, 1);
+
+    masked_red_copy_kernel<real><<<nblcks, nthrds, 0,
+      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real*) b,(int*) mask, *n, *m);
+    CUDA_CHECK(cudaGetLastError());
   }
 
   /** Fortran wrapper for masked atomic reduction
@@ -103,7 +116,7 @@ extern "C" {
                                       (int *) mask, *n, *m);
     CUDA_CHECK(cudaGetLastError());
 
-  } 
+  }
 
 
   /** Fortran wrapper for cfill_mask

--- a/src/math/bcknd/device/cuda/math_kernel.h
+++ b/src/math/bcknd/device/cuda/math_kernel.h
@@ -70,6 +70,24 @@ __global__ void masked_red_copy_kernel(T * __restrict__ a,
 }
 
 /**
+ * Device kernel for masked scatter copy
+ */
+template< typename T >
+__global__ void masked_scatter_copy_kernel(T * __restrict__ a,
+                                   T * __restrict__ b,
+                                   int * __restrict__ mask,
+                                   const int n,
+                                   const int m) {
+
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  for (int i = idx; i < m; i += str) {
+    a[mask[i+1]-1] = b[i];
+  }
+}
+
+/**
  * Device kernel for masked atomic update
  */
 template< typename T >
@@ -95,7 +113,7 @@ __global__ void masked_atomic_reduction_kernel(T * __restrict__ a,
 template< typename T >
 __global__ void masked_copy_kernel(T * __restrict__ a,
                                    T * __restrict__ b,
-                                   int * __restrict__ mask,                    
+                                   int * __restrict__ mask,
                                    const int n,
                                    const int m) {
 
@@ -128,7 +146,7 @@ __global__ void cfill_mask_kernel(T* __restrict__ a,
  */
 template< typename T >
 __global__ void cmult2_kernel(T * __restrict__ a,
-                 T * __restrict__ b, 
+                 T * __restrict__ b,
                              const T c,
                              const int n) {
 
@@ -359,13 +377,13 @@ __global__ void invcol2_kernel(T * __restrict__ a,
 
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const int str = blockDim.x * gridDim.x;
-  
+
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] / b[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for col2
  */
 template< typename T >
@@ -378,10 +396,10 @@ __global__ void col2_kernel(T * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] * b[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for col3
  */
 template< typename T >
@@ -395,10 +413,10 @@ __global__ void col3_kernel(T * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = b[i] * c[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for subcol3
  */
 template< typename T >
@@ -412,10 +430,10 @@ __global__ void subcol3_kernel(T * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] - b[i] * c[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for sub2
  */
 template< typename T >
@@ -428,10 +446,10 @@ __global__ void sub2_kernel(T * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] - b[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for sub3
  */
 template< typename T >
@@ -445,7 +463,7 @@ __global__ void sub3_kernel(T * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = b[i] - c[i];
-  }  
+  }
 }
 
 /**
@@ -462,8 +480,8 @@ __global__ void addcol3_kernel(T * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] + b[i] * c[i];
-  }  
-  
+  }
+
 }
 
 /**
@@ -481,8 +499,8 @@ __global__ void addcol4_kernel(T * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] + b[i] * c[i] * d[i];
-  }  
- 
+  }
+
 }
 
 /**
@@ -503,8 +521,8 @@ __global__ void vdot3_kernel(T * __restrict__ dot,
 
   for (int i = idx; i < n; i += str) {
     dot[i] = u1[i] * v1[i]  + u2[i] * v2[i] + u3[i] * v3[i];
-  }  
-  
+  }
+
 }
 
 /**
@@ -529,8 +547,8 @@ __global__ void vcross_kernel(T * __restrict__ u1,
     u1[i] = v2[i]*w3[i] - v3[i]*w2[i];
     u2[i] = v3[i]*w1[i] - v1[i]*w3[i];
     u3[i] = v1[i]*w2[i] - v2[i]*w1[i];
-  }  
-  
+  }
+
 }
 
 
@@ -552,11 +570,11 @@ __inline__ __device__ T reduce_warp(T val) {
  */
 template< typename T >
 __global__ void reduce_kernel(T * bufred, const int n) {
-                
+
   T sum = 0;
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const int str = blockDim.x * gridDim.x;
-  for (int i = idx; i<n ; i += str) 
+  for (int i = idx; i<n ; i += str)
   {
     sum += bufred[i];
   }
@@ -630,8 +648,8 @@ __global__ void glsc3_kernel(const T * a,
 
   const unsigned int lane = threadIdx.x % warpSize;
   const unsigned int wid = threadIdx.x / warpSize;
-  
-  __shared__ T shared[32];  
+
+  __shared__ T shared[32];
   T sum = 0.0;
   for (int i = idx; i < n; i+= str) {
     sum += a[i] * b[i] * c[i];
@@ -672,10 +690,10 @@ __global__ void glsc3_many_kernel(const T * a,
       tmp += a[i] * b[threadIdx.x][i] * c[i];
     }
   }
-  
+
   buf[threadIdx.y*blockDim.x+y] = tmp;
   __syncthreads();
-  
+
   int i = blockDim.y>>1;
   while (i != 0) {
     if (threadIdx.y < i) {
@@ -705,8 +723,8 @@ __global__ void glsc2_kernel(const T * a,
 
   const unsigned int lane = threadIdx.x % warpSize;
   const unsigned int wid = threadIdx.x / warpSize;
-  
-  __shared__ T shared[32];  
+
+  __shared__ T shared[32];
   T sum = 0.0;
   for (int i = idx; i < n; i+= str) {
     sum += a[i] * b[i];
@@ -723,7 +741,7 @@ __global__ void glsc2_kernel(const T * a,
 
   if (threadIdx.x == 0)
     buf_h[blockIdx.x] = sum;
-  
+
 }
 
 /**
@@ -739,10 +757,10 @@ __global__ void glsum_kernel(const T * a,
 
   const unsigned int lane = threadIdx.x % warpSize;
   const unsigned int wid = threadIdx.x / warpSize;
-  
+
   __shared__ T shared[32];
-  T sum = 0;    
-  for (int i = idx; i<n ; i += str) 
+  T sum = 0;
+  for (int i = idx; i<n ; i += str)
   {
     sum += a[i];
   }
@@ -758,7 +776,7 @@ __global__ void glsum_kernel(const T * a,
 
   if (threadIdx.x == 0)
     buf_h[blockIdx.x] = sum;
-  
+
 }
 
 /**

--- a/src/math/bcknd/device/cuda/math_kernel.h
+++ b/src/math/bcknd/device/cuda/math_kernel.h
@@ -87,23 +87,6 @@ __global__ void masked_scatter_copy_kernel(T * __restrict__ a,
   }
 }
 
-/**
- * Device kernel for masked scatter copy
- */
-template< typename T >
-__global__ void masked_scatter_copy_kernel(T * __restrict__ a,
-                                   T * __restrict__ b,
-                                   int * __restrict__ mask,
-                                   const int n,
-                                   const int m) {
-
-  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
-  const int str = blockDim.x * gridDim.x;
-
-  for (int i = idx; i < m; i += str) {
-    a[mask[i+1]-1] = b[i];
-  }
-}
 
 /**
  * Device kernel for masked atomic update

--- a/src/math/bcknd/device/device_math.F90
+++ b/src/math/bcknd/device/device_math.F90
@@ -67,7 +67,8 @@ module device_math
        device_glsc3, device_glsc3_many, device_add2s2_many, device_glsc2, &
        device_glsum, device_masked_copy, device_cfill_mask, &
        device_masked_red_copy, device_vcross, device_absval, &
-       device_pwmax, device_pwmin, device_masked_atomic_reduction
+       device_pwmax, device_pwmin, device_masked_atomic_reduction, &
+       device_masked_scatter_copy
 
 contains
 
@@ -109,11 +110,25 @@ contains
 #elif HAVE_CUDA
     call cuda_masked_red_copy(a_d, b_d, mask_d, n, m)
 #elif HAVE_OPENCL
-    call neko_error('No OpenCL bcknd, masked red copy')
+    call opencl_masked_red_copy(a_d, b_d, mask_d, n, m)
 #else
     call neko_error('no device backend configured')
 #endif
   end subroutine device_masked_red_copy
+
+  subroutine device_masked_scatter_copy(a_d, b_d, mask_d, n, m)
+    type(c_ptr) :: a_d, b_d, mask_d
+    integer :: n, m
+#if HAVE_HIP
+    call hip_masked_scatter_copy(a_d, b_d, mask_d, n, m)
+#elif HAVE_CUDA
+    call cuda_masked_scatter_copy(a_d, b_d, mask_d, n, m)
+#elif HAVE_OPENCL
+    call opencl_masked_scatter_copy(a_d, b_d, mask_d, n, m)
+#else
+    call neko_error('no device backend configured')
+#endif
+  end subroutine device_masked_scatter_copy
 
   subroutine device_masked_atomic_reduction(a_d, b_d, mask_d, n, m)
     type(c_ptr) :: a_d, b_d, mask_d

--- a/src/math/bcknd/device/device_math.F90
+++ b/src/math/bcknd/device/device_math.F90
@@ -115,7 +115,7 @@ contains
 #elif HAVE_CUDA
     call cuda_masked_gather_copy(a_d, b_d, mask_d, n, m)
 #elif HAVE_OPENCL
-    call opencl_masked_red_copy(a_d, b_d, mask_d, n, m)
+    call opencl_masked_gather_copy(a_d, b_d, mask_d, n, m)
 #else
     call neko_error('no device backend configured')
 #endif

--- a/src/math/bcknd/device/hip/hip_math.f90
+++ b/src/math/bcknd/device/hip/hip_math.f90
@@ -58,7 +58,7 @@ module hip_math
      end subroutine hip_masked_gather_copy
 
      subroutine hip_masked_scatter_copy(a_d, b_d, mask_d, n, m) &
-          bind(c, name = 'hip_masked_red_copy')
+          bind(c, name = 'hip_masked_scatter_copy')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        type(c_ptr), value :: a_d, b_d, mask_d
        integer(c_int) :: n, m

--- a/src/math/bcknd/device/hip/hip_math.f90
+++ b/src/math/bcknd/device/hip/hip_math.f90
@@ -57,6 +57,13 @@ module hip_math
        integer(c_int) :: n, m
      end subroutine hip_masked_red_copy
 
+     subroutine hip_masked_scatter_copy(a_d, b_d, mask_d, n, m) &
+          bind(c, name = 'hip_masked_red_copy')
+       use, intrinsic :: iso_c_binding, only: c_ptr, c_int
+       type(c_ptr), value :: a_d, b_d, mask_d
+       integer(c_int) :: n, m
+     end subroutine hip_masked_scatter_copy
+
      subroutine hip_masked_atomic_reduction(a_d, b_d, mask_d, n, m) &
           bind(c, name = 'hip_masked_atomic_reduction')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int

--- a/src/math/bcknd/device/hip/hip_math.f90
+++ b/src/math/bcknd/device/hip/hip_math.f90
@@ -58,13 +58,6 @@ module hip_math
      end subroutine hip_masked_gather_copy
 
      subroutine hip_masked_scatter_copy(a_d, b_d, mask_d, n, m) &
-          bind(c, name = 'hip_masked_scatter_copy')
-       use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d, mask_d
-       integer(c_int) :: n, m
-     end subroutine hip_masked_scatter_copy
-
-     subroutine hip_masked_scatter_copy(a_d, b_d, mask_d, n, m) &
           bind(c, name = 'hip_masked_red_copy')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        type(c_ptr), value :: a_d, b_d, mask_d

--- a/src/math/bcknd/device/hip/math.hip
+++ b/src/math/bcknd/device/hip/math.hip
@@ -46,7 +46,7 @@ extern "C" {
 #include <math/bcknd/device/device_nccl_reduce.h>
 #include <math/bcknd/device/device_nccl_op.h>
 #endif
-  
+
   /** Fortran wrapper for copy
    * Copy a vector \f$ a = b \f$
    */
@@ -71,8 +71,8 @@ extern "C" {
     HIP_CHECK(hipGetLastError());
 
   }
-  
- 
+
+
   /** Fortran wrapper for masked reduced copy
    * Copy a vector \f$ a = b(mask) \f$
    */
@@ -87,7 +87,23 @@ extern "C" {
 
     HIP_CHECK(hipGetLastError());
 
-  } 
+  }
+
+  /** Fortran wrapper for masked scattered copy
+   * Copy a vector \f$ a(mask) = b \f$
+   */
+  void hip_masked_scatter_copy(void *a, void *b, void *mask, int *n, int *m) {
+
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks(((*m)+1024 - 1)/ 1024, 1, 1);
+
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(masked_scatter_copy_kernel<real>),
+                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
+                       (real *) a, (real *) b, (int *) mask, *n, *m);
+
+    HIP_CHECK(hipGetLastError());
+
+  }
 
   /** Fortran wrapper for masked atomic reduction
    * update a vector \f$ a += b(mask) \f$ where mask is not unique
@@ -103,7 +119,7 @@ extern "C" {
 
     HIP_CHECK(hipGetLastError());
 
-  } 
+  }
 
   /** Fortran wrapper for cfill_mask
    * Fill a scalar to vector \f$ a_i = s, for i \in mask \f$
@@ -112,7 +128,7 @@ extern "C" {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
-      
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(cfill_mask_kernel<real>),
                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
                        (real*)a, *c, *size, (int*)mask, *mask_size);
@@ -135,12 +151,12 @@ extern "C" {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
-    
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(cmult_kernel<real>),
                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
                        (real *) a, *c, *n);
     HIP_CHECK(hipGetLastError());
-    
+
   }
 
   /** Fortran wrapper for cmult
@@ -150,12 +166,12 @@ extern "C" {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
-    
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(cmult2_kernel<real>),
                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
                        (real *) a,(real *) b, *c, *n);
     HIP_CHECK(hipGetLastError());
-    
+
   }
   /** Fortran wrapper for cadd
    * Add a scalar to vector \f$ a = \sum a_i + s \f$
@@ -164,11 +180,11 @@ extern "C" {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
-    
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(cadd_kernel<real>),
                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
                        (real *) a, *c, *n);
-    HIP_CHECK(hipGetLastError()); 
+    HIP_CHECK(hipGetLastError());
   }
 
   /**
@@ -193,7 +209,7 @@ extern "C" {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
-    if (*n > 0) { 
+    if (*n > 0) {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(cfill_kernel<real>),
                          nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
                          (real *) a, *c, *n);
@@ -206,25 +222,25 @@ extern "C" {
    * Vector addition \f$ a = a + b \f$
    */
   void hip_add2(void *a, void *b, int *n) {
-    
+
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
-    
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(add2_kernel<real>),
                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
                        (real *) a, (real *) b, *n);
     HIP_CHECK(hipGetLastError());
   }
-  
+
   /**
    * Fortran wrapper for add4
    * Vector addition \f$ a = b + c + d\f$
    */
   void hip_add4(void *a, void *b, void *c, void *d, int *n) {
-    
+
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
-    
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(add4_kernel<real>),
                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
                        (real *) a, (real *) b, (real *) c, (real *) d, *n);
@@ -234,13 +250,13 @@ extern "C" {
   /**
    * Fortran wrapper for add2s1
    * Vector addition with scalar multiplication \f$ a = c_1 a + b \f$
-   * (multiplication on first argument) 
+   * (multiplication on first argument)
    */
   void hip_add2s1(void *a, void *b, real *c1, int *n) {
-    
+
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
-    
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(add2s1_kernel<real>),
                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
                        (real *) a, (real *) b,
@@ -251,7 +267,7 @@ extern "C" {
   /**
    * Fortran wrapper for add2s2
    * Vector addition with scalar multiplication \f$ a = a + c_1 b \f$
-   * (multiplication on second argument) 
+   * (multiplication on second argument)
    */
   void hip_add2s2(void *a, void *b, real *c1, int *n) {
 
@@ -268,7 +284,7 @@ extern "C" {
   /**
    * Fortran wrapper for addsqr2s2
    * Vector addition with scalar multiplication \f$ a = a + c_1 (b * b) \f$
-   * (multiplication on second argument) 
+   * (multiplication on second argument)
    */
   void hip_addsqr2s2(void *a, void *b, real *c1, int *n) {
 
@@ -281,11 +297,11 @@ extern "C" {
                        *c1, *n);
     HIP_CHECK(hipGetLastError());
   }
-  
+
   /**
    * Fortran wrapper for add3s2
    * Vector addition with scalar multiplication \f$ a = c_1 b + c_2 c \f$
-   * (multiplication on second argument) 
+   * (multiplication on second argument)
    */
   void hip_add3s2(void *a, void *b, void *c, real *c1, real *c2, int *n) {
 
@@ -298,7 +314,7 @@ extern "C" {
                        *c1, *c2, *n);
     HIP_CHECK(hipGetLastError());
   }
-  
+
   /**
    * Fortran wrapper for invcol1
    * Invert a vector \f$ a = 1 / a \f$
@@ -328,7 +344,7 @@ extern "C" {
                        (real *) a, (real *) b, *n);
     HIP_CHECK(hipGetLastError());
   }
-  
+
   /**
    * Fortran wrapper for col2
    * Vector multiplication with 2 vectors \f$ a = a \cdot b \f$
@@ -343,7 +359,7 @@ extern "C" {
                        (real *) a, (real *) b, *n);
     HIP_CHECK(hipGetLastError());
   }
-  
+
   /**
    * Fortran wrapper for col3
    * Vector multiplication with 3 vectors \f$ a = b \cdot c \f$
@@ -373,7 +389,7 @@ extern "C" {
                        (real *) a, (real *) b, (real *) c, *n);
     HIP_CHECK(hipGetLastError());
   }
-  
+
   /**
    * Fortran wrapper for sub2
    * Vector subtraction \f$ a = a - b \f$
@@ -443,7 +459,7 @@ extern "C" {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
-    
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(vdot3_kernel<real>),
                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
                        (real *) dot, (real *) u1, (real *) u2, (real *) u3,
@@ -461,11 +477,11 @@ extern "C" {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
-    
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(vcross_kernel<real>),
                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
                        (real *) u1, (real *) u2, (real *) u3,
-                       (real *) v1, (real *) v2, (real *) v3, 
+                       (real *) v1, (real *) v2, (real *) v3,
                        (real *) w1, (real *) w2, (real *) w3, *n);
     HIP_CHECK(hipGetLastError());
   }
@@ -477,28 +493,28 @@ extern "C" {
   int red_s = 0;
   real * bufred = NULL;
   real * bufred_d = NULL;
-  
+
   /**
    * Fortran wrapper vlsc3
    * Compute multiplication sum \f$ dot = u \cdot v \cdot w \f$
    */
   real hip_vlsc3(void *u, void *v, void *w, int *n) {
-        
+
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     const int nb = ((*n) + 1024 - 1)/ 1024;
     const hipStream_t stream = (hipStream_t) glb_cmd_queue;
-    
+
     if ( nb > red_s){
       red_s = nb;
       if (bufred != NULL) {
         HIP_CHECK(hipHostFree(bufred));
-        HIP_CHECK(hipFree(bufred_d));        
+        HIP_CHECK(hipFree(bufred_d));
       }
       HIP_CHECK(hipHostMalloc(&bufred,nb*sizeof(real),hipHostMallocDefault));
       HIP_CHECK(hipMalloc(&bufred_d, nb*sizeof(real)));
     }
-     
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_kernel<real>),
                        nblcks, nthrds, 0, stream,
                        (real *) u, (real *) v,
@@ -514,29 +530,29 @@ extern "C" {
 
     return bufred[0];
   }
-  
+
 
   /**
    * Fortran wrapper glsc3
    * Weighted inner product \f$ a^T b c \f$
    */
   real hip_glsc3(void *a, void *b, void *c, int *n) {
-        
+
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     const int nb = ((*n) + 1024 - 1)/ 1024;
     const hipStream_t stream = (hipStream_t) glb_cmd_queue;
-    
+
     if ( nb > red_s){
       red_s = nb;
       if (bufred != NULL) {
         HIP_CHECK(hipHostFree(bufred));
-        HIP_CHECK(hipFree(bufred_d));        
+        HIP_CHECK(hipFree(bufred_d));
       }
       HIP_CHECK(hipHostMalloc(&bufred,nb*sizeof(real),hipHostMallocDefault));
       HIP_CHECK(hipMalloc(&bufred_d, nb*sizeof(real)));
     }
-     
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_kernel<real>),
                        nblcks, nthrds, 0, stream,
                        (real *) a, (real *) b,
@@ -567,25 +583,25 @@ extern "C" {
    * Fortran wrapper for doing an reduction to an array
    * Weighted inner product \f$ w^T v(n,1:j) c \f$
    */
-  void hip_glsc3_many(real *h, void * w, void *v,void *mult, int *j, int *n){ 
+  void hip_glsc3_many(real *h, void * w, void *v,void *mult, int *j, int *n){
     int pow2 = 1;
     while(pow2 < (*j)){
       pow2 = 2*pow2;
     }
-    const int nt = 1024/pow2;   
+    const int nt = 1024/pow2;
     const dim3 nthrds(pow2, nt, 1);
     const dim3 nblcks(((*n)+nt - 1)/nt, 1, 1);
     const dim3 nthrds_red(1024,1,1);
     const dim3 nblcks_red( (*j),1,1);
     const int nb = ((*n) + nt - 1)/nt;
     const hipStream_t stream = (hipStream_t) glb_cmd_queue;
-    
+
     if((*j)*nb>red_s){
       red_s = (*j)*nb;
       if (bufred != NULL) {
         HIP_CHECK(hipHostFree(bufred));
         HIP_CHECK(hipFree(bufred_d));
-      }      
+      }
       HIP_CHECK(hipHostMalloc(&bufred,(*j)*nb*sizeof(real),hipHostMallocDefault));
       HIP_CHECK(hipMalloc(&bufred_d, (*j)*nb*sizeof(real)));
     }
@@ -594,7 +610,7 @@ extern "C" {
                        (const real *) w, (const real **) v,
                        (const real *)mult, bufred_d, *j, *n);
     HIP_CHECK(hipGetLastError());
-    
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_reduce_kernel<real>),
                        nblcks_red, nthrds_red, 0, stream,
                        bufred_d, nb, *j);
@@ -613,20 +629,20 @@ extern "C" {
     HIP_CHECK(hipMemcpyAsync(h, bufred_d, (*j)* sizeof(real),
                              hipMemcpyDeviceToHost, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
-#endif    
+#endif
   }
 
   /**
    * Fortran wrapper for add2s2
-   * Vector addition with scalar multiplication 
+   * Vector addition with scalar multiplication
    * \f$ x = x + c_1 p1 + c_2p2 + ... + c_jpj \f$
-   * (multiplication on second argument) 
+   * (multiplication on second argument)
    */
   void hip_add2s2_many(void *x, void **p, void *alpha, int *j, int *n) {
-        
+
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
-    
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(add2s2_many_kernel<real>),
                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
                        (real *) x, (const real **) p, (real *) alpha, *j, *n);
@@ -654,22 +670,22 @@ extern "C" {
    * Weighted inner product \f$ a^T b \f$
    */
   real hip_glsc2(void *a, void *b, int *n) {
-        
+
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     const int nb = ((*n) + 1024 - 1)/ 1024;
     const hipStream_t stream = (hipStream_t) glb_cmd_queue;
-        
+
     if ( nb > red_s){
       red_s = nb;
       if (bufred != NULL) {
         HIP_CHECK(hipHostFree(bufred));
-        HIP_CHECK(hipFree(bufred_d));        
+        HIP_CHECK(hipFree(bufred_d));
       }
       HIP_CHECK(hipHostMalloc(&bufred,nb*sizeof(real),hipHostMallocDefault));
       HIP_CHECK(hipMalloc(&bufred_d, nb*sizeof(real)));
     }
-     
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc2_kernel<real>),
                        nblcks, nthrds, 0, stream,
                        (real *) a, (real *) b, bufred_d, *n);
@@ -695,7 +711,7 @@ extern "C" {
     return bufred[0];
   }
 
-  /** 
+  /**
    * Fortran wrapper glsum
    * Sum a vector of length n
    */
@@ -704,17 +720,17 @@ extern "C" {
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     const int nb = ((*n) + 1024 - 1)/ 1024;
     const hipStream_t stream = (hipStream_t) glb_cmd_queue;
-    
+
     if ( nb > red_s){
       red_s = nb;
       if (bufred != NULL) {
         HIP_CHECK(hipHostFree(bufred));
-        HIP_CHECK(hipFree(bufred_d));        
+        HIP_CHECK(hipFree(bufred_d));
       }
       HIP_CHECK(hipHostMalloc(&bufred,nb*sizeof(real),hipHostMallocDefault));
       HIP_CHECK(hipMalloc(&bufred_d, nb*sizeof(real)));
     }
-    if( *n > 0) { 
+    if( *n > 0) {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(glsum_kernel<real>),
                        nblcks, nthrds, 0, stream,
                        (real *) a, bufred_d, *n);
@@ -737,7 +753,7 @@ extern "C" {
     HIP_CHECK(hipMemcpyAsync(bufred, bufred_d,sizeof(real),
                              hipMemcpyDeviceToHost, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
-#endif    
+#endif
     return bufred[0];
   }
 
@@ -748,11 +764,11 @@ extern "C" {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
-    
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(absval_kernel<real>),
                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
                        (real *) a, *n);
     HIP_CHECK(hipGetLastError());
-    
+
   }
 }

--- a/src/math/bcknd/device/hip/math_kernel.h
+++ b/src/math/bcknd/device/hip/math_kernel.h
@@ -56,7 +56,7 @@ __global__ void cmult_kernel(T * __restrict__ a,
 template< typename T >
 __global__ void masked_copy_kernel(T * __restrict__ a,
                                    T * __restrict__ b,
-                                   int * __restrict__ mask,                    
+                                   int * __restrict__ mask,
                                    const int n,
                                    const int m) {
 
@@ -74,7 +74,7 @@ __global__ void masked_copy_kernel(T * __restrict__ a,
 template< typename T >
 __global__ void masked_red_copy_kernel(T * __restrict__ a,
                                    T * __restrict__ b,
-                                   int * __restrict__ mask,                    
+                                   int * __restrict__ mask,
                                    const int n,
                                    const int m) {
 
@@ -87,12 +87,30 @@ __global__ void masked_red_copy_kernel(T * __restrict__ a,
 }
 
 /**
+ * Device kernel for masked scattered copy
+ */
+template< typename T >
+__global__ void masked_scatter_copy_kernel(T * __restrict__ a,
+                                   T * __restrict__ b,
+                                   int * __restrict__ mask,
+                                   const int n,
+                                   const int m) {
+
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  for (int i = idx; i < m; i += str) {
+    a[mask[i+1]-1] = b[i];
+  }
+}
+
+/**
  * Device kernel for masked atomic update
  */
 template< typename T >
 __global__ void masked_atomic_reduction_kernel(T * __restrict__ a,
                                    T * __restrict__ b,
-                                   int * __restrict__ mask,                    
+                                   int * __restrict__ mask,
                                    const int n,
                                    const int m) {
 
@@ -126,7 +144,7 @@ __global__ void cfill_mask_kernel(T* __restrict__ a,
  */
 template< typename T >
 __global__ void cmult2_kernel(T * __restrict__ a,
-                 T * __restrict__ b, 
+                 T * __restrict__ b,
                              const T c,
                              const int n) {
 
@@ -357,13 +375,13 @@ __global__ void invcol2_kernel(T * __restrict__ a,
 
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const int str = blockDim.x * gridDim.x;
-  
+
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] / b[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for col2
  */
 template< typename T >
@@ -376,10 +394,10 @@ __global__ void col2_kernel(T * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] * b[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for col3
  */
 template< typename T >
@@ -393,10 +411,10 @@ __global__ void col3_kernel(T * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = b[i] * c[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for subcol3
  */
 template< typename T >
@@ -410,10 +428,10 @@ __global__ void subcol3_kernel(T * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] - b[i] * c[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for sub2
  */
 template< typename T >
@@ -426,10 +444,10 @@ __global__ void sub2_kernel(T * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] - b[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for sub3
  */
 template< typename T >
@@ -443,7 +461,7 @@ __global__ void sub3_kernel(T * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = b[i] - c[i];
-  }  
+  }
 }
 
 /**
@@ -460,8 +478,8 @@ __global__ void addcol3_kernel(T * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] + b[i] * c[i];
-  }  
- 
+  }
+
 }
 
 /**
@@ -479,8 +497,8 @@ __global__ void addcol4_kernel(T * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] + b[i] * c[i] * d[i];
-  }  
-  
+  }
+
 }
 
 /**
@@ -501,8 +519,8 @@ __global__ void vdot3_kernel(T * __restrict__ dot,
 
   for (int i = idx; i < n; i += str) {
     dot[i] = u1[i] * v1[i]  + u2[i] * v2[i] + u3[i] * v3[i];
-  }  
-  
+  }
+
 }
 
 /**
@@ -527,7 +545,7 @@ __global__ void vcross_kernel(T * __restrict__ u1,
     u1[i] = v2[i]*w3[i] - v3[i]*w2[i];
     u2[i] = v3[i]*w1[i] - v1[i]*w3[i];
     u3[i] = v1[i]*w2[i] - v2[i]*w1[i];
-  }  
+  }
 }
 
 /**
@@ -549,11 +567,11 @@ __inline__ __device__ T reduce_warp(T val) {
  */
 template< typename T >
 __global__ void reduce_kernel(T * bufred, const int n) {
-                
+
   T sum = 0;
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const int str = blockDim.x * gridDim.x;
-  for (int i = idx; i<n ; i += str) 
+  for (int i = idx; i<n ; i += str)
   {
     sum += bufred[i];
   }
@@ -625,8 +643,8 @@ __global__ void glsc3_kernel(const T * a,
 
   const unsigned int lane = threadIdx.x % warpSize;
   const unsigned int wid = threadIdx.x / warpSize;
-  
-  __shared__ T shared[64];  
+
+  __shared__ T shared[64];
   T sum = 0.0;
   for (int i = idx; i < n; i+= str) {
     sum += a[i] * b[i] * c[i];
@@ -642,7 +660,7 @@ __global__ void glsc3_kernel(const T * a,
     sum = reduce_warp<T>(sum);
 
   if (threadIdx.x == 0)
-    buf_h[blockIdx.x] = sum; 
+    buf_h[blockIdx.x] = sum;
 }
 
 /**
@@ -701,8 +719,8 @@ __global__ void glsc2_kernel(const T * a,
 
   const unsigned int lane = threadIdx.x % warpSize;
   const unsigned int wid = threadIdx.x / warpSize;
-  
-  __shared__ T shared[64];  
+
+  __shared__ T shared[64];
   T sum = 0.0;
   for (int i = idx; i < n; i+= str) {
     sum += a[i] * b[i];
@@ -734,10 +752,10 @@ __global__ void glsum_kernel(const T * a,
 
   const unsigned int lane = threadIdx.x % warpSize;
   const unsigned int wid = threadIdx.x / warpSize;
-  
+
   __shared__ T shared[64];
-  T sum = 0;    
-  for (int i = idx; i<n ; i += str) 
+  T sum = 0;
+  for (int i = idx; i<n ; i += str)
   {
     sum += a[i];
   }

--- a/src/math/bcknd/device/opencl/math.c
+++ b/src/math/bcknd/device/opencl/math.c
@@ -87,13 +87,13 @@ void opencl_masked_copy(void *a, void *b, void *mask, int *n, int *m) {
 /** Fortran wrapper for masked reduced copy
  * Copy a vector \f$ a = b(mask) \f$
  */
-void opencl_masked_red_copy(void *a, void *b, void *mask, int *n, int *m) {
+void opencl_masked_gather_copy(void *a, void *b, void *mask, int *n, int *m) {
   cl_int err;
 
   if (math_program == NULL)
     opencl_kernel_jit(math_kernel, (cl_program *) &math_program);
 
-  cl_kernel kernel = clCreateKernel(math_program, "masked_red_copy_kernel",
+  cl_kernel kernel = clCreateKernel(math_program, "masked_gather_copy_kernel",
     &err);
   CL_CHECK(err);
 

--- a/src/math/bcknd/device/opencl/math_kernel.cl
+++ b/src/math/bcknd/device/opencl/math_kernel.cl
@@ -48,18 +48,52 @@ __kernel void masked_copy_kernel(__global real * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[mask[i+1]-1] = b[mask[i+1]-1];
-  }  
+  }
+}
+
+/**
+ * Device kernel for masked reduced copy
+ */
+__kernel void masked_red_copy_kernel(__global real * __restrict__ a,
+                                     __global real * __restrict__ b,
+                                     __global int * __restrict__ mask,
+                                     const int n,
+                                     const int m) {
+
+  const int idx = get_global_id(0);
+  const int str = get_global_size(0);
+
+  for (int i = idx; i < n; i += str) {
+    a[i] = b[mask[i+1]-1];
+  }
+}
+
+/**
+ * Device kernel for masked reduced copy
+ */
+__kernel void masked_scatter_copy_kernel(__global real * __restrict__ a,
+                                         __global real * __restrict__ b,
+                                         __global int * __restrict__ mask,
+                                         const int n,
+                                         const int m) {
+
+  const int idx = get_global_id(0);
+  const int str = get_global_size(0);
+
+  for (int i = idx; i < n; i += str) {
+    a[mask[i+1]-1] = b[i];
+  }
 }
 
 /**
  * Device kernel for cfill_mask
  */
-__kernel void cfill_mask_kernel(__global real * __restrict__ a, 
-                                const real c, 
-                                const int size, 
+__kernel void cfill_mask_kernel(__global real * __restrict__ a,
+                                const real c,
+                                const int size,
                                 __global int * __restrict__ mask,
                                 const int mask_size) {
-  
+
   const int idx = get_global_id(0);
   const int str = get_global_size(0);
 
@@ -78,7 +112,7 @@ __kernel void cmult_kernel(__global real * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = c * a[i];
-  } 
+  }
 }
 
 /**
@@ -94,7 +128,7 @@ __kernel void cmult2_kernel(__global real * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = c * b[i];
-  } 
+  }
 }
 
 /**
@@ -109,7 +143,7 @@ __kernel void cadd_kernel(__global real * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] + c;
-  } 
+  }
 }
 
 /**
@@ -140,7 +174,7 @@ __kernel void cfill_kernel(__global real * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = c;
-  } 
+  }
 }
 
 /**
@@ -157,7 +191,7 @@ __kernel void add4_kernel(__global real * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = d[i] + c[i] + d[i];
-  } 
+  }
 }
 
 /**
@@ -172,7 +206,7 @@ __kernel void add2_kernel(__global real * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] + b[i];
-  } 
+  }
 }
 
 /**
@@ -204,7 +238,7 @@ __kernel void add2s1_kernel(__global real * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = c1 * a[i] + b[i];
-  } 
+  }
 }
 
 /**
@@ -287,13 +321,13 @@ __kernel void invcol1_kernel(__global real * __restrict__ a,
   const int idx = get_global_id(0);
   const int str = get_global_size(0);
   const real one = 1.0;
-  
+
   for (int i = idx; i < n; i += str) {
     a[i] = one / a[i];
   }
 }
 
-/** 
+/**
  * Device kernel for invcol2
  */
 __kernel void invcol2_kernel(__global real * __restrict__ a,
@@ -305,10 +339,10 @@ __kernel void invcol2_kernel(__global real * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] / b[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for col2
  */
 __kernel void col2_kernel(__global real * __restrict__ a,
@@ -320,10 +354,10 @@ __kernel void col2_kernel(__global real * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] * b[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for col3
  */
 __kernel void col3_kernel(__global real * __restrict__ a,
@@ -336,10 +370,10 @@ __kernel void col3_kernel(__global real * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = b[i] * c[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for subcol3
  */
 __kernel void subcol3_kernel(__global real * __restrict__ a,
@@ -352,10 +386,10 @@ __kernel void subcol3_kernel(__global real * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] - b[i] * c[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for sub2
  */
 __kernel void sub2_kernel(__global real * __restrict__ a,
@@ -367,10 +401,10 @@ __kernel void sub2_kernel(__global real * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] - b[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for sub3
  */
 __kernel void sub3_kernel(__global real * __restrict__ a,
@@ -383,10 +417,10 @@ __kernel void sub3_kernel(__global real * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = b[i] - c[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for addcol3
  */
 __kernel void addcol3_kernel(__global real * __restrict__ a,
@@ -399,10 +433,10 @@ __kernel void addcol3_kernel(__global real * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] + b[i] * c[i];
-  }  
+  }
 }
 
-/** 
+/**
  * Device kernel for addcol4
  */
 __kernel void addcol4_kernel(__global real * __restrict__ a,
@@ -416,7 +450,7 @@ __kernel void addcol4_kernel(__global real * __restrict__ a,
 
   for (int i = idx; i < n; i += str) {
     a[i] = a[i] + b[i] * c[i] * d[i];
-  }  
+  }
 }
 
 /**
@@ -436,8 +470,8 @@ __kernel void vdot3_kernel(__global real * __restrict__ dot,
 
   for (int i = idx; i < n; i += str) {
     dot[i] = u1[i] * v1[i]  + u2[i] * v2[i] + u3[i] * v3[i];
-  }  
-  
+  }
+
 }
 
 /**
@@ -469,7 +503,7 @@ __kernel void glsc3_kernel(__global const real * __restrict__ a,
     barrier(CLK_LOCAL_MEM_FENCE);
     i = i>>1;
   }
- 
+
   if (get_local_id(0) == 0) {
     buf_h[get_group_id(0)] = buf[0];
   }
@@ -510,7 +544,7 @@ __kernel void glsc3_many_kernel(__global const real * __restrict__ a,
     barrier(CLK_LOCAL_MEM_FENCE);
     i = i>>1;
   }
-  
+
   if (get_local_id(0) == 0) {
     if( y < j) {
       buf_h[j * get_group_id(0) + y] = buf[y];
@@ -546,7 +580,7 @@ __kernel void glsc2_kernel(__global const real * __restrict__ a,
     barrier(CLK_LOCAL_MEM_FENCE);
     i = i>>1;
   }
- 
+
   if (get_local_id(0) == 0) {
     buf_h[get_group_id(0)] = buf[0];
   }
@@ -580,7 +614,7 @@ __kernel void glsum_kernel(__global const real * __restrict__ a,
     barrier(CLK_LOCAL_MEM_FENCE);
     i = i>>1;
   }
- 
+
   if (get_local_id(0) == 0) {
     buf_h[get_group_id(0)] = buf[0];
   }

--- a/src/math/bcknd/device/opencl/math_kernel.cl
+++ b/src/math/bcknd/device/opencl/math_kernel.cl
@@ -54,7 +54,7 @@ __kernel void masked_copy_kernel(__global real * __restrict__ a,
 /**
  * Device kernel for masked reduced copy
  */
-__kernel void masked_red_copy_kernel(__global real * __restrict__ a,
+__kernel void masked_gather_copy_kernel(__global real * __restrict__ a,
                                      __global real * __restrict__ b,
                                      __global int * __restrict__ mask,
                                      const int n,

--- a/src/math/bcknd/device/opencl/opencl_math.f90
+++ b/src/math/bcknd/device/opencl/opencl_math.f90
@@ -50,6 +50,20 @@ module opencl_math
        integer(c_int) :: n, m
      end subroutine opencl_masked_copy
 
+     subroutine opencl_masked_red_copy(a_d, b_d, mask_d, n, m) &
+          bind(c, name = 'opencl_masked_red_copy')
+       use, intrinsic :: iso_c_binding, only: c_ptr, c_int
+       type(c_ptr), value :: a_d, b_d, mask_d
+       integer(c_int) :: n, m
+     end subroutine opencl_masked_red_copy
+
+     subroutine opencl_masked_scatter_copy(a_d, b_d, mask_d, n, m) &
+          bind(c, name = 'opencl_masked_scatter_copy')
+       use, intrinsic :: iso_c_binding, only: c_ptr, c_int
+       type(c_ptr), value :: a_d, b_d, mask_d
+       integer(c_int) :: n, m
+     end subroutine opencl_masked_scatter_copy
+
      subroutine opencl_cfill_mask(a_d, c, size, mask_d, mask_size) &
           bind(c, name = 'opencl_cfill_mask')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int

--- a/src/math/bcknd/device/opencl/opencl_math.f90
+++ b/src/math/bcknd/device/opencl/opencl_math.f90
@@ -50,12 +50,12 @@ module opencl_math
        integer(c_int) :: n, m
      end subroutine opencl_masked_copy
 
-     subroutine opencl_masked_red_copy(a_d, b_d, mask_d, n, m) &
-          bind(c, name = 'opencl_masked_red_copy')
+     subroutine opencl_masked_gather_copy(a_d, b_d, mask_d, n, m) &
+          bind(c, name = 'opencl_masked_gather_copy')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        type(c_ptr), value :: a_d, b_d, mask_d
        integer(c_int) :: n, m
-     end subroutine opencl_masked_red_copy
+     end subroutine opencl_masked_gather_copy
 
      subroutine opencl_masked_scatter_copy(a_d, b_d, mask_d, n, m) &
           bind(c, name = 'opencl_masked_scatter_copy')

--- a/src/math/math.f90
+++ b/src/math/math.f90
@@ -112,7 +112,8 @@ module math
        add2s1, add2s2, addsqr2s2, cmult2, invcol2, col2, col3, subcol3, &
        add3s2, subcol4, addcol3, addcol4, ascol5, p_update, x_update, glsc2, &
        glsc3, glsc4, sort, masked_copy, cfill_mask, relcmp, glimax, glimin, &
-       swap, reord, flipv, cadd2, masked_red_copy, absval, pwmax, pwmin
+       swap, reord, flipv, cadd2, masked_red_copy, masked_scatter_copy, &
+       absval, pwmax, pwmin
 
 contains
 
@@ -288,6 +289,29 @@ contains
     end do
 
   end subroutine masked_red_copy
+
+  !> Copy a contigous vector to another via a mask into the destination array.
+  !! \f$ a(mask) = b \f$.
+  !! @param a Destination array of size `m`.
+  !! @param b Source array of size `n`.
+  !! @param mask Mask array of length m+1, where `mask(0) =m`
+  !! the length of the mask array.
+  !! @param n Size of the array `b`.
+  !! @param m Size of the mask array `mask` and `a`.
+  !! @note Like `masked_red_copy`, but the mask is applied to the destination
+  !! array `a` instead of the source array `b`.
+  subroutine masked_scatter_copy(a, b, mask, n, m)
+    integer, intent(in) :: n, m
+    real(kind=rp), dimension(n), intent(in) :: b
+    real(kind=rp), dimension(m), intent(inout) :: a
+    integer, dimension(0:m) :: mask
+    integer :: i, j
+
+    do i = 1, m
+       j = mask(i)
+       a(j) = b(i)
+    end do
+  end subroutine masked_scatter_copy
 
 
   !> @brief Fill a constant to a masked vector.

--- a/src/math/math.f90
+++ b/src/math/math.f90
@@ -313,30 +313,6 @@ contains
 
   end subroutine masked_scatter_copy
 
-  !> Copy a contigous vector to another via a mask into the destination array.
-  !! \f$ a(mask) = b \f$.
-  !! @param a Destination array of size `m`.
-  !! @param b Source array of size `n`.
-  !! @param mask Mask array of length m+1, where `mask(0) =m`
-  !! the length of the mask array.
-  !! @param n Size of the array `b`.
-  !! @param m Size of the mask array `mask` and `a`.
-  !! @note Like `masked_red_copy`, but the mask is applied to the destination
-  !! array `a` instead of the source array `b`.
-  subroutine masked_scatter_copy(a, b, mask, n, m)
-    integer, intent(in) :: n, m
-    real(kind=rp), dimension(n), intent(in) :: b
-    real(kind=rp), dimension(m), intent(inout) :: a
-    integer, dimension(0:m) :: mask
-    integer :: i, j
-
-    do i = 1, m
-       j = mask(i)
-       a(j) = b(i)
-    end do
-  end subroutine masked_scatter_copy
-
-
   !> @brief Fill a constant to a masked vector.
   !! \f$ a_i = c, for i in mask \f$
   subroutine cfill_mask(a, c, size, mask, mask_size)


### PR DESCRIPTION
- Adds the OpenCL kernel for masked_red_copy.
- Adds a new math routine, and the device kernels for it, called `masked_scatter_copy`, which is just like `masked_red_copy`, but applies the mask to the destination array. So you copy an array into a bigger array, with the mask telling to which elements to scatter the contiguous array. The need came in wall modelling code where I want to scatter the $\tau_w$ predictions stored in a vector to the boundary nodes of a field, which is used for processing.