### PR TITLE
Rename abx{1,2} arrays to avoid nameconflicts in hdf5 file

### DIFF
--- a/src/scalar/scalar_pnpn.f90
+++ b/src/scalar/scalar_pnpn.f90
@@ -208,9 +208,9 @@ contains
 
       call this%s_res%init(dm_Xh, "s_res")
 
-      call this%abx1%init(dm_Xh, "abx1")
+      call this%abx1%init(dm_Xh, "s_abx1")
 
-      call this%abx2%init(dm_Xh, "abx2")
+      call this%abx2%init(dm_Xh, "s_abx2")
 
       call this%advs%init(dm_Xh, "advs")
 


### PR DESCRIPTION
This Fixes #1795 , the issue was caused by both fluid and scalar having fields named abx{1,2}.
