### PR TITLE
Refactor logger for improved access control and functionality

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -5,7 +5,7 @@ io/format/nmsh.lo : io/format/nmsh.f90 config/num_types.lo
 io/format/re2.lo : io/format/re2.f90 config/num_types.lo 
 io/format/map.lo : io/format/map.f90 mesh/mesh.lo 
 io/format/stl.lo : io/format/stl.f90 config/num_types.lo 
-common/log.lo : common/log.f90 config/num_types.lo comm/comm.lo 
+common/log.lo : common/log.f90 common/utils.lo config/num_types.lo comm/comm.lo 
 comm/comm.lo : comm/comm.F90 config/neko_config.lo common/utils.lo 
 mesh/curve.lo : mesh/curve.f90 common/utils.lo adt/stack.lo common/structs.lo config/num_types.lo 
 comm/mpi_types.lo : comm/mpi_types.f90 io/format/stl.lo io/format/nmsh.lo io/format/re2.lo comm/comm.lo 

--- a/src/common/log.f90
+++ b/src/common/log.f90
@@ -34,6 +34,7 @@
 module logger
   use comm, only : pe_rank
   use num_types, only : rp
+  use utils, only: neko_error
   use, intrinsic :: iso_fortran_env, only: stdout => output_unit, &
        stderr => error_unit
   implicit none
@@ -52,6 +53,7 @@ module logger
      integer, private :: unit_
    contains
      procedure, pass(this) :: init => log_init
+     procedure, pass(this) :: free => log_free
      procedure, pass(this) :: begin => log_begin
      procedure, pass(this) :: end => log_end
      procedure, pass(this) :: indent => log_indent
@@ -81,11 +83,19 @@ contains
   subroutine log_init(this)
     class(log_t), intent(inout) :: this
     character(len=255) :: log_level
+    character(len=255) :: log_tab_size
     character(len=255) :: log_file
     integer :: envvar_len
 
-    this%indent_ = 1
+    this%indent_ = 0
     this%section_id_ = 0
+
+    call get_environment_variable("NEKO_LOG_TAB_SIZE", log_tab_size, envvar_len)
+    if (envvar_len .gt. 0) then
+       read(log_tab_size(1:envvar_len), *) this%tab_size_
+    else
+       this%tab_size_ = 1
+    end if
 
     call get_environment_variable("NEKO_LOG_LEVEL", log_level, envvar_len)
     if (envvar_len .gt. 0) then
@@ -104,12 +114,31 @@ contains
 
   end subroutine log_init
 
+  !> Free a log
+  subroutine log_free(this)
+    class(log_t), intent(inout) :: this
+
+    if (this%section_id_ .ne. 0) then
+       call neko_error("Log is unbalanced")
+    end if
+
+    if (this%unit_ .ne. stdout) then
+       close(this%unit_)
+    end if
+
+    this%indent_ = 0
+    this%level_ = NEKO_LOG_INFO
+    this%unit_ = -1
+
+  end subroutine log_free
+
   !> Increase indention level
   subroutine log_begin(this)
     class(log_t), intent(inout) :: this
 
     if (pe_rank .eq. 0) then
-       this%indent_ = this%indent_ + 1
+       this%section_id_ = this%section_id_ + 1
+       this%indent_ = this%indent_ + this%tab_size_
     end if
 
   end subroutine log_begin
@@ -119,7 +148,11 @@ contains
     class(log_t), intent(inout) :: this
 
     if (pe_rank .eq. 0) then
-       this%indent_ = this%indent_ - 1
+       if (this%section_id_ .eq. 0) then
+          call neko_error("Log is unbalanced")
+       end if
+       this%section_id_ = this%section_id_ - 1
+       this%indent_ = this%indent_ - this%tab_size_
     end if
 
   end subroutine log_end
@@ -245,9 +278,8 @@ contains
     end if
 
     if (pe_rank .eq. 0) then
-
-       this%indent_ = this%indent_ + this%section_id_
        this%section_id_ = this%section_id_ + 1
+       this%indent_ = this%indent_ + this%tab_size_
 
        pre = (30 - len_trim(msg)) / 2
        pos = 30 - (len_trim(msg) + pre)
@@ -283,8 +315,11 @@ contains
     end if
 
     if (pe_rank .eq. 0) then
+       if (this%section_id_ .eq. 0) then
+          call neko_error("Log is unbalanced")
+       end if
        this%section_id_ = this%section_id_ - 1
-       this%indent_ = this%indent_ - this%section_id_
+       this%indent_ = this%indent_ - this%tab_size_
     end if
 
   end subroutine log_end_section

--- a/src/common/log.f90
+++ b/src/common/log.f90
@@ -45,10 +45,11 @@ module logger
   integer, public, parameter :: LOG_SIZE = 79
 
   type, public :: log_t
-     integer :: indent_
-     integer :: section_id_
-     integer :: level_
-     integer :: unit_
+     integer, private :: indent_
+     integer, private :: section_id_
+     integer, private :: tab_size_
+     integer, private :: level_
+     integer, private :: unit_
    contains
      procedure, pass(this) :: init => log_init
      procedure, pass(this) :: begin => log_begin

--- a/src/neko.f90
+++ b/src/neko.f90
@@ -264,6 +264,8 @@ contains
     end if
 
     call neko_field_registry%free()
+    call neko_log%free()
+
     call device_finalize
     call neko_mpi_types_free
     call comm_free

--- a/src/wall_models/bcknd/cpu/spalding_cpu.f90
+++ b/src/wall_models/bcknd/cpu/spalding_cpu.f90
@@ -104,6 +104,7 @@ contains
     real(kind=rp) :: yp, up, utau
     real(kind=rp) :: error, f, df, old
     integer :: niter, k, maxiter
+    character(len=:), allocatable :: log_msg
 
     utau = guess
 
@@ -134,8 +135,9 @@ contains
 
     enddo
 
-    if ((niter .eq. maxiter) .and. (neko_log%level_ .eq. NEKO_LOG_DEBUG)) then
-       write(*,*) "Newton not converged", error, f, utau, old, guess
+    if (niter .eq. maxiter) then
+       write(log_msg, *) "Newton not converged", error, f, utau, old, guess
+       call neko_log%message(log_msg, NEKO_LOG_DEBUG)
     end if
   end function solve_cpu
 end module spalding_cpu

--- a/src/wall_models/wall_model.f90
+++ b/src/wall_models/wall_model.f90
@@ -342,6 +342,7 @@ contains
     real(kind=rp) :: hmin, hmax
     type(field_t), pointer :: h_field
     type(file_t) :: h_file
+    character(len=:), allocatable :: log_msg
 
     n_nodes = this%msk(0)
     this%n_nodes = n_nodes
@@ -423,10 +424,10 @@ contains
 
        ! Look at how much the total distance distance from the normal and warn
        ! if significant
-       if ((this%h%x(i) - magp) / magp > 0.1 &
-            .and. (neko_log%level_ .eq. NEKO_LOG_DEBUG)) then
-          write(*,*) "Significant missalignment between wall normal and &
-          & sampling point direction at wall node", xw, yw, zw
+       if ((this%h%x(i) - magp) / magp > 0.1) then
+          write(log_msg,*) "Significant misalignment between wall normal and &
+          &sampling point direction at wall node", xw, yw, zw
+          call neko_log%message(log_msg, NEKO_LOG_DEBUG)
        end if
     end do
 


### PR DESCRIPTION
Enhance the logger by restricting access to its internals and ensuring proper resource management by freeing the log and closing the file after simulation.

Additionally, the handling of indentation levels are updated.
Previously, the indentations were done in a linear way, where the spacing followed the pattern:

- Level 0: 1 space
- Level 1: 2 spaces
- Level 2: 4 spaces
- Level 3: 7 spaces
- Level 4: 11 spaces

Now each level just adds a given number of spaces which can be set by the environment variable `NEKO_LOG_TAB_SIZE`, with a default of 1