### PR TITLE
Time-step log, Field variable name field too short

### DIFF
--- a/src/krylov/krylov.f90
+++ b/src/krylov/krylov.f90
@@ -55,7 +55,7 @@ module krylov
   !> Type for storing initial and final residuals in a Krylov solver.
   type, public :: ksp_monitor_t
      !> Name of the solver in question
-     character(len=10) :: name
+     character(len=18) :: name
      !> Iteration number.
      integer :: iter
      !> Initial residual.
@@ -380,7 +380,7 @@ contains
     class(ksp_monitor_t), intent(in) :: this
     character(len=LOG_SIZE) :: log_buf
 
-    write(log_buf, '((A5,7x),A3,(A5,5x),1x,A6,3x,A15,3x,A15)') &
+    write(log_buf, '((A5,7x),A3,(A5,13x),1x,A6,3x,A15,3x,A15)') &
          'Step:', ' | ', 'Field:', 'Iters:', &
          'Start residual:', 'Final residual:'
     call neko_log%message(log_buf)
@@ -396,7 +396,7 @@ contains
     character(len=:), allocatable :: output_format
 
     ! Define the output format
-    output_format = '(A12,A3,A10,1x,I6,3x,E15.9,3x,E15.9)'
+    output_format = '(A12,A3,A18,1x,I6,3x,E15.9,3x,E15.9)'
     write(step_str, '(I12)') step
     step_str = adjustl(step_str)
 

--- a/tests/regression/cylinder/test.sh
+++ b/tests/regression/cylinder/test.sh
@@ -14,10 +14,10 @@ ref2=ref2_${2}.log
 # We look for the 11'th pressure iterations and 3 lines following it.
 # Here we trim the first column, which is the time step number, since that is
 # not relevant for the comparison.
-grep -A3 -E ' 11\s+\| Pressure' log1 | sed 's/^[^|]*|/|/' >l1
-grep -A3 -E '  6\s+\| Pressure' log2 | sed 's/^[^|]*|/|/' >l2
-grep -A3 -E ' 11\s+\| Pressure' $ref1 | sed 's/^[^|]*|/|/' >r1
-grep -A3 -E '  6\s+\| Pressure' $ref2 | sed 's/^[^|]*|/|/' >r2
+grep -A3 -E ' 11\s+\| Pressure' log1 | sed 's/^[^|]*|/|/' | tr -s '[:space:]' >l1
+grep -A3 -E '  6\s+\| Pressure' log2 | sed 's/^[^|]*|/|/' | tr -s '[:space:]' >l2
+grep -A3 -E ' 11\s+\| Pressure' $ref1 | sed 's/^[^|]*|/|/' | tr -s '[:space:]' >r1
+grep -A3 -E '  6\s+\| Pressure' $ref2 | sed 's/^[^|]*|/|/' | tr -s '[:space:]' >r2
 
 # Compare that they are identical to what was done before
 diff l1 r1 >res

--- a/tests/regression/cylinder/test_easy.sh
+++ b/tests/regression/cylinder/test_easy.sh
@@ -11,16 +11,16 @@ ref1=ref1_${2}.log
 ref2=ref2_${2}.log
 
 # Check that first residual is the same, allowed to differ on last digit...
-grep -E '\d+\s+\| Pressure' log1 | head -1 >l1
-grep -E '\d+\s+\| Pressure' ${ref1} | head -1 >r1
+grep -E '\d+\s+\| Pressure' log1 | head -1 | tr -s '[:space:]' >l1
+grep -E '\d+\s+\| Pressure' ${ref1} | head -1 | tr -s '[:space:]' >r1
 diff l1 r1 >res
 # Check that we do same number of residuals
 grep -E '\d+\s+\| Pressure' log1 | wc -l >l1
 grep -E '\d+\s+\| Pressure' ${ref1} | wc -l >r1
 diff l1 r1 >>res
 # Check that residual is same after restart
-grep -E ' 7\s+\| Pressure' log1 | sed 's/^[^|]*|/|/' >l1
-grep -E ' 2\s+\| Pressure' log2 | sed 's/^[^|]*|/|/' >l2
+grep -E ' 7\s+\| Pressure' log1 | sed 's/^[^|]*|/|/' | tr -s '[:space:]' >l1
+grep -E ' 2\s+\| Pressure' log2 | sed 's/^[^|]*|/|/' | tr -s '[:space:]' >l2
 diff l1 l2 >res
 
 if [ -s res ]; then


### PR DESCRIPTION
Extends field name to the limit of our log size.
Should give more flexibility on the descriptive names.

Fixes ExtremeFLOW/neko#1974