### PR TITLE
Disable rho output for pnpn (added in #1981)

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -137,7 +137,7 @@ io/csv_file.lo : io/csv_file.f90 comm/comm.lo common/log.lo config/num_types.lo 
 io/hdf5_file.lo : io/hdf5_file.F90 comm/comm.lo common/log.lo sem/dofmap.lo field/field_series.lo field/field_list.lo field/field.lo mesh/mesh.lo common/utils.lo common/checkpoint.lo io/generic_file.lo config/num_types.lo 
 io/file.lo : io/file.f90 io/hdf5_file.lo io/csv_file.lo io/stl_file.lo io/vtk_file.lo io/fld_file_data.lo io/fld_file.lo io/bp_file.lo io/re2_file.lo io/rea_file.lo io/map_file.lo io/chkp_file.lo io/nmsh_file.lo io/generic_file.lo config/num_types.lo common/utils.lo 
 io/output.lo : io/output.f90 io/file.lo config/num_types.lo 
-io/fluid_output.lo : io/fluid_output.f90 field/field.lo field/field_registry.lo scalar/scalars.lo io/output.lo device/device.lo config/neko_config.lo field/field_list.lo scalar/scalar_scheme.lo fluid/fluid_scheme_base.lo fluid/fluid_scheme_incompressible.lo config/num_types.lo 
+io/fluid_output.lo : io/fluid_output.f90 field/field.lo field/field_registry.lo scalar/scalars.lo io/output.lo device/device.lo config/neko_config.lo field/field_list.lo scalar/scalar_scheme.lo fluid/fluid_scheme_base.lo fluid/fluid_scheme_compressible.lo fluid/fluid_scheme_incompressible.lo config/num_types.lo 
 io/fld_file_output.lo : io/fld_file_output.f90 io/output.lo device/device.lo config/neko_config.lo field/field_list.lo config/num_types.lo 
 io/chkp_output.lo : io/chkp_output.f90 config/num_types.lo io/output.lo common/checkpoint.lo 
 io/mean_flow_output.lo : io/mean_flow_output.f90 io/output.lo device/device.lo config/num_types.lo fluid/mean_flow.lo 

--- a/src/io/fluid_output.f90
+++ b/src/io/fluid_output.f90
@@ -34,6 +34,7 @@
 module fluid_output
   use num_types, only : rp
   use fluid_scheme_incompressible, only : fluid_scheme_incompressible_t
+  use fluid_scheme_compressible, only : fluid_scheme_compressible_t
   use fluid_scheme_base, only : fluid_scheme_base_t
   use scalar_scheme, only : scalar_scheme_t
   use field_list, only : field_list_t
@@ -106,7 +107,14 @@ contains
     has_max_wave_speed = neko_field_registry%field_exists("max_wave_speed")
 
     ! Check if density field exists (for compressible flows)
-    has_density = associated(fluid%rho)
+    ! We need to check the solver type here since the incompressible
+    ! solver also has a rho field due to the material properties
+    select type (fluid)
+    class is (fluid_scheme_compressible_t)
+       has_density = associated(fluid%rho)
+    class default
+       has_density = .false.
+    end select
 
     ! Initialize field list with appropriate size
     ! Standard fields: p, u, v, w (4)


### PR DESCRIPTION
Since we have a `rho` field in pnpn, the current check is a bit misleading. However, @timofeymukha, with variable material properties, maybe one wants to dump rho from pnpn as well? 