### PR TITLE
Add a device_memset before any gs operations (for extra safety)

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -45,7 +45,7 @@ gs/bcknd/device/gs_device.lo : gs/bcknd/device/gs_device.F90 common/utils.lo dev
 gs/gs_ops.lo : gs/gs_ops.f90 
 gs/gs_comm.lo : gs/gs_comm.f90 adt/stack.lo comm/comm.lo config/num_types.lo 
 gs/gs_mpi.lo : gs/gs_mpi.f90 comm/comm.lo adt/stack.lo gs/gs_ops.lo gs/gs_comm.lo config/num_types.lo 
-gs/bcknd/device/gs_device_mpi.lo : gs/bcknd/device/gs_device_mpi.F90 common/utils.lo device/device.lo adt/htable.lo comm/comm.lo adt/stack.lo gs/gs_ops.lo gs/gs_comm.lo config/num_types.lo 
+gs/bcknd/device/gs_device_mpi.lo : gs/bcknd/device/gs_device_mpi.F90 common/utils.lo device/device.lo adt/htable.lo comm/comm.lo adt/stack.lo gs/gs_comm.lo config/num_types.lo 
 gs/bcknd/device/gs_device_nccl.lo : gs/bcknd/device/gs_device_nccl.F90 common/utils.lo device/device.lo adt/htable.lo comm/comm.lo adt/stack.lo gs/gs_ops.lo gs/gs_comm.lo config/num_types.lo 
 gs/bcknd/device/gs_device_shmem.lo : gs/bcknd/device/gs_device_shmem.F90 common/utils.lo comm/comm.lo device/device.lo adt/htable.lo adt/stack.lo gs/gs_ops.lo gs/gs_comm.lo config/num_types.lo 
 gs/gather_scatter.lo : gs/gather_scatter.f90 device/device.lo common/profiler.lo common/log.lo common/utils.lo adt/stack.lo adt/htable.lo config/num_types.lo field/field.lo sem/dofmap.lo comm/comm.lo mesh/mesh.lo gs/bcknd/device/gs_device_shmem.lo gs/bcknd/device/gs_device_nccl.lo gs/bcknd/device/gs_device_mpi.lo gs/gs_mpi.lo gs/gs_comm.lo gs/gs_ops.lo gs/bcknd/cpu/gs_cpu.lo gs/bcknd/sx/gs_sx.lo gs/bcknd/device/gs_device.lo gs/gs_bcknd.lo config/neko_config.lo 

--- a/src/.depends
+++ b/src/.depends
@@ -41,7 +41,7 @@ sem/bcknd/device/device_coef.lo : sem/bcknd/device/device_coef.F90 common/utils.
 gs/gs_bcknd.lo : gs/gs_bcknd.f90 config/num_types.lo 
 gs/bcknd/cpu/gs_cpu.lo : gs/bcknd/cpu/gs_cpu.f90 gs/gs_ops.lo gs/gs_bcknd.lo config/num_types.lo 
 gs/bcknd/sx/gs_sx.lo : gs/bcknd/sx/gs_sx.f90 gs/gs_ops.lo gs/gs_bcknd.lo config/num_types.lo 
-gs/bcknd/device/gs_device.lo : gs/bcknd/device/gs_device.F90 common/utils.lo gs/gs_ops.lo device/device.lo gs/gs_bcknd.lo config/num_types.lo config/neko_config.lo 
+gs/bcknd/device/gs_device.lo : gs/bcknd/device/gs_device.F90 common/utils.lo device/device.lo gs/gs_bcknd.lo config/num_types.lo 
 gs/gs_ops.lo : gs/gs_ops.f90 
 gs/gs_comm.lo : gs/gs_comm.f90 adt/stack.lo comm/comm.lo config/num_types.lo 
 gs/gs_mpi.lo : gs/gs_mpi.f90 comm/comm.lo adt/stack.lo gs/gs_ops.lo gs/gs_comm.lo config/num_types.lo 

--- a/src/gs/bcknd/device/gs_device.F90
+++ b/src/gs/bcknd/device/gs_device.F90
@@ -1,4 +1,4 @@
-! Copyright (c) 2021-2022, The Neko Authors
+! Copyright (c) 2021-2025, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -32,14 +32,15 @@
 !
 !> Generic Gather-scatter backend for accelerators
 module gs_device
-  use neko_config
-  use num_types
-  use gs_bcknd
-  use device
-  use gs_ops
-  use utils
+  use num_types, only : rp, c_rp
+  use gs_bcknd, only : gs_bcknd_t
+  use device, only : device_map, device_memcpy, device_memset, &
+       device_free, device_event_destroy, device_event_create, &
+       device_event_record, device_get_ptr, glb_cmd_queue, &
+       device_sync, HOST_TO_DEVICE, DEVICE_TO_HOST
+  use utils, only: neko_error
   use, intrinsic :: iso_c_binding, only : c_ptr, c_int, C_NULL_PTR, &
-       c_associated
+       c_associated, c_sizeof, c_size_t
   implicit none
   private
 
@@ -256,6 +257,12 @@ contains
 
          if (.not. c_associated(v_d)) then
             call device_map(v, v_d, m)
+            block
+              real(c_rp) :: rp_dummy
+              integer(c_size_t) :: s
+              s = c_sizeof(rp_dummy) * m
+              call device_memset(v_d, 0, s, strm = strm)
+            end block
          end if
 
          if (.not. c_associated(dg_d)) then
@@ -310,6 +317,12 @@ contains
 
          if (.not. c_associated(v_d)) then
             call device_map(v, v_d, m)
+            block
+              real(c_rp) :: rp_dummy
+              integer(c_size_t) :: s
+              s = c_sizeof(rp_dummy) * m
+              call device_memset(v_d, 0, s, strm = strm)
+            end block
          end if
 
          if (.not. c_associated(dg_d)) then

--- a/src/gs/bcknd/device/gs_device_mpi.F90
+++ b/src/gs/bcknd/device/gs_device_mpi.F90
@@ -1,4 +1,4 @@
-! Copyright (c) 2020-2023, The Neko Authors
+! Copyright (c) 2020-2025, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -34,11 +34,14 @@
 module gs_device_mpi
   use num_types, only : rp, c_rp
   use gs_comm, only : gs_comm_t
-  use gs_ops
   use stack, only : stack_i4_t
   use comm, only : pe_size, pe_rank
   use htable, only : htable_i4_t
-  use device
+  use device, only : device_memcpy, device_alloc, device_event_create, &
+       device_event_destroy, device_stream_create_with_priority, device_sync, &
+       device_stream_wait_event, device_get_ptr, device_event_record, &
+       device_stream_destroy, device_free, device_memset, &
+       STRM_HIGH_PRIO, HOST_TO_DEVICE
   use utils, only : neko_error
   use, intrinsic :: iso_c_binding, only : c_sizeof, c_int32_t, &
        c_ptr, C_NULL_PTR, c_size_t, c_associated
@@ -218,6 +221,7 @@ contains
 
     sz = c_sizeof(rp_dummy) * total
     call device_alloc(this%buf_d, sz)
+    call device_memset(this%buf_d, 0, sz, sync=.true.)
 
     sz = c_sizeof(i4_dummy) * total
     call device_alloc(this%dof_d, sz)


### PR DESCRIPTION
Add a memset after gs buffers are allocated. This is not needed for normal gather-scatter operations since they operate on the full length (m) for each call, however async. operations (as the ones done by global interpolation #1542, could be different).

This is similar to what was done in #1932, but here we use memset in the operating stream, thus reduce the numbers of global sync. points.