### PR TITLE
Add possibility to add aliases to field_register_t

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -398,6 +398,7 @@ AC_CONFIG_FILES([tests/unit/stack/Makefile\
                  tests/unit/vector/Makefile\
                  tests/unit/matrix/Makefile\
                  tests/unit/scratch_registry/Makefile\
+                 tests/unit/field_registry/Makefile\
                  tests/unit/fast3d/Makefile\
                  tests/unit/time_scheme/Makefile\
                  tests/unit/time_scheme_controller/Makefile\

--- a/src/.depends
+++ b/src/.depends
@@ -71,7 +71,7 @@ mesh/search_tree/aabb.lo : mesh/search_tree/aabb.f90 common/utils.lo mesh/tet_me
 mesh/aabb_tree.lo : mesh/aabb_tree.f90 adt/stack.lo common/utils.lo config/num_types.lo mesh/tri.lo mesh/search_tree/aabb.lo 
 mesh/tet_mesh.lo : mesh/tet_mesh.f90 common/utils.lo mesh/point.lo mesh/tet.lo mesh/mesh.lo 
 mesh/tri_mesh.lo : mesh/tri_mesh.f90 mesh/point.lo mesh/tri.lo 
-field/field_registry.lo : field/field_registry.f90 comm/comm.lo adt/htable.lo common/utils.lo sem/dofmap.lo field/field.lo 
+field/field_registry.lo : field/field_registry.f90 common/json_utils.lo comm/comm.lo adt/htable.lo common/utils.lo sem/dofmap.lo field/field.lo 
 field/scratch_registry.lo : field/scratch_registry.f90 sem/dofmap.lo field/field.lo 
 field/field.lo : field/field.f90 sem/dofmap.lo sem/space.lo mesh/mesh.lo math/math.lo device/device.lo config/num_types.lo math/bcknd/device/device_math.lo config/neko_config.lo 
 field/field_list.lo : field/field_list.f90 common/utils.lo mesh/mesh.lo sem/dofmap.lo sem/space.lo config/num_types.lo field/field.lo 

--- a/src/field/field_registry.f90
+++ b/src/field/field_registry.f90
@@ -202,20 +202,20 @@ contains
     character(len=*), target, intent(in) :: fld_name
 
     if (this%field_exists(alias)) then
-         call neko_error("Cannot create alias. Field " // alias // &
-               " already exists in the registry")
+       call neko_error("Cannot create alias. Field " // alias // &
+            " already exists in the registry")
     end if
 
     if (this%field_exists(fld_name)) then
-      if (this%n_aliases_ == size(this%aliases)) then
-         call this%expand_aliases()
-      end if
+       if (this%n_aliases_ == size(this%aliases)) then
+          call this%expand_aliases()
+       end if
 
-      this%n_aliases_ = this%n_aliases_ + 1
+       this%n_aliases_ = this%n_aliases_ + 1
 
-      call this%aliases(this%n_aliases_)%initialize()
-      call this%aliases(this%n_aliases_)%add("alias", alias)
-      call this%aliases(this%n_aliases_)%add("target", fld_name)
+       call this%aliases(this%n_aliases_)%initialize()
+       call this%aliases(this%n_aliases_)%add("alias", alias)
+       call this%aliases(this%n_aliases_)%add("target", fld_name)
     else
        call neko_error("Cannot create alias. Field " // fld_name // &
             " could not be found in the registry")
@@ -292,9 +292,9 @@ contains
 
     do i = 1, this%n_aliases()
        alias_json => this%aliases(i)
-       call alias_json%get("alias", alias) 
+       call alias_json%get("alias", alias)
        if (alias == trim(name)) then
-          call alias_json%get("target", alias_target) 
+          call alias_json%get("target", alias_target)
           f => this%get_field_by_name(alias_target)
           found = .true.
           exit
@@ -318,7 +318,7 @@ contains
   function field_registry_field_exists(this, name) result(found)
     class(field_registry_t), target, intent(in) :: this
     character(len=*), intent(in) :: name
-    character(len=:), allocatable  :: alias
+    character(len=:), allocatable :: alias
     logical :: found
     integer :: i
     type(json_file), pointer :: alias_json
@@ -333,7 +333,7 @@ contains
 
     do i=1, this%n_aliases()
        alias_json => this%aliases(i)
-       call alias_json%get("alias", alias) 
+       call alias_json%get("alias", alias)
        if (alias == name) then
           found = .true.
           exit

--- a/src/field/field_registry.f90
+++ b/src/field/field_registry.f90
@@ -292,9 +292,9 @@ contains
 
     do i = 1, this%n_aliases()
        alias_json => this%aliases(i)
-       call alias_json%get("alias", alias)
+       call json_get(alias_json, "alias", alias)
        if (alias == trim(name)) then
-          call alias_json%get("target", alias_target)
+          call json_get(alias_json, "target", alias_target)
           f => this%get_field_by_name(alias_target)
           found = .true.
           exit

--- a/src/field/field_registry.f90
+++ b/src/field/field_registry.f90
@@ -133,7 +133,12 @@ contains
        deallocate(this%fields)
     end if
 
+    if (allocated(this%aliases)) then
+       deallocate(this%aliases)
+    end if
+
     this%n_fields_ = 0
+    this%n_aliases_ = 0
     this%expansion_size = 0
   end subroutine field_registry_free
 
@@ -287,7 +292,7 @@ contains
 
     do i = 1, this%n_aliases()
        alias_json => this%aliases(i)
-       call alias_json%get("alias", found) 
+       call alias_json%get("alias", alias) 
        if (alias == trim(name)) then
           call alias_json%get("target", alias_target) 
           f => this%get_field_by_name(alias_target)
@@ -312,13 +317,24 @@ contains
   !> Check if a field with a given name is already in the registry.
   function field_registry_field_exists(this, name) result(found)
     class(field_registry_t), target, intent(in) :: this
-    character(len=*), intent(in) ::name
+    character(len=*), intent(in) :: name
+    character(len=:), allocatable  :: alias
     logical :: found
     integer :: i
+    type(json_file), pointer :: alias_json
 
     found = .false.
     do i=1, this%n_fields()
        if (this%fields(i)%name == name) then
+          found = .true.
+          exit
+       end if
+    end do
+
+    do i=1, this%n_aliases()
+       alias_json => this%aliases(i)
+       call alias_json%get("alias", alias) 
+       if (alias == name) then
           found = .true.
           exit
        end if

--- a/src/field/field_registry.f90
+++ b/src/field/field_registry.f90
@@ -333,7 +333,7 @@ contains
 
     do i=1, this%n_aliases()
        alias_json => this%aliases(i)
-       call alias_json%get("alias", alias)
+       call json_get(alias_json, "alias", alias)
        if (alias == name) then
           found = .true.
           exit

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -27,6 +27,7 @@ SUBDIRS = tuple\
 	  vector\
 	  matrix\
 	  scratch_registry\
+	  field_registry\
 	  fast3d\
 	  time_scheme\
 	  time_scheme_controller\
@@ -63,6 +64,7 @@ TESTS = device/device_test\
 	vector/vector_test\
 	matrix/matrix_test\
 	scratch_registry/scratch_registry_test\
+	field_registry/field_registry_test\
 	fast3d/fast3d_test\
 	time_scheme/time_scheme_test\
 	time_scheme_controller/time_scheme_controller_test\
@@ -126,6 +128,7 @@ EXTRA_DIST = \
 	vector/vector_parallel.pf\
 	matrix/matrix_parallel.pf\
 	scratch_registry/test_scratch_registry.pf\
+	field_registry/test_field_registry.pf\
 	fast3d/test_fd_weights_full.pf\
 	fast3d/test_setup_intp.pf\
 	time_scheme/test_bdf.pf\

--- a/tests/unit/field_registry/Makefile.in
+++ b/tests/unit/field_registry/Makefile.in
@@ -1,0 +1,27 @@
+USEMPI=YES
+ifneq ("$(wildcard @PFUNIT_DIR@/include/PFUNIT.mk)", "")
+include @PFUNIT_DIR@/include/PFUNIT.mk
+endif
+FFLAGS += $(PFUNIT_EXTRA_FFLAGS) -I@top_builddir@/src
+FC = @FC@
+
+%.o : %.F90
+	$(FC) -c $(FFLAGS) $<
+
+
+check: field_registry_test
+
+field_registry_test_TESTS := test_field_registry.pf
+field_registry_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
+$(eval $(call make_pfunit_test,field_registry_test))
+
+distclean:
+clean:
+	$(RM) *.o *.mod *.a  *.inc *.F90  field_registry_test
+
+
+
+all:
+html:
+install:
+distdir:

--- a/tests/unit/field_registry/test_field_registry.pf
+++ b/tests/unit/field_registry/test_field_registry.pf
@@ -1,0 +1,156 @@
+module test_field_registry
+  use pfunit
+  use field
+  use point
+  use space
+  use mesh
+  use dofmap
+  use math
+  use field_registry
+  use comm, only : NEKO_COMM, pe_rank, pe_size
+  use num_types
+  implicit none
+
+contains
+
+  subroutine test_field_registry_gen_msh(msh)
+    type(mesh_t), intent(inout) :: msh
+    type(point_t) :: p(12)
+
+    p(1) = point_t(0d0, 0d0, 0d0)
+    call p(1)%set_id(1)
+    p(2) = point_t(1d0, 0d0, 0d0)
+    call p(2)%set_id(2)
+    p(3) = point_t(0d0, 1d0, 0d0)
+    call p(3)%set_id(4)
+    p(4) = point_t(1d0, 1d0, 0d0)
+    call p(4)%set_id(3)
+    p(5) = point_t(2d0, 0d0, 0d0)
+    call p(5)%set_id(5)
+    p(6) = point_t(2d0, 1d0, 0d0)
+    call p(6)%set_id(6)
+    p(7) = point_t(0d0, 0d0, 1d0)
+    call p(7)%set_id(7)
+    p(8) = point_t(1d0, 0d0, 1d0)
+    call p(8)%set_id(8)
+    p(9) = point_t(1d0, 1d0, 1d0)
+    call p(9)%set_id(9)
+    p(10) = point_t(0d0, 1d0, 1d0)
+    call p(10)%set_id(10)
+    p(11) = point_t(2d0, 0d0, 1d0)
+    call p(11)%set_id(11)
+    p(12) = point_t(2d0, 1d0, 1d0)
+    call p(12)%set_id(12)
+    
+    call msh%init(3, 1)
+    call msh%add_element(1, 1, p(1), p(2), p(4), p(3), &
+         p(7), p(8), p(9), p(10))
+    pe_rank = 1
+    pe_size = 1
+    call msh%generate_conn()
+    
+  end subroutine test_field_registry_gen_msh
+  
+  @test
+  subroutine test_field_registry_init()
+    type(field_registry_t) :: registry
+
+    call registry%init()
+     
+    @assertEqual(registry%n_fields(), 0)
+    @assertEqual(registry%n_aliases(), 0)
+    @assertEqual(registry%get_expansion_size(), 50)
+
+    call registry%init(5, 10)
+    @assertEqual(registry%n_fields(), 0)
+    @assertEqual(registry%n_aliases(), 0)
+    @assertEqual(registry%get_expansion_size(), 10)
+  end subroutine
+
+  @test
+  subroutine test_field_registry_add_field()
+    type(space_t) :: Xh
+    type(mesh_t) :: msh
+    type(dofmap_t) :: dm
+    integer, parameter :: lx = 4
+    type(field_registry_t) :: registry
+    type(field_t), pointer :: field_ptr
+
+    call test_field_registry_gen_msh(msh)
+  
+    call Xh%init(GLL, lx, lx, lx)
+    call dm%init(msh, Xh)
+    
+    call registry%init()
+
+    call registry%add_field(dm , 'test_field')
+     
+    @assertEqual(registry%n_fields(), 1)
+
+    field_ptr => registry%get_field('test_field')
+
+    @assertEqual(field_ptr%name, 'test_field')
+
+    call registry%add_field(dm , 'test_field', ignore_existing=.true.)
+    @assertEqual(registry%n_fields(), 1)
+  end subroutine 
+
+  @test
+  subroutine test_field_registry_add_alias()
+    type(space_t) :: Xh
+    type(mesh_t) :: msh
+    type(dofmap_t) :: dm
+    integer, parameter :: lx = 4
+    type(field_registry_t) :: registry
+    type(field_t), pointer :: field_ptr
+
+    call test_field_registry_gen_msh(msh)
+  
+    call Xh%init(GLL, lx, lx, lx)
+    call dm%init(msh, Xh)
+    
+    call registry%init()
+
+    call registry%add_field(dm , 'test_field')
+    call registry%add_alias('test_alias', 'test_field')
+    call registry%add_alias('test_alias2', 'test_field')
+     
+    @assertEqual(registry%n_aliases(), 1)
+
+    field_ptr => registry%get_field('test_alias')
+    @assertEqual(field_ptr%name, 'test_field')
+
+    field_ptr => registry%get_field('test_alias2')
+    @assertEqual(field_ptr%name, 'test_field')
+
+    call registry%add_field(dm , 'test_field', ignore_existing=.true.)
+    @assertEqual(registry%n_fields(), 1)
+    @assertEqual(registry%n_aliases(), 2)
+  end subroutine 
+
+  @test
+  subroutine test_field_registry_expand()
+    type(space_t) :: Xh
+    type(mesh_t) :: msh
+    type(dofmap_t) :: dm
+    integer, parameter :: lx = 4
+    type(field_registry_t) :: registry
+    type(field_t), pointer :: field_ptr
+
+    call test_field_registry_gen_msh(msh)
+  
+    call Xh%init(GLL, lx, lx, lx)
+    call dm%init(msh, Xh)
+    
+    call registry%init(1, 1)
+
+    call registry%add_field(dm , 'test_field1')
+    call registry%add_field(dm , 'test_field2')
+
+    call registry%add_alias('test_field1', 'test_field2')
+     
+    @assertEqual(registry%n_fields(), 2)
+  end subroutine 
+
+
+end module test_field_registry

--- a/tests/unit/field_registry/test_field_registry.pf
+++ b/tests/unit/field_registry/test_field_registry.pf
@@ -115,17 +115,13 @@ contains
     call registry%add_alias('test_alias', 'test_field')
     call registry%add_alias('test_alias2', 'test_field')
      
-    @assertEqual(registry%n_aliases(), 1)
+    @assertEqual(registry%n_aliases(), 2)
 
     field_ptr => registry%get_field('test_alias')
     @assertEqual(field_ptr%name, 'test_field')
 
     field_ptr => registry%get_field('test_alias2')
     @assertEqual(field_ptr%name, 'test_field')
-
-    call registry%add_field(dm , 'test_field', ignore_existing=.true.)
-    @assertEqual(registry%n_fields(), 1)
-    @assertEqual(registry%n_aliases(), 2)
   end subroutine 
 
   @test
@@ -147,8 +143,6 @@ contains
     call registry%add_field(dm , 'test_field1')
     call registry%add_field(dm , 'test_field2')
 
-    call registry%add_alias('test_field1', 'test_field2')
-     
     @assertEqual(registry%n_fields(), 2)
   end subroutine 
 


### PR DESCRIPTION
- Adds the possibility to add alieases to an exsiting field in the registry. For, example if there is a `field1` in the registry, we can add an alias for it, say `alias1`. Then if we call `get_field`, we can retrieve the field `field1` by both names: `field1` and `alias1`. I think this may be useful in contexts where we want have a field register under a particular name, but not take up extra memory. Material properties was an inspiration. If we have many scalars with the same properties, we still want fields like `saclar1_lambda` and `scalar2_lambda` to be in the registry. Otherwise, external objects somehow have to know that e.g. `scalar1_lambda` exists and `scalar2` uses it. With aliases, `scalar2` can just add an alias to the registry.

   Internally the aliasing is done using an array of small jsons containing
  ```json5
  {
  "alias": "alias_name",
  "target": "name_of_actual_field"
  }
  ```

- Refactored internal routine names to follow the standard conventions.
- Added some unit tests.