### PR TITLE
Fix mesh_checker for boundary visualization with VisIt

### DIFF
--- a/contrib/mesh_checker/mesh_checker.f90
+++ b/contrib/mesh_checker/mesh_checker.f90
@@ -80,7 +80,7 @@ program mesh_checker
   mesh_file = file_t(trim(mesh_fname))
   call mesh_file%read(msh)
 
-  call Xh%init(1, 2, 2, 2)
+  call Xh%init(1, 3, 3, 3)
   call dofmap%init(msh, Xh)
 
   call MPI_Allreduce(msh%periodic%size, periodic_size, 1, &


### PR DESCRIPTION
For visualizing the zone indices, VisIt didn't like polynomial order 2.