### PR TITLE
Refactor file_t constructor to a normal procedure

### DIFF
--- a/contrib/adios2_to_nek5000/adios2_to_nek5000.f90
+++ b/contrib/adios2_to_nek5000/adios2_to_nek5000.f90
@@ -37,14 +37,14 @@ program adios2_to_nek5000
      file_precision = sp
   end if
 
-  field_file = file_t(trim(field_fname), precision = file_precision)
+  call field_file%init(trim(field_fname), precision = file_precision)
 
   call field_data%init()
   if (pe_rank .eq. 0) write(*,*) 'Reading file:', 1
   call field_file%read(field_data)
 
   ! output at t=0
-  output_file = file_t(trim(output_fname), precision = file_precision, &
+  call output_file%init(trim(output_fname), precision = file_precision, &
        layout = layout)
   call output_file%write(field_data, field_data%time)
 

--- a/contrib/average_field_in_space/average_field_in_space.f90
+++ b/contrib/average_field_in_space/average_field_in_space.f90
@@ -50,10 +50,10 @@ program average_field_in_space
 
   call get_command_argument(1, inputchar)
   read(inputchar, *) mesh_fname
-  mesh_file = file_t(trim(mesh_fname))
+  call mesh_file%init(trim(mesh_fname))
   call get_command_argument(2, inputchar)
   read(inputchar, *) field_fname
-  field_file = file_t(trim(field_fname))
+  call field_file%init(trim(field_fname))
   call get_command_argument(3, inputchar)
   read(inputchar, *) hom_dir
   call get_command_argument(4, inputchar)
@@ -128,10 +128,10 @@ program average_field_in_space
   else
      call map_2d%init(coef, dir, 1e-7_rp)
   end if
-  
+
   !allocate array with pointers to all vectors in the file
 
-  output_file = file_t(trim(output_fname))
+  call output_file%init(trim(output_fname))
   do tstep = 0, field_data%meta_nsamples-1
     if (pe_rank .eq. 0) write(*,*) 'Averaging field:', tstep
      if (tstep .gt. 0) call field_file%read(field_data)

--- a/contrib/average_field_in_space/average_field_in_space.f90
+++ b/contrib/average_field_in_space/average_field_in_space.f90
@@ -133,7 +133,7 @@ program average_field_in_space
 
   call output_file%init(trim(output_fname))
   do tstep = 0, field_data%meta_nsamples-1
-    if (pe_rank .eq. 0) write(*,*) 'Averaging field:', tstep
+     if (pe_rank .eq. 0) write(*,*) 'Averaging field:', tstep
      if (tstep .gt. 0) call field_file%read(field_data)
      if (avg_to_1d) then
         call map_1d%average_planes(avg_matrix, fields)

--- a/contrib/average_fields_in_time/average_fields_in_time.f90
+++ b/contrib/average_fields_in_time/average_fields_in_time.f90
@@ -3,18 +3,18 @@
 program average_fields_in_time
   use neko
   implicit none
-  
+
   character(len=NEKO_FNAME_LEN) :: inputchar, mesh_fname, fld_fname, output_fname
   type(file_t) :: fld_file, part_file, output_file
   real(kind=rp) :: start_time
   type(fld_file_data_t) :: fld_data, fld_data_avg
   integer :: argc, i
-  
+
   argc = command_argument_count()
 
   if ((argc .lt. 3) .or. (argc .gt. 3)) then
      if (pe_rank .eq. 0) then
-     write(*,*) 'Usage: ./average_fields_in_time field_series_name.fld start_time output_name.fld' 
+     write(*,*) 'Usage: ./average_fields_in_time field_series_name.fld start_time output_name.fld'
      write(*,*) 'Example command: ./average_fields_in_time mean_field104.fld 103.2 mean_field_avg.fld'
      write(*,*) 'Computes the average field over the fld files described in mean_field104.nek5000'
      write(*,*) 'The start time is the time at which the first file startsto collect stats'
@@ -23,22 +23,22 @@ program average_fields_in_time
      end if
      stop
   end if
-  
-  call neko_init 
 
-  call get_command_argument(1, inputchar) 
+  call neko_init
+
+  call get_command_argument(1, inputchar)
   read(inputchar, *) fld_fname
-  fld_file = file_t(trim(fld_fname))
-  call get_command_argument(2, inputchar) 
+  call fld_file%init(trim(fld_fname))
+  call get_command_argument(2, inputchar)
   read(inputchar, *) start_time
-  call get_command_argument(3, inputchar) 
+  call get_command_argument(3, inputchar)
   read(inputchar, *) output_fname
 
   call fld_data%init()
   call fld_data_avg%init()
 
   call fld_file%read(fld_data_avg)
-  
+
   call fld_data_avg%scale(fld_data_avg%time-start_time)
   if (pe_rank .eq. 0) write(*,*) fld_data_avg%nelv, fld_data_avg%n_scalars
 
@@ -53,14 +53,14 @@ program average_fields_in_time
   end do
   call fld_data_avg%scale(1.0_rp/(fld_data_avg%time-start_time))
 
-  output_file = file_t(trim(output_fname))
+  call output_file%init(trim(output_fname))
 
 
-  
+
   if (pe_rank .eq. 0) write(*,*) 'Writing file: ', trim(output_fname)
   call output_file%write(fld_data_avg, fld_data_avg%time)
   if (pe_rank .eq. 0) write(*,*) 'Done'
-  
+
   call neko_finalize
 
 end program average_fields_in_time

--- a/contrib/average_fields_in_time/average_fields_in_time.f90
+++ b/contrib/average_fields_in_time/average_fields_in_time.f90
@@ -14,12 +14,12 @@ program average_fields_in_time
 
   if ((argc .lt. 3) .or. (argc .gt. 3)) then
      if (pe_rank .eq. 0) then
-     write(*,*) 'Usage: ./average_fields_in_time field_series_name.fld start_time output_name.fld'
-     write(*,*) 'Example command: ./average_fields_in_time mean_field104.fld 103.2 mean_field_avg.fld'
-     write(*,*) 'Computes the average field over the fld files described in mean_field104.nek5000'
-     write(*,*) 'The start time is the time at which the first file startsto collect stats'
-     write(*,*) 'The files need to be aranged chronological order.'
-     write(*,*) 'The average field is then stored in a fld series, i.e. output_name.nek5000 and output_name.f00000'
+        write(*,*) 'Usage: ./average_fields_in_time field_series_name.fld start_time output_name.fld'
+        write(*,*) 'Example command: ./average_fields_in_time mean_field104.fld 103.2 mean_field_avg.fld'
+        write(*,*) 'Computes the average field over the fld files described in mean_field104.nek5000'
+        write(*,*) 'The start time is the time at which the first file startsto collect stats'
+        write(*,*) 'The files need to be aranged chronological order.'
+        write(*,*) 'The average field is then stored in a fld series, i.e. output_name.nek5000 and output_name.f00000'
      end if
      stop
   end if

--- a/contrib/calc_lift_from_field/calc_lift_from_field.f90
+++ b/contrib/calc_lift_from_field/calc_lift_from_field.f90
@@ -36,7 +36,7 @@ program calc_lift_from_field
         write(*,*) 'Usage: ./calc_lift_from_field mesh.nmsh field.fld zone_number viscosity function_of_coord output.csv'
         write(*,*) 'Example command: ./calc_lift_from_field mesh.nmsh fieldblabla.fld 5 0.04 y out.csv'
         write(*,*) 'Outputs the total force and torque on zone 5 using velocity values from fieldblabla.fld'
-        write(*,*)  'as well as writes the distribution of the force and torque across y to output.csv'
+        write(*,*) 'as well as writes the distribution of the force and torque across y to output.csv'
      end if
      stop
   end if
@@ -132,8 +132,8 @@ program calc_lift_from_field
   glb_n_gll_pts = map_1d%n_el_lvls*lx
   call drag_torq%init(glb_n_gll_pts, 14)
   if (pe_rank .eq. 0) call output_file%set_header('time, coord, forcepx, forcepy, &
-             & forcepz, forcevx, forcevy, forcevz, torqpx, torqpy, &
-             & torqpz, torqvx, torqvy, torqvz')
+  & forcepz, forcevx, forcevy, forcevz, torqpx, torqpy, &
+  & torqpz, torqvx, torqvy, torqvz')
 
   do t = 1, field_data%meta_nsamples
      if (t .ne. 1) call field_file%read(field_data)
@@ -152,16 +152,16 @@ program calc_lift_from_field
 
      call strain_rate(s11%x, s22%x, s33%x, s12%x, s13%x, s23%x, u, v, w, coef)
      call drag_torque_zone(dgtq,field_data%t_counter, msh%labeled_zones(zone_id), center,&
-                           s11%x, s22%x, s33%x, s12%x, s13%x, s23%x,&
-                           p, coef, visc)
+          s11%x, s22%x, s33%x, s12%x, s13%x, s23%x,&
+          p, coef, visc)
      if (pe_rank .eq. 0) then
-         write(*,*) field_data%t_counter,dgtq(1)+dgtq(4),dgtq(1),dgtq(4),'dragx'
-         write(*,*) field_data%t_counter,dgtq(2)+dgtq(5),dgtq(2),dgtq(5),'dragy'
-         write(*,*) field_data%t_counter,dgtq(3)+dgtq(6),dgtq(3),dgtq(6),'dragz'
-      end if
+        write(*,*) field_data%t_counter,dgtq(1)+dgtq(4),dgtq(1),dgtq(4),'dragx'
+        write(*,*) field_data%t_counter,dgtq(2)+dgtq(5),dgtq(2),dgtq(5),'dragy'
+        write(*,*) field_data%t_counter,dgtq(3)+dgtq(6),dgtq(3),dgtq(6),'dragz'
+     end if
 
 
-     do mem  = 1,msh%labeled_zones(zone_id)%size
+     do mem = 1,msh%labeled_zones(zone_id)%size
         e = msh%labeled_zones(zone_id)%facet_el(mem)%x(2)
         f = msh%labeled_zones(zone_id)%facet_el(mem)%x(1)
         do k = 1, lx
@@ -176,12 +176,12 @@ program calc_lift_from_field
                     s23_ = s23%x(i,j,k,e)
                     s33_ = s33%x(i,j,k,e)
                     call drag_torque_pt(dgtq,dof%x(i,j,k,e), dof%y(i,j,k,e),dof%z(i,j,k,e),&
-                                        center, &
-                                        s11_, s22_, s33_, s12_, s13_, s23_,&
-                                        p%x(i,j,k,e), nv(1), nv(2), nv(3), visc)
+                         center, &
+                         s11_, s22_, s33_, s12_, s13_, s23_,&
+                         p%x(i,j,k,e), nv(1), nv(2), nv(3), visc)
                     drag_torq%x(map_1d%pt_lvl(i,j,k,e),3:14) = &
-                    drag_torq%x(map_1d%pt_lvl(i,j,k,e),3:14) + dgtq
-                    drag_torq%x(map_1d%pt_lvl(i,j,k,e),2) =  line(i,j,k,e)
+                         drag_torq%x(map_1d%pt_lvl(i,j,k,e),3:14) + dgtq
+                    drag_torq%x(map_1d%pt_lvl(i,j,k,e),2) = line(i,j,k,e)
                  end if
               end do
            end do
@@ -189,9 +189,9 @@ program calc_lift_from_field
      end do
 
      call MPI_Allreduce(MPI_IN_PLACE,drag_torq%x(1,3), 12*glb_n_gll_pts, &
-        MPI_REAL_PRECISION, MPI_SUM, NEKO_COMM, ierr)
+          MPI_REAL_PRECISION, MPI_SUM, NEKO_COMM, ierr)
      call MPI_Allreduce(MPI_IN_PLACE,drag_torq%x(1,2), glb_n_gll_pts, &
-        MPI_REAL_PRECISION, MPI_MIN, NEKO_COMM, ierr)
+          MPI_REAL_PRECISION, MPI_MIN, NEKO_COMM, ierr)
      drag_torq%x(:,1) = field_data%time
      if (pe_rank .eq. 0) then
         call output_file%write(drag_torq)

--- a/contrib/calc_lift_from_field/calc_lift_from_field.f90
+++ b/contrib/calc_lift_from_field/calc_lift_from_field.f90
@@ -9,7 +9,7 @@ program calc_lift_from_field
   use mean_flow
   use matrix
   implicit none
-  
+
   character(len=NEKO_FNAME_LEN) :: inputchar, mesh_fname, field_fname, hom_dir, output_fname
   type(file_t) :: field_file, mesh_file, output_file
   real(kind=rp) :: start_time
@@ -28,46 +28,46 @@ program calc_lift_from_field
   real(kind=rp), pointer :: line(:,:,:,:)
   integer :: argc, i, j, k, n, lx, e, zone_id, dir, f, glb_n_gll_pts, ierr, mem, t
   real(kind=rp) :: visc, nv(3), dgtq(12)
-  
+
   argc = command_argument_count()
 
   if ((argc .lt. 6) .or. (argc .gt. 6)) then
      if (pe_rank .eq. 0) then
-        write(*,*) 'Usage: ./calc_lift_from_field mesh.nmsh field.fld zone_number viscosity function_of_coord output.csv' 
+        write(*,*) 'Usage: ./calc_lift_from_field mesh.nmsh field.fld zone_number viscosity function_of_coord output.csv'
         write(*,*) 'Example command: ./calc_lift_from_field mesh.nmsh fieldblabla.fld 5 0.04 y out.csv'
         write(*,*) 'Outputs the total force and torque on zone 5 using velocity values from fieldblabla.fld'
         write(*,*)  'as well as writes the distribution of the force and torque across y to output.csv'
      end if
      stop
   end if
-  
-  call neko_init 
 
-  call get_command_argument(1, inputchar) 
+  call neko_init
+
+  call get_command_argument(1, inputchar)
   read(inputchar, *) mesh_fname
-  mesh_file = file_t(trim(mesh_fname))
-  call get_command_argument(2, inputchar) 
+  call mesh_file%init(trim(mesh_fname))
+  call get_command_argument(2, inputchar)
   read(inputchar, *) field_fname
-  field_file = file_t(trim(field_fname))
-  call get_command_argument(3, inputchar) 
+  call field_file%init(trim(field_fname))
+  call get_command_argument(3, inputchar)
   read(inputchar, *) zone_id
-  call get_command_argument(4, inputchar) 
+  call get_command_argument(4, inputchar)
   read(inputchar, *) visc
-  call get_command_argument(5, inputchar) 
+  call get_command_argument(5, inputchar)
   read(inputchar, *) hom_dir
-  call get_command_argument(6, inputchar) 
+  call get_command_argument(6, inputchar)
   read(inputchar, *) output_fname
-  output_file = file_t(trim(output_fname))
+  call output_file%init(trim(output_fname))
 
   call mesh_file%read(msh)
-   
+
   call field_data%init(msh%nelv,msh%offset_el)
   call field_file%read(field_data)
-  
+
   lx = field_data%lx
   !To make sure any deformation made in the user file is passed onto here as well
   do i = 1,msh%nelv
-     msh%elements(i)%e%pts(1)%p%x(1) = field_data%x%x(linear_index(1,1,1,i,lx,lx,lx))  
+     msh%elements(i)%e%pts(1)%p%x(1) = field_data%x%x(linear_index(1,1,1,i,lx,lx,lx))
      msh%elements(i)%e%pts(2)%p%x(1) = field_data%x%x(linear_index(lx,1,1,i,lx,lx,lx))
      msh%elements(i)%e%pts(3)%p%x(1) = field_data%x%x(linear_index(1,lx,1,i,lx,lx,lx))
      msh%elements(i)%e%pts(4)%p%x(1) = field_data%x%x(linear_index(lx,lx,1,i,lx,lx,lx))
@@ -76,7 +76,7 @@ program calc_lift_from_field
      msh%elements(i)%e%pts(7)%p%x(1) = field_data%x%x(linear_index(1,lx,lx,i,lx,lx,lx))
      msh%elements(i)%e%pts(8)%p%x(1) = field_data%x%x(linear_index(lx,lx,lx,i,lx,lx,lx))
 
-     msh%elements(i)%e%pts(1)%p%x(2) = field_data%y%x(linear_index(1,1,1,i,lx,lx,lx))  
+     msh%elements(i)%e%pts(1)%p%x(2) = field_data%y%x(linear_index(1,1,1,i,lx,lx,lx))
      msh%elements(i)%e%pts(2)%p%x(2) = field_data%y%x(linear_index(lx,1,1,i,lx,lx,lx))
      msh%elements(i)%e%pts(3)%p%x(2) = field_data%y%x(linear_index(1,lx,1,i,lx,lx,lx))
      msh%elements(i)%e%pts(4)%p%x(2) = field_data%y%x(linear_index(lx,lx,1,i,lx,lx,lx))
@@ -85,7 +85,7 @@ program calc_lift_from_field
      msh%elements(i)%e%pts(7)%p%x(2) = field_data%y%x(linear_index(1,lx,lx,i,lx,lx,lx))
      msh%elements(i)%e%pts(8)%p%x(2) = field_data%y%x(linear_index(lx,lx,lx,i,lx,lx,lx))
 
-     msh%elements(i)%e%pts(1)%p%x(3) = field_data%z%x(linear_index(1,1,1,i,lx,lx,lx))  
+     msh%elements(i)%e%pts(1)%p%x(3) = field_data%z%x(linear_index(1,1,1,i,lx,lx,lx))
      msh%elements(i)%e%pts(2)%p%x(3) = field_data%z%x(linear_index(lx,1,1,i,lx,lx,lx))
      msh%elements(i)%e%pts(3)%p%x(3) = field_data%z%x(linear_index(1,lx,1,i,lx,lx,lx))
      msh%elements(i)%e%pts(4)%p%x(3) = field_data%z%x(linear_index(lx,lx,1,i,lx,lx,lx))
@@ -113,7 +113,7 @@ program calc_lift_from_field
   else if (trim(hom_dir) .eq. 'z') then
      dir = 3
      line => dof%z
-  else 
+  else
      call neko_error('The homogeneous direction should be "x", "y"or "z"')
   end if
   call map_1d%init(coef, dir, 1e-7_rp)
@@ -146,11 +146,11 @@ program calc_lift_from_field
      drag_torq = 0.0_rp
      !set coords to somoething big
      drag_torq%x(:,2) = 1e15
-   
-   
+
+
      if(pe_rank .eq. 0) write(*,*) 'Total drag'
-   
-     call strain_rate(s11%x, s22%x, s33%x, s12%x, s13%x, s23%x, u, v, w, coef) 
+
+     call strain_rate(s11%x, s22%x, s33%x, s12%x, s13%x, s23%x, u, v, w, coef)
      call drag_torque_zone(dgtq,field_data%t_counter, msh%labeled_zones(zone_id), center,&
                            s11%x, s22%x, s33%x, s12%x, s13%x, s23%x,&
                            p, coef, visc)
@@ -187,7 +187,7 @@ program calc_lift_from_field
            end do
         end do
      end do
-   
+
      call MPI_Allreduce(MPI_IN_PLACE,drag_torq%x(1,3), 12*glb_n_gll_pts, &
         MPI_REAL_PRECISION, MPI_SUM, NEKO_COMM, ierr)
      call MPI_Allreduce(MPI_IN_PLACE,drag_torq%x(1,2), glb_n_gll_pts, &
@@ -197,7 +197,7 @@ program calc_lift_from_field
         call output_file%write(drag_torq)
      end if
   end do
-     
+
   call neko_finalize
 
 end program calc_lift_from_field

--- a/contrib/genmeshbox/genmeshbox.f90
+++ b/contrib/genmeshbox/genmeshbox.f90
@@ -143,7 +143,7 @@ program genmeshbox
   if (trim(dist_x_fname) .eq. 'uniform') then
      el_len_x(:) = (x1 - x0)/nelx
   else
-     dist_x_file = file_t(trim(dist_x_fname))
+     call dist_x_file%init(trim(dist_x_fname))
      call dist_x%init(nelx+1)
      call dist_x_file%read(dist_x)
      do i = 1, nelx
@@ -156,7 +156,7 @@ program genmeshbox
   if (trim(dist_y_fname) .eq. 'uniform') then
      el_len_y(:) = (y1 - y0)/nely
   else
-     dist_y_file = file_t(trim(dist_y_fname))
+     call dist_y_file%init(trim(dist_y_fname))
      call dist_y%init(nely+1)
      call dist_y_file%read(dist_y)
      do i = 1, nely
@@ -169,7 +169,7 @@ program genmeshbox
   if (trim(dist_z_fname) .eq. 'uniform') then
      el_len_z(:) = (z1 - z0)/nelz
   else
-     dist_z_file = file_t(trim(dist_z_fname))
+     call dist_z_file%init(trim(dist_z_fname))
      call dist_z%init(nelz+1)
      call dist_z_file%read(dist_z)
      do i = 1, nelz
@@ -348,7 +348,7 @@ program genmeshbox
   call msh%finalize()
 
 
-  nmsh_file = file_t(fname)
+  call nmsh_file%init(fname)
 
   call nmsh_file%write(msh)
 

--- a/contrib/map_to_equidistant_1d/map_to_equidistant_1d.f90
+++ b/contrib/map_to_equidistant_1d/map_to_equidistant_1d.f90
@@ -48,7 +48,7 @@ program map_to_equidistant_1d
      file_precision = sp
   end if
 
-  field_file = file_t(trim(field_fname),precision=file_precision)
+  call field_file%init(trim(field_fname),precision=file_precision)
 
   if (trim(hom_dir) .ne. 'x' .and. trim(hom_dir) .ne. 'y' .and. trim(hom_dir) .ne. 'z') then
      call neko_error('The homogenous direction should be "x", "y" or "z"')
@@ -97,7 +97,7 @@ program map_to_equidistant_1d
   end do
 
   ! output at t=0
-  output_file = file_t(trim(output_fname),precision=file_precision)
+  call output_file%init(trim(output_fname),precision=file_precision)
   call output_file%write(field_data, field_data%time)
 
   ! interpolate field for t>0

--- a/contrib/map_to_equidistant_1d/map_to_equidistant_1d.f90
+++ b/contrib/map_to_equidistant_1d/map_to_equidistant_1d.f90
@@ -68,19 +68,19 @@ program map_to_equidistant_1d
   allocate(ident(lx,lx))
   ident = 0.0_rp
   do i = 1, lx
-    x_equid = -1.0_rp + (i-1) * 2.0_rp/(lx-1)
-    call fd_weights_full(x_equid, Xh%zg(:,1), lx-1, 0, wtt(:,i))
-    wt(i,:) = wtt(:,i)
-    ident(i,i) = 1.0_rp
+     x_equid = -1.0_rp + (i-1) * 2.0_rp/(lx-1)
+     call fd_weights_full(x_equid, Xh%zg(:,1), lx-1, 0, wtt(:,i))
+     wt(i,:) = wtt(:,i)
+     ident(i,i) = 1.0_rp
   end do
 
   ! redistribute the coordinates to be equidistant within elements
   if (trim(hom_dir) .eq. 'x') then
-    call tnsr1_3d(field_data%x%x, lx, lx, wt, ident, ident, field_data%nelv)
+     call tnsr1_3d(field_data%x%x, lx, lx, wt, ident, ident, field_data%nelv)
   else if (trim(hom_dir) .eq. 'y') then
-    call tnsr1_3d(field_data%y%x, lx, lx, ident, wtt, ident, field_data%nelv)
+     call tnsr1_3d(field_data%y%x, lx, lx, ident, wtt, ident, field_data%nelv)
   else if (trim(hom_dir) .eq. 'z') then
-    call tnsr1_3d(field_data%z%x, lx, lx, ident, ident, wtt, field_data%nelv)
+     call tnsr1_3d(field_data%z%x, lx, lx, ident, ident, wtt, field_data%nelv)
   end if
 
   ! interpolate the field at t=0

--- a/contrib/mesh_checker/mesh_checker.f90
+++ b/contrib/mesh_checker/mesh_checker.f90
@@ -77,7 +77,7 @@ program mesh_checker
      end if
   end do
 
-  mesh_file = file_t(trim(mesh_fname))
+  call mesh_file%init(trim(mesh_fname))
   call mesh_file%read(msh)
 
   call Xh%init(1, 3, 3, 3)
@@ -137,7 +137,7 @@ program mesh_checker
         call bdry_mask%free()
      end do
 
-     bdry_file = file_t('zone_indices.fld')
+     call bdry_file%init('zone_indices.fld')
      call bdry_file%write(bdry_field)
 
      call dofmap%free()

--- a/contrib/postprocess_fluid_stats/postprocess_fluid_stats.f90
+++ b/contrib/postprocess_fluid_stats/postprocess_fluid_stats.f90
@@ -55,10 +55,10 @@ program postprocess_fluid_stats
 
   call get_command_argument(1, inputchar)
   read(inputchar, *) mesh_fname
-  mesh_file = file_t(trim(mesh_fname))
+  call mesh_file%init(trim(mesh_fname))
   call get_command_argument(2, inputchar)
   read(inputchar, *) stats_fname
-  stats_file = file_t(trim(stats_fname))
+  call stats_file%init(trim(stats_fname))
 
   call mesh_file%read(msh)
 
@@ -144,7 +144,7 @@ program postprocess_fluid_stats
   call reynolds%assign_to_field(7, vw)
 
   call fld_stats%post_process(reynolds=reynolds)
-  output_file = file_t('reynolds.fld')
+  call output_file%init('reynolds.fld')
   if (pe_rank .eq. 0) write(*,*) 'Wrtiting Reynolds stresses into reynolds'
   call output_file%write(reynolds, stats_data%time)
   if (pe_rank .eq. 0) write(*,*) 'Done'
@@ -174,7 +174,7 @@ program postprocess_fluid_stats
 
 
   if (pe_rank .eq. 0) write(*,*) 'Writing mean velocity gradient into mean_vel_grad'
-  output_file = file_t('mean_vel_grad.fld')
+  call output_file%init('mean_vel_grad.fld')
   call output_file%write(mean_vel_grad, stats_data%time)
   if (pe_rank .eq. 0) write(*,*) 'Done'
 

--- a/contrib/prepart/prepart.f90
+++ b/contrib/prepart/prepart.f90
@@ -22,8 +22,7 @@ program prepart
   call get_command_argument(2, nprtschr)
   read(nprtschr, *) nprts
 
-  nmsh_file = file_t(fname)
-
+  call nmsh_file%init(fname)
   call nmsh_file%read(msh)
 
   ! Reset possible periodic ids
@@ -122,7 +121,7 @@ program prepart
   output_ = trim(fname(1:scan(trim(fname), '.', back = .true.) - 1)) // &
        '_' // trim(nprtschr) // '.nmsh'
 
-  new_msh_file = file_t(output_)
+  call new_msh_file%init(output_)
   call new_msh_file%write(new_msh)
   call new_msh%free()
 

--- a/contrib/psnr/psnr.f90
+++ b/contrib/psnr/psnr.f90
@@ -135,12 +135,12 @@ program psnr
   end if
 
   if (pe_rank .eq. 0) write(*,*) 'Reading file:', trim(original_fname)
-  original_file = file_t(trim(original_fname), precision = file_precision)
+  call original_file%init(trim(original_fname), precision = file_precision)
   call original_data%init()
   call original_file%read(original_data)
 
   if (pe_rank .eq. 0) write(*,*) 'Reading file:', trim(compressed_fname)
-  compressed_file = file_t(trim(compressed_fname), precision = file_precision)
+  call compressed_file%init(trim(compressed_fname), precision = file_precision)
   call compressed_data%init()
   call compressed_file%read(compressed_data)
 

--- a/contrib/rea2nbin/rea2nbin.f90
+++ b/contrib/rea2nbin/rea2nbin.f90
@@ -7,21 +7,21 @@ program rea2nbin
   type(file_t) :: rea_file, nmsh_file
   integer :: argc
   character(len=80) :: suffix
-  
+
   argc = command_argument_count()
 
   if ((argc .lt. 1) .or. (argc .gt. 2)) then
      write(*,*) 'Usage: ./rea2nbin <reafile> <neko mesh>'
      stop
   end if
-  
-  call neko_init 
+
+  call neko_init
 
   if (pe_size .gt. 1) then
      call neko_error("rea2nbin can only run on 1 rank")
   end if
-  
-  call get_command_argument(1, fname) 
+
+  call get_command_argument(1, fname)
   call filename_suffix(fname, suffix)
   if (suffix .ne. "re2") then
      call neko_error("rea is no longer supported. Please convert to re2 first")
@@ -37,20 +37,20 @@ program rea2nbin
   else
      call filename_chsuffix(fname, output_, 'nmsh')
   end if
-     
-  
-  rea_file = file_t(fname)
-    
+
+
+  call rea_file%init(fname)
+
   msh%lgenc = .false.
-  
+
   call rea_file%read(msh)
-  
-  nmsh_file = file_t(output_)
-  
+
+  call nmsh_file%init(output_)
+
   call nmsh_file%write(msh)
-  
+
   call msh%free()
-  
+
   call neko_finalize
 
 end program rea2nbin

--- a/examples/poisson/driver.f90
+++ b/examples/poisson/driver.f90
@@ -40,7 +40,7 @@ program poisson
   read(lxchar, *) lx
   read(iterchar, *) niter
 
-  nmsh_file = file_t(fname)
+  call nmsh_file%init(fname)
   call nmsh_file%read(msh)
 
   call Xh%init(GLL, lx, lx, lx)
@@ -80,7 +80,7 @@ program poisson
   call set_timer_flop_cnt(1, msh%glb_nelv, x%Xh%lx, niter, n_glb, ksp_mon)
 
   fname = 'out.fld'
-  mf =  file_t(fname)
+  call mf%init(fname)
   call mf%write(x)
   deallocate(f)
   call solver%free()

--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -594,7 +594,7 @@ contains
        k = this%msk(i)
        bdry_field%x(k,1,1,1) = 1.0_rp
     end do
-    dump_file = file_t(file_name)
+    call dump_file%init(file_name)
     call dump_file%write(bdry_field)
 
   end subroutine bc_debug_mask

--- a/src/case.f90
+++ b/src/case.f90
@@ -321,12 +321,12 @@ contains
 
              if (trim(string_val) .ne. 'user') then
                 call set_scalar_ic(this%scalars%scalar_fields(i)%s, &
-                    this%scalars%scalar_fields(i)%c_Xh, this%scalars%scalar_fields(i)%gs_Xh, &
-                    string_val, json_subdict)
+                     this%scalars%scalar_fields(i)%c_Xh, this%scalars%scalar_fields(i)%gs_Xh, &
+                     string_val, json_subdict)
              else
                 call set_scalar_ic(this%scalars%scalar_fields(i)%name, this%scalars%scalar_fields(i)%s, &
-                    this%scalars%scalar_fields(i)%c_Xh, this%scalars%scalar_fields(i)%gs_Xh, &
-                    this%user%scalar_user_ic, this%params)
+                     this%scalars%scalar_fields(i)%c_Xh, this%scalars%scalar_fields(i)%gs_Xh, &
+                     this%user%scalar_user_ic, this%params)
              end if
           end do
        end if

--- a/src/case.f90
+++ b/src/case.f90
@@ -169,7 +169,7 @@ contains
        call neko_error('The mesh_file keyword could not be found in the .' // &
             'case file. Often caused by incorrectly formatted json.')
     end if
-    msh_file = file_t(string_val)
+    call msh_file%init(string_val)
 
     call msh_file%read(this%msh)
 
@@ -187,7 +187,7 @@ contains
        ! store the balanced mesh (for e.g. restarts)
        string_val = trim(string_val(1:scan(trim(string_val), &
             '.', back = .true.) - 1)) // '_lb.nmsh'
-       msh_file = file_t(string_val)
+       call msh_file%init(string_val)
        call msh_file%write(this%msh)
 
        call neko_log%end_section()
@@ -375,7 +375,7 @@ contains
     if (logical_val) then
        call mesh_field_init(msh_part, this%msh, 'MPI_Rank')
        msh_part%data = pe_rank
-       part_file = file_t(trim(this%output_directory)//'partitions.vtk')
+       call part_file%init(trim(this%output_directory)//'partitions.vtk')
        call part_file%write(msh_part)
        call mesh_field_free(msh_part)
     end if

--- a/src/common/runtime_statistics.f90
+++ b/src/common/runtime_statistics.f90
@@ -46,7 +46,7 @@ module runtime_stats
   private
 
   integer :: RT_STATS_MAX_REGIONS = 50
-  
+
   type :: runtime_stats_t
      !> Name of measured region
      character(len=19), allocatable :: rt_stats_id(:)
@@ -73,7 +73,7 @@ contains
     class(runtime_stats_t), intent(inout) :: this
     type(json_file), intent(inout) :: params
     integer :: i
-    
+
     call this%free()
 
     call json_get_or_default(params, 'case.runtime_statistics.enabled', &
@@ -85,25 +85,25 @@ contains
     if (this%enabled_) then
 
        allocate(this%rt_stats_id(RT_STATS_MAX_REGIONS))
-       
+
        this%rt_stats_id = ''
-       
+
        allocate(this%elapsed_time_(RT_STATS_MAX_REGIONS))
        do i = 1, RT_STATS_MAX_REGIONS
           call this%elapsed_time_(i)%init()
        end do
-       
+
        call this%region_timestamp_%init(100)
 
     end if
-    
+
   end subroutine runtime_stats_init
 
-  !> Destroy runtime statistics 
+  !> Destroy runtime statistics
   subroutine runtime_stats_free(this)
     class(runtime_stats_t), intent(inout) :: this
     integer :: i
-    
+
     if (allocated(this%rt_stats_id)) then
        deallocate(this%rt_stats_id)
     end if
@@ -116,7 +116,7 @@ contains
     end if
 
     call this%region_timestamp_%free()
-    
+
   end subroutine runtime_stats_free
 
   !> Start measuring time for the region
@@ -130,7 +130,7 @@ contains
     if (.not. this%enabled_) then
        return
     end if
-    
+
     if (region_id .gt. 0 .and. region_id .le. RT_STATS_MAX_REGIONS) then
        if (len_trim(this%rt_stats_id(region_id)) .eq. 0) then
           this%rt_stats_id(region_id) = trim(name)
@@ -145,7 +145,7 @@ contains
     else
        call neko_error('Invalid profiling region id')
     end if
-    
+
   end subroutine runtime_stats_start_region
 
   !> Compute elapsed time for the current region
@@ -167,7 +167,7 @@ contains
             &expected: ' // trim(this%rt_stats_id(region_id)) // ')')
     end if
     region_data = this%region_timestamp_%pop()
-    
+
     if (region_data%x .gt. 0) then
        elapsed_time = end_time - region_data%y
        call this%elapsed_time_(region_data%x)%push(elapsed_time)
@@ -187,7 +187,7 @@ contains
     if (.not. this%enabled_) then
        return
     end if
-    
+
     call neko_log%section('Runtime statistics')
     call neko_log%newline()
     write(log_buf, '(A,A,1x,A,1x,A)') '                  ',&
@@ -203,9 +203,9 @@ contains
     do i = 1, size(this%elapsed_time_)
        if (len_trim(this%rt_stats_id(i)) .gt. 0) then
           nsamples = this%elapsed_time_(i)%size()
-          ncols = ncols + 1          
+          ncols = ncols + 1
           hdr = trim(hdr) // trim(this%rt_stats_id(i)) // ', '
-          nrows = max(nrows, nsamples)             
+          nrows = max(nrows, nsamples)
           if (nsamples .gt. 0) then
              select type (region_sample => this%elapsed_time_(i)%data)
              type is (double precision)
@@ -232,7 +232,7 @@ contains
        do i = 1, size(this%elapsed_time_)
           if (len_trim(this%rt_stats_id(i)) .gt. 0) then
              nsamples = this%elapsed_time_(i)%size()
-             col_idx = col_idx + 1             
+             col_idx = col_idx + 1
              if (nsamples .gt. 0) then
                 select type (region_sample => this%elapsed_time_(i)%data)
                 type is (double precision)
@@ -247,11 +247,11 @@ contains
              end if
           end if
        end do
-       
+
        if (pe_rank .eq. 0) then
           block
-            type(file_t) :: profile_file    
-            profile_file = file_t('profile.csv')
+            type(file_t) :: profile_file
+            call profile_file%init('profile.csv')
             call profile_file%set_header(hdr)
             call profile_file%write(profile_data)
           end block
@@ -262,5 +262,5 @@ contains
     call profile_data%free()
 
   end subroutine runtime_stats_report
-  
+
 end module runtime_stats

--- a/src/common/runtime_statistics.f90
+++ b/src/common/runtime_statistics.f90
@@ -56,7 +56,7 @@ module runtime_stats
      type(stack_i4r8t2_t) :: region_timestamp_
      logical :: enabled_
      logical :: output_profile_
-    contains
+   contains
      procedure, pass(this) :: init => runtime_stats_init
      procedure, pass(this) :: free => runtime_stats_free
      procedure, pass(this) :: start_region => runtime_stats_start_region
@@ -164,7 +164,7 @@ contains
 
     if (trim(this%rt_stats_id(region_id)) .ne. trim(name)) then
        call neko_error('Invalid profiler region closed (' // name // ', &
-            &expected: ' // trim(this%rt_stats_id(region_id)) // ')')
+       &expected: ' // trim(this%rt_stats_id(region_id)) // ')')
     end if
     region_data = this%region_timestamp_%pop()
 
@@ -217,7 +217,7 @@ contains
                 std = (total - avg)**2 / nsamples
                 sem = std /sqrt(real(nsamples, dp))
              end select
-             write(log_buf, '(A, E15.7,1x,1x,E15.7,1x,1x,E15.7)')  &
+             write(log_buf, '(A, E15.7,1x,1x,E15.7,1x,1x,E15.7)') &
                   this%rt_stats_id(i), total, avg, 2.5758_dp * sem
              call neko_log%message(log_buf)
           end if

--- a/src/fluid/flow_ic.f90
+++ b/src/fluid/flow_ic.f90
@@ -61,7 +61,7 @@ module flow_ic
 
   interface set_flow_ic
      module procedure set_flow_ic_int, set_flow_ic_usr, &
-      set_compressible_flow_ic_usr
+          set_compressible_flow_ic_usr
   end interface set_flow_ic
 
   public :: set_flow_ic
@@ -415,7 +415,7 @@ contains
 
     if (sample_idx .eq. -1) &
          call neko_error("Invalid file name for the initial condition. The&
-      & file format must be e.g. 'mean0.f00001'")
+    & file format must be e.g. 'mean0.f00001'")
 
     ! Change from "field0.f000*" to "field0.fld" for the fld reader
     call filename_chsuffix(file_name, file_name, 'fld')
@@ -436,7 +436,7 @@ contains
 
           if (sample_mesh_idx .eq. -1) then
              call neko_error("Invalid file name for the initial condition. &
-               &The file format must be e.g. 'mean0.f00001'")
+             &The file format must be e.g. 'mean0.f00001'")
           end if
 
           write (log_buf, '(A,ES12.6)') "Tolerance     : ", tolerance
@@ -470,10 +470,10 @@ contains
 
     if (mesh_mismatch .and. .not. interpolate) then
        call neko_error("The fld file must match the current mesh! &
-         &Use 'interpolate': 'true' to enable interpolation.")
+       &Use 'interpolate': 'true' to enable interpolation.")
     else if (.not. mesh_mismatch .and. interpolate) then
        call neko_log%warning("You have activated interpolation but you might &
-         &still be using the same mesh.")
+       &still be using the same mesh.")
     end if
 
     ! Mesh interpolation if specified
@@ -484,11 +484,11 @@ contains
        type is (fld_file_t)
           if (.not. ft%dp_precision) then
              call neko_warning("The coordinates read from the field file are &
-               &in single precision.")
+             &in single precision.")
              call neko_log%message("It is recommended to use a mesh in double &
-               &precision for better interpolation results.")
+             &precision for better interpolation results.")
              call neko_log%message("If the interpolation does not work, you&
-               &can try to increase the tolerance.")
+             &can try to increase the tolerance.")
           end if
        class default
        end select

--- a/src/fluid/flow_ic.f90
+++ b/src/fluid/flow_ic.f90
@@ -421,7 +421,7 @@ contains
     call filename_chsuffix(file_name, file_name, 'fld')
 
     call fld_data%init
-    f = file_t(trim(file_name))
+    call f%init(trim(file_name))
 
     if (interpolate) then
 

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -1173,7 +1173,7 @@ contains
     end do
 
 
-    bdry_file = file_t('bdry.fld')
+    call bdry_file%init('bdry.fld')
     call bdry_file%write(bdry_field)
 
     call this%scratch%relinquish_field(temp_index)

--- a/src/io/file.f90
+++ b/src/io/file.f90
@@ -55,6 +55,8 @@ module file
   type file_t
      class(generic_file_t), allocatable :: file_type
    contains
+     !> Constructor
+     procedure, pass (this) :: init => file_init
      !> Writes data to a file.
      procedure :: write => file_write
      !> Read @a data from a file.
@@ -75,20 +77,16 @@ module file
      final :: file_free
   end type file_t
 
-  interface file_t
-     module procedure file_init
-  end interface file_t
-
 contains
 
-  !> File reader/writer constructor.
+  !> Constructor.
   !! @param fname Filename.
-  function file_init(fname, header, precision, layout) result(this)
+  subroutine file_init(this, fname, header, precision, layout)
+    class(file_t), intent(inout) :: this
     character(len=*) :: fname
     character(len=*), optional :: header
     integer, optional :: precision
     integer, optional :: layout
-    type(file_t), target :: this
     character(len=80) :: suffix
     class(generic_file_t), pointer :: q
 
@@ -140,7 +138,7 @@ contains
        call this%set_layout(layout)
     end if
 
-  end function file_init
+  end subroutine file_init
 
   !> File operation destructor.
   subroutine file_free(this)

--- a/src/io/file.f90
+++ b/src/io/file.f90
@@ -83,10 +83,10 @@ contains
   !! @param fname Filename.
   subroutine file_init(this, fname, header, precision, layout)
     class(file_t), intent(inout) :: this
-    character(len=*) :: fname
-    character(len=*), optional :: header
-    integer, optional :: precision
-    integer, optional :: layout
+    character(len=*), intent(in) :: fname
+    character(len=*), intent(in), optional :: header
+    integer, intent(in), optional :: precision
+    integer, intent(in), optional :: layout
     character(len=80) :: suffix
     class(generic_file_t), pointer :: q
 

--- a/src/io/output.f90
+++ b/src/io/output.f90
@@ -74,13 +74,13 @@ contains
     integer, intent(in), optional :: layout
 
     if (present(precision) .and. present(layout)) then
-       this%file_ = file_t(fname, precision = precision, layout = layout)
+       call this%file_%init(fname, precision = precision, layout = layout)
     else if (present(precision)) then
-       this%file_ = file_t(fname, precision = precision)
+       call this%file_%init(fname, precision = precision)
     else if (present(layout)) then
-       this%file_ = file_t(fname, layout = layout)
+       call this%file_%init(fname, layout = layout)
     else
-       this%file_ = file_t(fname)
+       call this%file_%init(fname)
     end if
 
   end subroutine output_init

--- a/src/scalar/scalar_ic.f90
+++ b/src/scalar/scalar_ic.f90
@@ -287,7 +287,7 @@ contains
     call filename_chsuffix(file_name, file_name, 'fld')
 
     call fld_data%init
-    f = file_t(trim(file_name))
+    call f%init(trim(file_name))
 
     if (interpolate) then
 

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -242,7 +242,7 @@ contains
     call C%params%get('case.restart_mesh_file', restart_mesh_file, found)
 
     if (found) then
-       previous_meshf = file_t(trim(restart_mesh_file))
+       call previous_meshf%init(trim(restart_mesh_file))
        call previous_meshf%read(C%chkp%previous_mesh)
     end if
 
@@ -250,7 +250,7 @@ contains
 
     if (found) C%chkp%mesh2mesh_tol = tol
 
-    chkpf = file_t(trim(restart_file))
+    call chkpf%init(trim(restart_file))
     call chkpf%read(C%chkp)
     C%time%dtlag = C%chkp%dtlag
     C%time%tlag = C%chkp%tlag
@@ -293,7 +293,7 @@ contains
           format_str = '.h5'
        end if
     end if
-    chkpf = file_t(C%output_directory // 'joblimit'//trim(format_str))
+    call chkpf%init(C%output_directory // 'joblimit'//trim(format_str))
     call chkpf%write(C%chkp, t)
     write(log_buf, '(A)') '! saving checkpoint >>>'
     call neko_log%message(log_buf)

--- a/src/simulation_components/probes.F90
+++ b/src/simulation_components/probes.F90
@@ -485,7 +485,7 @@ contains
     end if
 
     !> Initialize the output file
-    this%fout = file_t(trim(output_file))
+    call this%fout%init(trim(output_file))
 
     select type (ft => this%fout%file_type)
     type is (csv_file_t)
@@ -696,7 +696,7 @@ contains
     !> Supporting variables
     type(file_t) :: file_in
 
-    file_in = file_t(trim(points_file))
+    call file_in%init(trim(points_file))
     !> Reads on rank 0 and distributes the probes across the different ranks
     select type (ft => file_in%file_type)
     type is (csv_file_t)

--- a/src/source_terms/brinkman_source_term.f90
+++ b/src/source_terms/brinkman_source_term.f90
@@ -69,12 +69,12 @@ module brinkman_source_term
      private
 
      !> The unfiltered indicator field
-     type(field_t) :: indicator_unfiltered 
+     type(field_t) :: indicator_unfiltered
      !> The value of the source term.
      type(field_t) :: indicator
      !> Brinkman permeability field.
      type(field_t) :: brinkman
-     !> Filter 
+     !> Filter
      class(filter_t), allocatable :: filter
    contains
      !> The common constructor using a JSON object.
@@ -190,7 +190,7 @@ contains
           ! Initialize the filter
           call this%filter%init(json, coef)
 
-          ! Copy the current indicator to unfiltered (essentially a rename) 
+          ! Copy the current indicator to unfiltered (essentially a rename)
           call field_copy(this%indicator_unfiltered, this%indicator)
 
           ! Apply the filter
@@ -301,7 +301,7 @@ contains
     ! ------------------------------------------------------------------------ !
     ! Load the immersed boundary mesh
 
-    mesh_file = file_t(mesh_file_name)
+    call mesh_file%init(mesh_file_name)
     call mesh_file%read(boundary_mesh)
 
     if (boundary_mesh%nelv .eq. 0) then

--- a/src/source_terms/brinkman_source_term.f90
+++ b/src/source_terms/brinkman_source_term.f90
@@ -161,15 +161,15 @@ contains
        call json_get_or_default(object_settings, 'type', object_type, 'none')
 
        select case (object_type)
-         case ('boundary_mesh')
+       case ('boundary_mesh')
           call this%init_boundary_mesh(object_settings)
-         case ('point_zone')
+       case ('point_zone')
           call this%init_point_zone(object_settings)
 
-         case ('none')
+       case ('none')
           call object_settings%print()
           call neko_error('Brinkman source term objects require a region type')
-         case default
+       case default
           call neko_error('Brinkman source term unknown region type')
        end select
 
@@ -180,36 +180,36 @@ contains
 
     call json_get_or_default(json, 'filter.type', filter_type, 'none')
     select case (filter_type)
-       case ('PDE')
-          ! Initialize the unfiltered design field
-          call this%indicator_unfiltered%init(coef%dof)
+    case ('PDE')
+       ! Initialize the unfiltered design field
+       call this%indicator_unfiltered%init(coef%dof)
 
-          ! Allocate a PDE filter
-          allocate(PDE_filter_t::this%filter)
+       ! Allocate a PDE filter
+       allocate(PDE_filter_t::this%filter)
 
-          ! Initialize the filter
-          call this%filter%init(json, coef)
+       ! Initialize the filter
+       call this%filter%init(json, coef)
 
-          ! Copy the current indicator to unfiltered (essentially a rename)
-          call field_copy(this%indicator_unfiltered, this%indicator)
+       ! Copy the current indicator to unfiltered (essentially a rename)
+       call field_copy(this%indicator_unfiltered, this%indicator)
 
-          ! Apply the filter
-          call this%filter%apply(this%indicator, this%indicator_unfiltered)
+       ! Apply the filter
+       call this%filter%apply(this%indicator, this%indicator_unfiltered)
 
-          ! Set up sampler to include the unfiltered and filtered fields
-          call output%init(sp, 'brinkman', 3)
-          call output%fields%assign_to_field(1, this%indicator_unfiltered)
-          call output%fields%assign_to_field(2, this%indicator)
-          call output%fields%assign_to_field(3, this%brinkman)
+       ! Set up sampler to include the unfiltered and filtered fields
+       call output%init(sp, 'brinkman', 3)
+       call output%fields%assign_to_field(1, this%indicator_unfiltered)
+       call output%fields%assign_to_field(2, this%indicator)
+       call output%fields%assign_to_field(3, this%brinkman)
 
-       case ('none')
-          ! Set up sampler to include the unfiltered field
-          call output%init(sp, 'brinkman', 2)
-          call output%fields%assign_to_field(1, this%indicator)
-          call output%fields%assign_to_field(2, this%brinkman)
+    case ('none')
+       ! Set up sampler to include the unfiltered field
+       call output%init(sp, 'brinkman', 2)
+       call output%fields%assign_to_field(1, this%indicator)
+       call output%fields%assign_to_field(2, this%brinkman)
 
-       case default
-          call neko_error('Brinkman source term unknown filter type')
+    case default
+       call neko_error('Brinkman source term unknown filter type')
     end select
 
     ! ------------------------------------------------------------------------ !
@@ -315,9 +315,9 @@ contains
          mesh_transform, 'none')
 
     select case (mesh_transform)
-      case ('none')
+    case ('none')
        ! Do nothing
-      case ('bounding_box')
+    case ('bounding_box')
        call json_get(json, 'mesh_transform.box_min', box_min)
        call json_get(json, 'mesh_transform.box_max', box_max)
        call json_get_or_default(json, 'mesh_transform.keep_aspect_ratio', &
@@ -325,7 +325,7 @@ contains
 
        if (size(box_min) .ne. 3 .or. size(box_max) .ne. 3) then
           call neko_error('Case file: mesh_transform. &
-               &box_min and box_max must be 3 element arrays of reals')
+          &box_min and box_max must be 3 element arrays of reals')
        end if
 
        call target_box%init(box_min, box_max)
@@ -352,7 +352,7 @@ contains
        write(log_msg, '(A, 3F12.6)') "Translation: ", translation
        call neko_log%message(log_msg)
 
-      case default
+    case default
        call neko_error('Unknown mesh transform')
     end select
 
@@ -368,14 +368,14 @@ contains
 
     ! Select how to transform the distance field to a design field
     select case (distance_transform)
-      case ('smooth_step')
+    case ('smooth_step')
        call json_get(json, 'distance_transform.value', scalar_d)
        scalar_r = real(scalar_d, kind=rp)
 
        call signed_distance_field(temp_field, boundary_mesh, scalar_d)
        call smooth_step_field(temp_field, scalar_r, 0.0_rp)
 
-      case ('step')
+    case ('step')
 
        call json_get(json, 'distance_transform.value', scalar_d)
        scalar_r = real(scalar_d, kind=rp)
@@ -383,7 +383,7 @@ contains
        call signed_distance_field(temp_field, boundary_mesh, scalar_d)
        call step_function_field(temp_field, scalar_r, 1.0_rp, 0.0_rp)
 
-      case default
+    case default
        call neko_error('Unknown distance transform')
     end select
 

--- a/src/wall_models/wall_model.f90
+++ b/src/wall_models/wall_model.f90
@@ -450,7 +450,7 @@ contains
 
     ! Each wall_model bc will do a write unfortunately... But very helpful
     ! for setup debugging.
-    h_file = file_t("sampling_height.fld")
+    call h_file%init("sampling_height.fld")
     call h_file%write(h_field)
   end subroutine wall_model_find_points
 

--- a/tests/bench/ax/driver.f90
+++ b/tests/bench/ax/driver.f90
@@ -14,26 +14,26 @@ program axbench
   real(kind=dp), allocatable :: u(:), ur(:), us(:), ut(:), wk(:)
   real(kind=dp), allocatable :: g(:, :, :, :, :)
   integer :: i
-  
+
   argc = command_argument_count()
 
   if ((argc .lt. 2) .or. (argc .gt. 2)) then
      write(*,*) 'Usage: ./axbench <neko mesh> <N>'
      stop
   end if
-  
-  call neko_init 
-  
+
+  call neko_init
+
   call get_command_argument(1, fname)
   call get_command_argument(2, lxchar)
   read(lxchar, *) lx
-  
-  nmsh_file = file_t(fname)
-  call nmsh_file%read(msh)  
+
+  call nmsh_file%init(fname)
+  call nmsh_file%read(msh)
 
   call space_init(Xh, GLL, lx, lx, lx)
   call w%init(msh, Xh, "w")
- 
+
   allocate(g(6, Xh%lx, Xh%ly, Xh%lz, msh%nelv))
   call setup_g(g, Xh%wx, Xh%lx, Xh%ly, Xh%lz, msh%nelv)
 
@@ -49,18 +49,18 @@ program axbench
   call ax(w, u, g, ur, us, ut, wk, m)
 
   n_glb = n * msh%glb_nelv
-  
+
   call set_timer_flop_cnt(0, msh%glb_nelv, Xh%lx, niter, n_glb)
   do i = 1, niter
      call ax(w, u, g, ur, us, ut, wk, m)
   end do
   call set_timer_flop_cnt(1, msh%glb_nelv, Xh%lx, niter, n_glb)
-  
+
   deallocate(u,ur,us,ut,wk)
   call space_free(Xh)
   call w%free()
   call msh%free()
-  
+
   call neko_finalize
 
 end program axbench
@@ -76,12 +76,12 @@ subroutine set_timer_flop_cnt(iset, nelt, nx1, niter, n)
   integer, intent(inout) :: niter
   integer, intent(inout) :: n
   real(kind=dp), save :: time0, time1, mflops, flop_a, flop_cg
-  integer :: ierr  
+  integer :: ierr
   real(kind=dp) :: nxyz, nx
-  
+
   nx = dble(nx1)
   nxyz = dble(nx1 * nx1 * nx1)
-  call MPI_Barrier(NEKO_COMM, ierr)  
+  call MPI_Barrier(NEKO_COMM, ierr)
   if (iset .eq. 0) then
      time0 = MPI_Wtime()
   else

--- a/tests/bench/gs/driver.f90
+++ b/tests/bench/gs/driver.f90
@@ -37,7 +37,7 @@ program gsbench
   call get_command_argument(2, lxchar)
   read(lxchar, *) lx
 
-  nmsh_file = file_t(fname)
+  call nmsh_file%init(fname)
   call nmsh_file%read(msh)
   call msh%generate_conn()
 

--- a/tests/bench/nekbone/driver.f90
+++ b/tests/bench/nekbone/driver.f90
@@ -21,22 +21,22 @@ program nekobone
      write(*,*) 'Usage: ./nekobone <neko mesh> <N>'
      stop
   end if
-  
-  call neko_init 
-  
+
+  call neko_init
+
   call get_command_argument(1, fname)
   call get_command_argument(2, lxchar)
   read(lxchar, *) lx
-  
-  nmsh_file = file_t(fname)
-  call nmsh_file%read(msh)  
+
+  call nmsh_file%init(fname)
+  call nmsh_file%read(msh)
   call mesh_generate_conn(msh)
 
   call space_init(Xh, GLL, lx, lx, lx)
 
   call dm%init(msh, Xh)
   call gs_init(gs_h, dm)
-  
+
   call field_init(x, msh, Xh, "x")
   call field_init(w, msh, Xh, "work")
 
@@ -46,16 +46,16 @@ program nekobone
 
   allocate(g(6, Xh%lx, Xh%ly, Xh%lz, msh%nelv))
   call setup_g(g, Xh%wx, Xh%lx, Xh%ly, Xh%lz, msh%nelv)
-  
+
   niter = 100
   allocate(f(n), c(n), r(n), p(n), z(n))
   call set_multiplicity(c, n, gs_h)
   call set_f(f, c, n, gs_h)
-  
+
   call cg(x, f, g, c, r, w, p, z, n, msk, niter, gs_h)
 
   n_glb = Xh%lx * Xh%ly * Xh%lz * msh%glb_nelv
-  
+
   call MPI_Barrier(NEKO_COMM, ierr)
 
   call set_timer_flop_cnt(0, msh%glb_nelv, x%Xh%lx, niter, n_glb)
@@ -66,7 +66,7 @@ program nekobone
   call space_free(Xh)
   call field_free(x)
   call mesh_free(msh)
-  
+
   call neko_finalize
 
 end program nekobone


### PR DESCRIPTION
Removes the `= file_t()` constructor and adds the standard `%init` subroutine. As @MartinKarp pointed out, the = don't work well, and we use `%init` for everything else.