### PR TITLE
Fix missing case.time object and improve configuration files

### DIFF
--- a/examples/api/c/cylinder.case
+++ b/examples/api/c/cylinder.case
@@ -7,10 +7,12 @@
     "output_checkpoints": true,
     "checkpoint_control": "simulationtime",
     "checkpoint_value": 50,
-    "end_time": 200.0,
-    "variable_timestep": true,
-    "target_cfl": 0.5,
-    "max_timestep": 1e-1,
+    "time": {
+        "end_time": 200.0,
+        "variable_timestep": true,
+        "target_cfl": 0.5,
+        "max_timestep": 1e-1
+    },
     "numerics": {
         "time_order": 3,
         "polynomial_order": 5,

--- a/examples/api/pyneko/cylinder.case
+++ b/examples/api/pyneko/cylinder.case
@@ -7,10 +7,12 @@
     "output_checkpoints": true,
     "checkpoint_control": "simulationtime",
     "checkpoint_value": 50,
-    "end_time": 200.0,
-    "variable_timestep": true,
-    "target_cfl": 0.5,
-    "max_timestep": 1e-1,
+    "time": {
+        "end_time": 200.0,
+        "variable_timestep": true,
+        "target_cfl": 0.5,
+        "max_timestep": 1e-1
+    },
     "numerics": {
         "time_order": 3,
         "polynomial_order": 5,

--- a/examples/hemi/run.sh
+++ b/examples/hemi/run.sh
@@ -2,5 +2,4 @@
 rea2nbin hemi.re2
 
 # Run
-mpirun -n 12 neko hemi.case
-
+mpirun -n 4 neko hemi.case

--- a/examples/lid/lid.case
+++ b/examples/lid/lid.case
@@ -1,64 +1,66 @@
 // Case file for the lid-driven cavity
 // Here, a 3D mesh is loaded.
 {
-  "version": 1.0,
-  "case":
-  {
-  "mesh_file": "lid.nmsh",
-  "end_time": 300,
-  "output_at_end": false,
-  "output_checkpoints": false,
-  "variable_timestep": true,
-  "max_timestep": 0.25e-2,
-  // some options for timestepping to play around
-  //"target_cfl": 0.2,
-  //"timestep": 1e-3,
-  "numerics": {
-    "time_order": 3,
-    "polynomial_order": 7,
-    "dealias": true
-  },
-  "fluid": {
-    "scheme": "pnpn",
-    "Re": 3000,
-    "inflow_condition": {
-      "type": "user"
-    },
-    // frequency of postprocessing (energy and enstrophy)
-    "ipostproc": 50,
-    "initial_condition": {
-      "type": "user"
-    },
-    "velocity_solver": {
-      "type": "cg",
-      "preconditioner": {
-          "type": "jacobi"
-      },
-      "absolute_tolerance": 1e-7,
-      "max_iterations": 200,
-      "projection_space_size": 8,
-    },
-    "pressure_solver": {
-      "type": "gmres",
-      "preconditioner": {
-          "type": "hsmg"
-      },
-      "projection_space_size": 8,
-      "absolute_tolerance": 1e-7,
-      "max_iterations": 200
-    },
-    "output_control": "simulationtime",
-    "output_value": 5.,
-    "boundary_conditions": [
-      {
-        "type": "no_slip",
-        "zone_indices": [1]
-      },
-      {
-        "type": "user_velocity_pointwise",
-        "zone_indices": [2]
-      }
-    ]
-  },
-  }
+    "version": 1.0,
+    "case":
+    {
+        "mesh_file": "lid.nmsh",
+        "output_at_end": false,
+        "output_checkpoints": false,
+        "time": {
+            "end_time": 300,
+            "variable_timestep": true,
+            "max_timestep": 0.25e-2,
+            // some options for timestepping to play around
+            //"target_cfl": 0.2,
+            //"timestep": 1e-3,
+        },
+        "numerics": {
+            "time_order": 3,
+            "polynomial_order": 7,
+            "dealias": true
+        },
+        "fluid": {
+            "scheme": "pnpn",
+            "Re": 3000,
+            "inflow_condition": {
+                "type": "user"
+            },
+            // frequency of postprocessing (energy and enstrophy)
+            "ipostproc": 50,
+            "initial_condition": {
+                "type": "user"
+            },
+            "velocity_solver": {
+                "type": "cg",
+                "preconditioner": {
+                    "type": "jacobi"
+                },
+                "absolute_tolerance": 1e-7,
+                "max_iterations": 200,
+                "projection_space_size": 8,
+            },
+            "pressure_solver": {
+                "type": "gmres",
+                "preconditioner": {
+                    "type": "hsmg"
+                },
+                "projection_space_size": 8,
+                "absolute_tolerance": 1e-7,
+                "max_iterations": 200
+            },
+            "output_control": "simulationtime",
+            "output_value": 5.,
+            "boundary_conditions": [
+                {
+                    "type": "no_slip",
+                    "zone_indices": [ 1 ]
+                },
+                {
+                    "type": "user_velocity_pointwise",
+                    "zone_indices": [ 2 ]
+                }
+            ]
+        },
+    }
 }

--- a/examples/lid/lid2d.case
+++ b/examples/lid/lid2d.case
@@ -2,64 +2,66 @@
 // Here, a 2D mesh is loaded, which is then extended to a 3D
 // mesh with width one element.
 {
-  "version": 1.0,
-  "case":
-  {
-  "mesh_file": "lid2d.nmsh",
-  "end_time": 300,
-  "output_at_end": false,
-  "output_checkpoints": false,
-  "variable_timestep": true,
-  "max_timestep": 0.25e-2,
-  // some options for timestepping to play around
-  //"target_cfl": 0.2,
-  //"timestep": 1e-3,
-  "numerics": {
-    "time_order": 3,
-    "polynomial_order": 7,
-    "dealias": true
-  },
-  "fluid": {
-    "scheme": "pnpn",
-    "Re": 3000,
-    "inflow_condition": {
-      "type": "user"
-    },
-    // frequency of postprocessing (energy and enstrophy)
-    "ipostproc": 50,
-    "initial_condition": {
-      "type": "user"
-    },
-    "velocity_solver": {
-      "type": "cg",
-      "preconditioner": {
-          "type": "jacobi"
-      },
-      "absolute_tolerance": 1e-7,
-      "max_iterations": 200,
-      "projection_space_size": 8,
-    },
-    "pressure_solver": {
-      "type": "gmres",
-      "preconditioner": {
-          "type": "hsmg"
-      },
-      "projection_space_size": 8,
-      "absolute_tolerance": 1e-7,
-      "max_iterations": 200
-    },
-    "output_control": "simulationtime",
-    "output_value": 5.,
-    "boundary_conditions": [
-      {
-        "type": "no_slip",
-        "zone_indices": [1]
-      },
-      {
-        "type": "user_velocity_pointwise",
-        "zone_indices": [2]
-      }
-    ]
-  },
-  }
+    "version": 1.0,
+    "case":
+    {
+        "mesh_file": "lid2d.nmsh",
+        "output_at_end": false,
+        "output_checkpoints": false,
+        "time": {
+            "end_time": 300,
+            "variable_timestep": true,
+            "max_timestep": 0.25e-2,
+            // some options for timestepping to play around
+            //"target_cfl": 0.2,
+            //"timestep": 1e-3,
+        },
+        "numerics": {
+            "time_order": 3,
+            "polynomial_order": 7,
+            "dealias": true
+        },
+        "fluid": {
+            "scheme": "pnpn",
+            "Re": 3000,
+            "inflow_condition": {
+                "type": "user"
+            },
+            // frequency of postprocessing (energy and enstrophy)
+            "ipostproc": 50,
+            "initial_condition": {
+                "type": "user"
+            },
+            "velocity_solver": {
+                "type": "cg",
+                "preconditioner": {
+                    "type": "jacobi"
+                },
+                "absolute_tolerance": 1e-7,
+                "max_iterations": 200,
+                "projection_space_size": 8,
+            },
+            "pressure_solver": {
+                "type": "gmres",
+                "preconditioner": {
+                    "type": "hsmg"
+                },
+                "projection_space_size": 8,
+                "absolute_tolerance": 1e-7,
+                "max_iterations": 200
+            },
+            "output_control": "simulationtime",
+            "output_value": 5.,
+            "boundary_conditions": [
+                {
+                    "type": "no_slip",
+                    "zone_indices": [ 1 ]
+                },
+                {
+                    "type": "user_velocity_pointwise",
+                    "zone_indices": [ 2 ]
+                }
+            ]
+        },
+    }
 }

--- a/examples/rayleigh_benard_cylinder/rayleigh.case
+++ b/examples/rayleigh_benard_cylinder/rayleigh.case
@@ -101,7 +101,7 @@
                 "output_file": "output.csv",
                 "fields": [
                     "w",
-                    "s"
+                    "temperature"
                 ]
             }
         ]

--- a/examples/turb_pipe/turb_pipe_source.case
+++ b/examples/turb_pipe/turb_pipe_source.case
@@ -31,14 +31,18 @@
             },
             "velocity_solver": {
                 "type": "cg",
-                "preconditioner": "jacobi",
+                "preconditioner": {
+                    "type": "jacobi"
+                },
                 "projection_space_size": 3,
                 "absolute_tolerance": 1e-7,
                 "max_iterations": 800
             },
             "pressure_solver": {
                 "type": "gmres",
-                "preconditioner": "hsmg",
+                "preconditioner": {
+                    "type": "hsmg"
+                },
                 "projection_space_size": 10,
                 "absolute_tolerance": 1e-4,
                 "max_iterations": 800


### PR DESCRIPTION
The changes address multiple issues related to missing `case.time` objects in various case files, ensuring that the necessary time parameters are correctly structured within the JSON configuration. Additionally, the number of processors for the hemi case has been reduced to match other examples.

Fixes #1991, #1990, #1989, #1988, #1992, #1925