### PR TITLE
Add _ to ksp names

### DIFF
--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -320,15 +320,15 @@ A more detailed description of each boundary condition is provided below.
   ```
 * `outflow+user`. Same as `outflow`, but with user-specified
   pressure. The pressure is specified via the same interface as `user_pressure`,
-  see the 
+  see the
   [relevant section](#user-file_field-dirichlet-update) for more information.
 
 * `normal_outflow+user`. Same as `normal_outflow`, but with user-specified
-  pressure. The pressure profile is specified via the same interface as 
+  pressure. The pressure profile is specified via the same interface as
   `user_pressure`, see
   the [relevant section](#user-file_field-dirichlet-update) for more information.
   Note that, similarly to `normal_outflow`, surface-parallel velocity components
-  are taken from the initial conditions. 
+  are taken from the initial conditions.
 
 * `outflow+dong`. Same as `outflow`, but additionally applies the Dong boundary
   condition on the pressure. This is a way to prevent backflow and therefore
@@ -672,14 +672,14 @@ The following keywords are used, with the corresponding options.
 
 * `type`, solver type.
   - `cg`, a conjugate gradient solver.
-  - `pipecg`, a pipelined conjugate gradient solver.
+  - `pipe_cg`, a pipelined conjugate gradient solver.
   - `bicgstab`, a bi-conjugate gradient stabilized solver.
-  - `cacg`, a communication-avoiding conjugate gradient solver.
-  - `coupledcg`, a coupled conjugate gradient solver. Must be used for velocity
+  - `ca_cg`, a communication-avoiding conjugate gradient solver.
+  - `coupled_cg`, a coupled conjugate gradient solver. Must be used for velocity
     when viscosity varies in space.
   - `gmres`, a GMRES solver. Typically used for pressure.
-  - `fusedcg`, a conjugate gradient solver optimised for accelerators using
-  - `fusedcoupledcg`, a coupled conjugate gradient solver optimised for accelerators using
+  - `fused_cg`, a conjugate gradient solver optimised for accelerators using
+  - `fused_coupled_cg`, a coupled conjugate gradient solver optimised for accelerators using
     kernel fusion. Must be used for velocity when viscosity varies in space and
     device backened is used.
     using kernel fusion.

--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -672,9 +672,9 @@ The following keywords are used, with the corresponding options.
 
 * `type`, solver type.
   - `cg`, a conjugate gradient solver.
-  - `pipe_cg`, a pipelined conjugate gradient solver.
+  - `pipecg`, a pipelined conjugate gradient solver.
   - `bicgstab`, a bi-conjugate gradient stabilized solver.
-  - `ca_cg`, a communication-avoiding conjugate gradient solver.
+  - `cacg`, a communication-avoiding conjugate gradient solver.
   - `coupled_cg`, a coupled conjugate gradient solver. Must be used for velocity
     when viscosity varies in space.
   - `gmres`, a GMRES solver. Typically used for pressure.

--- a/src/krylov/krylov_fctry.f90
+++ b/src/krylov/krylov_fctry.f90
@@ -106,7 +106,7 @@ contains
           call neko_error('Coupled CG only supported for CPU')
        end if
 
-    case ('pipe_cg')
+    case ('pipecg')
        if (NEKO_BCKND_SX .eq. 1) then
           allocate(sx_pipecg_t::object)
        else if (NEKO_BCKND_DEVICE .eq. 1) then
@@ -138,7 +138,7 @@ contains
           call neko_error('Coupled FusedCG only supported for CUDA/HIP')
        end if
 
-    case ('ca_cg')
+    case ('cacg')
        allocate(cacg_t::object)
 
     case ('gmres')

--- a/src/krylov/krylov_fctry.f90
+++ b/src/krylov/krylov_fctry.f90
@@ -56,14 +56,14 @@ submodule (krylov) krylov_fctry
   ! List of all possible types created by the factory routine
   character(len=20) :: KSP_KNOWN_TYPES(9) = [character(len=20) :: &
        "cg", &
-       "pipecg", &
-       "fusedcg", &
-       "cacg", &
+       "pipe_cg", &
+       "fused_cg", &
+       "ca_cg", &
        "gmres", &
        "cheby", &
        "bicgstab", &
-       "fusedcoupledcg", &
-       "coupledcg"]
+       "fused_coupled_cg", &
+       "coupled_cg"]
 
 contains
 
@@ -100,13 +100,13 @@ contains
           allocate(cg_t::object)
        end if
 
-    case ('coupledcg')
+    case ('coupled_cg')
        allocate(cg_cpld_t::object)
        if (NEKO_BCKND_DEVICE .eq. 1) then
           call neko_error('Coupled CG only supported for CPU')
        end if
 
-    case ('pipecg')
+    case ('pipe_cg')
        if (NEKO_BCKND_SX .eq. 1) then
           allocate(sx_pipecg_t::object)
        else if (NEKO_BCKND_DEVICE .eq. 1) then
@@ -118,7 +118,7 @@ contains
           allocate(pipecg_t::object)
        end if
 
-    case ('fusedcg')
+    case ('fused_cg')
        if (NEKO_BCKND_DEVICE .eq. 1) then
           if (NEKO_BCKND_OPENCL .eq. 1) then
              call neko_error('FusedCG not supported for OpenCL')
@@ -128,7 +128,7 @@ contains
           call neko_error('FusedCG only supported for CUDA/HIP')
        end if
 
-    case ('fusedcoupledcg')
+    case ('fused_coupled_cg')
        if (NEKO_BCKND_DEVICE .eq. 1) then
           if (NEKO_BCKND_OPENCL .eq. 1) then
              call neko_error('Coupled FusedCG not supported for OpenCL')
@@ -138,7 +138,7 @@ contains
           call neko_error('Coupled FusedCG only supported for CUDA/HIP')
        end if
 
-    case ('cacg')
+    case ('ca_cg')
        allocate(cacg_t::object)
 
     case ('gmres')

--- a/src/krylov/krylov_fctry.f90
+++ b/src/krylov/krylov_fctry.f90
@@ -56,9 +56,9 @@ submodule (krylov) krylov_fctry
   ! List of all possible types created by the factory routine
   character(len=20) :: KSP_KNOWN_TYPES(9) = [character(len=20) :: &
        "cg", &
-       "pipe_cg", &
+       "pipecg", &
        "fused_cg", &
-       "ca_cg", &
+       "cacg", &
        "gmres", &
        "cheby", &
        "bicgstab", &


### PR DESCRIPTION
Closes issue #1620 by adding _ to some of the KSP type names. None used in examples, as far as I can see. Will break LES cases.