### PR TITLE
Add documentation for non-MPI based comm. backends

### DIFF
--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -18,6 +18,7 @@ of the code. But can be useful for users and developers alike.
 | `NEKO_LOG_TAB_SIZE` | Number of spaces added for each level of indentation in the log file. | 1             |
 | `NEKO_LOG_LEVEL`    | Log verbosity level (integer > 0, default: 1)                         | Unset         |
 | `NEKO_GS_STRTGY`    | Gather-scatter device MPI sync. strategy (0 < integer < 5 )           | Unset         |
+| `NEKO_GS_COMM`      | Gather-scatter communication backend                                  | Unset         |
 | `NEKO_COMM_ID`      | Communicator id for this process (non-negative integer)               | 0             |
 
 ### Logging level details
@@ -28,3 +29,12 @@ A number of logging levels are supported.
 - `NEKO_LOG_LEVEL=1`   : Default information mode, adding step informations.
 - `NEKO_LOG_LEVEL=2`   : Verbose mode, logging extra details.
 - `NEKO_LOG_LEVEL=10`  : Debug mode.
+
+### Gather-scatter communication backend details
+
+A number of gather-scatter backends are supported.
+
+- `NEKO_GS_COMM=MPI`    : Host based MPI
+- `NEKO_GS_COMM=MPIGPU` : Device based MPI
+- `NEKO_GS_COMM=NCCL`   : NCCL/RCCL using its point-to-point interface
+- `NEKO_GS_COMM=SHMEM`  : NVSHMEM based (for NVIDIA GPUs)

--- a/doc/pages/user-guide/installation.md
+++ b/doc/pages/user-guide/installation.md
@@ -162,6 +162,8 @@ Optional packages are controlled by passing either `--with-PACKAGE[=ARG]` or `--
 | `--with-opencl=DIR`             | Compile with OpenCL backend                   |
 | `--with-nvtx=DIR`               | Compile with support for NVTX                 |
 | `--with-roctx=DIR`              | Compile with support for ROCTX                |
+| `--with-nccl=DIR`               | Compiler with support for NCCL                |
+| `--with-rccl=DIR`               | Compiler with support for RCCL                |
 | `--with-hdf5`                   | Compile with support for HDF5                 |
 | `--with-pfunit=DIR`             | Directory for pFUnit (see \subpage testing)   |
 
@@ -204,6 +206,13 @@ $ ./configure  --with-hip=/opt/rocm/hip HIP_HIPCC_FLAGS=-O3  HIPCC=/opt/rocm/hip
 ```
 
 @note More examples, and instructions for specific machines can be found on Neko's [user discussions](https://github.com/ExtremeFLOW/neko/discussions) pages.
+
+#### Compiling Neko with a collective communications library
+To compile Neko to use a collective communcations library on GPUs
+* Configure Neko to use NCCL (on NVIDIA GPUs) using the `--with-nccl=/path/to/nccl` argument to `configure`
+* Configure Neko to use RCCL (on AMD GPUs) using the `--with-rccl=/path/to/rccl` argument to `configure`
+
+@note This will change all collective communications (reductions etc) during a simulation step to use NCCL/RCCL, while gather-scatter operations still uses MPI.
 
 ## Installing via Spack
 Neko is distributed as part of the package manager Spack as `neko`. The package can install releases of Neko as well as the latest commit to the `develop` branch, for most of Neko's supported backends. For a list of all supported variants, see `spack info neko`


### PR DESCRIPTION
Fixes #1729

Installation instructions for NVSHMEM we need to defer for now.
