### PR TITLE
Fix void pointer increment and race in gs_scatter

### DIFF
--- a/src/gs/bcknd/device/cuda/gs_kernels.h
+++ b/src/gs/bcknd/device/cuda/gs_kernels.h
@@ -241,9 +241,11 @@ __global__ void scatter_kernel(T * __restrict__ v,
       u[gd[k + j] - 1] = tmp;
     }      
   }
-
-  const int facet_offset = bo[nb - 1] + b[nb - 1];
-  
+  int facet_offset = 0;
+  if ( nb > 0) {
+    facet_offset = bo[nb - 1] + b[nb - 1];
+  }
+ 
   for (int i = ((facet_offset - 1) + idx); i < m; i += str) {
     u[gd[i] - 1] = v[dg[i] - 1];
   }

--- a/src/gs/bcknd/device/cuda/gs_kernels.h
+++ b/src/gs/bcknd/device/cuda/gs_kernels.h
@@ -246,7 +246,7 @@ __global__ void scatter_kernel(T * __restrict__ v,
     facet_offset = bo[nb - 1] + b[nb - 1];
   }
  
-  for (int i = ((facet_offset - 1) + idx); i < m; i += str) {
+  for (int i = (facet_offset + idx); i < m; i += str) {
     u[gd[i] - 1] = v[dg[i] - 1];
   }
   

--- a/src/gs/bcknd/device/device_mpi.c
+++ b/src/gs/bcknd/device/device_mpi.c
@@ -63,7 +63,8 @@ void device_mpi_isend(void *buf_d, int offset, int nbytes, int rank,
 #else
   int tid = 0;
 #endif
-  MPI_Isend(buf_d+offset, nbytes, MPI_BYTE, rank, tid, NEKO_COMM, &reqs[i-1]);
+  void *buf = (char *)buf_d + offset; // Adjust pointer to the correct offset
+  MPI_Isend(buf, nbytes, MPI_BYTE, rank, tid, NEKO_COMM, &reqs[i-1]);
 }
 
 void device_mpi_irecv(void *buf_d, int offset, int nbytes, int rank,
@@ -74,8 +75,8 @@ void device_mpi_irecv(void *buf_d, int offset, int nbytes, int rank,
 #else
   int tid = 0;
 #endif
-
-  MPI_Irecv(buf_d+offset, nbytes, MPI_BYTE, rank, tid, NEKO_COMM, &reqs[i-1]);
+  void *buf = (char *)buf_d + offset; // Adjust pointer to the correct offset
+  MPI_Irecv(buf, nbytes, MPI_BYTE, rank, tid, NEKO_COMM, &reqs[i-1]);
 }
 
 int device_mpi_test(void *vreqs, int i) {

--- a/src/gs/bcknd/device/hip/gs_kernels.h
+++ b/src/gs/bcknd/device/hip/gs_kernels.h
@@ -242,7 +242,11 @@ __global__ void scatter_kernel(T * __restrict__ v,
     }
   }
 
-  const int facet_offset = bo[nb - 1] + b[nb - 1];
+  int facet_offset = 0;
+  if ( nb > 0) {
+    facet_offset = bo[nb - 1] + b[nb - 1];
+  }
+  
 
   for (int i = ((facet_offset - 1) + idx); i < m; i += str) {
     u[gd[i] - 1] = v[dg[i] - 1];

--- a/src/gs/bcknd/device/hip/gs_kernels.h
+++ b/src/gs/bcknd/device/hip/gs_kernels.h
@@ -248,7 +248,7 @@ __global__ void scatter_kernel(T * __restrict__ v,
   }
   
 
-  for (int i = ((facet_offset - 1) + idx); i < m; i += str) {
+  for (int i = (facet_offset + idx); i < m; i += str) {
     u[gd[i] - 1] = v[dg[i] - 1];
   }
 


### PR DESCRIPTION
gs_scatter could have two threads writing to the same place.

Incrementing a void pointer is apparently some gnu extension is I understand correctly and this would be more portable.

Continuing my search, sorry for the delay with interpolation.