### PR TITLE
Fix JIT error for facet normal and neumann kernel (OpenCL)

### DIFF
--- a/src/bc/bcknd/device/opencl/neumann_kernel.cl
+++ b/src/bc/bcknd/device/opencl/neumann_kernel.cl
@@ -35,7 +35,28 @@
 #ifndef __BC_NEUMANN_KERNEL__
 #define __BC_NEUMANN_KERNEL__
 
-#include "bc_utils.h"
+/**
+ * Computes the linear index for area and normal arrays
+ * @note Fortran indexing input, C indexing output
+ */
+#define coef_normal_area_idx(i, j, k, l, lx, nf) \
+  (((i) + (lx) * (((j) - 1) + (lx) * (((k) - 1) + (nf) * (((l) - 1))))) - 1)
+
+/**
+ * Device function to compute i,j,k,e indices from a linear index
+ * @note Assumes idx is a Fortran index
+ */
+void nonlinear_index(const int idx, const int lx, int *index) {
+  const int idx2 = idx -1;
+  index[3] = idx2/(lx * lx * lx) ;
+  index[2] = (idx2 - (lx*lx*lx)*index[3])/(lx * lx);
+  index[1] = (idx2 - (lx*lx*lx)*index[3] - (lx*lx) * index[2]) / lx;
+  index[0] = (idx2 - (lx*lx*lx)*index[3] - (lx*lx) * index[2]) - lx*index[1];
+  index[0]++;
+  index[1]++;
+  index[2]++;
+  index[3]++;
+}
 
 /**
  * Device kernel for neumann scalar boundary condition
@@ -86,4 +107,4 @@ void neumann_apply_scalar_kernel(__global const int *msk,
   }
 }
 
-#endif 
+#endif


### PR DESCRIPTION
Sorry I should seen this earlier when checking the neumann PR...

Due to Neko's way of JITting OpenCL kernels, we can't include none system header files in the `.cl` files without having runtime error thrown during the JIT phase. 

