### PR TITLE
Added tanh Blasius profile

### DIFF
--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -436,6 +436,7 @@ file documentation.
       - `cubic`, cubic approximation.
       - `quartic`, quartic approximation.
       - `sin`, sine function approximation.
+      - `tanh`, hyperbolic tangent approximation of Savaş (2012). In this case `delta` is the 99\% thickness.
 4. `point_zone`, the values are set to a constant base value, supplied under the
    `base_value` keyword, and then assigned a zone value inside a point zone. The
    point zone is specified by the `name` keyword, and should be defined in the
@@ -774,7 +775,7 @@ concisely directly in the table.
 | `initial_condition.tolerance`           | If `"type" = "field"`, and file type is `chkp`, tolerance to use for mesh interpolation.          | Positive real.                                              | 1e-6          |
 | `blasius.delta`                         | Boundary layer thickness in the Blasius profile.                                                  | Positive real                                               | -             |
 | `blasius.freestream_velocity`           | Free-stream velocity in the Blasius profile.                                                      | Vector of 3 reals                                           | -             |
-| `blasius.approximation`                 | Numerical approximation of the Blasius profile.                                                   | `linear`, `quadratic`, `cubic`, `quartic`, `sin`            | -             |
+| `blasius.approximation`                 | Numerical approximation of the Blasius profile.                                                   | `linear`, `quadratic`, `cubic`, `quartic`, `sin`, `tanh`    | -             |
 | `shear_stress.value`                    | The shear stress vector value for `sh` boundaries                                                 | Vector of 3 reals                                           | `[0, 0, 0]`   |
 | `wall_modelling.type`                   | The wall model type for `wm` boundaries. See documentation for additional config parameters.      | `rough_log_law`, `spalding`                                 | -             |
 | `source_terms`                          | Array of JSON objects, defining additional source terms.                                          | See list of source terms above                              | -             |

--- a/src/bc/blasius.f90
+++ b/src/bc/blasius.f90
@@ -130,6 +130,8 @@ contains
        this%bla => blasius_quartic
     case ('sin')
        this%bla => blasius_sin
+    case ('tanh')
+       this%bla => blasius_tanh
     case default
        call neko_error('Invalid Blasius approximation')
     end select
@@ -318,6 +320,8 @@ contains
        this%bla => blasius_quartic
     case ('sin')
        this%bla => blasius_sin
+    case ('tanh')
+       this%bla => blasius_tanh
     case default
        call neko_error('Invalid Blasius approximation')
     end select

--- a/src/fluid/flow_ic.f90
+++ b/src/fluid/flow_ic.f90
@@ -37,7 +37,7 @@ module flow_ic
   use gather_scatter, only : gs_t, GS_OP_ADD
   use neko_config, only : NEKO_BCKND_DEVICE
   use flow_profile, only : blasius_profile, blasius_linear, blasius_cubic, &
-       blasius_quadratic, blasius_quartic, blasius_sin
+       blasius_quadratic, blasius_quartic, blasius_sin, blasius_tanh
   use device, only: device_memcpy, HOST_TO_DEVICE
   use field, only : field_t
   use utils, only : neko_error, filename_suffix, filename_chsuffix, &
@@ -289,6 +289,8 @@ contains
        bla => blasius_quartic
     case ('sin')
        bla => blasius_sin
+    case ('tanh')
+       bla => blasius_tanh
     case default
        call neko_error('Invalid Blasius approximation')
     end select

--- a/src/fluid/flow_profile.f90
+++ b/src/fluid/flow_profile.f90
@@ -46,7 +46,7 @@ module flow_profile
   end interface
 
   public :: blasius_profile, blasius_linear, blasius_cubic, blasius_quadratic, &
-            blasius_quartic, blasius_sin
+            blasius_quartic, blasius_sin, blasius_tanh
 
 contains
 
@@ -135,5 +135,21 @@ contains
     end if
 
   end function blasius_sin
+
+  !> Hyperbolic tangent approximate Blasius Profile from O. Savas (2012)
+  !! \f$ \frac{u}{U} = (\tanh((5.075 a \frac{y}{\delta})^n))^{1/n} \f$
+  !! where \f$ \delta \f$ is the 99 percent thickness and the
+  !! coefficients are \f$ a = 0.33245 \f$ and \f$ n = 5/3 \f$
+  !! Reference: https://doi.org/10.1016/j.cnsns.2012.02.002
+  function blasius_tanh(y, delta, u)
+    real(kind=rp), intent(in) :: y, delta, u
+    real(kind=rp) :: blasius_tanh
+    real(kind=rp), parameter :: a = 0.33245_rp, &
+                                n = 5.0_rp/3.0_rp, &
+                                eta99 = 5.075
+
+    blasius_tanh = u * tanh((a * eta99 * (y/delta))**n)**(1/n)
+
+  end function blasius_tanh
 
 end module flow_profile


### PR DESCRIPTION
Adding the tanh-based Blasius profile approximation from [Ö. Savaş (2012)](https://doi.org/10.1016/j.cnsns.2012.02.002) (equations 2 and 11), which has good accuracy compared to the existing approximations. 

The only notable difference to existing approximations is that `delta` in this case corresponds to the 99\% thickness, such that flow for $y > \delta$ takes the slowly varying value of the approximation instead of an imposed constant $U_\infty$. `delta` could be changed to correspond to a different percent thickness if you think that would be more appropriate.

![blasius_profiles](https://github.com/user-attachments/assets/04e68427-721b-4b0d-b613-3cecd83a9c0b)
