### PR TITLE
Fix dangling pointers after fluid/bc refactoring

### DIFF
--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -136,7 +136,7 @@ module bc
      subroutine bc_constructor(this, coef, json)
        import :: bc_t, coef_t, json_file
        class(bc_t), intent(inout), target :: this
-       type(coef_t), intent(in) :: coef
+       type(coef_t), target, intent(in) :: coef
        type(json_file), intent(inout) :: json
      end subroutine bc_constructor
   end interface

--- a/src/bc/blasius.f90
+++ b/src/bc/blasius.f90
@@ -80,7 +80,7 @@ contains
   !! @param[inout] json The JSON object configuring the boundary condition.
   subroutine blasius_init(this, coef, json)
     class(blasius_t), intent(inout), target :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(json_file), intent(inout) :: json
     real(kind=rp) :: delta
     real(kind=rp), allocatable :: uinf(:)
@@ -109,7 +109,7 @@ contains
   subroutine blasius_init_from_components(this, coef, delta, uinf, &
        approximation)
     class(blasius_t), intent(inout), target :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     real(kind=rp) :: delta
     real(kind=rp) :: uinf(3)
     character(len=*) :: approximation

--- a/src/bc/dirichlet.f90
+++ b/src/bc/dirichlet.f90
@@ -70,7 +70,7 @@ contains
   !! @param[inout] json The JSON object configuring the boundary condition.
   subroutine dirichlet_init(this, coef, json)
     class(dirichlet_t), intent(inout), target :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(json_file), intent(inout) ::json
     real(kind=rp) :: g
 
@@ -85,7 +85,7 @@ contains
   !! @param[in] g The value to apply at the boundary.
   subroutine dirichlet_init_from_components(this, coef, g)
     class(dirichlet_t), intent(inout), target :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     real(kind=rp), intent(in) :: g
 
     call this%init_base(coef)

--- a/src/bc/dong_outflow.f90
+++ b/src/bc/dong_outflow.f90
@@ -83,7 +83,7 @@ contains
   !! @param[inout] json The JSON object configuring the boundary condition.
   subroutine dong_outflow_init(this, coef, json)
     class(dong_outflow_t), target, intent(inout) :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(json_file), intent(inout) :: json
     call this%free()
     call this%init_base(coef)

--- a/src/bc/facet_normal.f90
+++ b/src/bc/facet_normal.f90
@@ -81,7 +81,7 @@ contains
   !! @param[inout] json The JSON object configuring the boundary condition.
   subroutine facet_normal_init(this, coef, json)
     class(facet_normal_t), intent(inout), target :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(json_file), intent(inout) ::json
 
     call this%init_from_components(coef)
@@ -91,7 +91,7 @@ contains
   !! @param[in] coef The SEM coefficients.
   subroutine facet_normal_init_from_components(this, coef)
     class(facet_normal_t), intent(inout), target :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
 
     call this%init_base(coef)
   end subroutine facet_normal_init_from_components

--- a/src/bc/field_dirichlet.f90
+++ b/src/bc/field_dirichlet.f90
@@ -122,7 +122,7 @@ contains
   !! @param[inout] json The JSON object configuring the boundary condition.
   subroutine field_dirichlet_init(this, coef, json)
     class(field_dirichlet_t), intent(inout), target :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(json_file), intent(inout) ::json
     character(len=:), allocatable :: field_name
 

--- a/src/bc/field_dirichlet_vector.f90
+++ b/src/bc/field_dirichlet_vector.f90
@@ -96,7 +96,7 @@ contains
   !! @param[inout] json The JSON object configuring the boundary condition.
   subroutine field_dirichlet_vector_init(this, coef, json)
     class(field_dirichlet_vector_t), intent(inout), target :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(json_file), intent(inout) ::json
 
     call this%init_from_components(coef)

--- a/src/bc/inflow.f90
+++ b/src/bc/inflow.f90
@@ -65,7 +65,7 @@ contains
   !! @param[inout] json The JSON object configuring the boundary condition.
   subroutine inflow_init(this, coef, json)
     class(inflow_t), intent(inout), target :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(json_file), intent(inout) ::json
     real(kind=rp), allocatable :: x(:)
 

--- a/src/bc/neumann.f90
+++ b/src/bc/neumann.f90
@@ -86,7 +86,7 @@ contains
   !! @param[inout] json The JSON object configuring the boundary condition.
   subroutine neumann_init(this, coef, json)
     class(neumann_t), intent(inout), target :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(json_file), intent(inout) :: json
     real(kind=rp) :: flux
 

--- a/src/bc/non_normal.f90
+++ b/src/bc/non_normal.f90
@@ -63,7 +63,7 @@ contains
   !! @param[inout] json The JSON object configuring the boundary condition.
   subroutine non_normal_init(this, coef, json)
     class(non_normal_t), target, intent(inout) :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(json_file), intent(inout) ::json
 
     call this%init_from_components(coef)
@@ -73,7 +73,7 @@ contains
   !! @param[in] coef The SEM coefficients.
   subroutine non_normal_init_from_components(this, coef)
     class(non_normal_t), target, intent(inout) :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
 
     call this%free()
     call this%symmetry_t%init_from_components(coef)

--- a/src/bc/shear_stress.f90
+++ b/src/bc/shear_stress.f90
@@ -168,7 +168,7 @@ contains
   !! @param[inout] json The JSON object configuring the boundary condition.
   subroutine shear_stress_init(this, coef, json)
     class(shear_stress_t), target, intent(inout) :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(json_file), intent(inout) ::json
     real(kind=rp), allocatable :: value(:)
 

--- a/src/bc/symmetry.f90
+++ b/src/bc/symmetry.f90
@@ -74,7 +74,7 @@ contains
   !! @param[inout] json The JSON object configuring the boundary condition.
   subroutine symmetry_init(this, coef, json)
     class(symmetry_t), intent(inout), target :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(json_file), intent(inout) ::json
 
     call this%init_from_components(coef)
@@ -85,7 +85,7 @@ contains
   !! @param[in] coef The SEM coefficients.
   subroutine symmetry_init_from_components(this, coef)
     class(symmetry_t), intent(inout), target :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
 
     call this%free()
     this%strong = .false.

--- a/src/bc/usr_inflow.f90
+++ b/src/bc/usr_inflow.f90
@@ -113,7 +113,7 @@ contains
   !! @param[inout] json The JSON object configuring the boundary condition.
   subroutine usr_inflow_init(this, coef, json)
     class(usr_inflow_t), intent(inout), target :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(json_file), intent(inout) ::json
 
     call this%init_base(coef)

--- a/src/bc/usr_scalar.f90
+++ b/src/bc/usr_scalar.f90
@@ -112,7 +112,7 @@ contains
   !! @param[inout] json The JSON object configuring the boundary condition.
   subroutine usr_scalar_init(this, coef, json)
     class(usr_scalar_t), intent(inout), target :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(json_file), intent(inout) :: json
     character(len=:), allocatable :: field_name_temp
 

--- a/src/bc/wall_model_bc.f90
+++ b/src/bc/wall_model_bc.f90
@@ -175,7 +175,7 @@ contains
   !! @param[inout] json The JSON object configuring the boundary condition.
   subroutine wall_model_bc_init(this, coef, json)
     class(wall_model_bc_t), target, intent(inout) :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(json_file), intent(inout) :: json
     real(kind=rp) :: value(3) = [0, 0, 0]
 

--- a/src/bc/zero_dirichlet.f90
+++ b/src/bc/zero_dirichlet.f90
@@ -70,7 +70,7 @@ contains
   !! @param[inout] json The JSON object configuring the boundary condition.
   subroutine zero_dirichlet_init(this, coef, json)
     class(zero_dirichlet_t), intent(inout), target :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(json_file), intent(inout) :: json
 
     call this%init_from_components(coef)
@@ -80,7 +80,7 @@ contains
   !! @param[in] coef The SEM coefficients.
   subroutine zero_dirichlet_init_from_components(this, coef)
     class(zero_dirichlet_t), intent(inout), target :: this
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
 
     call this%init_base(coef)
   end subroutine zero_dirichlet_init_from_components

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -216,7 +216,7 @@ module fluid_pnpn
        class(bc_t), pointer, intent(inout) :: object
        type(fluid_pnpn_t), intent(in) :: scheme
        type(json_file), intent(inout) :: json
-       type(coef_t), intent(in) :: coef
+       type(coef_t), target, intent(in) :: coef
        type(user_t), intent(in) :: user
      end subroutine pressure_bc_factory
   end interface
@@ -233,7 +233,7 @@ module fluid_pnpn
        class(bc_t), pointer, intent(inout) :: object
        type(fluid_pnpn_t), intent(in) :: scheme
        type(json_file), intent(inout) :: json
-       type(coef_t), intent(in) :: coef
+       type(coef_t), target, intent(in) :: coef
        type(user_t), intent(in) :: user
      end subroutine velocity_bc_factory
   end interface
@@ -822,7 +822,7 @@ contains
   !> Sets up the boundary condition for the scheme.
   !! @param user The user interface.
   subroutine fluid_pnpn_setup_bcs(this, user, params)
-    class(fluid_pnpn_t), intent(inout) :: this
+    class(fluid_pnpn_t), target, intent(inout) :: this
     type(user_t), target, intent(in) :: user
     type(json_file), intent(inout) :: params
     integer :: i, n_bcs, zone_index, j, zone_size, global_zone_size, ierr

--- a/src/fluid/fluid_pnpn_bc_fctry.f90
+++ b/src/fluid/fluid_pnpn_bc_fctry.f90
@@ -77,7 +77,7 @@ contains
     class(bc_t), pointer, intent(inout) :: object
     type(fluid_pnpn_t), intent(in) :: scheme
     type(json_file), intent(inout) :: json
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(user_t), intent(in) :: user
     character(len=:), allocatable :: type
     integer :: i, j, k
@@ -139,7 +139,7 @@ contains
     class(bc_t), pointer, intent(inout) :: object
     type(fluid_pnpn_t), intent(in) :: scheme
     type(json_file), intent(inout) :: json
-    type(coef_t), intent(in) :: coef
+    type(coef_t), target, intent(in) :: coef
     type(user_t), intent(in) :: user
     character(len=:), allocatable :: type
     integer :: i, j, k

--- a/src/fluid/fluid_scheme_base.f90
+++ b/src/fluid/fluid_scheme_base.f90
@@ -251,7 +251,7 @@ module fluid_scheme_base
   abstract interface
      subroutine fluid_scheme_setup_bcs_intrf(this, user, params)
        import fluid_scheme_base_t, user_t, json_file
-       class(fluid_scheme_base_t), intent(inout) :: this
+       class(fluid_scheme_base_t), target, intent(inout) :: this
        type(user_t), target, intent(in) :: user
        type(json_file), intent(inout) :: params
      end subroutine fluid_scheme_setup_bcs_intrf

--- a/src/fluid/fluid_scheme_compressible_euler.f90
+++ b/src/fluid/fluid_scheme_compressible_euler.f90
@@ -342,7 +342,7 @@ contains
   !> @param user User-defined boundary conditions
   !> @param params Configuration parameters
   subroutine fluid_scheme_compressible_euler_setup_bcs(this, user, params)
-    class(fluid_scheme_compressible_euler_t), intent(inout) :: this
+    class(fluid_scheme_compressible_euler_t), target, intent(inout) :: this
     type(user_t), target, intent(in) :: user
     type(json_file), intent(inout) :: params
     integer :: i, n_bcs, zone_index, j, zone_size, global_zone_size, ierr

--- a/src/fluid/fluid_scheme_incompressible.f90
+++ b/src/fluid/fluid_scheme_incompressible.f90
@@ -597,7 +597,7 @@ contains
   !! @param params The case paramter file.
   !! @param user The user interface.
   subroutine fluid_scheme_set_material_properties(this, params, user)
-    class(fluid_scheme_incompressible_t), intent(inout) :: this
+    class(fluid_scheme_incompressible_t), target, intent(inout) :: this
     type(json_file), intent(inout) :: params
     type(user_t), target, intent(in) :: user
     character(len=LOG_SIZE) :: log_buf


### PR DESCRIPTION
Fix several danling pointers introduced by recent refactoring of fluid and bc strucutres.

To find these, compiel with nagfor -C=dangling