### PR TITLE
Add  material properties to the field registry

### DIFF
--- a/examples/rayleigh_benard_cylinder/rayleigh.f90
+++ b/examples/rayleigh_benard_cylinder/rayleigh.f90
@@ -39,11 +39,11 @@ contains
     type(field_list_t), intent(inout) :: properties
 
     if (name .eq. "fluid") then
-       call field_cfill(properties%get_by_name("rho"), 1.0_rp)
-       call field_cfill(properties%get_by_name("mu"), mu)
+       call field_cfill(properties%get_by_name("fluid_rho"), 1.0_rp)
+       call field_cfill(properties%get_by_name("fluid_mu"), mu)
     else if (name .eq. "scalar") then
-       call field_cfill(properties%get_by_name("cp"), 1.0_rp)
-       call field_cfill(properties%get_by_name("lambda"), mu / Pr)
+       call field_cfill(properties%get_by_name("scalar_cp"), 1.0_rp)
+       call field_cfill(properties%get_by_name("scalar_lambda"), mu / Pr)
     end if
   end subroutine set_material_properties
 

--- a/src/fluid/fluid_scheme_base.f90
+++ b/src/fluid/fluid_scheme_base.f90
@@ -100,10 +100,10 @@ module fluid_scheme_base
      character(len=NEKO_MSH_MAX_ZLBL_LEN), allocatable :: bc_labels(:)
 
      !> Density field
-     type(field_t) :: rho
+     type(field_t), pointer :: rho => null()
 
      !> The dynamic viscosity
-     type(field_t) :: mu
+     type(field_t), pointer :: mu => null()
 
      !> A helper that packs material properties to pass to the user routine.
      type(field_list_t) :: material_properties

--- a/src/fluid/fluid_scheme_incompressible.f90
+++ b/src/fluid/fluid_scheme_incompressible.f90
@@ -398,9 +398,8 @@ contains
     nullify(this%f_x)
     nullify(this%f_y)
     nullify(this%f_z)
-
-    call this%rho%free()
-    call this%mu%free()
+    nullify(this%rho)
+    nullify(this%mu)
 
   end subroutine fluid_scheme_free
 
@@ -610,11 +609,13 @@ contains
 
     dummy_mp_ptr => dummy_user_material_properties
 
-    call this%mu%init(this%dm_Xh, "mu")
-    call this%rho%init(this%dm_Xh, "rho")
+    call neko_field_registry%add_field(this%dm_Xh, this%name // "_mu")
+    call neko_field_registry%add_field(this%dm_Xh, this%name // "_rho")
+    this%mu => neko_field_registry%get_field(this%name // "_mu")
+    this%rho => neko_field_registry%get_field(this%name // "_rho")
     call this%material_properties%init(2)
-    call this%material_properties%assign_to_field(1, this%rho)
-    call this%material_properties%assign_to_field(2, this%mu)
+    call this%material_properties%assign(1, this%rho)
+    call this%material_properties%assign(2, this%mu)
 
     if (.not. associated(user%material_properties, dummy_mp_ptr)) then
 

--- a/src/scalar/scalar_scheme.f90
+++ b/src/scalar/scalar_scheme.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2022-2024, The Neko Authors
+! Copyright (c) 2022-2025, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -127,9 +127,9 @@ module scalar_scheme
      !> Density.
      type(field_t), pointer :: rho => null()
      !> Thermal diffusivity.
-     type(field_t) :: lambda
+     type(field_t), pointer :: lambda => null()
      !> Specific heat capacity.
-     type(field_t) :: cp
+     type(field_t), pointer :: cp => null()
      !> Turbulent Prandtl number.
      real(kind=rp) :: pr_turb
      !> Field list with cp and lambda
@@ -395,10 +395,10 @@ contains
     call this%source_term%free()
 
     call this%bcs%free()
-
-    call this%cp%free()
-    call this%lambda%free()
     call this%slag%free()
+
+    nullify(this%cp)
+    nullify(this%lambda)
 
   end subroutine scalar_scheme_free
 
@@ -545,12 +545,15 @@ contains
     dummy_mp_ptr => dummy_user_material_properties
 
     ! Fill lambda field with the physical value
-    call this%lambda%init(this%dm_Xh, "lambda")
-    call this%cp%init(this%dm_Xh, "cp")
+
+    call neko_field_registry%add_field(this%dm_Xh, this%name // "_lambda")
+    call neko_field_registry%add_field(this%dm_Xh, this%name // "_cp")
+    this%lambda => neko_field_registry%get_field(this%name // "_lambda")
+    this%cp => neko_field_registry%get_field(this%name // "_cp")
 
     call this%material_properties%init(2)
-    call this%material_properties%assign_to_field(1, this%cp)
-    call this%material_properties%assign_to_field(2, this%lambda)
+    call this%material_properties%assign(1, this%cp)
+    call this%material_properties%assign(2, this%lambda)
 
     if (.not. associated(user%material_properties, dummy_mp_ptr)) then
 


### PR DESCRIPTION
Added as `this%name`, plus `_rho`, `_mu`, `_lambda`, `_cp`.

I am mainly doing this to have easy access to this in wall models and also force_torque simcomp.

I guess we are kid of drifting towards registering more and more things, but maybe that's not too bad as long as the naming is solidly unique.