### PR TITLE
Add device memset interfaces

### DIFF
--- a/src/device/cuda_intf.F90
+++ b/src/device/cuda_intf.F90
@@ -1,4 +1,4 @@
-! Copyright (c) 2021-2022, The Neko Authors
+! Copyright (c) 2021-2025, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -95,6 +95,17 @@ module cuda_intf
        integer(c_size_t), value :: s
        integer(c_int), value :: dir
      end function cudaMemcpyAsync
+  end interface
+
+  interface
+     integer(c_int) function cudaMemsetAsync(ptr, v, s, stream) &
+          bind(c, name = 'cudaMemsetAsync')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr), value :: ptr, stream
+       integer(c_int), value :: v
+       integer(c_size_t), value :: s
+     end function cudaMemsetAsync
   end interface
 
   interface
@@ -320,7 +331,7 @@ contains
   subroutine cuda_finalize(glb_cmd_queue, aux_cmd_queue)
     type(c_ptr), intent(inout) :: glb_cmd_queue
     type(c_ptr), intent(inout) :: aux_cmd_queue
-    
+
     if (cudaStreamDestroy(glb_cmd_queue) .ne. cudaSuccess) then
        call neko_error('Error destroying main stream')
     end if

--- a/src/device/device.F90
+++ b/src/device/device.F90
@@ -259,7 +259,7 @@ contains
        call neko_error('Device memset async failed')
     end if
 #elif HAVE_OPENCL
-    if (clEnqueueFillBuffer(strm, x_d, c_loc(v), s, c_sizeof(v), 0, &
+    if (clEnqueueFillBuffer(strm, x_d, c_loc(v), c_sizeof(v), 0, &
          s, 0, C_NULL_PTR, C_NULL_PTR) .ne. CL_SUCCESS) then
        call neko_error('Device memset async failed')
     end if

--- a/src/device/device.F90
+++ b/src/device/device.F90
@@ -112,7 +112,7 @@ module device
        device_profiler_start, device_profiler_stop, device_alloc, &
        device_init, device_name, device_event_create, device_event_destroy, &
        device_event_record, device_event_sync, device_finalize, &
-       device_stream_wait_event, device_count, &
+       device_stream_wait_event, device_count, device_memset, &
        device_stream_create_with_priority
 
   private :: device_memcpy_common
@@ -227,6 +227,49 @@ contains
 #endif
     x_d = C_NULL_PTR
   end subroutine device_free
+
+  !> Set memory on the device to a value
+  subroutine device_memset(x_d, v, s, sync, strm)
+    type(c_ptr), intent(inout) :: x_d
+    integer(c_int), target, value :: v
+    integer(c_size_t), intent(in) :: s
+    logical, optional :: sync
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: stream
+    logical :: sync_device
+
+    if (present(sync)) then
+       sync_device = sync
+    else
+       sync_device = .false.
+    end if
+
+    if (present(strm)) then
+       stream = strm
+    else
+       stream = glb_cmd_queue
+    end if
+
+#ifdef HAVE_HIP
+    if (hipMemsetAsync(x_d, v, s, stream) .ne. hipSuccess) then
+       call neko_error('Device memset async failed')
+    end if
+#elif HAVE_CUDA
+    if (cudaMemsetAsync(x_d, v, s, stream) .ne. cudaSuccess) then
+       call neko_error('Device memset async failed')
+    end if
+#elif HAVE_OPENCL
+    if (clEnqueueFillBuffer(strm, x_d, c_loc(v), s, c_sizeof(v), 0, &
+         s, 0, C_NULL_PTR, C_NULL_PTR) .ne. CL_SUCCESS) then
+       call neko_error('Device memset async failed')
+    end if
+#endif
+
+    if (sync_device) then
+       call device_sync_stream(stream)
+    end if
+
+  end subroutine device_memset
 
   !> Copy data between host and device (rank 1 arrays)
   subroutine device_memcpy_r1(x, x_d, n, dir, sync, strm)

--- a/src/device/device.F90
+++ b/src/device/device.F90
@@ -259,7 +259,7 @@ contains
        call neko_error('Device memset async failed')
     end if
 #elif HAVE_OPENCL
-    if (clEnqueueFillBuffer(strm, x_d, c_loc(v), c_sizeof(v), 0, &
+    if (clEnqueueFillBuffer(strm, x_d, c_loc(v), c_sizeof(v), 0_i8, &
          s, 0, C_NULL_PTR, C_NULL_PTR) .ne. CL_SUCCESS) then
        call neko_error('Device memset async failed')
     end if

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -1,4 +1,4 @@
-! Copyright (c) 2021-2022, The Neko Authors
+! Copyright (c) 2021-2025, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -107,6 +107,17 @@ module hip_intf
        integer(c_size_t), value :: s
        integer(c_int), value :: dir
      end function hipMemcpyAsync
+
+     interface
+        integer(c_int) function hipMemsetAsync(ptr, v, s, stream) &
+             bind(c, name = 'hipMemsetAsync')
+          use, intrinsic :: iso_c_binding
+          implicit none
+          type(c_ptr), value :: ptr, stream
+          integer(c_int), value :: v
+          integer(c_size_t), value :: s
+        end function hipMemsetAsync
+     end interface
 
      integer(c_int) function hipDeviceSynchronize() &
           bind(c, name = 'hipDeviceSynchronize')
@@ -248,7 +259,7 @@ contains
   subroutine hip_finalize(glb_cmd_queue, aux_cmd_queue)
     type(c_ptr), intent(inout) :: glb_cmd_queue
     type(c_ptr), intent(inout) :: aux_cmd_queue
-    
+
     if (hipStreamDestroy(glb_cmd_queue) .ne. hipSuccess) then
        call neko_error('Error destroying main stream')
     end if

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -108,16 +108,14 @@ module hip_intf
        integer(c_int), value :: dir
      end function hipMemcpyAsync
 
-     interface
-        integer(c_int) function hipMemsetAsync(ptr, v, s, stream) &
-             bind(c, name = 'hipMemsetAsync')
-          use, intrinsic :: iso_c_binding
-          implicit none
-          type(c_ptr), value :: ptr, stream
-          integer(c_int), value :: v
-          integer(c_size_t), value :: s
-        end function hipMemsetAsync
-     end interface
+     integer(c_int) function hipMemsetAsync(ptr, v, s, stream) &
+          bind(c, name = 'hipMemsetAsync')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr), value :: ptr, stream
+       integer(c_int), value :: v
+       integer(c_size_t), value :: s
+     end function hipMemsetAsync
 
      integer(c_int) function hipDeviceSynchronize() &
           bind(c, name = 'hipDeviceSynchronize')

--- a/src/device/opencl_intf.F90
+++ b/src/device/opencl_intf.F90
@@ -199,7 +199,7 @@ module opencl_intf
   interface
      integer(c_int) function clEnqueueWriteBuffer(queue, buffer, &
           blocking_write, offset, size, ptr, num_events_in_wait_list, &
-          event_wait_list, event)  bind(c, name = 'clEnqueueWriteBuffer')
+          event_wait_list, event) bind(c, name = 'clEnqueueWriteBuffer')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: queue
@@ -234,7 +234,7 @@ module opencl_intf
 
   interface
      integer(c_int) function clEnqueueFillBuffer(queue, buffer, &
-          pattern, pattern_size, offset, size,  num_events_in_wait_list, &
+          pattern, pattern_size, offset, size, num_events_in_wait_list, &
           event_wait_list, event) bind(c, name = 'clEnqueueFillBuffer')
        use, intrinsic :: iso_c_binding
        implicit none
@@ -244,7 +244,7 @@ module opencl_intf
        integer(c_size_t), value :: pattern_size
        integer(c_size_t), value :: offset,
        integer(c_size_t), value :: size,
-              integer(c_int), value :: num_events_in_wait_list
+       integer(c_int), value :: num_events_in_wait_list
        type(c_ptr), value :: event_wait_list
        type(c_ptr), value :: event
      end function clEnqueueFillBuffer
@@ -273,7 +273,7 @@ module opencl_intf
      end function clEnqueueMarker
   end interface
 
-    interface
+  interface
      integer(c_int) function clEnqueueBarrier(cmd_queue) &
           bind(c, name = 'clEnqueueBarrier')
        use, intrinsic :: iso_c_binding

--- a/src/device/opencl_intf.F90
+++ b/src/device/opencl_intf.F90
@@ -242,8 +242,8 @@ module opencl_intf
        type(c_ptr), value :: buffer
        type(c_ptr), value :: pattern
        integer(c_size_t), value :: pattern_size
-       integer(c_size_t), value :: offset,
-       integer(c_size_t), value :: size,
+       integer(c_size_t), value :: offset
+       integer(c_size_t), value :: size
        integer(c_int), value :: num_events_in_wait_list
        type(c_ptr), value :: event_wait_list
        type(c_ptr), value :: event

--- a/src/device/opencl_intf.F90
+++ b/src/device/opencl_intf.F90
@@ -1,4 +1,4 @@
-! Copyright (c) 2021-2023, The Neko Authors
+! Copyright (c) 2021-2025, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -107,8 +107,7 @@ module opencl_intf
 
   interface
      integer(c_int) function clGetPlatformIDs(num_entries, platforms, &
-                                              num_platforms) &
-          bind(c, name = 'clGetPlatformIDs')
+          num_platforms) bind(c, name = 'clGetPlatformIDs')
        use, intrinsic :: iso_c_binding
        implicit none
        integer(c_int), value :: num_entries
@@ -119,8 +118,7 @@ module opencl_intf
 
   interface
      integer(c_int) function clGetDeviceIDs(platform, device_type, &
-                                            num_entries, devices, num_devices) &
-          bind(c, name = 'clGetDeviceIDs')
+          num_entries, devices, num_devices) bind(c, name = 'clGetDeviceIDs')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: platform
@@ -133,8 +131,7 @@ module opencl_intf
 
   interface
      type (c_ptr) function clCreateContext(properties, num_devices, devices, &
-                                           pfn_notify, user_data, ierr) &
-          bind(c, name = 'clCreateContext')
+          pfn_notify, user_data, ierr) bind(c, name = 'clCreateContext')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: properties
@@ -148,8 +145,7 @@ module opencl_intf
 
   interface
      type(c_ptr) function clCreateCommandQueue(context, device, &
-                                               properties, ierr) &
-          bind(c, name = 'clCreateCommandQueue')
+          properties, ierr) bind(c, name = 'clCreateCommandQueue')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: context
@@ -184,9 +180,7 @@ module opencl_intf
 
   interface
      integer(c_int) function clEnqueueReadBuffer(queue, buffer, blocking_read, &
-                                                 offset, size, ptr, &
-                                                 num_events_in_wait_list, &
-                                                 event_wait_list, event) &
+          offset, size, ptr, num_events_in_wait_list, event_wait_list, event) &
           bind(c, name = 'clEnqueueReadBuffer')
        use, intrinsic :: iso_c_binding
        implicit none
@@ -204,11 +198,8 @@ module opencl_intf
 
   interface
      integer(c_int) function clEnqueueWriteBuffer(queue, buffer, &
-                                                  blocking_write, offset, &
-                                                  size, ptr, &
-                                                  num_events_in_wait_list, &
-                                                  event_wait_list, event) &
-          bind(c, name = 'clEnqueueWriteBuffer')
+          blocking_write, offset, size, ptr, num_events_in_wait_list, &
+          event_wait_list, event)  bind(c, name = 'clEnqueueWriteBuffer')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: queue
@@ -225,11 +216,8 @@ module opencl_intf
 
   interface
      integer(c_int) function clEnqueueCopyBuffer(queue, src_buffer, &
-                                                 dst_buffer, src_offset, &
-                                                 dst_offset, size, &
-                                                 num_events_in_wait_list, &
-                                                 event_wait_list, event) &
-          bind(c, name = 'clEnqueueCopyBuffer')
+          dst_buffer, src_offset, dst_offset, size, num_events_in_wait_list, &
+          event_wait_list, event) bind(c, name = 'clEnqueueCopyBuffer')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: queue
@@ -242,6 +230,24 @@ module opencl_intf
        type(c_ptr), value :: event_wait_list
        type(c_ptr), value :: event
      end function clEnqueueCopyBuffer
+  end interface
+
+  interface
+     integer(c_int) function clEnqueueFillBuffer(queue, buffer, &
+          pattern, pattern_size, offset, size,  num_events_in_wait_list, &
+          event_wait_list, event) bind(c, name = 'clEnqueueFillBuffer')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr), value :: queue
+       type(c_ptr), value :: buffer
+       type(c_ptr), value :: pattern
+       integer(c_size_t), value :: pattern_size
+       integer(c_size_t), value :: offset,
+       integer(c_size_t), value :: size,
+              integer(c_int), value :: num_events_in_wait_list
+       type(c_ptr), value :: event_wait_list
+       type(c_ptr), value :: event
+     end function clEnqueueFillBuffer
   end interface
 
   interface
@@ -278,8 +284,7 @@ module opencl_intf
 
   interface
      integer(c_int) function clEnqueueWaitForEvents(queue, &
-                                                    num_events, event_list) &
-          bind(c, name = 'clEnqueueWaitForEvents')
+          num_events, event_list) bind(c, name = 'clEnqueueWaitForEvents')
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: queue
@@ -310,8 +315,7 @@ module opencl_intf
 
   interface
      integer(c_int) function clGetDeviceInfo(device, param_name, &
-                                             param_value_size, param_value, &
-                                             param_value_size_ret) &
+          param_value_size, param_value, param_value_size_ret) &
           bind(c, name = 'clGetDeviceInfo')
        use, intrinsic :: iso_c_binding
        implicit none
@@ -452,7 +456,7 @@ contains
   subroutine opencl_finalize(glb_cmd_queue, aux_cmd_queue)
     type(c_ptr), intent(inout) :: glb_cmd_queue
     type(c_ptr), intent(inout) :: aux_cmd_queue
-    
+
     if (c_associated(glb_ctx)) then
        if (clReleaseContext(glb_ctx) .ne. CL_SUCCESS) then
           call neko_error('Failed to release context')


### PR DESCRIPTION
This adds a `device_memset` that can be use to zero an array. The interface accepts both `sync` and `stream` arguments to allow for sync, without calling the costly `device_sync`