### PR TITLE
Move device check to `device_init` function

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -265,7 +265,7 @@ device/cuda/nvtx.lo : device/cuda/nvtx.F90
 device/hip/roctx.lo : device/hip/roctx.F90 
 device/opencl_intf.lo : device/opencl_intf.F90 common/utils.lo config/num_types.lo 
 device/opencl/prgm_lib.lo : device/opencl/prgm_lib.F90 common/utils.lo device/opencl_intf.lo 
-device/device.lo : device/device.F90 device/opencl/prgm_lib.lo common/utils.lo adt/htable.lo device/hip_intf.lo device/cuda_intf.lo device/opencl_intf.lo config/num_types.lo 
+device/device.lo : device/device.F90 device/opencl/prgm_lib.lo common/utils.lo adt/htable.lo config/neko_config.lo device/hip_intf.lo device/cuda_intf.lo device/opencl_intf.lo config/num_types.lo 
 math/field_math.lo : math/field_math.f90 math/bcknd/device/device_math.lo math/math.lo device/device.lo field/field.lo config/num_types.lo config/neko_config.lo 
 math/bcknd/device/device_math.lo : math/bcknd/device/device_math.F90 math/bcknd/device/opencl/opencl_math.lo math/bcknd/device/cuda/cuda_math.lo math/bcknd/device/hip/hip_math.lo comm/comm.lo common/utils.lo config/num_types.lo 
 math/bcknd/device/hip/hip_math.lo : math/bcknd/device/hip/hip_math.f90 config/num_types.lo 

--- a/src/device/device.F90
+++ b/src/device/device.F90
@@ -36,6 +36,7 @@ module device
   use opencl_intf
   use cuda_intf
   use hip_intf
+  use neko_config, only: NEKO_BCKND_DEVICE
   use htable, only : htable_cptr_t, h_cptr_t
   use utils, only : neko_error
   use opencl_prgm_lib
@@ -131,6 +132,13 @@ contains
 #endif
     call device_event_create(glb_cmd_event, 2)
 #endif
+
+    ! Check the device count against the number of MPI ranks
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       if (device_count() .ne. 1) then
+          call neko_error('Only one device is supported per MPI rank')
+       end if
+    end if
   end subroutine device_init
 
   subroutine device_finalize
@@ -408,17 +416,17 @@ contains
 #ifdef HAVE_HIP
     if (dir .eq. HOST_TO_DEVICE) then
        if (hipMemcpyAsync(x_d, ptr_h, s, &
-                          hipMemcpyHostToDevice, stream) .ne. hipSuccess) then
+            hipMemcpyHostToDevice, stream) .ne. hipSuccess) then
           call neko_error('Device memcpy async (host-to-device) failed')
        end if
     else if (dir .eq. DEVICE_TO_HOST) then
        if (hipMemcpyAsync(ptr_h, x_d, s, &
-                          hipMemcpyDeviceToHost, stream) .ne. hipSuccess) then
+            hipMemcpyDeviceToHost, stream) .ne. hipSuccess) then
           call neko_error('Device memcpy async (device-to-host) failed')
        end if
     else if (dir .eq. DEVICE_TO_DEVICE) then
        if (hipMemcpyAsync(ptr_h, x_d, s, hipMemcpyDeviceToDevice, stream) &
-           .ne. hipSuccess) then
+            .ne. hipSuccess) then
           call neko_error('Device memcpy async (device-to-device) failed')
        end if
     else
@@ -430,17 +438,17 @@ contains
 #elif HAVE_CUDA
     if (dir .eq. HOST_TO_DEVICE) then
        if (cudaMemcpyAsync(x_d, ptr_h, s, cudaMemcpyHostToDevice, stream) &
-           .ne. cudaSuccess) then
+            .ne. cudaSuccess) then
           call neko_error('Device memcpy async (host-to-device) failed')
        end if
     else if (dir .eq. DEVICE_TO_HOST) then
        if (cudaMemcpyAsync(ptr_h, x_d, s, cudaMemcpyDeviceToHost, stream) &
-           .ne. cudaSuccess) then
+            .ne. cudaSuccess) then
           call neko_error('Device memcpy async (device-to-host) failed')
        end if
     else if (dir .eq. DEVICE_TO_DEVICE) then
        if (cudaMemcpyAsync(ptr_h, x_d, s, cudaMemcpyDeviceToDevice, stream) &
-           .ne. cudaSuccess) then
+            .ne. cudaSuccess) then
           call neko_error('Device memcpy async (device-to-device) failed')
        end if
     else
@@ -453,20 +461,20 @@ contains
     if (sync_device) then
        if (dir .eq. HOST_TO_DEVICE) then
           if (clEnqueueWriteBuffer(stream, x_d, CL_TRUE, 0_i8, s, &
-                                   ptr_h, 0, C_NULL_PTR, C_NULL_PTR) &
-              .ne. CL_SUCCESS) then
+               ptr_h, 0, C_NULL_PTR, C_NULL_PTR) &
+               .ne. CL_SUCCESS) then
              call neko_error('Device memcpy (host-to-device) failed')
           end if
        else if (dir .eq. DEVICE_TO_HOST) then
           if (clEnqueueReadBuffer(stream, x_d, CL_TRUE, 0_i8, s, ptr_h, &
-                                  0, C_NULL_PTR, C_NULL_PTR) &
-              .ne. CL_SUCCESS) then
+               0, C_NULL_PTR, C_NULL_PTR) &
+               .ne. CL_SUCCESS) then
              call neko_error('Device memcpy (device-to-host) failed')
           end if
        else if (dir .eq. DEVICE_TO_DEVICE) then
           if (clEnqueueCopyBuffer(stream, x_d, ptr_h, 0_i8, 0_i8, s, &
-                                  0, C_NULL_PTR, C_NULL_PTR) &
-              .ne. CL_SUCCESS) then
+               0, C_NULL_PTR, C_NULL_PTR) &
+               .ne. CL_SUCCESS) then
              call neko_error('Device memcpy (device-to-device) failed')
           end if
        else
@@ -475,20 +483,20 @@ contains
     else
        if (dir .eq. HOST_TO_DEVICE) then
           if (clEnqueueWriteBuffer(stream, x_d, CL_FALSE, 0_i8, s, &
-                                   ptr_h, 0, C_NULL_PTR, C_NULL_PTR) &
-              .ne. CL_SUCCESS) then
+               ptr_h, 0, C_NULL_PTR, C_NULL_PTR) &
+               .ne. CL_SUCCESS) then
              call neko_error('Device memcpy (host-to-device) failed')
           end if
        else if (dir .eq. DEVICE_TO_HOST) then
           if (clEnqueueReadBuffer(stream, x_d, CL_FALSE, 0_i8, s, ptr_h,&
-                                  0, C_NULL_PTR, C_NULL_PTR) &
-              .ne. CL_SUCCESS) then
+               0, C_NULL_PTR, C_NULL_PTR) &
+               .ne. CL_SUCCESS) then
              call neko_error('Device memcpy (device-to-host) failed')
           end if
        else if (dir .eq. DEVICE_TO_DEVICE) then
           if (clEnqueueCopyBuffer(stream, x_d, ptr_h, 0_i8, 0_i8, s, &
-                                  0, C_NULL_PTR, C_NULL_PTR) &
-              .ne. CL_SUCCESS) then
+               0, C_NULL_PTR, C_NULL_PTR) &
+               .ne. CL_SUCCESS) then
              call neko_error('Device memcpy (device-to-device) failed')
           end if
        else

--- a/src/neko.f90
+++ b/src/neko.f90
@@ -163,6 +163,9 @@ contains
 
     if (present(C)) then
 
+       !
+       ! Command line arguments
+       !
        argc = command_argument_count()
 
        if (argc .lt. 1) then
@@ -178,13 +181,6 @@ contains
           call neko_error('Invalid case file')
        end if
 
-       ! Check the device count against the number of MPI ranks
-       if (NEKO_BCKND_DEVICE .eq. 1) then
-          if (device_count() .ne. 1) then
-             call neko_error('Only one device is supported per MPI rank')
-          end if
-       end if
-
        if (argc .gt. 1) then
           write(log_buf, '(a)') 'Running with command line arguments: '
           call neko_log%message(log_buf, NEKO_LOG_QUIET)
@@ -193,6 +189,7 @@ contains
              call neko_log%message(args, NEKO_LOG_QUIET)
           end do
        end if
+
        !
        ! Job information
        !


### PR DESCRIPTION
Relocate the device count validation from `neko_init` to `device_init` to ensure proper checks are performed during device initialization.