### PR TITLE
Adds a python log parser for neko logs

### DIFF
--- a/contrib/neko_log_parser/neko_log_parser.py
+++ b/contrib/neko_log_parser/neko_log_parser.py
@@ -110,7 +110,7 @@ def save_as_csv(array, columns, output_file):
 
     header = ",".join(columns)
     np.savetxt(
-        output_file, array, delimiter=",", header=header, comments="", fmt="fmt=%.17e"
+        output_file, array, delimiter=",", header=header, comments="", fmt="%.17e"
     )
     print(f"Saved CSV to {output_file}")
 


### PR DESCRIPTION
Pretty shamelessly vibe-coded, but seems to work well. Builds a json-like dict tree, that can be output json, csv and hdf5. Extracts t, dt, CFL, total step wall time, and then for each field the iterations, start and end residuals.
