### PR TITLE
Add optional stream/queue argument for all device math routines

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -274,7 +274,7 @@ device/opencl_intf.lo : device/opencl_intf.F90 common/utils.lo config/num_types.
 device/opencl/prgm_lib.lo : device/opencl/prgm_lib.F90 common/utils.lo device/opencl_intf.lo 
 device/device.lo : device/device.F90 device/opencl/prgm_lib.lo common/utils.lo adt/htable.lo config/neko_config.lo device/hip_intf.lo device/cuda_intf.lo device/opencl_intf.lo config/num_types.lo 
 math/field_math.lo : math/field_math.f90 math/bcknd/device/device_math.lo math/math.lo device/device.lo field/field.lo config/num_types.lo config/neko_config.lo 
-math/bcknd/device/device_math.lo : math/bcknd/device/device_math.F90 math/bcknd/device/opencl/opencl_math.lo math/bcknd/device/cuda/cuda_math.lo math/bcknd/device/hip/hip_math.lo comm/comm.lo common/utils.lo config/num_types.lo 
+math/bcknd/device/device_math.lo : math/bcknd/device/device_math.F90 math/bcknd/device/opencl/opencl_math.lo math/bcknd/device/cuda/cuda_math.lo math/bcknd/device/hip/hip_math.lo device/device.lo comm/comm.lo common/utils.lo config/num_types.lo 
 math/bcknd/device/hip/hip_math.lo : math/bcknd/device/hip/hip_math.f90 config/num_types.lo 
 math/bcknd/device/cuda/cuda_math.lo : math/bcknd/device/cuda/cuda_math.f90 config/num_types.lo 
 math/bcknd/device/opencl/opencl_math.lo : math/bcknd/device/opencl/opencl_math.f90 config/num_types.lo 

--- a/src/math/bcknd/device/cuda/cuda_math.f90
+++ b/src/math/bcknd/device/cuda/cuda_math.f90
@@ -36,331 +36,333 @@ module cuda_math
   public
 
   interface
-     subroutine cuda_copy(a_d, b_d, n) &
+     subroutine cuda_copy(a_d, b_d, n, strm) &
           bind(c, name = 'cuda_copy')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine cuda_copy
 
-     subroutine cuda_masked_copy(a_d, b_d, mask_d, n, n_mask) &
+     subroutine cuda_masked_copy(a_d, b_d, mask_d, n, n_mask, strm) &
           bind(c, name = 'cuda_masked_copy')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d, mask_d
+       type(c_ptr), value :: a_d, b_d, mask_d, strm
        integer(c_int) :: n, n_mask
      end subroutine cuda_masked_copy
 
-     subroutine cuda_masked_gather_copy(a_d, b_d, mask_d, n, n_mask) &
+     subroutine cuda_masked_gather_copy(a_d, b_d, mask_d, n, n_mask, strm) &
           bind(c, name = 'cuda_masked_gather_copy')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d, mask_d
+       type(c_ptr), value :: a_d, b_d, mask_d, strm
        integer(c_int) :: n, n_mask
      end subroutine cuda_masked_gather_copy
 
-     subroutine cuda_masked_scatter_copy(a_d, b_d, mask_d, n, n_mask) &
+     subroutine cuda_masked_scatter_copy(a_d, b_d, mask_d, n, n_mask, strm) &
           bind(c, name = 'cuda_masked_scatter_copy')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d, mask_d
+       type(c_ptr), value :: a_d, b_d, mask_d, strm
        integer(c_int) :: n, n_mask
      end subroutine cuda_masked_scatter_copy
 
-     subroutine cuda_masked_atomic_reduction(a_d, b_d, mask_d, n, m) &
+     subroutine cuda_masked_atomic_reduction(a_d, b_d, mask_d, n, m, strm) &
           bind(c, name = 'cuda_masked_atomic_reduction')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d, mask_d
+       type(c_ptr), value :: a_d, b_d, mask_d, strm
        integer(c_int) :: n, m
      end subroutine cuda_masked_atomic_reduction
 
-     subroutine cuda_cfill_mask(a_d, c, n, mask_d, n_mask) &
+     subroutine cuda_cfill_mask(a_d, c, n, mask_d, n_mask, strm) &
           bind(c, name = 'cuda_cfill_mask')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
        type(c_ptr), value :: mask_d
        integer(c_int) :: n_mask
      end subroutine cuda_cfill_mask
 
-     subroutine cuda_cmult(a_d, c, n) &
+     subroutine cuda_cmult(a_d, c, n, strm) &
           bind(c, name = 'cuda_cmult')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine cuda_cmult
 
-     subroutine cuda_cmult2(a_d, b_d, c, n) &
+     subroutine cuda_cmult2(a_d, b_d, c, n, strm) &
           bind(c, name = 'cuda_cmult2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine cuda_cmult2
 
-     subroutine cuda_cdiv(a_d, c, n) &
+     subroutine cuda_cdiv(a_d, c, n, strm) &
           bind(c, name = 'cuda_cdiv')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine cuda_cdiv
 
-     subroutine cuda_cdiv2(a_d, b_d, c, n) &
+     subroutine cuda_cdiv2(a_d, b_d, c, n, strm) &
           bind(c, name = 'cuda_cdiv2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine cuda_cdiv2
 
-     subroutine cuda_cadd(a_d, c, n) &
+     subroutine cuda_cadd(a_d, c, n, strm) &
           bind(c, name = 'cuda_cadd')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine cuda_cadd
 
-     subroutine cuda_cadd2(a_d, b_d, c, n) &
+     subroutine cuda_cadd2(a_d, b_d, c, n, strm) &
           bind(c, name = 'cuda_cadd2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
        type(c_ptr), value :: a_d
        type(c_ptr), value :: b_d
+       type(c_ptr), value :: strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine cuda_cadd2
 
-     subroutine cuda_cfill(a_d, c, n) &
+     subroutine cuda_cfill(a_d, c, n, strm) &
           bind(c, name = 'cuda_cfill')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine cuda_cfill
 
-     subroutine cuda_rzero(a_d, n) &
+     subroutine cuda_rzero(a_d, n, strm) &
           bind(c, name = 'cuda_rzero')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        integer(c_int) :: n
      end subroutine cuda_rzero
 
-     subroutine cuda_add2(a_d, b_d, n) &
+     subroutine cuda_add2(a_d, b_d, n, strm) &
           bind(c, name = 'cuda_add2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine cuda_add2
 
-     subroutine cuda_add4(a_d, b_d, c_d, d_d, n) &
+     subroutine cuda_add4(a_d, b_d, c_d, d_d, n, strm) &
           bind(c, name = 'cuda_add4')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d, b_d, c_d, d_d
+       type(c_ptr), value :: a_d, b_d, c_d, d_d, strm
        integer(c_int) :: n
      end subroutine cuda_add4
 
-     subroutine cuda_add2s1(a_d, b_d, c1, n) &
+     subroutine cuda_add2s1(a_d, b_d, c1, n, strm) &
           bind(c, name = 'cuda_add2s1')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c1
        integer(c_int) :: n
      end subroutine cuda_add2s1
 
-     subroutine cuda_add2s2(a_d, b_d, c1, n) &
+     subroutine cuda_add2s2(a_d, b_d, c1, n, strm) &
           bind(c, name = 'cuda_add2s2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c1
        integer(c_int) :: n
      end subroutine cuda_add2s2
 
-     subroutine cuda_addsqr2s2(a_d, b_d, c1, n) &
+     subroutine cuda_addsqr2s2(a_d, b_d, c1, n, strm) &
           bind(c, name = 'cuda_addsqr2s2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c1
        integer(c_int) :: n
      end subroutine cuda_addsqr2s2
 
-     subroutine cuda_add3s2(a_d, b_d, c_d, c1, c2, n) &
+     subroutine cuda_add3s2(a_d, b_d, c_d, c1, c2, n, strm) &
           bind(c, name = 'cuda_add3s2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        real(c_rp) :: c1, c2
        integer(c_int) :: n
      end subroutine cuda_add3s2
 
-     subroutine cuda_invcol1(a_d, n) &
+     subroutine cuda_invcol1(a_d, n, strm) &
           bind(c, name = 'cuda_invcol1')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        integer(c_int) :: n
      end subroutine cuda_invcol1
 
-     subroutine cuda_invcol2(a_d, b_d, n) &
+     subroutine cuda_invcol2(a_d, b_d, n, strm) &
           bind(c, name = 'cuda_invcol2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine cuda_invcol2
 
-     subroutine cuda_invcol3(a_d, b_d, c_d, n) &
+     subroutine cuda_invcol3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'cuda_invcol3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine cuda_invcol3
 
-     subroutine cuda_col2(a_d, b_d, n) &
+     subroutine cuda_col2(a_d, b_d, n, strm) &
           bind(c, name = 'cuda_col2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine cuda_col2
 
-     subroutine cuda_col3(a_d, b_d, c_d, n) &
+     subroutine cuda_col3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'cuda_col3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine cuda_col3
 
-     subroutine cuda_subcol3(a_d, b_d, c_d, n) &
+     subroutine cuda_subcol3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'cuda_subcol3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine cuda_subcol3
 
-     subroutine cuda_sub2(a_d, b_d, n) &
+     subroutine cuda_sub2(a_d, b_d, n, strm) &
           bind(c, name = 'cuda_sub2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine cuda_sub2
 
-     subroutine cuda_sub3(a_d, b_d, c_d, n) &
+     subroutine cuda_sub3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'cuda_sub3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine cuda_sub3
 
-     subroutine cuda_add3(a_d, b_d, c_d, n) &
+     subroutine cuda_add3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'cuda_add3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine cuda_add3
 
-     subroutine cuda_addcol3(a_d, b_d, c_d, n) &
+     subroutine cuda_addcol3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'cuda_addcol3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine cuda_addcol3
 
-     subroutine cuda_addcol4(a_d, b_d, c_d, d_d, n) &
+     subroutine cuda_addcol4(a_d, b_d, c_d, d_d, n, strm) &
           bind(c, name = 'cuda_addcol4')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d, c_d, d_d
+       type(c_ptr), value :: a_d, b_d, c_d, d_d, strm
        integer(c_int) :: n
      end subroutine cuda_addcol4
 
-     subroutine cuda_vdot3(dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, n) &
+     subroutine cuda_vdot3(dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, n, strm) &
           bind(c, name = 'cuda_vdot3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d
+       type(c_ptr), value :: dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, strm
        integer(c_int) :: n
      end subroutine cuda_vdot3
 
      subroutine cuda_vcross(u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, &
-          w1_d, w2_d, w3_d, n) &
+          w1_d, w2_d, w3_d, n, strm) &
           bind(c, name = 'cuda_vcross')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        type(c_ptr), value :: u1_d, u2_d, u3_d
        type(c_ptr), value :: v1_d, v2_d, v3_d
        type(c_ptr), value :: w1_d, w2_d, w3_d
+       type(c_ptr), value :: strm
        integer(c_int) :: n
      end subroutine cuda_vcross
 
-     real(c_rp) function cuda_vlsc3(u_d, v_d, w_d, n) &
+     real(c_rp) function cuda_vlsc3(u_d, v_d, w_d, n, strm) &
           bind(c, name = 'cuda_vlsc3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: u_d, v_d, w_d
+       type(c_ptr), value :: u_d, v_d, w_d, strm
        integer(c_int) :: n
      end function cuda_vlsc3
 
-     subroutine cuda_add2s2_many(y_d, x_d_d, a_d, j, n) &
+     subroutine cuda_add2s2_many(y_d, x_d_d, a_d, j, n, strm) &
           bind(c, name = 'cuda_add2s2_many')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: y_d, x_d_d, a_d
+       type(c_ptr), value :: y_d, x_d_d, a_d, strm
        integer(c_int) :: j, n
      end subroutine cuda_add2s2_many
 
-     real(c_rp) function cuda_glsc3(a_d, b_d, c_d, n) &
+     real(c_rp) function cuda_glsc3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'cuda_glsc3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end function cuda_glsc3
 
-     subroutine cuda_glsc3_many(h, w_d, v_d_d, mult_d, j, n) &
+     subroutine cuda_glsc3_many(h, w_d, v_d_d, mult_d, j, n, strm) &
           bind(c, name = 'cuda_glsc3_many')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: w_d, v_d_d, mult_d
+       type(c_ptr), value :: w_d, v_d_d, mult_d, strm
        integer(c_int) :: j, n
        real(c_rp) :: h(j)
      end subroutine cuda_glsc3_many
 
-     real(c_rp) function cuda_glsc2(a_d, b_d, n) &
+     real(c_rp) function cuda_glsc2(a_d, b_d, n, strm) &
           bind(c, name = 'cuda_glsc2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end function cuda_glsc2
 
-     real(c_rp) function cuda_glsubnorm2(a_d, b_d, n) &
+     real(c_rp) function cuda_glsubnorm2(a_d, b_d, n, strm) &
           bind(c, name = 'cuda_glsubnorm2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end function cuda_glsubnorm2
 
-     real(c_rp) function cuda_glsum(a_d, n) &
+     real(c_rp) function cuda_glsum(a_d, n, strm) &
           bind(c, name = 'cuda_glsum')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        integer(c_int) :: n
      end function cuda_glsum
 
-     subroutine cuda_absval(a_d, n) &
+     subroutine cuda_absval(a_d, n, strm) &
           bind(c, name = 'cuda_absval')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        integer(c_int) :: n
      end subroutine cuda_absval
   end interface
@@ -369,66 +371,66 @@ module cuda_math
   ! Interfaces for the pointwise operations.
 
   interface
-     subroutine cuda_pwmax_vec2(a_d, b_d, n) &
+     subroutine cuda_pwmax_vec2(a_d, b_d, n, strm) &
           bind(c, name = 'cuda_pwmax_vec2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine cuda_pwmax_vec2
 
-     subroutine cuda_pwmax_vec3(a_d, b_d, c_d, n) &
+     subroutine cuda_pwmax_vec3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'cuda_pwmax_vec3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine cuda_pwmax_vec3
 
-     subroutine cuda_pwmax_sca2(a_d, c_d, n) &
+     subroutine cuda_pwmax_sca2(a_d, c_d, n, strm) &
           bind(c, name = 'cuda_pwmax_sca2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        real(c_rp) :: c_d
        integer(c_int) :: n
      end subroutine cuda_pwmax_sca2
 
-     subroutine cuda_pwmax_sca3(a_d, b_d, c_d, n) &
+     subroutine cuda_pwmax_sca3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'cuda_pwmax_sca3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c_d
        integer(c_int) :: n
      end subroutine cuda_pwmax_sca3
 
-     subroutine cuda_pwmin_vec2(a_d, b_d, n) &
+     subroutine cuda_pwmin_vec2(a_d, b_d, n, strm) &
           bind(c, name = 'cuda_pwmin_vec2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine cuda_pwmin_vec2
 
-     subroutine cuda_pwmin_vec3(a_d, b_d, c_d, n) &
+     subroutine cuda_pwmin_vec3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'cuda_pwmin_vec3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine cuda_pwmin_vec3
 
-     subroutine cuda_pwmin_sca2(a_d, c_d, n) &
+     subroutine cuda_pwmin_sca2(a_d, c_d, n, strm) &
           bind(c, name = 'cuda_pwmin_sca2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        real(c_rp) :: c_d
        integer(c_int) :: n
      end subroutine cuda_pwmin_sca2
 
-     subroutine cuda_pwmin_sca3(a_d, b_d, c_d, n) &
+     subroutine cuda_pwmin_sca3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'cuda_pwmin_sca3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c_d
        integer(c_int) :: n
      end subroutine cuda_pwmin_sca3

--- a/src/math/bcknd/device/cuda/math.cu
+++ b/src/math/bcknd/device/cuda/math.cu
@@ -56,22 +56,22 @@ extern "C" {
   /** Fortran wrapper for copy
    * Copy a vector \f$ a = b \f$
    */
-  void cuda_copy(void *a, void *b, int *n) {
+  void cuda_copy(void *a, void *b, int *n, cudaStream_t strm) {
     CUDA_CHECK(cudaMemcpyAsync(a, b, (*n) * sizeof(real),
-                               cudaMemcpyDeviceToDevice,
-                               (cudaStream_t) glb_cmd_queue));
+                               cudaMemcpyDeviceToDevice, strm));
   }
 
   /** Fortran wrapper for masked copy
    * Copy a vector \f$ a(mask) = b(mask) \f$
    */
-  void cuda_masked_copy(void *a, void *b, void *mask, int *n, int *m) {
+  void cuda_masked_copy(void *a, void *b, void *mask,
+                        int *n, int *m, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*m)+1024 - 1)/ 1024, 1, 1);
 
-    masked_copy_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real*) b,(int*) mask, *n, *m);
+    masked_copy_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real*) b,(int*) mask, *n, *m);
     CUDA_CHECK(cudaGetLastError());
 
   }
@@ -79,13 +79,14 @@ extern "C" {
   /** Fortran wrapper for masked gather copy
    * Copy a vector \f$ a(i) = b(mask(i)) \f$
    */
-  void cuda_masked_gather_copy(void *a, void *b, void *mask, int *n, int *m) {
+  void cuda_masked_gather_copy(void *a, void *b, void *mask,
+                               int *n, int *m, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*m)+1024 - 1)/ 1024, 1, 1);
 
-    masked_gather_copy_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real*) b,(int*) mask, *n, *m);
+    masked_gather_copy_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real*) b,(int*) mask, *n, *m);
     CUDA_CHECK(cudaGetLastError());
 
   }
@@ -93,27 +94,28 @@ extern "C" {
   /** Fortran wrapper for masked atomic reduction
    * update a vector \f$ a += b(mask) \f$ where mask is not unique
    */
-  void cuda_masked_atomic_reduction(void *a, void *b, void *mask, int *n, int *m) {
+  void cuda_masked_atomic_reduction(void *a, void *b, void *mask,
+                                    int *n, int *m, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*m)+1024 - 1)/ 1024, 1, 1);
 
-    masked_atomic_reduction_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b,
-                                      (int *) mask, *n, *m);
+    masked_atomic_reduction_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, (int *) mask, *n, *m);
     CUDA_CHECK(cudaGetLastError());
 
   }
   /** Fortran wrapper for masked scatter copy
    * Copy a vector \f$ a(mask(i)) = b(i) \f$
    */
-  void cuda_masked_scatter_copy(void *a, void *b, void *mask, int *n, int *m) {
+  void cuda_masked_scatter_copy(void *a, void *b, void *mask,
+                                int *n, int *m, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*m)+1024 - 1)/ 1024, 1, 1);
 
-    masked_scatter_copy_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real*) b,(int*) mask, *n, *m);
+    masked_scatter_copy_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real*) b,(int*) mask, *n, *m);
     CUDA_CHECK(cudaGetLastError());
   }
 
@@ -121,34 +123,33 @@ extern "C" {
   /** Fortran wrapper for cfill_mask
    * Fill a scalar to vector \f$ a_i = s, for i \in mask \f$
    */
-  void cuda_cfill_mask(void* a, real* c, int* size, int* mask, int* mask_size) {
+  void cuda_cfill_mask(void* a, real* c, int* size, int* mask, int* mask_size,
+                       cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
 
-    cfill_mask_kernel<real><<<nblcks, nthrds, 0, (cudaStream_t)glb_cmd_queue>>>(
-        (real*)a, *c, *size, mask, *mask_size);
+    cfill_mask_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real*)a, *c, *size, mask, *mask_size);
     CUDA_CHECK(cudaGetLastError());
   }
 
   /** Fortran wrapper for rzero
    * Zero a real vector
    */
-  void cuda_rzero(void *a, int *n) {
-      CUDA_CHECK(cudaMemsetAsync(a, 0, (*n) * sizeof(real),
-                                 (cudaStream_t) glb_cmd_queue));
+  void cuda_rzero(void *a, int *n, cudaStream_t strm) {
+    CUDA_CHECK(cudaMemsetAsync(a, 0, (*n) * sizeof(real), strm));
   }
 
   /** Fortran wrapper for cmult
    * Multiplication by constant c \f$ a = c \cdot a \f$
    */
-  void cuda_cmult(void *a, real *c, int *n) {
+  void cuda_cmult(void *a, real *c, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    cmult_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, *c, *n);
+    cmult_kernel<real><<<nblcks, nthrds, 0, strm>>>((real *) a, *c, *n);
     CUDA_CHECK(cudaGetLastError());
 
   }
@@ -156,27 +157,26 @@ extern "C" {
   /** Fortran wrapper for cmult2
    * Multiplication by constant c \f$ a = c \cdot b \f$
    */
-  void cuda_cmult2(void *a, void *b, real *c, int *n) {
+  void cuda_cmult2(void *a, void *b, real *c, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    cmult2_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b, *c, *n);
+    cmult2_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, *c, *n);
     CUDA_CHECK(cudaGetLastError());
 
   }
-  
+
   /** Fortran wrapper for cdiv
    * Division of constant c by array \f$ a = c / a \f$
    */
-  void cuda_cdiv(void *a, real *c, int *n) {
+  void cuda_cdiv(void *a, real *c, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    cdiv_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, *c, *n);
+    cdiv_kernel<real><<<nblcks, nthrds, 0, strm>>>((real *) a, *c, *n);
     CUDA_CHECK(cudaGetLastError());
 
   }
@@ -184,27 +184,26 @@ extern "C" {
   /** Fortran wrapper for cdiv2
    * Division of constant c by array \f$ a = c / b \f$
    */
-  void cuda_cdiv2(void *a, void *b, real *c, int *n) {
+  void cuda_cdiv2(void *a, void *b, real *c, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    cdiv2_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b, *c, *n);
+    cdiv2_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, *c, *n);
     CUDA_CHECK(cudaGetLastError());
 
   }
-  
+
   /** Fortran wrapper for cadd
    * Add a scalar to vector \f$ a_i = a_i + c \f$
    */
-  void cuda_cadd(void *a, real *c, int *n) {
+  void cuda_cadd(void *a, real *c, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    cadd_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, *c, *n);
+    cadd_kernel<real><<<nblcks, nthrds, 0, strm>>>((real *) a, *c, *n);
     CUDA_CHECK(cudaGetLastError());
 
   }
@@ -213,13 +212,13 @@ extern "C" {
    * Fortran wrapper for cadd2
    * Add a scalar to vector \f$ a_i = b_i + c \f$
    */
-  void cuda_cadd2(void *a, void *b, real *c, int *n) {
+  void cuda_cadd2(void *a, void *b, real *c, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    cadd2_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b, *c, *n);
+    cadd2_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, *c, *n);
     CUDA_CHECK(cudaGetLastError());
 
   }
@@ -227,14 +226,13 @@ extern "C" {
   /** Fortran wrapper for cfill
    * Set all elements to a constant c \f$ a = c \f$
    */
-  void cuda_cfill(void *a, real *c, int *n) {
+  void cuda_cfill(void *a, real *c, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     if (*n > 0){
-      cfill_kernel<real><<<nblcks, nthrds, 0,
-        (cudaStream_t) glb_cmd_queue>>>((real *) a, *c, *n);
+      cfill_kernel<real><<<nblcks, nthrds, 0, strm>>>((real *) a, *c, *n);
       CUDA_CHECK(cudaGetLastError());
     }
 
@@ -244,13 +242,13 @@ extern "C" {
    * Fortran wrapper for add2
    * Vector addition \f$ a = a + b \f$
    */
-  void cuda_add2(void *a, void *b, int *n) {
+  void cuda_add2(void *a, void *b, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    add2_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b, *n);
+    add2_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, *n);
     CUDA_CHECK(cudaGetLastError());
 
   }
@@ -259,14 +257,13 @@ extern "C" {
    * Fortran wrapper for add3
    * Vector addition \f$ a = b + c \f$
    */
-  void cuda_add3(void *a, void *b, void *c, int *n) {
+  void cuda_add3(void *a, void *b, void *c, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    add3_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b,
-                                            (real *) c, *n);
+    add3_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, (real *) c, *n);
     CUDA_CHECK(cudaGetLastError());
   }
 
@@ -274,13 +271,14 @@ extern "C" {
    * Fortran wrapper for add4
    * Vector addition \f$ a = b + c + d \f$
    */
-  void cuda_add4(void *a, void *b, void *c, void *d, int *n) {
+  void cuda_add4(void *a, void *b, void *c, void *d, int *n,
+                 cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    add4_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b, (real *) c, (real *) d, *n);
+    add4_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, (real *) c, (real *) d, *n);
     CUDA_CHECK(cudaGetLastError());
 
   }
@@ -289,13 +287,13 @@ extern "C" {
    * Vector addition with scalar multiplication \f$ a = c_1 a + b \f$
    * (multiplication on first argument)
    */
-  void cuda_add2s1(void *a, void *b, real *c1, int *n) {
+  void cuda_add2s1(void *a, void *b, real *c1, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    add2s1_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b, *c1, *n);
+    add2s1_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, *c1, *n);
     CUDA_CHECK(cudaGetLastError());
 
   }
@@ -305,13 +303,13 @@ extern "C" {
    * Vector addition with scalar multiplication \f$ a = a + c_1 b \f$
    * (multiplication on second argument)
    */
-  void cuda_add2s2(void *a, void *b, real *c1, int *n) {
+  void cuda_add2s2(void *a, void *b, real *c1, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    add2s2_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b, *c1, *n);
+    add2s2_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, *c1, *n);
     CUDA_CHECK(cudaGetLastError());
 
   }
@@ -322,14 +320,14 @@ extern "C" {
    * \f$ x = x + c_1 p1 + c_2p2 + ... + c_jpj \f$
    * (multiplication on second argument)
    */
-  void cuda_add2s2_many(void *x, void **p, void *alpha, int *j, int *n) {
+  void cuda_add2s2_many(void *x, void **p, void *alpha, int *j, int *n,
+                        cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    add2s2_many_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) x, (const real **) p,
-                                      (real *) alpha, *j, *n);
+    add2s2_many_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) x, (const real **) p, (real *) alpha, *j, *n);
     CUDA_CHECK(cudaGetLastError());
 
   }
@@ -339,14 +337,13 @@ extern "C" {
    * Vector addition with scalar multiplication \f$ a = a + c_1 (b * b) \f$
    * (multiplication on second argument)
    */
-  void cuda_addsqr2s2(void *a, void *b, real *c1, int *n) {
+  void cuda_addsqr2s2(void *a, void *b, real *c1, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    addsqr2s2_kernel<real><<<nblcks, nthrds, 0, (cudaStream_t) glb_cmd_queue>>>((real *) a,
-                                               (real *) b,
-                                               *c1, *n);
+    addsqr2s2_kernel<real><<<nblcks, nthrds, 0,strm>>>
+      ((real *) a, (real *) b, *c1, *n);
     CUDA_CHECK(cudaGetLastError());
 
   }
@@ -356,14 +353,14 @@ extern "C" {
    * Vector addition with scalar multiplication \f$ a = c_1 b + c_2 c \f$
    * (multiplication on second argument)
    */
-  void cuda_add3s2(void *a, void *b, void *c, real *c1, real *c2, int *n) {
+  void cuda_add3s2(void *a, void *b, void *c, real *c1, real *c2, int *n,
+                   cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    add3s2_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b, (real *) c,
-                                      *c1, *c2, *n);
+    add3s2_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, (real *) c, *c1, *c2, *n);
     CUDA_CHECK(cudaGetLastError());
 
   }
@@ -372,13 +369,12 @@ extern "C" {
    * Fortran wrapper for invcol1
    * Invert a vector \f$ a = 1 / a \f$
    */
-  void cuda_invcol1(void *a, int *n) {
+  void cuda_invcol1(void *a, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    invcol1_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, *n);
+    invcol1_kernel<real><<<nblcks, nthrds, 0, strm>>>((real *) a, *n);
     CUDA_CHECK(cudaGetLastError());
   }
 
@@ -386,13 +382,13 @@ extern "C" {
    * Fortran wrapper for invcol2
    * Vector division \f$ a = a / b \f$
    */
-  void cuda_invcol2(void *a, void *b, int *n) {
+  void cuda_invcol2(void *a, void *b, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    invcol2_kernel<real><<<nblcks, nthrds, 0, (cudaStream_t) glb_cmd_queue>>>((real *) a,
-                                             (real *) b, *n);
+    invcol2_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, *n);
     CUDA_CHECK(cudaGetLastError());
   }
 
@@ -400,13 +396,13 @@ extern "C" {
    * Fortran wrapper for invcol3
    * Vector division \f$ a = b / c \f$
    */
-  void cuda_invcol3(void *a, void *b, void *c, int *n) {
+  void cuda_invcol3(void *a, void *b, void *c, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    invcol3_kernel<real><<<nblcks, nthrds, 0, (cudaStream_t) glb_cmd_queue>>>((real *) a,
-                                             (real *) b,  (real *) c, *n);
+    invcol3_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b,  (real *) c, *n);
     CUDA_CHECK(cudaGetLastError());
   }
 
@@ -414,13 +410,12 @@ extern "C" {
    * Fortran wrapper for col2
    * Vector multiplication with 2 vectors \f$ a = a \cdot b \f$
    */
-  void cuda_col2(void *a, void *b, int *n) {
+  void cuda_col2(void *a, void *b, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    col2_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b, *n);
+    col2_kernel<real><<<nblcks, nthrds, 0, strm>>>((real *) a, (real *) b, *n);
     CUDA_CHECK(cudaGetLastError());
   }
 
@@ -428,13 +423,13 @@ extern "C" {
    * Fortran wrapper for col3
    * Vector multiplication with 3 vectors \f$ a = b \cdot c \f$
    */
-  void cuda_col3(void *a, void *b, void *c, int *n) {
+  void cuda_col3(void *a, void *b, void *c, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    col3_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b, (real *) c, *n);
+    col3_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, (real *) c, *n);
     CUDA_CHECK(cudaGetLastError());
   }
 
@@ -442,13 +437,13 @@ extern "C" {
    * Fortran wrapper for subcol3
    * Vector multiplication with 3 vectors \f$ a = a - b \cdot c \f$
    */
-  void cuda_subcol3(void *a, void *b, void *c, int *n) {
+  void cuda_subcol3(void *a, void *b, void *c, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    subcol3_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b, (real *) c, *n);
+    subcol3_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, (real *) c, *n);
     CUDA_CHECK(cudaGetLastError());
   }
 
@@ -457,13 +452,13 @@ extern "C" {
    * Fortran wrapper for sub2
    * Vector subtraction \f$ a = a - b \f$
    */
-  void cuda_sub2(void *a, void *b, int *n) {
+  void cuda_sub2(void *a, void *b, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    sub2_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b, *n);
+    sub2_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, *n);
     CUDA_CHECK(cudaGetLastError());
   }
 
@@ -471,14 +466,13 @@ extern "C" {
    * Fortran wrapper for sub3
    * Vector subtraction \f$ a = b - c \f$
    */
-  void cuda_sub3(void *a, void *b, void *c, int *n) {
+  void cuda_sub3(void *a, void *b, void *c, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    sub3_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b,
-                                            (real *) c, *n);
+    sub3_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, (real *) c, *n);
     CUDA_CHECK(cudaGetLastError());
   }
 
@@ -486,14 +480,13 @@ extern "C" {
    * Fortran wrapper for addcol3
    * \f$ a = a + b * c \f$
    */
-  void cuda_addcol3(void *a, void *b, void *c, int *n) {
+  void cuda_addcol3(void *a, void *b, void *c, int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    addcol3_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b,
-                                      (real *) c, *n);
+    addcol3_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, (real *) c, *n);
     CUDA_CHECK(cudaGetLastError());
   }
 
@@ -501,14 +494,14 @@ extern "C" {
    * Fortran wrapper for addcol4
    * \f$ a = a + b * c * d\f$
    */
-  void cuda_addcol4(void *a, void *b, void *c, void *d, int *n) {
+  void cuda_addcol4(void *a, void *b, void *c, void *d, int *n,
+                    cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    addcol4_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) a, (real *) b,
-                                      (real *) c, (real *) d, *n);
+    addcol4_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) a, (real *) b, (real *) c, (real *) d, *n);
     CUDA_CHECK(cudaGetLastError());
   }
 
@@ -517,16 +510,15 @@ extern "C" {
    * \f$ dot = u \cdot v \f$
    */
   void cuda_vdot3(void *dot, void *u1, void *u2, void *u3,
-                  void *v1, void *v2, void *v3, int *n) {
+                  void *v1, void *v2, void *v3, int *n,
+                  cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    vdot3_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) dot, (real *) u1,
-                                      (real *) u2, (real *) u3,
-                                      (real *) v1, (real *) v2,
-                                      (real *) v3, *n);
+    vdot3_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) dot, (real *) u1, (real *) u2, (real *) u3,
+       (real *) v1, (real *) v2, (real *) v3, *n);
     CUDA_CHECK(cudaGetLastError());
   }
 
@@ -536,18 +528,16 @@ extern "C" {
    */
   void cuda_vcross(void *u1, void *u2, void *u3,
                   void *v1, void *v2, void *v3,
-                  void *w1, void *w2, void *w3, int *n) {
+                  void *w1, void *w2, void *w3,
+                   int *n, cudaStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    vcross_kernel<real><<<nblcks, nthrds, 0,
-      (cudaStream_t) glb_cmd_queue>>>((real *) u1,
-                                      (real *) u2, (real *) u3,
-                                      (real *) v1, (real *) v2,
-                                      (real *) v3,
-                                      (real *) w1, (real *) w2,
-                                      (real *) w3, *n);
+    vcross_kernel<real><<<nblcks, nthrds, 0, strm>>>
+      ((real *) u1, (real *) u2, (real *) u3,
+       (real *) v1, (real *) v2, (real *) v3,
+       (real *) w1, (real *) w2, (real *) w3, *n);
     CUDA_CHECK(cudaGetLastError());
   }
 
@@ -585,8 +575,8 @@ extern "C" {
   /**
    * Global additive reduction
    */
-  void cuda_global_reduce_add(real * bufred, void * bufred_d, int n, const cudaStream_t stream) {
-
+  void cuda_global_reduce_add(real * bufred, void * bufred_d,
+                              int n, const cudaStream_t stream) {
 
 #ifdef HAVE_NCCL
     device_nccl_allreduce(bufred_d, bufred_d, n, sizeof(real),
@@ -625,12 +615,11 @@ extern "C" {
    * Fortran wrapper vlsc3
    * Compute multiplication sum \f$ dot = u \cdot v \cdot w \f$
    */
-  real cuda_vlsc3(void *u, void *v, void *w, int *n) {
+  real cuda_vlsc3(void *u, void *v, void *w, int *n, cudaStream_t stream) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     const int nb = ((*n) + 1024 - 1)/ 1024;
-    const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
     cuda_redbuf_check_alloc(nb);
 
@@ -654,22 +643,24 @@ extern "C" {
    * Fortran wrapper glsc3
    * Weighted inner product \f$ a^T b c \f$
    */
-  real cuda_glsc3(void *a, void *b, void *c, int *n) {
+  real cuda_glsc3(void *a, void *b, void *c, int *n, cudaStream_t stream) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     const int nb = ((*n) + 1024 - 1)/ 1024;
-    const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
     cuda_redbuf_check_alloc(nb);
 
     if ( *n > 0) {
-    glsc3_kernel<real><<<nblcks, nthrds, 0, stream>>>
-      ((real *) a, (real *) b, (real *) c, (real *) bufred_d, *n);
-    CUDA_CHECK(cudaGetLastError());
-    reduce_kernel<real><<<1, 1024, 0, stream>>> ((real *) bufred_d, nb);
-    CUDA_CHECK(cudaGetLastError());
-    } else { cuda_rzero(bufred_d,&red_s); }
+      glsc3_kernel<real><<<nblcks, nthrds, 0, stream>>>
+        ((real *) a, (real *) b, (real *) c, (real *) bufred_d, *n);
+      CUDA_CHECK(cudaGetLastError());
+      reduce_kernel<real><<<1, 1024, 0, stream>>> ((real *) bufred_d, nb);
+      CUDA_CHECK(cudaGetLastError());
+    }
+    else {
+      cuda_rzero(bufred_d, &red_s, stream);
+    }
     cuda_global_reduce_add(bufred, bufred_d, 1, stream);
 
     return bufred[0];
@@ -679,7 +670,8 @@ extern "C" {
    * Fortran wrapper for doing an reduction to an array
    * Weighted inner product \f$ w^T v(n,1:j) c \f$
    */
-  void cuda_glsc3_many(real *h, void * w, void *v,void *mult, int *j, int *n){
+  void cuda_glsc3_many(real *h, void * w, void *v,void *mult, int *j, int *n,
+                       cudaStream_t stream){
     int pow2 = 1;
     while(pow2 < (*j)){
       pow2 = 2*pow2;
@@ -688,18 +680,21 @@ extern "C" {
     const dim3 nthrds(pow2, nt, 1);
     const dim3 nblcks(((*n)+nt - 1)/nt, 1, 1);
     const int nb = ((*n) + nt - 1)/nt;
-    const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
+
     cuda_redbuf_check_alloc((*j)*nb);
 
     if ( *n > 0) {
-    glsc3_many_kernel<real><<<nblcks, nthrds, 0, stream>>>
-      ((const real *) w, (const real **) v,
-       (const real *)mult, (real *)bufred_d, *j, *n);
-    CUDA_CHECK(cudaGetLastError());
-    glsc3_reduce_kernel<real>
-      <<<(*j), 1024, 0, stream>>>((real *) bufred_d, nb, *j);
-    CUDA_CHECK(cudaGetLastError());
-    } else { cuda_rzero(bufred_d,&red_s); }
+      glsc3_many_kernel<real><<<nblcks, nthrds, 0, stream>>>
+        ((const real *) w, (const real **) v,
+         (const real *)mult, (real *)bufred_d, *j, *n);
+      CUDA_CHECK(cudaGetLastError());
+      glsc3_reduce_kernel<real>
+        <<<(*j), 1024, 0, stream>>>((real *) bufred_d, nb, *j);
+      CUDA_CHECK(cudaGetLastError());
+    }
+    else {
+      cuda_rzero(bufred_d, &red_s, stream);
+    }
     cuda_global_reduce_add(h, bufred_d, (*j), stream);
   }
 
@@ -707,12 +702,11 @@ extern "C" {
    * Fortran wrapper glsc2
    * Weighted inner product \f$ a^T b c \f$
    */
-  real cuda_glsc2(void *a, void *b, int *n) {
+  real cuda_glsc2(void *a, void *b, int *n, cudaStream_t stream) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     const int nb = ((*n) + 1024 - 1)/ 1024;
-    const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
     cuda_redbuf_check_alloc(nb);
 
@@ -724,7 +718,10 @@ extern "C" {
       CUDA_CHECK(cudaGetLastError());
       reduce_kernel<real><<<1, 1024, 0, stream>>> ((real *) bufred_d, nb);
       CUDA_CHECK(cudaGetLastError());
-    } else { cuda_rzero(bufred_d,&red_s); }
+    }
+    else {
+      cuda_rzero(bufred_d, &red_s, stream);
+    }
     cuda_global_reduce_add(bufred, bufred_d, 1, stream);
 
     return bufred[0];
@@ -734,12 +731,11 @@ extern "C" {
    * Fortran wrapper glsubnorm
    * Squared Norm of difference \f$ \| a - b \|_2^2 \f$
    */
-  real cuda_glsubnorm2(void *a, void *b, int *n) {
+  real cuda_glsubnorm2(void *a, void *b, int *n, cudaStream_t stream) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     const int nb = ((*n) + 1024 - 1)/ 1024;
-    const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
     cuda_redbuf_check_alloc(nb);
 
@@ -751,20 +747,23 @@ extern "C" {
       CUDA_CHECK(cudaGetLastError());
       reduce_kernel<real><<<1, 1024, 0, stream>>> ((real *) bufred_d, nb);
       CUDA_CHECK(cudaGetLastError());
-    } else { cuda_rzero(bufred_d,&red_s); }
+    }
+    else {
+      cuda_rzero(bufred_d, &red_s, stream);
+    }
     cuda_global_reduce_add(bufred, bufred_d, 1, stream);
 
     return bufred[0];
   }
+
    /**
    * Fortran wrapper glsum
    * Sum a vector of length n
    */
-  real cuda_glsum(void *a, int *n) {
+  real cuda_glsum(void *a, int *n, cudaStream_t stream) {
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     const int nb = ((*n) + 1024 - 1)/ 1024;
-    const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
     cuda_redbuf_check_alloc(nb);
     if ( *n > 0) {
@@ -774,8 +773,13 @@ extern "C" {
       CUDA_CHECK(cudaGetLastError());
       reduce_kernel<real><<<1, 1024, 0, stream>>> ((real *) bufred_d, nb);
       CUDA_CHECK(cudaGetLastError());
-    } else { cuda_rzero(bufred_d,&red_s); }
+    }
+    else {
+      cuda_rzero(bufred_d, &red_s, stream);
+    }
+
     cuda_global_reduce_add(bufred, bufred_d, 1, stream);
+
     return bufred[0];
   }
 
@@ -783,14 +787,13 @@ extern "C" {
    * Fortran wrapper absval
    * Take the abs value of a vector of length n
    */
-  void cuda_absval(void *a, int *n) {
+  void cuda_absval(void *a, int *n, cudaStream_t stream) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
-    const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
     absval_kernel<real>
-    <<<nblcks, nthrds,0, stream>>>((real *) a, * n);
+      <<<nblcks, nthrds,0, stream>>>((real *) a, * n);
     CUDA_CHECK(cudaGetLastError());
 
   }
@@ -802,14 +805,13 @@ extern "C" {
    *
    * Compute the maximum of two vectors \f$ a = \max(a, b) \f$
    */
-  void cuda_pwmax_vec2(void *a, void *b, int *n) {
+  void cuda_pwmax_vec2(void *a, void *b, int *n, cudaStream_t stream) {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
-      const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
-      pwmax_vec2_kernel<real><<<nblcks, nthrds, 0, stream>>>(
-          (real *)a, (real *)b, *n);
+      pwmax_vec2_kernel<real><<<nblcks, nthrds, 0, stream>>>
+        ((real *)a, (real *)b, *n);
       CUDA_CHECK(cudaGetLastError());
   }
 
@@ -817,14 +819,13 @@ extern "C" {
    *
    * Compute the maximum of two vectors \f$ a = \max(b, c) \f$
    */
-  void cuda_pwmax_vec3(void *a, void *b, void *c, int *n) {
+  void cuda_pwmax_vec3(void *a, void *b, void *c, int *n, cudaStream_t stream) {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
-      const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
-      pwmax_vec3_kernel<real><<<nblcks, nthrds, 0, stream>>>(
-          (real *)a, (real *)b, (real *)c, *n);
+      pwmax_vec3_kernel<real><<<nblcks, nthrds, 0, stream>>>
+        ((real *)a, (real *)b, (real *)c, *n);
       CUDA_CHECK(cudaGetLastError());
   }
 
@@ -832,14 +833,13 @@ extern "C" {
    *
    * Compute the maximum of vector and scalar \f$ a = \max(a, c) \f$
    */
-  void cuda_pwmax_sca2(void *a, real *c, int *n) {
+  void cuda_pwmax_sca2(void *a, real *c, int *n, cudaStream_t stream) {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
-      const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
-      pwmax_sca2_kernel<real><<<nblcks, nthrds, 0, stream>>>(
-          (real *)a, *c, *n);
+      pwmax_sca2_kernel<real><<<nblcks, nthrds, 0, stream>>>
+        ((real *)a, *c, *n);
       CUDA_CHECK(cudaGetLastError());
   }
 
@@ -847,14 +847,13 @@ extern "C" {
    *
    * Compute the maximum of vector and scalar \f$ a = \max(b, c) \f$
    */
-  void cuda_pwmax_sca3(void *a, void *b, real *c, int *n) {
+  void cuda_pwmax_sca3(void *a, void *b, real *c, int *n, cudaStream_t stream) {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
-      const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
-      pwmax_sca3_kernel<real><<<nblcks, nthrds, 0, stream>>>(
-          (real *)a, (real *)b, *c, *n);
+      pwmax_sca3_kernel<real><<<nblcks, nthrds, 0, stream>>>
+        ((real *)a, (real *)b, *c, *n);
       CUDA_CHECK(cudaGetLastError());
   }
 
@@ -862,14 +861,13 @@ extern "C" {
    *
    * Compute the minimum of two vectors \f$ a = \min(a, b) \f$
    */
-  void cuda_pwmin_vec2(void *a, void *b, int *n) {
+  void cuda_pwmin_vec2(void *a, void *b, int *n, cudaStream_t stream) {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
-      const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
-      pwmin_vec2_kernel<real><<<nblcks, nthrds, 0, stream>>>(
-          (real *)a, (real *)b, *n);
+      pwmin_vec2_kernel<real><<<nblcks, nthrds, 0, stream>>>
+        ((real *)a, (real *)b, *n);
       CUDA_CHECK(cudaGetLastError());
   }
 
@@ -877,14 +875,13 @@ extern "C" {
    *
    * Compute the minimum of two vectors \f$ a = \min(b, c) \f$
    */
-  void cuda_pwmin_vec3(void *a, void *b, void *c, int *n) {
+  void cuda_pwmin_vec3(void *a, void *b, void *c, int *n, cudaStream_t stream) {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
-      const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
-      pwmin_vec3_kernel<real><<<nblcks, nthrds, 0, stream>>>(
-          (real *)a, (real *)b, (real *)c, *n);
+      pwmin_vec3_kernel<real><<<nblcks, nthrds, 0, stream>>>
+        ((real *)a, (real *)b, (real *)c, *n);
       CUDA_CHECK(cudaGetLastError());
   }
 
@@ -892,14 +889,12 @@ extern "C" {
    *
    * Compute the minimum of vector and scalar \f$ a = \min(a, c) \f$
    */
-  void cuda_pwmin_sca2(void *a, real *c, int *n) {
+  void cuda_pwmin_sca2(void *a, real *c, int *n, cudaStream_t stream) {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
-      const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
-      pwmin_sca2_kernel<real><<<nblcks, nthrds, 0, stream>>>(
-          (real *)a, *c, *n);
+      pwmin_sca2_kernel<real><<<nblcks, nthrds, 0, stream>>>((real *)a, *c, *n);
       CUDA_CHECK(cudaGetLastError());
   }
 
@@ -907,14 +902,13 @@ extern "C" {
    *
    * Compute the minimum of vector and scalar \f$ a = \min(b, c) \f$
    */
-  void cuda_pwmin_sca3(void *a, void *b, real *c, int *n) {
+  void cuda_pwmin_sca3(void *a, void *b, real *c, int *n, cudaStream_t stream) {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
-      const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
-      pwmin_sca3_kernel<real><<<nblcks, nthrds, 0, stream>>>(
-          (real *)a, (real *)b, *c, *n);
+      pwmin_sca3_kernel<real><<<nblcks, nthrds, 0, stream>>>
+        ((real *)a, (real *)b, *c, *n);
       CUDA_CHECK(cudaGetLastError());
   }
 

--- a/src/math/bcknd/device/device_math.F90
+++ b/src/math/bcknd/device/device_math.F90
@@ -32,11 +32,11 @@
 !
 module device_math
   use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-  use num_types, only: rp, c_rp
-  use utils, only: neko_error
-  use comm, only: NEKO_COMM, pe_size, MPI_REAL_PRECISION
-  use mpi_f08, only: MPI_SUM, MPI_IN_PLACE, MPI_Allreduce
-
+  use num_types, only : rp, c_rp
+  use utils, only : neko_error
+  use comm, only : NEKO_COMM, pe_size, MPI_REAL_PRECISION
+  use mpi_f08, only : MPI_SUM, MPI_IN_PLACE, MPI_Allreduce
+  use device, only : glb_cmd_queue
   ! ========================================================================== !
   ! Device math interfaces
 
@@ -73,78 +73,127 @@ module device_math
 contains
 
   !> Copy a vector \f$ a = b \f$
-  subroutine device_copy(a_d, b_d, n)
+  subroutine device_copy(a_d, b_d, n, strm)
     type(c_ptr) :: a_d, b_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
 
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_copy(a_d, b_d, n)
+    call hip_copy(a_d, b_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_copy(a_d, b_d, n)
+    call cuda_copy(a_d, b_d, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_copy(a_d, b_d, n)
+    call opencl_copy(a_d, b_d, n, strm_)
 #else
     call neko_error('no device backend configured')
 #endif
   end subroutine device_copy
 
   !> Copy a masked vector \f$ a(mask) = b(mask) \f$.
-  subroutine device_masked_copy(a_d, b_d, mask_d, n, n_mask)
+  subroutine device_masked_copy(a_d, b_d, mask_d, n, n_mask, strm)
     type(c_ptr) :: a_d, b_d, mask_d
     integer :: n, n_mask
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1 .or. n_mask .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_masked_copy(a_d, b_d, mask_d, n, n_mask)
+    call hip_masked_copy(a_d, b_d, mask_d, n, n_mask, strm_)
 #elif HAVE_CUDA
-    call cuda_masked_copy(a_d, b_d, mask_d, n, n_mask)
+    call cuda_masked_copy(a_d, b_d, mask_d, n, n_mask, strm_)
 #elif HAVE_OPENCL
-    call opencl_masked_copy(a_d, b_d, mask_d, n, n_mask)
+    call opencl_masked_copy(a_d, b_d, mask_d, n, n_mask, strm_)
 #else
     call neko_error('no device backend configured')
 #endif
   end subroutine device_masked_copy
 
   !> Gather a masked vector \f$ a(i) = b(mask(i)) \f$.
-  subroutine device_masked_gather_copy(a_d, b_d, mask_d, n, n_mask)
+  subroutine device_masked_gather_copy(a_d, b_d, mask_d, n, n_mask, strm)
     type(c_ptr) :: a_d, b_d, mask_d
     integer :: n, n_mask
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1 .or. n_mask .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_masked_gather_copy(a_d, b_d, mask_d, n, n_mask)
+    call hip_masked_gather_copy(a_d, b_d, mask_d, n, n_mask, strm_)
 #elif HAVE_CUDA
-    call cuda_masked_gather_copy(a_d, b_d, mask_d, n, n_mask)
+    call cuda_masked_gather_copy(a_d, b_d, mask_d, n, n_mask, strm_)
 #elif HAVE_OPENCL
-    call opencl_masked_gather_copy(a_d, b_d, mask_d, n, n_mask)
+    call opencl_masked_gather_copy(a_d, b_d, mask_d, n, n_mask, strm_)
 #else
     call neko_error('no device backend configured')
 #endif
   end subroutine device_masked_gather_copy
 
   !> Scatter a masked vector \f$ a((mask(i)) = b(i) \f$.
-  subroutine device_masked_scatter_copy(a_d, b_d, mask_d, n, n_mask)
+  subroutine device_masked_scatter_copy(a_d, b_d, mask_d, n, n_mask, strm)
     type(c_ptr) :: a_d, b_d, mask_d
     integer :: n, n_mask
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1 .or. n_mask .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_masked_scatter_copy(a_d, b_d, mask_d, n, n_mask)
+    call hip_masked_scatter_copy(a_d, b_d, mask_d, n, n_mask, strm_)
 #elif HAVE_CUDA
-    call cuda_masked_scatter_copy(a_d, b_d, mask_d, n, n_mask)
+    call cuda_masked_scatter_copy(a_d, b_d, mask_d, n, n_mask, strm_)
 #elif HAVE_OPENCL
-    call opencl_masked_scatter_copy(a_d, b_d, mask_d, n, n_mask)
+    call opencl_masked_scatter_copy(a_d, b_d, mask_d, n, n_mask, strm_)
 #else
     call neko_error('no device backend configured')
 #endif
   end subroutine device_masked_scatter_copy
 
-  subroutine device_masked_atomic_reduction(a_d, b_d, mask_d, n, n_mask)
+  subroutine device_masked_atomic_reduction(a_d, b_d, mask_d, n, n_mask, strm)
     type(c_ptr) :: a_d, b_d, mask_d
     integer :: n, n_mask
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1 .or. n_mask .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_masked_atomic_reduction(a_d, b_d, mask_d, n, n_mask)
+    call hip_masked_atomic_reduction(a_d, b_d, mask_d, n, n_mask, strm_)
 #elif HAVE_CUDA
-    call cuda_masked_atomic_reduction(a_d, b_d, mask_d, n, n_mask)
+    call cuda_masked_atomic_reduction(a_d, b_d, mask_d, n, n_mask, strm_)
 #elif HAVE_OPENCL
     call neko_error('No OpenCL bcknd, masked atomic reduction')
 #else
@@ -154,213 +203,341 @@ contains
 
   !> @brief Fill a constant to a masked vector.
   !! \f$ a_i = c, for i in mask \f$
-  subroutine device_cfill_mask(a_d, c, n, mask_d, n_mask)
+  subroutine device_cfill_mask(a_d, c, n, mask_d, n_mask, strm)
     type(c_ptr) :: a_d
     real(kind=rp), intent(in) :: c
     integer :: n
     type(c_ptr) :: mask_d
     integer :: n_mask
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1 .or. n_mask .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_cfill_mask(a_d, c, n, mask_d, n_mask)
+    call hip_cfill_mask(a_d, c, n, mask_d, n_mask, strm_)
 #elif HAVE_CUDA
-    call cuda_cfill_mask(a_d, c, n, mask_d, n_mask)
+    call cuda_cfill_mask(a_d, c, n, mask_d, n_mask, strm_)
 #elif HAVE_OPENCL
-    call opencl_cfill_mask(a_d, c, n, mask_d, n_mask)
+    call opencl_cfill_mask(a_d, c, n, mask_d, n_mask, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_cfill_mask
 
   !> Zero a real vector
-  subroutine device_rzero(a_d, n)
+  subroutine device_rzero(a_d, n, strm)
     type(c_ptr) :: a_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_rzero(a_d, n)
+    call hip_rzero(a_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_rzero(a_d, n)
+    call cuda_rzero(a_d, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_rzero(a_d, n)
+    call opencl_rzero(a_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_rzero
 
   !> Set all elements to one
-  subroutine device_rone(a_d, n)
+  subroutine device_rone(a_d, n, strm)
     type(c_ptr) :: a_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
     real(kind=rp), parameter :: one = 1.0_rp
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP || HAVE_CUDA || HAVE_OPENCL
-    call device_cfill(a_d, one, n)
+    call device_cfill(a_d, one, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_rone
 
   !> Multiplication by constant c \f$ a = c \cdot a \f$
-  subroutine device_cmult(a_d, c, n)
+  subroutine device_cmult(a_d, c, n, strm)
     type(c_ptr) :: a_d
     real(kind=rp), intent(in) :: c
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_cmult(a_d, c, n)
+    call hip_cmult(a_d, c, n, strm_)
 #elif HAVE_CUDA
-    call cuda_cmult(a_d, c, n)
+    call cuda_cmult(a_d, c, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_cmult(a_d, c, n)
+    call opencl_cmult(a_d, c, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_cmult
 
   !> Multiplication by constant c \f$ a = c \cdot b \f$
-  subroutine device_cmult2(a_d, b_d, c, n)
+  subroutine device_cmult2(a_d, b_d, c, n, strm)
     type(c_ptr) :: a_d, b_d
     real(kind=rp), intent(in) :: c
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_cmult2(a_d, b_d, c, n)
+    call hip_cmult2(a_d, b_d, c, n, strm_)
 #elif HAVE_CUDA
-    call cuda_cmult2(a_d, b_d, c, n)
+    call cuda_cmult2(a_d, b_d, c, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_cmult2(a_d, b_d, c, n)
+    call opencl_cmult2(a_d, b_d, c, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_cmult2
 
   !> Division of constant c by array \f$ a = c / a \f$
-  subroutine device_cdiv(a_d, c, n)
+  subroutine device_cdiv(a_d, c, n, strm)
     type(c_ptr) :: a_d
     real(kind=rp), intent(in) :: c
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_cdiv(a_d, c, n)
+    call hip_cdiv(a_d, c, n, strm_)
 #elif HAVE_CUDA
-    call cuda_cdiv(a_d, c, n)
+    call cuda_cdiv(a_d, c, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_cdiv(a_d, c, n)
+    call opencl_cdiv(a_d, c, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_cdiv
 
   !> Division of constant c by array \f$ a = c / b \f$
-  subroutine device_cdiv2(a_d, b_d, c, n)
+  subroutine device_cdiv2(a_d, b_d, c, n, strm)
     type(c_ptr) :: a_d, b_d
     real(kind=rp), intent(in) :: c
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_cdiv2(a_d, b_d, c, n)
+    call hip_cdiv2(a_d, b_d, c, n, strm_)
 #elif HAVE_CUDA
-    call cuda_cdiv2(a_d, b_d, c, n)
+    call cuda_cdiv2(a_d, b_d, c, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_cdiv2(a_d, b_d, c, n)
+    call opencl_cdiv2(a_d, b_d, c, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_cdiv2
 
   !> Add a scalar to vector \f$ a = a + s \f$
-  subroutine device_cadd(a_d, c, n)
+  subroutine device_cadd(a_d, c, n, strm)
     type(c_ptr) :: a_d
     real(kind=rp), intent(in) :: c
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_cadd(a_d, c, n)
+    call hip_cadd(a_d, c, n, strm_)
 #elif HAVE_CUDA
-    call cuda_cadd(a_d, c, n)
+    call cuda_cadd(a_d, c, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_cadd(a_d, c, n)
+    call opencl_cadd(a_d, c, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_cadd
 
   !> Add a scalar to vector \f$ a = b + s \f$
-  subroutine device_cadd2(a_d, b_d, c, n)
+  subroutine device_cadd2(a_d, b_d, c, n, strm)
     type(c_ptr) :: a_d
     type(c_ptr) :: b_d
     real(kind=rp), intent(in) :: c
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_cadd2(a_d, b_d, c, n)
+    call hip_cadd2(a_d, b_d, c, n, strm_)
 #elif HAVE_CUDA
-    call cuda_cadd2(a_d, b_d, c, n)
+    call cuda_cadd2(a_d, b_d, c, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_cadd2(a_d, b_d, c, n)
+    call opencl_cadd2(a_d, b_d, c, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_cadd2
 
   !> Set all elements to a constant c \f$ a = c \f$
-  subroutine device_cfill(a_d, c, n)
+  subroutine device_cfill(a_d, c, n, strm)
     type(c_ptr) :: a_d
     real(kind=rp), intent(in) :: c
     integer :: n
+    type(c_ptr), optional ::strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_cfill(a_d, c, n)
+    call hip_cfill(a_d, c, n, strm_)
 #elif HAVE_CUDA
-    call cuda_cfill(a_d, c, n)
+    call cuda_cfill(a_d, c, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_cfill(a_d, c, n)
+    call opencl_cfill(a_d, c, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_cfill
 
   !> Vector addition \f$ a = a + b \f$
-  subroutine device_add2(a_d, b_d, n)
+  subroutine device_add2(a_d, b_d, n, strm)
     type(c_ptr) :: a_d, b_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_add2(a_d, b_d, n)
+    call hip_add2(a_d, b_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_add2(a_d, b_d, n)
+    call cuda_add2(a_d, b_d, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_add2(a_d, b_d, n)
+    call opencl_add2(a_d, b_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_add2
 
-  subroutine device_add4(a_d, b_d, c_d, d_d, n)
+  subroutine device_add4(a_d, b_d, c_d, d_d, n, strm)
     type(c_ptr) :: a_d, b_d, c_d, d_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_add4(a_d, b_d, c_d, d_d, n)
+    call hip_add4(a_d, b_d, c_d, d_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_add4(a_d, b_d, c_d, d_d, n)
+    call cuda_add4(a_d, b_d, c_d, d_d, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_add4(a_d, b_d, c_d, d_d, n)
+    call opencl_add4(a_d, b_d, c_d, d_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_add4
 
-  subroutine device_add2s1(a_d, b_d, c1, n)
+  subroutine device_add2s1(a_d, b_d, c1, n, strm)
     type(c_ptr) :: a_d, b_d
     real(kind=rp) :: c1
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_add2s1(a_d, b_d, c1, n)
+    call hip_add2s1(a_d, b_d, c1, n, strm_)
 #elif HAVE_CUDA
-    call cuda_add2s1(a_d, b_d, c1, n)
+    call cuda_add2s1(a_d, b_d, c1, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_add2s1(a_d, b_d, c1, n)
+    call opencl_add2s1(a_d, b_d, c1, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
@@ -368,112 +545,181 @@ contains
 
   !> Vector addition with scalar multiplication \f$ a = c_1 a + b \f$
   !! (multiplication on first argument)
-  subroutine device_add2s2(a_d, b_d, c1, n)
+  subroutine device_add2s2(a_d, b_d, c1, n, strm)
     type(c_ptr) :: a_d, b_d
     real(kind=rp) :: c1
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_add2s2(a_d, b_d, c1, n)
+    call hip_add2s2(a_d, b_d, c1, n, strm_)
 #elif HAVE_CUDA
-    call cuda_add2s2(a_d, b_d, c1, n)
+    call cuda_add2s2(a_d, b_d, c1, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_add2s2(a_d, b_d, c1, n)
+    call opencl_add2s2(a_d, b_d, c1, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_add2s2
 
   !> Returns \f$ a = a + c1 * (b * b )\f$
-  subroutine device_addsqr2s2(a_d, b_d, c1, n)
+  subroutine device_addsqr2s2(a_d, b_d, c1, n, strm)
     type(c_ptr) :: a_d, b_d
     real(kind=rp) :: c1
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_addsqr2s2(a_d, b_d, c1, n)
+    call hip_addsqr2s2(a_d, b_d, c1, n, strm_)
 #elif HAVE_CUDA
-    call cuda_addsqr2s2(a_d, b_d, c1, n)
+    call cuda_addsqr2s2(a_d, b_d, c1, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_addsqr2s2(a_d, b_d, c1, n)
+    call opencl_addsqr2s2(a_d, b_d, c1, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_addsqr2s2
 
   !> Vector addition \f$ a = b + c \f$
-  subroutine device_add3(a_d, b_d, c_d, n)
+  subroutine device_add3(a_d, b_d, c_d, n, strm)
     type(c_ptr) :: a_d, b_d, c_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_add3(a_d, b_d, c_d, n)
+    call hip_add3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_add3(a_d, b_d, c_d, n)
+    call cuda_add3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_add3(a_d, b_d, c_d, n)
+    call opencl_add3(a_d, b_d, c_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_add3
 
   !> Returns \f$ a = c1 * b + c2 * c \f$
-  subroutine device_add3s2(a_d, b_d, c_d, c1, c2 , n)
+  subroutine device_add3s2(a_d, b_d, c_d, c1, c2 , n, strm)
     type(c_ptr) :: a_d, b_d, c_d
     real(kind=rp) :: c1, c2
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_add3s2(a_d, b_d, c_d, c1, c2, n)
+    call hip_add3s2(a_d, b_d, c_d, c1, c2, n, strm_)
 #elif HAVE_CUDA
-    call cuda_add3s2(a_d, b_d, c_d, c1, c2, n)
+    call cuda_add3s2(a_d, b_d, c_d, c1, c2, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_add3s2(a_d, b_d, c_d, c1, c2, n)
+    call opencl_add3s2(a_d, b_d, c_d, c1, c2, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_add3s2
 
   !> Invert a vector \f$ a = 1 / a \f$
-  subroutine device_invcol1(a_d, n)
+  subroutine device_invcol1(a_d, n, strm)
     type(c_ptr) :: a_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_invcol1(a_d, n)
+    call hip_invcol1(a_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_invcol1(a_d, n)
+    call cuda_invcol1(a_d, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_invcol1(a_d, n)
+    call opencl_invcol1(a_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_invcol1
 
   !> Vector division \f$ a = a / b \f$
-  subroutine device_invcol2(a_d, b_d, n)
+  subroutine device_invcol2(a_d, b_d, n, strm)
     type(c_ptr) :: a_d, b_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_invcol2(a_d, b_d, n)
+    call hip_invcol2(a_d, b_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_invcol2(a_d, b_d, n)
+    call cuda_invcol2(a_d, b_d, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_invcol2(a_d, b_d, n)
+    call opencl_invcol2(a_d, b_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_invcol2
 
   !> Vector division \f$ a = b / c \f$
-  subroutine device_invcol3(a_d, b_d, c_d, n)
+  subroutine device_invcol3(a_d, b_d, c_d, n, strm)
     type(c_ptr) :: a_d, b_d, c_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #ifdef HAVE_HIP
-    call hip_invcol3(a_d, b_d, c_d, n)
+    call hip_invcol3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_invcol3(a_d, b_d, c_d, n)
+    call cuda_invcol3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_OPENCL
     ! call opencl_invcol3(a_d, b_d, c_d, n)
     call neko_error('opencl_invcol3 not implemented')
@@ -483,112 +729,181 @@ contains
   end subroutine device_invcol3
 
   !> Vector multiplication \f$ a = a \cdot b \f$
-  subroutine device_col2(a_d, b_d, n)
+  subroutine device_col2(a_d, b_d, n, strm)
     type(c_ptr) :: a_d, b_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
     if (n .lt. 1) return
 #if HAVE_HIP
-    call hip_col2(a_d, b_d, n)
+    call hip_col2(a_d, b_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_col2(a_d, b_d, n)
+    call cuda_col2(a_d, b_d, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_col2(a_d, b_d, n)
+    call opencl_col2(a_d, b_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_col2
 
   !> Vector multiplication with 3 vectors \f$ a =  b \cdot c \f$
-  subroutine device_col3(a_d, b_d, c_d, n)
+  subroutine device_col3(a_d, b_d, c_d, n, strm)
     type(c_ptr) :: a_d, b_d, c_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_col3(a_d, b_d, c_d, n)
+    call hip_col3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_col3(a_d, b_d, c_d, n)
+    call cuda_col3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_col3(a_d, b_d, c_d, n)
+    call opencl_col3(a_d, b_d, c_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_col3
 
   !> Returns \f$ a = a - b*c \f$
-  subroutine device_subcol3(a_d, b_d, c_d, n)
+  subroutine device_subcol3(a_d, b_d, c_d, n, strm)
     type(c_ptr) :: a_d, b_d, c_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_subcol3(a_d, b_d, c_d, n)
+    call hip_subcol3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_subcol3(a_d, b_d, c_d, n)
+    call cuda_subcol3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_subcol3(a_d, b_d, c_d, n)
+    call opencl_subcol3(a_d, b_d, c_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_subcol3
 
   !> Vector substraction \f$ a = a - b \f$
-  subroutine device_sub2(a_d, b_d, n)
+  subroutine device_sub2(a_d, b_d, n, strm)
     type(c_ptr) :: a_d, b_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_sub2(a_d, b_d, n)
+    call hip_sub2(a_d, b_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_sub2(a_d, b_d, n)
+    call cuda_sub2(a_d, b_d, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_sub2(a_d, b_d, n)
+    call opencl_sub2(a_d, b_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_sub2
 
   !> Vector subtraction \f$ a = b - c \f$
-  subroutine device_sub3(a_d, b_d, c_d, n)
+  subroutine device_sub3(a_d, b_d, c_d, n, strm)
     type(c_ptr) :: a_d, b_d, c_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_sub3(a_d, b_d, c_d, n)
+    call hip_sub3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_sub3(a_d, b_d, c_d, n)
+    call cuda_sub3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_sub3(a_d, b_d, c_d, n)
+    call opencl_sub3(a_d, b_d, c_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_sub3
 
   !> Returns \f$ a = a + b*c \f$
-  subroutine device_addcol3(a_d, b_d, c_d, n)
+  subroutine device_addcol3(a_d, b_d, c_d, n, strm)
     type(c_ptr) :: a_d, b_d, c_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_addcol3(a_d, b_d, c_d, n)
+    call hip_addcol3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_addcol3(a_d, b_d, c_d, n)
+    call cuda_addcol3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_addcol3(a_d, b_d, c_d, n)
+    call opencl_addcol3(a_d, b_d, c_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_addcol3
 
   !> Returns \f$ a = a + b*c*d \f$
-  subroutine device_addcol4(a_d, b_d, c_d, d_d, n)
+  subroutine device_addcol4(a_d, b_d, c_d, d_d, n, strm)
     type(c_ptr) :: a_d, b_d, c_d, d_D
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_addcol4(a_d, b_d, c_d, d_d, n)
+    call hip_addcol4(a_d, b_d, c_d, d_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_addcol4(a_d, b_d, c_d, d_d, n)
+    call cuda_addcol4(a_d, b_d, c_d, d_d, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_addcol4(a_d, b_d, c_d, d_d, n)
+    call opencl_addcol4(a_d, b_d, c_d, d_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
@@ -596,16 +911,26 @@ contains
 
   !> Compute a dot product \f$ dot = u \cdot v \f$ (3-d version)
   !! assuming vector components \f$ u = (u_1, u_2, u_3) \f$ etc.
-  subroutine device_vdot3(dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, n)
+  subroutine device_vdot3(dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, n, strm)
     type(c_ptr) :: dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_vdot3(dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, n)
+    call hip_vdot3(dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_vdot3(dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, n)
+    call cuda_vdot3(dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_vdot3(dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, n)
+    call opencl_vdot3(dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
@@ -614,21 +939,31 @@ contains
   !> Compute a cross product \f$ u = v \times w \f$ (3-d version)
   !! assuming vector components \f$ u = (u_1, u_2, u_3) \f$ etc.
   subroutine device_vcross(u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, &
-       w1_d, w2_d, w3_d, n)
+       w1_d, w2_d, w3_d, n, strm)
     type(c_ptr) :: u1_d, u2_d, u3_d
     type(c_ptr) :: v1_d, v2_d, v3_d
     type(c_ptr) :: w1_d, w2_d, w3_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
     call hip_vcross(u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, &
-         w1_d, w2_d, w3_d, n)
+         w1_d, w2_d, w3_d, n, strm_)
 #elif HAVE_CUDA
     call cuda_vcross(u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, &
-         w1_d, w2_d, w3_d, n)
+         w1_d, w2_d, w3_d, n, strm_)
 #elif HAVE_OPENCL
     call opencl_vcross(u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, &
-         w1_d, w2_d, w3_d, n)
+         w1_d, w2_d, w3_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
@@ -636,36 +971,56 @@ contains
 
 
   !> Compute multiplication sum \f$ dot = u \cdot v \cdot w \f$
-  function device_vlsc3(u_d, v_d, w_d, n) result(res)
+  function device_vlsc3(u_d, v_d, w_d, n, strm) result(res)
     type(c_ptr) :: u_d, v_d, w_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
     real(kind=rp) :: res
+
     res = 0.0_rp
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    res = hip_vlsc3(u_d, v_d, w_d, n)
+    res = hip_vlsc3(u_d, v_d, w_d, n, strm_)
 #elif HAVE_CUDA
-    res = cuda_vlsc3(u_d, v_d, w_d, n)
+    res = cuda_vlsc3(u_d, v_d, w_d, n, strm_)
 #elif HAVE_OPENCL
     ! Same kernel as glsc3 (currently no device MPI for OpenCL)
-    res = opencl_glsc3(u_d, v_d, w_d, n)
+    res = opencl_glsc3(u_d, v_d, w_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end function device_vlsc3
 
   !> Weighted inner product \f$ a^T b c \f$
-  function device_glsc3(a_d, b_d, c_d, n) result(res)
+  function device_glsc3(a_d, b_d, c_d, n, strm) result(res)
     type(c_ptr) :: a_d, b_d, c_d
     integer :: n, ierr
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
     real(kind=rp) :: res
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
     res = 0.0_rp
 #if HAVE_HIP
-    res = hip_glsc3(a_d, b_d, c_d, n)
+    res = hip_glsc3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_CUDA
-    res = cuda_glsc3(a_d, b_d, c_d, n)
+    res = cuda_glsc3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_OPENCL
-    res = opencl_glsc3(a_d, b_d, c_d, n)
+    res = opencl_glsc3(a_d, b_d, c_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
@@ -678,17 +1033,26 @@ contains
 #endif
   end function device_glsc3
 
-  subroutine device_glsc3_many(h, w_d, v_d_d, mult_d, j, n)
+  subroutine device_glsc3_many(h, w_d, v_d_d, mult_d, j, n, strm)
     type(c_ptr), value :: w_d, v_d_d, mult_d
     integer(c_int) :: j, n
     real(c_rp) :: h(j)
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
     integer :: ierr
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_glsc3_many(h, w_d, v_d_d, mult_d, j, n)
+    call hip_glsc3_many(h, w_d, v_d_d, mult_d, j, n, strm_)
 #elif HAVE_CUDA
-    call cuda_glsc3_many(h, w_d, v_d_d, mult_d, j, n)
+    call cuda_glsc3_many(h, w_d, v_d_d, mult_d, j, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_glsc3_many(h, w_d, v_d_d, mult_d, j, n)
+    call opencl_glsc3_many(h, w_d, v_d_d, mult_d, j, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
@@ -701,33 +1065,52 @@ contains
 #endif
   end subroutine device_glsc3_many
 
-  subroutine device_add2s2_many(y_d, x_d_d, a_d, j, n)
+  subroutine device_add2s2_many(y_d, x_d_d, a_d, j, n, strm)
     type(c_ptr), value :: y_d, x_d_d, a_d
     integer(c_int) :: j, n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_add2s2_many(y_d, x_d_d, a_d, j, n)
+    call hip_add2s2_many(y_d, x_d_d, a_d, j, n, strm_)
 #elif HAVE_CUDA
-    call cuda_add2s2_many(y_d, x_d_d, a_d, j, n)
+    call cuda_add2s2_many(y_d, x_d_d, a_d, j, n, strm_)
 #elif HAVE_OPENCL
-    call opencl_add2s2_many(y_d, x_d_d, a_d, j, n)
+    call opencl_add2s2_many(y_d, x_d_d, a_d, j, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
   end subroutine device_add2s2_many
 
   !> Weighted inner product \f$ a^T b \f$
-  function device_glsc2(a_d, b_d, n) result(res)
+  function device_glsc2(a_d, b_d, n, strm) result(res)
     type(c_ptr) :: a_d, b_d
     integer :: n, ierr
     real(kind=rp) :: res
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
     res = 0.0_rp
 #if HAVE_HIP
-    res = hip_glsc2(a_d, b_d, n)
+    res = hip_glsc2(a_d, b_d, n, strm_)
 #elif HAVE_CUDA
-    res = cuda_glsc2(a_d, b_d, n)
+    res = cuda_glsc2(a_d, b_d, n, strm_)
 #elif HAVE_OPENCL
-    res = opencl_glsc2(a_d, b_d, n)
+    res = opencl_glsc2(a_d, b_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
@@ -742,18 +1125,27 @@ contains
 
   !> Returns the norm of the difference of two vectors
   !! \f$ \sqrt{(a-b)^T (a-b)} \f$
-  function device_glsubnorm(a_d, b_d, n) result(res)
+  function device_glsubnorm(a_d, b_d, n, strm) result(res)
     type(c_ptr), intent(in) :: a_d, b_d
     integer, intent(in) :: n
     integer :: ierr
     real(kind=rp) :: res
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
     res = 0.0_rp
 #if HAVE_HIP
-    res = hip_glsubnorm2(a_d, b_d, n)
+    res = hip_glsubnorm2(a_d, b_d, n, strm_)
 #elif HAVE_CUDA
-    res = cuda_glsubnorm2(a_d, b_d, n)
+    res = cuda_glsubnorm2(a_d, b_d, n, strm_)
 #elif HAVE_OPENCL
-    res = opencl_glsubnorm2(a_d, b_d, n)
+    res = opencl_glsubnorm2(a_d, b_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
@@ -769,17 +1161,26 @@ contains
   end function device_glsubnorm
 
   !> Sum a vector of length n
-  function device_glsum(a_d, n) result(res)
+  function device_glsum(a_d, n, strm) result(res)
     type(c_ptr) :: a_d
     integer :: n, ierr
     real(kind=rp) :: res
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
     res = 0.0_rp
 #if HAVE_HIP
-    res = hip_glsum(a_d, n)
+    res = hip_glsum(a_d, n, strm_)
 #elif HAVE_CUDA
-    res = cuda_glsum(a_d, n)
+    res = cuda_glsum(a_d, n, strm_)
 #elif HAVE_OPENCL
-    res = opencl_glsum(a_d, n)
+    res = opencl_glsum(a_d, n, strm_)
 #else
     call neko_error('No device backend configured')
 #endif
@@ -792,14 +1193,24 @@ contains
 #endif
   end function device_glsum
 
-  subroutine device_absval(a_d, n)
+  subroutine device_absval(a_d, n, strm)
     integer, intent(in) :: n
     type(c_ptr) :: a_d
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
+
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #ifdef HAVE_HIP
-    call hip_absval(a_d, n)
+    call hip_absval(a_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_absval(a_d, n)
+    call cuda_absval(a_d, n, strm_)
 #elif HAVE_OPENCL
     call neko_error('OPENCL is not implemented for device_absval')
 #else
@@ -813,15 +1224,24 @@ contains
 
   !> Compute the point-wise maximum of two vectors
   !! \f$ a_i = \max(a_i, b_i) \f$
-  subroutine device_pwmax_vec2(a_d, b_d, n)
+  subroutine device_pwmax_vec2(a_d, b_d, n, strm)
     type(c_ptr) :: a_d, b_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
 
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_pwmax_vec2(a_d, b_d, n)
+    call hip_pwmax_vec2(a_d, b_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_pwmax_vec2(a_d, b_d, n)
+    call cuda_pwmax_vec2(a_d, b_d, n, strm_)
 #elif HAVE_OPENCL
     call neko_error('No OpenCL backend for device_pwmax_vec2')
 #else
@@ -831,15 +1251,24 @@ contains
 
   !> Compute the point-wise maximum of two vectors
   !! \f$ a_i = \max(b_i, c_i) \f$
-  subroutine device_pwmax_vec3(a_d, b_d, c_d, n)
+  subroutine device_pwmax_vec3(a_d, b_d, c_d, n, strm)
     type(c_ptr) :: a_d, b_d, c_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
 
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_pwmax_vec3(a_d, b_d, c_d, n)
+    call hip_pwmax_vec3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_pwmax_vec3(a_d, b_d, c_d, n)
+    call cuda_pwmax_vec3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_OPENCL
     call neko_error('No OpenCL backend for device_pwmax_vec3')
 #else
@@ -850,16 +1279,25 @@ contains
 
   !> Compute the point-wise maximum of a vector and a scalar
   !! \f$ a_i = \max(a_i, c) \f$
-  subroutine device_pwmax_sca2(a_d, c, n)
+  subroutine device_pwmax_sca2(a_d, c, n, strm)
     type(c_ptr) :: a_d
     real(kind=rp), intent(in) :: c
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
 
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_pwmax_sca2(a_d, c, n)
+    call hip_pwmax_sca2(a_d, c, n, strm_)
 #elif HAVE_CUDA
-    call cuda_pwmax_sca2(a_d, c, n)
+    call cuda_pwmax_sca2(a_d, c, n, strm_)
 #elif HAVE_OPENCL
     call neko_error('No OpenCL backend for device_pwmax_sca2')
 #else
@@ -870,16 +1308,25 @@ contains
 
   !> Compute the point-wise maximum of a vector and a scalar
   !! \f$ a_i = \max(b_i, c) \f$
-  subroutine device_pwmax_sca3(a_d, b_d, c, n)
+  subroutine device_pwmax_sca3(a_d, b_d, c, n, strm)
     type(c_ptr) :: a_d, b_d
     real(kind=rp), intent(in) :: c
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
 
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_pwmax_sca3(a_d, b_d, c, n)
+    call hip_pwmax_sca3(a_d, b_d, c, n, strm_)
 #elif HAVE_CUDA
-    call cuda_pwmax_sca3(a_d, b_d, c, n)
+    call cuda_pwmax_sca3(a_d, b_d, c, n, strm_)
 #elif HAVE_OPENCL
     call neko_error('No OpenCL backend for device_pwmax_sca3')
 #else
@@ -893,15 +1340,24 @@ contains
 
   !> Compute the point-wise minimum of two vectors
   !! \f$ a_i = \min(a_i, b_i) \f$
-  subroutine device_pwmin_vec2(a_d, b_d, n)
+  subroutine device_pwmin_vec2(a_d, b_d, n, strm)
     type(c_ptr) :: a_d, b_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
 
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_pwmin_vec2(a_d, b_d, n)
+    call hip_pwmin_vec2(a_d, b_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_pwmin_vec2(a_d, b_d, n)
+    call cuda_pwmin_vec2(a_d, b_d, n, strm_)
 #elif HAVE_OPENCL
     call neko_error('No OpenCL backend for device_pwmin_vec2')
 #else
@@ -911,15 +1367,24 @@ contains
 
   !> Compute the point-wise minimum of two vectors
   !! \f$ a_i = \min(b_i, c_i) \f$
-  subroutine device_pwmin_vec3(a_d, b_d, c_d, n)
+  subroutine device_pwmin_vec3(a_d, b_d, c_d, n, strm)
     type(c_ptr) :: a_d, b_d, c_d
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
 
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_pwmin_vec3(a_d, b_d, c_d, n)
+    call hip_pwmin_vec3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_CUDA
-    call cuda_pwmin_vec3(a_d, b_d, c_d, n)
+    call cuda_pwmin_vec3(a_d, b_d, c_d, n, strm_)
 #elif HAVE_OPENCL
     call neko_error('No OpenCL backend for device_pwmin_vec3')
 #else
@@ -930,16 +1395,25 @@ contains
 
   !> Compute the point-wise minimum of a vector and a scalar
   !! \f$ a_i = \min(a_i, c) \f$
-  subroutine device_pwmin_sca2(a_d, c, n)
+  subroutine device_pwmin_sca2(a_d, c, n, strm)
     type(c_ptr) :: a_d
     real(kind=rp), intent(in) :: c
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
 
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_pwmin_sca2(a_d, c, n)
+    call hip_pwmin_sca2(a_d, c, n, strm_)
 #elif HAVE_CUDA
-    call cuda_pwmin_sca2(a_d, c, n)
+    call cuda_pwmin_sca2(a_d, c, n, strm_)
 #elif HAVE_OPENCL
     call neko_error('No OpenCL backend for device_pwmin_sca2')
 #else
@@ -950,16 +1424,25 @@ contains
 
   !> Compute the point-wise minimum of a vector and a scalar
   !! \f$ a_i = \min(b_i, c) \f$
-  subroutine device_pwmin_sca3(a_d, b_d, c, n)
+  subroutine device_pwmin_sca3(a_d, b_d, c, n, strm)
     type(c_ptr) :: a_d, b_d
     real(kind=rp), intent(in) :: c
     integer :: n
+    type(c_ptr), optional :: strm
+    type(c_ptr) :: strm_
+
     if (n .lt. 1) return
 
+    if (present(strm)) then
+       strm_ = strm
+    else
+       strm_ = glb_cmd_queue
+    end if
+
 #if HAVE_HIP
-    call hip_pwmin_sca3(a_d, b_d, c, n)
+    call hip_pwmin_sca3(a_d, b_d, c, n, strm_)
 #elif HAVE_CUDA
-    call cuda_pwmin_sca3(a_d, b_d, c, n)
+    call cuda_pwmin_sca3(a_d, b_d, c, n, strm_)
 #elif HAVE_OPENCL
     call neko_error('No OpenCL backend for device_pwmin_sca3')
 #else

--- a/src/math/bcknd/device/hip/hip_math.f90
+++ b/src/math/bcknd/device/hip/hip_math.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2024, The Neko Authors
+! Copyright (c) 2024-2025, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -36,42 +36,42 @@ module hip_math
   public
 
   interface
-     subroutine hip_copy(a_d, b_d, n) &
+     subroutine hip_copy(a_d, b_d, n, strm) &
           bind(c, name = 'hip_copy')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine hip_copy
 
-     subroutine hip_masked_copy(a_d, b_d, mask_d, n, n_mask) &
+     subroutine hip_masked_copy(a_d, b_d, mask_d, n, n_mask, strm) &
           bind(c, name = 'hip_masked_copy')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d, mask_d
+       type(c_ptr), value :: a_d, b_d, mask_d, strm
        integer(c_int) :: n, n_mask
      end subroutine hip_masked_copy
 
-     subroutine hip_masked_gather_copy(a_d, b_d, mask_d, n, n_mask) &
+     subroutine hip_masked_gather_copy(a_d, b_d, mask_d, n, n_mask, strm) &
           bind(c, name = 'hip_masked_gather_copy')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d, mask_d
+       type(c_ptr), value :: a_d, b_d, mask_d, strm
        integer(c_int) :: n, n_mask
      end subroutine hip_masked_gather_copy
 
-     subroutine hip_masked_scatter_copy(a_d, b_d, mask_d, n, n_mask) &
+     subroutine hip_masked_scatter_copy(a_d, b_d, mask_d, n, n_mask, strm) &
           bind(c, name = 'hip_masked_scatter_copy')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d, mask_d
+       type(c_ptr), value :: a_d, b_d, mask_d, strm
        integer(c_int) :: n, n_mask
      end subroutine hip_masked_scatter_copy
 
-     subroutine hip_masked_atomic_reduction(a_d, b_d, mask_d, n, m) &
+     subroutine hip_masked_atomic_reduction(a_d, b_d, mask_d, n, m, strm) &
           bind(c, name = 'hip_masked_atomic_reduction')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d, mask_d
+       type(c_ptr), value :: a_d, b_d, mask_d, strm
        integer(c_int) :: n, m
      end subroutine hip_masked_atomic_reduction
 
-     subroutine hip_cfill_mask(a_d, c, n, mask_d, n_mask) &
+     subroutine hip_cfill_mask(a_d, c, n, mask_d, n_mask, strm) &
           bind(c, name = 'hip_cfill_mask')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
@@ -80,288 +80,291 @@ module hip_math
        integer(c_int) :: n
        type(c_ptr), value :: mask_d
        integer(c_int) :: n_mask
+       type(c_ptr), value :: strm
      end subroutine hip_cfill_mask
 
-     subroutine hip_cmult(a_d, c, n) &
+     subroutine hip_cmult(a_d, c, n, strm) &
           bind(c, name = 'hip_cmult')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine hip_cmult
 
-     subroutine hip_cmult2(a_d, b_d, c, n) &
+     subroutine hip_cmult2(a_d, b_d, c, n, strm) &
           bind(c, name = 'hip_cmult2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine hip_cmult2
 
-     subroutine hip_cdiv(a_d, c, n) &
+     subroutine hip_cdiv(a_d, c, n, strm) &
           bind(c, name = 'hip_cdiv')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine hip_cdiv
 
-     subroutine hip_cdiv2(a_d, b_d, c, n) &
+     subroutine hip_cdiv2(a_d, b_d, c, n, strm) &
           bind(c, name = 'hip_cdiv2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine hip_cdiv2
 
-     subroutine hip_cadd(a_d, c, n) &
+     subroutine hip_cadd(a_d, c, n, strm) &
           bind(c, name = 'hip_cadd')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine hip_cadd
 
-     subroutine hip_cadd2(a_d, b_d, c, n) &
+     subroutine hip_cadd2(a_d, b_d, c, n, strm) &
           bind(c, name = 'hip_cadd2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
        type(c_ptr), value :: a_d
        type(c_ptr), value :: b_d
+       type(c_ptr), value :: strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine hip_cadd2
 
-     subroutine hip_cfill(a_d, c, n) &
+     subroutine hip_cfill(a_d, c, n, strm) &
           bind(c, name = 'hip_cfill')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine hip_cfill
 
-     subroutine hip_rzero(a_d, n) &
+     subroutine hip_rzero(a_d, n, strm) &
           bind(c, name = 'hip_rzero')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        integer(c_int) :: n
      end subroutine hip_rzero
 
-     subroutine hip_add2(a_d, b_d, n) &
+     subroutine hip_add2(a_d, b_d, n, strm) &
           bind(c, name = 'hip_add2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine hip_add2
 
-     subroutine hip_add4(a_d, b_d, c_d, d_d, n) &
+     subroutine hip_add4(a_d, b_d, c_d, d_d, n, strm) &
           bind(c, name = 'hip_add4')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d, b_d, c_d, d_d
+       type(c_ptr), value :: a_d, b_d, c_d, d_d, strm
        integer(c_int) :: n
      end subroutine hip_add4
 
-     subroutine hip_add2s1(a_d, b_d, c1, n) &
+     subroutine hip_add2s1(a_d, b_d, c1, n, strm) &
           bind(c, name = 'hip_add2s1')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c1
        integer(c_int) :: n
      end subroutine hip_add2s1
 
-     subroutine hip_add2s2(a_d, b_d, c1, n) &
+     subroutine hip_add2s2(a_d, b_d, c1, n, strm) &
           bind(c, name = 'hip_add2s2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c1
        integer(c_int) :: n
      end subroutine hip_add2s2
 
-     subroutine hip_addsqr2s2(a_d, b_d, c1, n) &
+     subroutine hip_addsqr2s2(a_d, b_d, c1, n, strm) &
           bind(c, name = 'hip_addsqr2s2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c1
        integer(c_int) :: n
      end subroutine hip_addsqr2s2
 
-     subroutine hip_add3s2(a_d, b_d, c_d, c1, c2, n) &
+     subroutine hip_add3s2(a_d, b_d, c_d, c1, c2, n, strm) &
           bind(c, name = 'hip_add3s2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        real(c_rp) :: c1, c2
        integer(c_int) :: n
      end subroutine hip_add3s2
 
-     subroutine hip_invcol1(a_d, n) &
+     subroutine hip_invcol1(a_d, n, strm) &
           bind(c, name = 'hip_invcol1')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        integer(c_int) :: n
      end subroutine hip_invcol1
 
-     subroutine hip_invcol2(a_d, b_d, n) &
+     subroutine hip_invcol2(a_d, b_d, n, strm) &
           bind(c, name = 'hip_invcol2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine hip_invcol2
 
-     subroutine hip_invcol3(a_d, b_d, c_d, n) &
+     subroutine hip_invcol3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'hip_invcol3')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine hip_invcol3
 
-     subroutine hip_col2(a_d, b_d, n) &
+     subroutine hip_col2(a_d, b_d, n, strm) &
           bind(c, name = 'hip_col2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine hip_col2
 
-     subroutine hip_col3(a_d, b_d, c_d, n) &
+     subroutine hip_col3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'hip_col3')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine hip_col3
 
-     subroutine hip_subcol3(a_d, b_d, c_d, n) &
+     subroutine hip_subcol3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'hip_subcol3')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine hip_subcol3
 
-     subroutine hip_sub2(a_d, b_d, n) &
+     subroutine hip_sub2(a_d, b_d, n, strm) &
           bind(c, name = 'hip_sub2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine hip_sub2
 
-     subroutine hip_sub3(a_d, b_d, c_d, n) &
+     subroutine hip_sub3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'hip_sub3')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine hip_sub3
 
-     subroutine hip_add3(a_d, b_d, c_d, n) &
+     subroutine hip_add3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'hip_add3')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine hip_add3
 
-     subroutine hip_addcol3(a_d, b_d, c_d, n) &
+     subroutine hip_addcol3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'hip_addcol3')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine hip_addcol3
 
-     subroutine hip_addcol4(a_d, b_d, c_d, d_d, n) &
+     subroutine hip_addcol4(a_d, b_d, c_d, d_d, n, strm) &
           bind(c, name = 'hip_addcol4')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d, c_d, d_d
+       type(c_ptr), value :: a_d, b_d, c_d, d_d, strm
        integer(c_int) :: n
      end subroutine hip_addcol4
 
-     subroutine hip_vdot3(dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, n) &
+     subroutine hip_vdot3(dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, n, strm) &
           bind(c, name = 'hip_vdot3')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d
+       type(c_ptr), value :: dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, strm
        integer(c_int) :: n
      end subroutine hip_vdot3
 
      subroutine hip_vcross(u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, &
-          w1_d, w2_d, w3_d, n) &
+          w1_d, w2_d, w3_d, n, strm) &
           bind(c, name = 'hip_vcross')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
 
        type(c_ptr), value :: u1_d, u2_d, u3_d
        type(c_ptr), value :: v1_d, v2_d, v3_d
        type(c_ptr), value :: w1_d, w2_d, w3_d
+       type(c_ptr), value :: strm
        integer(c_int) :: n
      end subroutine hip_vcross
 
-     real(c_rp) function hip_vlsc3(u_d, v_d, w_d, n) &
+     real(c_rp) function hip_vlsc3(u_d, v_d, w_d, n, strm) &
           bind(c, name = 'hip_vlsc3')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: u_d, v_d, w_d
+       type(c_ptr), value :: u_d, v_d, w_d, strm
        integer(c_int) :: n
      end function hip_vlsc3
 
-     subroutine hip_add2s2_many(y_d, x_d_d, a_d, j, n) &
+     subroutine hip_add2s2_many(y_d, x_d_d, a_d, j, n, strm) &
           bind(c, name = 'hip_add2s2_many')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: y_d, x_d_d, a_d
+       type(c_ptr), value :: y_d, x_d_d, a_d, strm
        integer(c_int) :: j, n
      end subroutine hip_add2s2_many
 
-     real(c_rp) function hip_glsc3(a_d, b_d, c_d, n) &
+     real(c_rp) function hip_glsc3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'hip_glsc3')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end function hip_glsc3
 
-     subroutine hip_glsc3_many(h, w_d, v_d_d, mult_d, j, n) &
+     subroutine hip_glsc3_many(h, w_d, v_d_d, mult_d, j, n, strm) &
           bind(c, name = 'hip_glsc3_many')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: w_d, v_d_d, mult_d
+       type(c_ptr), value :: w_d, v_d_d, mult_d, strm
        integer(c_int) :: j, n
        real(c_rp) :: h(j)
      end subroutine hip_glsc3_many
 
-     real(c_rp) function hip_glsc2(a_d, b_d, n) &
+     real(c_rp) function hip_glsc2(a_d, b_d, n, strm) &
           bind(c, name = 'hip_glsc2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end function hip_glsc2
 
-     real(c_rp) function hip_glsubnorm2(a_d, b_d, n) &
+     real(c_rp) function hip_glsubnorm2(a_d, b_d, n, strm) &
           bind(c, name = 'hip_glsubnorm2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end function hip_glsubnorm2
 
-     real(c_rp) function hip_glsum(a_d, n) &
+     real(c_rp) function hip_glsum(a_d, n, strm) &
           bind(c, name = 'hip_glsum')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        integer(c_int) :: n
      end function hip_glsum
 
-     subroutine hip_absval(a_d, n) &
+     subroutine hip_absval(a_d, n, strm) &
           bind(c, name = 'hip_absval')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        integer(c_int) :: n
      end subroutine hip_absval
   end interface
@@ -370,66 +373,66 @@ module hip_math
   ! Interfaces for the pointwise operations.
 
   interface
-     subroutine hip_pwmax_vec2(a_d, b_d, n) &
+     subroutine hip_pwmax_vec2(a_d, b_d, n, strm) &
           bind(c, name = 'hip_pwmax_vec2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine hip_pwmax_vec2
 
-     subroutine hip_pwmax_vec3(a_d, b_d, c_d, n) &
+     subroutine hip_pwmax_vec3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'hip_pwmax_vec3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine hip_pwmax_vec3
 
-     subroutine hip_pwmax_sca2(a_d, c_d, n) &
+     subroutine hip_pwmax_sca2(a_d, c_d, n, strm) &
           bind(c, name = 'hip_pwmax_sca2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        real(c_rp) :: c_d
        integer(c_int) :: n
      end subroutine hip_pwmax_sca2
 
-     subroutine hip_pwmax_sca3(a_d, b_d, c_d, n) &
+     subroutine hip_pwmax_sca3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'hip_pwmax_sca3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c_d
        integer(c_int) :: n
      end subroutine hip_pwmax_sca3
 
-     subroutine hip_pwmin_vec2(a_d, b_d, n) &
+     subroutine hip_pwmin_vec2(a_d, b_d, n, strm) &
           bind(c, name = 'hip_pwmin_vec2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine hip_pwmin_vec2
 
-     subroutine hip_pwmin_vec3(a_d, b_d, c_d, n) &
+     subroutine hip_pwmin_vec3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'hip_pwmin_vec3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine hip_pwmin_vec3
 
-     subroutine hip_pwmin_sca2(a_d, c_d, n) &
+     subroutine hip_pwmin_sca2(a_d, c_d, n, strm) &
           bind(c, name = 'hip_pwmin_sca2')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        real(c_rp) :: c_d
        integer(c_int) :: n
      end subroutine hip_pwmin_sca2
 
-     subroutine hip_pwmin_sca3(a_d, b_d, c_d, n) &
+     subroutine hip_pwmin_sca3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'hip_pwmin_sca3')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c_d
        integer(c_int) :: n
      end subroutine hip_pwmin_sca3

--- a/src/math/bcknd/device/hip/math.hip
+++ b/src/math/bcknd/device/hip/math.hip
@@ -50,23 +50,23 @@ extern "C" {
   /** Fortran wrapper for copy
    * Copy a vector \f$ a = b \f$
    */
-  void hip_copy(void *a, void *b, int *n) {
+  void hip_copy(void *a, void *b, int *n, hipStream_t strm) {
     HIP_CHECK(hipMemcpyAsync(a, b, (*n) * sizeof(real),
-                             hipMemcpyDeviceToDevice,
-                             (hipStream_t) glb_cmd_queue));
+                             hipMemcpyDeviceToDevice, strm));
   }
 
   /** Fortran wrapper for masked copy
    * Copy a vector \f$ a(mask) = b(mask) \f$
    */
-  void hip_masked_copy(void *a, void *b, void *mask, int *n, int *m) {
+  void hip_masked_copy(void *a, void *b, void *mask,
+                       int *n, int *m, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*m)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(masked_copy_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, (int *) mask, *n, *m);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b, (int *) mask, *n, *m);
 
     HIP_CHECK(hipGetLastError());
 
@@ -75,14 +75,15 @@ extern "C" {
   /** Fortran wrapper for masked gather copy
    * Copy a vector \f$ a = b(mask) \f$
    */
-  void hip_masked_gather_copy(void *a, void *b, void *mask, int *n, int *m) {
+  void hip_masked_gather_copy(void *a, void *b, void *mask,
+                              int *n, int *m, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*m)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(masked_gather_copy_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, (int *) mask, *n, *m);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b, (int *) mask, *n, *m);
     HIP_CHECK(hipGetLastError());
 
   }
@@ -90,14 +91,15 @@ extern "C" {
   /** Fortran wrapper for masked scatter copy
    * Copy a vector \f$ a(mask) = b \f$
    */
-  void hip_masked_scatter_copy(void *a, void *b, void *mask, int *n, int *m) {
+  void hip_masked_scatter_copy(void *a, void *b, void *mask,
+                               int *n, int *m, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*m)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(masked_scatter_copy_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, (int *) mask, *n, *m);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b, (int *) mask, *n, *m);
 
     HIP_CHECK(hipGetLastError());
 
@@ -106,14 +108,15 @@ extern "C" {
   /** Fortran wrapper for masked atomic reduction
    * update a vector \f$ a += b(mask) \f$ where mask is not unique
    */
-  void hip_masked_atomic_reduction(void *a, void *b, void *mask, int *n, int *m) {
+  void hip_masked_atomic_reduction(void *a, void *b, void *mask,
+                                   int *n, int *m, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*m)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(masked_atomic_reduction_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, (int *) mask, *n, *m);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b, (int *) mask, *n, *m);
 
     HIP_CHECK(hipGetLastError());
 
@@ -122,14 +125,15 @@ extern "C" {
   /** Fortran wrapper for cfill_mask
    * Fill a scalar to vector \f$ a_i = s, for i \in mask \f$
    */
-  void hip_cfill_mask(void* a, real* c, int* size, void* mask, int* mask_size) {
+  void hip_cfill_mask(void* a, real* c, int* size, void* mask, int* mask_size,
+                      hipStream_t strm) {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(cfill_mask_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real*)a, *c, *size, (int*)mask, *mask_size);
+                       nblcks, nthrds, 0, strm, (real*)a,
+                       *c, *size, (int*)mask, *mask_size);
 
     HIP_CHECK(hipGetLastError());
   }
@@ -137,22 +141,20 @@ extern "C" {
   /** Fortran wrapper for rzero
    * Zero a real vector
    */
-  void hip_rzero(void *a, int *n) {
-    HIP_CHECK(hipMemsetAsync(a, 0, (*n) * sizeof(real),
-                             (hipStream_t) glb_cmd_queue));
+  void hip_rzero(void *a, int *n, hipStream_t strm) {
+    HIP_CHECK(hipMemsetAsync(a, 0, (*n) * sizeof(real), strm));
   }
 
   /** Fortran wrapper for cmult
    * Multiplication by constant c \f$ a = c \cdot a \f$
    */
-  void hip_cmult(void *a, real *c, int *n) {
+  void hip_cmult(void *a, real *c, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(cmult_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, *c, *n);
+                       nblcks, nthrds, 0, strm, (real *) a, *c, *n);
     HIP_CHECK(hipGetLastError());
 
   }
@@ -160,59 +162,55 @@ extern "C" {
   /** Fortran wrapper for cmult
    * Multiplication by constant c \f$ a = c \cdot b \f$
    */
-  void hip_cmult2(void *a, void *b, real *c, int *n) {
+  void hip_cmult2(void *a, void *b, real *c, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(cmult2_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a,(real *) b, *c, *n);
+                       nblcks, nthrds, 0, strm, (real *) a,(real *) b, *c, *n);
     HIP_CHECK(hipGetLastError());
 
   }
-  
+
   /** Fortran wrapper for cdiv
    * Division of constant c by array \f$ a = c / a \f$
    */
-  void hip_cdiv(void *a, real *c, int *n) {
+  void hip_cdiv(void *a, real *c, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
-    
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(cdiv_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, *c, *n);
+                       nblcks, nthrds, 0, strm, (real *) a, *c, *n);
     HIP_CHECK(hipGetLastError());
-    
+
   }
 
   /** Fortran wrapper for cdiv
    * Division of constant c by \f$ a = c / b \f$
    */
-  void hip_cdiv2(void *a, void *b, real *c, int *n) {
+  void hip_cdiv2(void *a, void *b, real *c, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
-    
+
     hipLaunchKernelGGL(HIP_KERNEL_NAME(cdiv2_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a,(real *) b, *c, *n);
+                       nblcks, nthrds, 0, strm, (real *) a,(real *) b, *c, *n);
     HIP_CHECK(hipGetLastError());
-    
+
   }
 
   /** Fortran wrapper for cadd
    * Add a scalar to vector \f$ a = \sum a_i + s \f$
    */
-  void hip_cadd(void *a, real *c, int *n) {
+  void hip_cadd(void *a, real *c, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(cadd_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, *c, *n);
+                       nblcks, nthrds, 0, strm, (real *) a, *c, *n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -220,29 +218,27 @@ extern "C" {
    * Fortran wrapper for cadd2
    * Add a scalar to a vector \f$ a = b + s \f$
    */
-  void hip_cadd2(void *a, void *b, real *c, int *n) {
+  void hip_cadd2(void *a, void *b, real *c, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(cadd2_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, *c, *n);
+                       nblcks, nthrds, 0, strm, (real *) a, (real *) b, *c, *n);
     HIP_CHECK(hipGetLastError());
   }
 
   /** Fortran wrapper for cfill
    * Multiplication by constant c \f$ a = c \cdot a \f$
    */
-  void hip_cfill(void *a, real *c, int *n) {
+  void hip_cfill(void *a, real *c, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     if (*n > 0) {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(cfill_kernel<real>),
-                         nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                         (real *) a, *c, *n);
+                         nblcks, nthrds, 0, strm, (real *) a, *c, *n);
       HIP_CHECK(hipGetLastError());
     }
 
@@ -252,14 +248,13 @@ extern "C" {
    * Fortran wrapper for add2
    * Vector addition \f$ a = a + b \f$
    */
-  void hip_add2(void *a, void *b, int *n) {
+  void hip_add2(void *a, void *b, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(add2_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, *n);
+                       nblcks, nthrds, 0, strm, (real *) a, (real *) b, *n);
     HIP_CHECK(hipGetLastError());
 
   }
@@ -268,14 +263,14 @@ extern "C" {
    * Fortran wrapper for add4
    * Vector addition \f$ a = b + c + d\f$
    */
-  void hip_add3(void *a, void *b, void *c, int *n) {
+  void hip_add3(void *a, void *b, void *c, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(add3_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, (real *) c, *n);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b, (real *) c, *n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -283,14 +278,14 @@ extern "C" {
    * Fortran wrapper for add4
    * Vector addition \f$ a = b + c + d\f$
    */
-  void hip_add4(void *a, void *b, void *c, void *d, int *n) {
+  void hip_add4(void *a, void *b, void *c, void *d, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(add4_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, (real *) c, (real *) d, *n);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b, (real *) c, (real *) d, *n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -299,15 +294,14 @@ extern "C" {
    * Vector addition with scalar multiplication \f$ a = c_1 a + b \f$
    * (multiplication on first argument)
    */
-  void hip_add2s1(void *a, void *b, real *c1, int *n) {
+  void hip_add2s1(void *a, void *b, real *c1, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(add2s1_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b,
-                       *c1, *n);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b, *c1, *n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -316,32 +310,32 @@ extern "C" {
    * Vector addition with scalar multiplication \f$ a = a + c_1 b \f$
    * (multiplication on second argument)
    */
-  void hip_add2s2(void *a, void *b, real *c1, int *n) {
+  void hip_add2s2(void *a, void *b, real *c1, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(add2s2_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b,
+                       nblcks, nthrds, 0, strm, (real *) a, (real *) b,
                        *c1, *n);
     HIP_CHECK(hipGetLastError());
   }
-  
+
   /**
    * Fortran wrapper for add2s2
    * Vector addition with scalar multiplication
    * \f$ x = x + c_1 p1 + c_2p2 + ... + c_jpj \f$
    * (multiplication on second argument)
    */
-  void hip_add2s2_many(void *x, void **p, void *alpha, int *j, int *n) {
+  void hip_add2s2_many(void *x, void **p, void *alpha, int *j, int *n,
+                       hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(add2s2_many_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) x, (const real **) p, (real *) alpha, *j, *n);
+                       nblcks, nthrds, 0, strm, (real *) x,
+                       (const real **) p, (real *) alpha, *j, *n);
     HIP_CHECK(hipGetLastError());
 
   }
@@ -351,15 +345,14 @@ extern "C" {
    * Vector addition with scalar multiplication \f$ a = a + c_1 (b * b) \f$
    * (multiplication on second argument)
    */
-  void hip_addsqr2s2(void *a, void *b, real *c1, int *n) {
+  void hip_addsqr2s2(void *a, void *b, real *c1, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(addsqr2s2_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b,
-                       *c1, *n);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b, *c1, *n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -368,15 +361,15 @@ extern "C" {
    * Vector addition with scalar multiplication \f$ a = c_1 b + c_2 c \f$
    * (multiplication on second argument)
    */
-  void hip_add3s2(void *a, void *b, void *c, real *c1, real *c2, int *n) {
+  void hip_add3s2(void *a, void *b, void *c, real *c1, real *c2, int *n,
+                  hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(add3s2_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, (real *) c,
-                       *c1, *c2, *n);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b, (real *) c, *c1, *c2, *n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -384,14 +377,13 @@ extern "C" {
    * Fortran wrapper for invcol1
    * Invert a vector \f$ a = 1 / a \f$
    */
-  void hip_invcol1(void *a, int *n) {
+  void hip_invcol1(void *a, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(invcol1_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, *n);
+                       nblcks, nthrds, 0, strm, (real *) a, *n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -399,14 +391,13 @@ extern "C" {
    * Fortran wrapper for invcol2
    * Vector division \f$ a = a / b \f$
    */
-  void hip_invcol2(void *a, void *b, int *n) {
+  void hip_invcol2(void *a, void *b, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(invcol2_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, *n);
+                       nblcks, nthrds, 0, strm, (real *) a, (real *) b, *n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -414,14 +405,14 @@ extern "C" {
    * Fortran wrapper for invcol3
    * Vector division \f$ a = b / c \f$
    */
-  void hip_invcol3(void *a, void *b, void *c, int *n) {
+  void hip_invcol3(void *a, void *b, void *c, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(invcol3_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b,  (real *) c, *n);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b,  (real *) c, *n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -429,14 +420,14 @@ extern "C" {
    * Fortran wrapper for col2
    * Vector multiplication with 2 vectors \f$ a = a \cdot b \f$
    */
-  void hip_col2(void *a, void *b, int *n) {
+  void hip_col2(void *a, void *b, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(col2_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, *n);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b, *n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -444,14 +435,14 @@ extern "C" {
    * Fortran wrapper for col3
    * Vector multiplication with 3 vectors \f$ a = b \cdot c \f$
    */
-  void hip_col3(void *a, void *b, void *c, int *n) {
+  void hip_col3(void *a, void *b, void *c, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(col3_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, (real *) c, *n);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b, (real *) c, *n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -459,14 +450,14 @@ extern "C" {
    * Fortran wrapper for subcol3
    * Vector multiplication with 3 vectors \f$ a = b \cdot c \f$
    */
-  void hip_subcol3(void *a, void *b, void *c, int *n) {
+  void hip_subcol3(void *a, void *b, void *c, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(subcol3_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, (real *) c, *n);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b, (real *) c, *n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -474,14 +465,14 @@ extern "C" {
    * Fortran wrapper for sub2
    * Vector subtraction \f$ a = a - b \f$
    */
-  void hip_sub2(void *a, void *b, int *n) {
+  void hip_sub2(void *a, void *b, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(sub2_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, *n);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b, *n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -489,14 +480,14 @@ extern "C" {
    * Fortran wrapper for sub3
    * Vector subtraction \f$ a = b - c \f$
    */
-  void hip_sub3(void *a, void *b, void *c, int *n) {
+  void hip_sub3(void *a, void *b, void *c, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(sub3_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, (real *) c, *n);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b, (real *) c, *n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -504,14 +495,14 @@ extern "C" {
    * Fortran wrapper for addcol3
    * \f$ a = a + b * c \f$
    */
-  void hip_addcol3(void *a, void *b, void *c, int *n) {
+  void hip_addcol3(void *a, void *b, void *c, int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(addcol3_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, (real *) c, *n);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b, (real *) c, *n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -519,14 +510,15 @@ extern "C" {
    * Fortran wrapper for addcol4
    * \f$ a = a + b * c * d \f$
    */
-  void hip_addcol4(void *a, void *b, void *c, void *d, int *n) {
+  void hip_addcol4(void *a, void *b, void *c, void *d, int *n,
+                   hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(addcol4_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, (real *) b, (real *) c, (real *) d, *n);
+                       nblcks, nthrds, 0, strm, (real *) a,
+                       (real *) b, (real *) c, (real *) d, *n);
     HIP_CHECK(hipGetLastError());
   }
 
@@ -535,13 +527,14 @@ extern "C" {
    * \f$ dot = u \cdot v \f$
    */
   void hip_vdot3(void *dot, void *u1, void *u2, void *u3,
-                 void *v1, void *v2, void *v3, int *n) {
+                 void *v1, void *v2, void *v3, int *n,
+                 hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(vdot3_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
+                       nblcks, nthrds, 0, strm,
                        (real *) dot, (real *) u1, (real *) u2, (real *) u3,
                        (real *) v1, (real *) v2, (real *) v3, *n);
     HIP_CHECK(hipGetLastError());
@@ -552,14 +545,15 @@ extern "C" {
    * \f$ u = v \times w \f$
    */
   void hip_vcross(void *u1, void *u2, void *u3,
-                 void *v1, void *v2, void *v3,
-                 void *w1, void *w2, void *w3, int *n) {
+                  void *v1, void *v2, void *v3,
+                  void *w1, void *w2, void *w3,
+                  int *n, hipStream_t strm) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(vcross_kernel<real>),
-                       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
+                       nblcks, nthrds, 0, strm,
                        (real *) u1, (real *) u2, (real *) u3,
                        (real *) v1, (real *) v2, (real *) v3,
                        (real *) w1, (real *) w2, (real *) w3, *n);
@@ -575,7 +569,7 @@ extern "C" {
   real * bufred_d = NULL;
 
   void hip_redbuf_check_alloc(int nb) {
-    if ( nb >= red_s){
+    if ( nb >= red_s) {
       red_s = nb+1;
       if (bufred != NULL) {
         HIP_CHECK(hipHostFree(bufred));
@@ -589,7 +583,8 @@ extern "C" {
   /**
    * Global additive reduction
    */
-  void hip_global_reduce_add(real * bufred, void * bufred_d, int n, const hipStream_t stream) {
+  void hip_global_reduce_add(real * bufred, void * bufred_d, int n,
+                             const hipStream_t stream) {
     #ifdef HAVE_RCCL
         device_nccl_allreduce(bufred_d, bufred_d, n, sizeof(real),
                               DEVICE_NCCL_SUM, stream);
@@ -610,12 +605,12 @@ extern "C" {
    * Fortran wrapper vlsc3
    * Compute multiplication sum \f$ dot = u \cdot v \cdot w \f$
    */
-  real hip_vlsc3(void *u, void *v, void *w, int *n) {
+  real hip_vlsc3(void *u, void *v, void *w, int *n, hipStream_t stream) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     const int nb = ((*n) + 1024 - 1)/ 1024;
-    const hipStream_t stream = (hipStream_t) glb_cmd_queue;
+
     hip_redbuf_check_alloc(nb);
 
 
@@ -639,26 +634,29 @@ extern "C" {
    * Fortran wrapper glsc3
    * Weighted inner product \f$ a^T b c \f$
    */
-  real hip_glsc3(void *a, void *b, void *c, int *n) {
+  real hip_glsc3(void *a, void *b, void *c, int *n, hipStream_t stream) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     const int nb = ((*n) + 1024 - 1)/ 1024;
-    const hipStream_t stream = (hipStream_t) glb_cmd_queue;
 
     hip_redbuf_check_alloc(nb);
 
     if (*n > 0) {
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_kernel<real>),
-                       nblcks, nthrds, 0, stream,
-                       (real *) a, (real *) b,
-                       (real *) c, bufred_d, *n);
-    HIP_CHECK(hipGetLastError());
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real>),
-                       1, 1024, 0, stream, bufred_d, nb);
-    HIP_CHECK(hipGetLastError());
-    } else { hip_rzero(bufred_d,&red_s); }
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_kernel<real>),
+                         nblcks, nthrds, 0, stream,
+                         (real *) a, (real *) b,
+                         (real *) c, bufred_d, *n);
+      HIP_CHECK(hipGetLastError());
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real>),
+                         1, 1024, 0, stream, bufred_d, nb);
+      HIP_CHECK(hipGetLastError());
+    }
+    else {
+      hip_rzero(bufred_d, &red_s, stream);
+    }
     hip_global_reduce_add(bufred, bufred_d, 1, stream);
+
     return bufred[0];
   }
 
@@ -666,7 +664,8 @@ extern "C" {
    * Fortran wrapper for doing an reduction to an array
    * Weighted inner product \f$ w^T v(n,1:j) c \f$
    */
-  void hip_glsc3_many(real *h, void * w, void *v,void *mult, int *j, int *n){
+  void hip_glsc3_many(real *h, void * w, void *v,void *mult, int *j, int *n,
+                      hipStream_t stream){
     int pow2 = 1;
     while(pow2 < (*j)){
       pow2 = 2*pow2;
@@ -677,20 +676,24 @@ extern "C" {
     const dim3 nthrds_red(1024,1,1);
     const dim3 nblcks_red( (*j),1,1);
     const int nb = ((*n) + nt - 1)/nt;
-    const hipStream_t stream = (hipStream_t) glb_cmd_queue;
-    hip_redbuf_check_alloc((*j)*nb);
-    if (*n > 0) {
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_many_kernel<real>),
-                       nblcks, nthrds, 0, stream,
-                       (const real *) w, (const real **) v,
-                       (const real *)mult, bufred_d, *j, *n);
-    HIP_CHECK(hipGetLastError());
 
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_reduce_kernel<real>),
-                       nblcks_red, nthrds_red, 0, stream,
-                       bufred_d, nb, *j);
-    HIP_CHECK(hipGetLastError());
-    } else { hip_rzero(bufred_d,&red_s); }
+    hip_redbuf_check_alloc((*j)*nb);
+
+    if (*n > 0) {
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_many_kernel<real>),
+                         nblcks, nthrds, 0, stream,
+                         (const real *) w, (const real **) v,
+                         (const real *)mult, bufred_d, *j, *n);
+      HIP_CHECK(hipGetLastError());
+
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_reduce_kernel<real>),
+                         nblcks_red, nthrds_red, 0, stream,
+                         bufred_d, nb, *j);
+      HIP_CHECK(hipGetLastError());
+    }
+    else {
+      hip_rzero(bufred_d, &red_s, stream);
+    }
     hip_global_reduce_add(h, bufred_d, (*j), stream);
   }
 
@@ -698,25 +701,27 @@ extern "C" {
    * Fortran wrapper glsc2
    * Weighted inner product \f$ a^T b \f$
    */
-  real hip_glsc2(void *a, void *b, int *n) {
+  real hip_glsc2(void *a, void *b, int *n, hipStream_t stream) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     const int nb = ((*n) + 1024 - 1)/ 1024;
-    const hipStream_t stream = (hipStream_t) glb_cmd_queue;
 
 
     hip_redbuf_check_alloc(nb);
 
     if( *n > 0) {
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc2_kernel<real>),
-                       nblcks, nthrds, 0, stream,
-                       (real *) a, (real *) b, bufred_d, *n);
-    HIP_CHECK(hipGetLastError());
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real>),
-                       1, 1024, 0, stream, bufred_d, nb);
-    HIP_CHECK(hipGetLastError());
-    } else { hip_rzero(bufred_d,&red_s); }
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc2_kernel<real>),
+                         nblcks, nthrds, 0, stream,
+                         (real *) a, (real *) b, bufred_d, *n);
+      HIP_CHECK(hipGetLastError());
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real>),
+                         1, 1024, 0, stream, bufred_d, nb);
+      HIP_CHECK(hipGetLastError());
+    }
+    else {
+      hip_rzero(bufred_d, &red_s, stream);
+    }
     hip_global_reduce_add(bufred, bufred_d, 1, stream);
 
     return bufred[0];
@@ -726,26 +731,25 @@ extern "C" {
    * Fortran wrapper glsubnorm2
    * Weighted inner product \f$ a^T b \f$
    */
-  real hip_glsubnorm2(void* a, void* b, int* n) {
+  real hip_glsubnorm2(void* a, void* b, int* n, hipStream_t stream) {
 
       const dim3        nthrds(1024, 1, 1);
       const dim3        nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
       const int         nb     = ((*n) + 1024 - 1) / 1024;
-      const hipStream_t stream = (hipStream_t)glb_cmd_queue;
 
       hip_redbuf_check_alloc(nb);
 
       if (*n > 0) {
-          hipLaunchKernelGGL(
-              HIP_KERNEL_NAME(glsubnorm2_kernel<real>), nblcks, nthrds, 0,
-              stream, (real*)a, (real*)b, bufred_d, *n);
-          HIP_CHECK(hipGetLastError());
-          hipLaunchKernelGGL(
-              HIP_KERNEL_NAME(reduce_kernel<real>), 1, 1024, 0, stream,
-              bufred_d, nb);
-          HIP_CHECK(hipGetLastError());
-      } else {
-          hip_rzero(bufred_d, &red_s);
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(glsubnorm2_kernel<real>),
+                           nblcks, nthrds, 0, stream,
+                           (real*)a, (real*)b, bufred_d, *n);
+        HIP_CHECK(hipGetLastError());
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real>),
+                           1, 1024, 0, stream, bufred_d, nb);
+        HIP_CHECK(hipGetLastError());
+      }
+      else {
+        hip_rzero(bufred_d, &red_s, stream);
       }
       hip_global_reduce_add(bufred, bufred_d, 1, stream);
 
@@ -756,23 +760,27 @@ extern "C" {
    * Fortran wrapper glsum
    * Sum a vector of length n
    */
-  real hip_glsum(void *a, int *n) {
+  real hip_glsum(void *a, int *n, hipStream_t stream) {
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     const int nb = ((*n) + 1024 - 1)/ 1024;
-    const hipStream_t stream = (hipStream_t) glb_cmd_queue;
 
     hip_redbuf_check_alloc(nb);
     if( *n > 0) {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(glsum_kernel<real>),
-                       nblcks, nthrds, 0, stream,
-                       (real *) a, bufred_d, *n);
+                         nblcks, nthrds, 0, stream,
+                         (real *) a, bufred_d, *n);
       HIP_CHECK(hipGetLastError());
       hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real>),
-                       1, 1024, 0, stream, bufred_d, nb);
+                         1, 1024, 0, stream, bufred_d, nb);
       HIP_CHECK(hipGetLastError());
-    } else { hip_rzero(bufred_d,&red_s); }
+    }
+    else {
+      hip_rzero(bufred_d, &red_s, stream);
+    }
+
     hip_global_reduce_add(bufred, bufred_d, 1, stream);
+
     return bufred[0];
   }
 
@@ -780,14 +788,13 @@ extern "C" {
    * Fortran wrapper for absval
    * \f$ a = abs(a) \f$
    */
-  void hip_absval(void *a, int *n) {
+  void hip_absval(void *a, int *n, hipStream_t stream) {
 
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
 
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(absval_kernel<real>), 
-                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                       (real *) a, *n);
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(absval_kernel<real>),
+                       nblcks, nthrds, 0, stream, (real *) a, *n);
     HIP_CHECK(hipGetLastError());
 
 }
@@ -799,15 +806,13 @@ extern "C" {
    *
    * Compute the maximum of two vectors \f$ a = \max(a, b) \f$
    */
-void hip_pwmax_vec2(void* a, void* b, int* n) {
+  void hip_pwmax_vec2(void* a, void* b, int* n, hipStream_t stream) {
 
     const dim3        nthrds(1024, 1, 1);
     const dim3        nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
-    const hipStream_t stream = (hipStream_t)glb_cmd_queue;
 
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(pwmax_vec2_kernel<real>), nblcks, nthrds, 0,
-        (hipStream_t)glb_cmd_queue, (real*)a, (real*)b, *n);
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(pwmax_vec2_kernel<real>),
+                       nblcks, nthrds, 0, stream, (real*)a, (real*)b, *n);
     HIP_CHECK(hipGetLastError());
 }
 
@@ -815,15 +820,14 @@ void hip_pwmax_vec2(void* a, void* b, int* n) {
    *
    * Compute the maximum of two vectors \f$ a = \max(b, c) \f$
    */
-  void hip_pwmax_vec3(void *a, void *b, void *c, int *n) {
+  void hip_pwmax_vec3(void *a, void *b, void *c, int *n, hipStream_t stream) {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
-      const hipStream_t stream = (hipStream_t) glb_cmd_queue;
 
-      hipLaunchKernelGGL(HIP_KERNEL_NAME(pwmax_vec3_kernel<real>), 
-                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                        (real *)a, (real *)b, (real *)c, *n);
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(pwmax_vec3_kernel<real>),
+                         nblcks, nthrds, 0, stream,
+                         (real *)a, (real *)b, (real *)c, *n);
       HIP_CHECK(hipGetLastError());
   }
 
@@ -831,15 +835,13 @@ void hip_pwmax_vec2(void* a, void* b, int* n) {
    *
    * Compute the maximum of vector and scalar \f$ a = \max(a, c) \f$
    */
-  void hip_pwmax_sca2(void *a, real *c, int *n) {
+  void hip_pwmax_sca2(void *a, real *c, int *n, hipStream_t stream) {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
-      const hipStream_t stream = (hipStream_t) glb_cmd_queue;
 
-      hipLaunchKernelGGL(HIP_KERNEL_NAME(pwmax_sca2_kernel<real>), 
-                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                        (real *)a, *c, *n);
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(pwmax_sca2_kernel<real>),
+                         nblcks, nthrds, 0, stream, (real *)a, *c, *n);
       HIP_CHECK(hipGetLastError());
   }
 
@@ -847,15 +849,14 @@ void hip_pwmax_vec2(void* a, void* b, int* n) {
    *
    * Compute the maximum of vector and scalar \f$ a = \max(b, c) \f$
    */
-  void hip_pwmax_sca3(void *a, void *b, real *c, int *n) {
+  void hip_pwmax_sca3(void *a, void *b, real *c, int *n, hipStream_t stream) {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
-      const hipStream_t stream = (hipStream_t) glb_cmd_queue;
 
-      hipLaunchKernelGGL(HIP_KERNEL_NAME(pwmax_sca3_kernel<real>), 
-                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                        (real *)a, (real *)b, *c, *n);
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(pwmax_sca3_kernel<real>),
+                         nblcks, nthrds, 0, stream,
+                         (real *)a, (real *)b, *c, *n);
       HIP_CHECK(hipGetLastError());
   }
 
@@ -863,15 +864,14 @@ void hip_pwmax_vec2(void* a, void* b, int* n) {
    *
    * Compute the minimum of two vectors \f$ a = \min(a, b) \f$
    */
-  void hip_pwmin_vec2(void *a, void *b, int *n) {
+  void hip_pwmin_vec2(void *a, void *b, int *n, hipStream_t stream) {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
-      const hipStream_t stream = (hipStream_t) glb_cmd_queue;
 
-      hipLaunchKernelGGL(HIP_KERNEL_NAME(pwmin_vec2_kernel<real>), 
-                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                        (real *)a, (real *)b, *n);
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(pwmin_vec2_kernel<real>),
+                         nblcks, nthrds, 0, stream,
+                         (real *)a, (real *)b, *n);
       HIP_CHECK(hipGetLastError());
   }
 
@@ -879,14 +879,13 @@ void hip_pwmax_vec2(void* a, void* b, int* n) {
    *
    * Compute the minimum of two vectors \f$ a = \min(b, c) \f$
    */
-  void hip_pwmin_vec3(void *a, void *b, void *c, int *n) {
+  void hip_pwmin_vec3(void *a, void *b, void *c, int *n, hipStream_t stream) {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
-      const hipStream_t stream = (hipStream_t) glb_cmd_queue;
 
-      hipLaunchKernelGGL(HIP_KERNEL_NAME(pwmin_vec3_kernel<real>), 
-                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(pwmin_vec3_kernel<real>),
+                         nblcks, nthrds, 0, stream,
                         (real *)a, (real *)b, (real *)c, *n);
       HIP_CHECK(hipGetLastError());
   }
@@ -895,14 +894,13 @@ void hip_pwmax_vec2(void* a, void* b, int* n) {
    *
    * Compute the minimum of vector and scalar \f$ a = \min(a, c) \f$
    */
-  void hip_pwmin_sca2(void *a, real *c, int *n) {
+  void hip_pwmin_sca2(void *a, real *c, int *n, hipStream_t stream) {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
-      const hipStream_t stream = (hipStream_t) glb_cmd_queue;
 
-      hipLaunchKernelGGL(HIP_KERNEL_NAME(pwmin_sca2_kernel<real>), 
-                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(pwmin_sca2_kernel<real>),
+                         nblcks, nthrds, 0, stream,
                         (real *)a, *c, *n);
       HIP_CHECK(hipGetLastError());
   }
@@ -911,15 +909,14 @@ void hip_pwmax_vec2(void* a, void* b, int* n) {
    *
    * Compute the minimum of vector and scalar \f$ a = \min(b, c) \f$
    */
-  void hip_pwmin_sca3(void *a, void *b, real *c, int *n) {
+  void hip_pwmin_sca3(void *a, void *b, real *c, int *n, hipStream_t stream) {
 
       const dim3 nthrds(1024, 1, 1);
       const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
-      const hipStream_t stream = (hipStream_t) glb_cmd_queue;
 
-      hipLaunchKernelGGL(HIP_KERNEL_NAME(pwmin_sca3_kernel<real>), 
-                        nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                        (real *)a, (real *)b, *c, *n);
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(pwmin_sca3_kernel<real>),
+                         nblcks, nthrds, 0, stream,
+                         (real *)a, (real *)b, *c, *n);
       HIP_CHECK(hipGetLastError());
   }
 

--- a/src/math/bcknd/device/opencl/math.c
+++ b/src/math/bcknd/device/opencl/math.c
@@ -50,8 +50,8 @@
 /** Fortran wrapper for copy
  * Copy a vector \f$ a = b \f$
  */
-void opencl_copy(void *a, void *b, int *n) {
-  CL_CHECK(clEnqueueCopyBuffer((cl_command_queue) glb_cmd_queue,
+void opencl_copy(void *a, void *b, int *n, cl_command_queue cmd_queue) {
+  CL_CHECK(clEnqueueCopyBuffer(cmd_queue,
                                b, a, 0, 0, (*n) * sizeof(real),
                                0, NULL, NULL));
 }
@@ -59,7 +59,8 @@ void opencl_copy(void *a, void *b, int *n) {
 /** Fortran wrapper for masked copy
  * Copy a vector \f$ a(mask) = b(mask) \f$
  */
-void opencl_masked_copy(void *a, void *b, void *mask, int *n, int *m) {
+void opencl_masked_copy(void *a, void *b, void *mask, int *n, int *m,
+                        cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -78,8 +79,8 @@ void opencl_masked_copy(void *a, void *b, void *mask, int *n, int *m) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 
 }
@@ -87,7 +88,8 @@ void opencl_masked_copy(void *a, void *b, void *mask, int *n, int *m) {
 /** Fortran wrapper for masked reduced copy
  * Copy a vector \f$ a = b(mask) \f$
  */
-void opencl_masked_gather_copy(void *a, void *b, void *mask, int *n, int *m) {
+void opencl_masked_gather_copy(void *a, void *b, void *mask, int *n, int *m,
+                               cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -107,8 +109,8 @@ void opencl_masked_gather_copy(void *a, void *b, void *mask, int *n, int *m) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 
 }
@@ -116,7 +118,8 @@ void opencl_masked_gather_copy(void *a, void *b, void *mask, int *n, int *m) {
 /** Fortran wrapper for masked scatter copy
  * Copy a vector \f$ a(mask) = b \f$
  */
-void opencl_masked_scatter_copy(void *a, void *b, void *mask, int *n, int *m) {
+void opencl_masked_scatter_copy(void *a, void *b, void *mask, int *n, int *m,
+                                cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -136,8 +139,8 @@ void opencl_masked_scatter_copy(void *a, void *b, void *mask, int *n, int *m) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 
 }
@@ -145,7 +148,8 @@ void opencl_masked_scatter_copy(void *a, void *b, void *mask, int *n, int *m) {
 /** Fortran wrapper for cfill_mask
  * Fill a scalar to vector \f$ a_i = s, for i \in mask \f$
  */
-void opencl_cfill_mask(void* a, void* c, int* size, void* mask, int* mask_size) {
+void opencl_cfill_mask(void* a, void* c, int* size, void* mask, int* mask_size,
+                       cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -164,20 +168,19 @@ void opencl_cfill_mask(void* a, void* c, int* size, void* mask, int* mask_size) 
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
   }
 
 /** Fortran wrapper for rzero
  * Zero a real vector
  */
-void opencl_rzero(void *a, int *n) {
+void opencl_rzero(void *a, int *n, cl_command_queue cmd_queue) {
   cl_event wait_kern;
   real zero = 0.0;
 
-  CL_CHECK(clEnqueueFillBuffer((cl_command_queue) glb_cmd_queue,
-                               a, &zero, sizeof(real), 0,
+  CL_CHECK(clEnqueueFillBuffer(cmd_queue, a, &zero, sizeof(real), 0,
                                (*n) * sizeof(real), 0, NULL, &wait_kern));
   CL_CHECK(clWaitForEvents(1, &wait_kern));
 }
@@ -185,12 +188,11 @@ void opencl_rzero(void *a, int *n) {
 /** Fortran wrapper for rone
  * Set all elements to one
  */
-void opencl_rone(void *a, int *n) {
+void opencl_rone(void *a, int *n, cl_command_queue cmd_queue) {
   cl_event wait_kern;
   real one = 1.0;
 
-  CL_CHECK(clEnqueueFillBuffer((cl_command_queue) glb_cmd_queue,
-                               a, &one, sizeof(real), 0,
+  CL_CHECK(clEnqueueFillBuffer(cmd_queue, a, &one, sizeof(real), 0,
                                (*n) * sizeof(real), 0, NULL, &wait_kern));
   CL_CHECK(clWaitForEvents(1, &wait_kern));
 }
@@ -198,7 +200,7 @@ void opencl_rone(void *a, int *n) {
 /** Fortran wrapper for cmult
  * Multiplication by constant c \f$ a = c \cdot a \f$
  */
-void opencl_cmult(void *a, real *c, int *n) {
+void opencl_cmult(void *a, real *c, int *n, cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -215,15 +217,16 @@ void opencl_cmult(void *a, real *c, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
 /** Fortran wrapper for cmult2
  * Multiplication by constant c \f$ a = c \cdot b \f$
  */
-void opencl_cmult2(void *a, void *b, real *c, int *n) {
+void opencl_cmult2(void *a, void *b, real *c, int *n,
+                   cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -241,15 +244,15 @@ void opencl_cmult2(void *a, void *b, real *c, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
 /** Fortran wrapper for cdiv
  * Division of constant c by array \f$ a = c / a \f$
  */
-void opencl_cdiv(void *a, real *c, int *n) {
+void opencl_cdiv(void *a, real *c, int *n, cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -266,15 +269,16 @@ void opencl_cdiv(void *a, real *c, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
 /** Fortran wrapper for cdiv2
  * Division of constant c by array \f$ a = c / b \f$
  */
-void opencl_cdiv2(void *a, void *b, real *c, int *n) {
+void opencl_cdiv2(void *a, void *b, real *c, int *n,
+                  cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -292,15 +296,15 @@ void opencl_cdiv2(void *a, void *b, real *c, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
 /** Fortran wrapper for cadd
  * Add a scalar to vector \f$ a = \sum a_i + s \f$
  */
-void opencl_cadd(void *a, real *c, int *n) {
+void opencl_cadd(void *a, real *c, int *n, cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -317,15 +321,16 @@ void opencl_cadd(void *a, real *c, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
 /** Fortran wrapper for cadd
  * Add a scalar to vector \f$ a = b + s \f$
  */
-void opencl_cadd2(void *a, void *b, real *c, int *n) {
+void opencl_cadd2(void *a, void *b, real *c, int *n,
+                  cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -343,15 +348,15 @@ void opencl_cadd2(void *a, void *b, real *c, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
 /** Fortran wrapper for cfill
  * Fill all elements to a constant c \f$ a = c  \f$
  */
-void opencl_cfill(void *a, real *c, int *n) {
+void opencl_cfill(void *a, real *c, int *n, cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -368,8 +373,8 @@ void opencl_cfill(void *a, real *c, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -377,7 +382,7 @@ void opencl_cfill(void *a, real *c, int *n) {
  * Fortran wrapper for add2
  * Vector addition \f$ a = a + b \f$
  */
-void opencl_add2(void *a, void *b, int *n) {
+void opencl_add2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -394,8 +399,8 @@ void opencl_add2(void *a, void *b, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -403,7 +408,8 @@ void opencl_add2(void *a, void *b, int *n) {
  * Fortran wrapper for add3
  * Vector addition \f$ a = b + c \f$
  */
-void opencl_add3(void *a, void *b, void *c, int *n) {
+void opencl_add3(void *a, void *b, void *c, int *n,
+                 cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -421,8 +427,8 @@ void opencl_add3(void *a, void *b, void *c, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -430,7 +436,8 @@ void opencl_add3(void *a, void *b, void *c, int *n) {
  * Fortran wrapper for add4
  * Vector addition \f$ a = b + c + d \f$
  */
-void opencl_add4(void *a, void *b, void *c, void *d, int *n) {
+void opencl_add4(void *a, void *b, void *c, void *d, int *n,
+                 cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -449,8 +456,8 @@ void opencl_add4(void *a, void *b, void *c, void *d, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -459,7 +466,8 @@ void opencl_add4(void *a, void *b, void *c, void *d, int *n) {
  * Vector addition with scalar multiplication \f$ a = c_1 a + b \f$
  * (multiplication on first argument)
  */
-void opencl_add2s1(void *a, void *b, real *c1, int *n) {
+void opencl_add2s1(void *a, void *b, real *c1, int *n,
+                   cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -477,8 +485,8 @@ void opencl_add2s1(void *a, void *b, real *c1, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -487,7 +495,8 @@ void opencl_add2s1(void *a, void *b, real *c1, int *n) {
  * Vector addition with scalar multiplication \f$ a = a + c_1 b \f$
  * (multiplication on second argument)
  */
-void opencl_add2s2(void *a, void *b, real *c1, int *n) {
+void opencl_add2s2(void *a, void *b, real *c1, int *n,
+                   cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -505,8 +514,8 @@ void opencl_add2s2(void *a, void *b, real *c1, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -516,7 +525,8 @@ void opencl_add2s2(void *a, void *b, real *c1, int *n) {
  * \f$ x = x + c_1 p1 + c_2p2 + ... + c_jpj \f$
  * (multiplication on second argument)
  */
-void opencl_add2s2_many(void *x, void *p, void *alpha, int *j, int *n) {
+void opencl_add2s2_many(void *x, void *p, void *alpha, int *j, int *n,
+                        cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -535,8 +545,8 @@ void opencl_add2s2_many(void *x, void *p, void *alpha, int *j, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 
 }
@@ -546,7 +556,8 @@ void opencl_add2s2_many(void *x, void *p, void *alpha, int *j, int *n) {
  * Vector addition with scalar multiplication \f$ a = a + c_1 (b * b) \f$
  * (multiplication on second argument)
  */
-void opencl_addsqr2s2(void *a, void *b, real *c1, int *n) {
+void opencl_addsqr2s2(void *a, void *b, real *c1, int *n,
+                      cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -564,8 +575,8 @@ void opencl_addsqr2s2(void *a, void *b, real *c1, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                               NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -573,7 +584,8 @@ void opencl_addsqr2s2(void *a, void *b, real *c1, int *n) {
  * Fortran wrapper for add3s2
  * Vector addition with scalar multiplication \f$ a = c1 * b + c2 * c \f$
  */
-void opencl_add3s2(void *a, void *b, void * c, real *c1, real *c2, int *n) {
+void opencl_add3s2(void *a, void *b, void * c, real *c1, real *c2, int *n,
+                   cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -593,8 +605,8 @@ void opencl_add3s2(void *a, void *b, void * c, real *c1, real *c2, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -602,7 +614,7 @@ void opencl_add3s2(void *a, void *b, void * c, real *c1, real *c2, int *n) {
  * Fortran wrapper for invcol1
  * Invert a vector \f$ a = 1 / a \f$
  */
-void opencl_invcol1(void *a, int *n) {
+void opencl_invcol1(void *a, int *n, cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -618,8 +630,8 @@ void opencl_invcol1(void *a, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -627,7 +639,7 @@ void opencl_invcol1(void *a, int *n) {
  * Fortran wrapper for invcol2
  * Vector division \f$ a = a / b \f$
  */
-void opencl_invcol2(void *a, void *b, int *n) {
+void opencl_invcol2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -644,8 +656,8 @@ void opencl_invcol2(void *a, void *b, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -653,7 +665,7 @@ void opencl_invcol2(void *a, void *b, int *n) {
  * Fortran wrapper for col2
  * Vector multiplication with 2 vectors \f$ a = a \cdot b \f$
  */
-void opencl_col2(void *a, void *b, int *n) {
+void opencl_col2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -670,8 +682,8 @@ void opencl_col2(void *a, void *b, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -679,7 +691,8 @@ void opencl_col2(void *a, void *b, int *n) {
  * Fortran wrapper for col3
  * Vector multiplication with 3 vectors \f$ a = b \cdot c \f$
  */
-void opencl_col3(void *a, void *b, void *c, int *n) {
+void opencl_col3(void *a, void *b, void *c, int *n,
+                 cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -697,8 +710,8 @@ void opencl_col3(void *a, void *b, void *c, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -706,7 +719,8 @@ void opencl_col3(void *a, void *b, void *c, int *n) {
  * Fortran wrapper for subcol3
  * Vector multiplication with 3 vectors \f$ a = a - b \cdot c \f$
  */
-void opencl_subcol3(void *a, void *b, void *c, int *n) {
+void opencl_subcol3(void *a, void *b, void *c, int *n,
+                    cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -724,8 +738,8 @@ void opencl_subcol3(void *a, void *b, void *c, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -733,7 +747,7 @@ void opencl_subcol3(void *a, void *b, void *c, int *n) {
  * Fortran wrapper for sub2
  * Vector subtraction \f$ a = a - b \f$
  */
-void opencl_sub2(void *a, void *b, int *n) {
+void opencl_sub2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -750,8 +764,8 @@ void opencl_sub2(void *a, void *b, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -759,7 +773,8 @@ void opencl_sub2(void *a, void *b, int *n) {
  * Fortran wrapper for sub3
  * Vector subtraction \f$ a = b - c \f$
  */
-void opencl_sub3(void *a, void *b, void *c, int *n) {
+void opencl_sub3(void *a, void *b, void *c, int *n,
+                 cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -777,8 +792,8 @@ void opencl_sub3(void *a, void *b, void *c, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -786,7 +801,8 @@ void opencl_sub3(void *a, void *b, void *c, int *n) {
  * Fortran wrapper for addcol3
  * \f$ a = a + b * c \f$
  */
-void opencl_addcol3(void *a, void *b, void *c, int *n) {
+void opencl_addcol3(void *a, void *b, void *c, int *n,
+                    cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -804,8 +820,8 @@ void opencl_addcol3(void *a, void *b, void *c, int *n) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -813,7 +829,8 @@ void opencl_addcol3(void *a, void *b, void *c, int *n) {
  * Fortran wrapper for addcol4
  * \f$ a = a + b * c * d \f$
  */
-void opencl_addcol4(void *a, void *b, void *c, void *d, int *n) {
+void opencl_addcol4(void *a, void *b, void *c, void *d, int *n,
+                    cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -843,7 +860,8 @@ void opencl_addcol4(void *a, void *b, void *c, void *d, int *n) {
  */
 
 void opencl_vdot3(void *dot, void *u1, void *u2, void *u3,
-                  void *v1, void *v2, void *v3, int *n) {
+                  void *v1, void *v2, void *v3, int *n,
+                  cl_command_queue cmd_queue) {
   cl_int err;
 
   if (math_program == NULL)
@@ -865,8 +883,8 @@ void opencl_vdot3(void *dot, void *u1, void *u2, void *u3,
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 }
 
@@ -877,7 +895,8 @@ void opencl_vdot3(void *dot, void *u1, void *u2, void *u3,
 
 void opencl_vcross(void *u1, void *u2, void *u3,
                    void *v1, void *v2, void *v3,
-                   void *w1, void *w2, void *w3, int *n) {
+                   void *w1, void *w2, void *w3,
+                   int *n, cl_command_queue cmd_queue) {
 
   cl_int err;
 
@@ -902,8 +921,8 @@ void opencl_vcross(void *u1, void *u2, void *u3,
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 
 }
@@ -917,7 +936,8 @@ cl_mem bufred_d = NULL;
  * Fortran wrapper glsc3
  * Weighted inner product \f$ a^T b c \f$
  */
-real opencl_glsc3(void *a, void *b, void *c, int *n) {
+real opencl_glsc3(void *a, void *b, void *c, int *n,
+                  cl_command_queue cmd_queue) {
   cl_int err;
   cl_event kern_wait;
   int i;
@@ -951,12 +971,12 @@ real opencl_glsc3(void *a, void *b, void *c, int *n) {
   CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &bufred_d));
   CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int), n));
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, &kern_wait));
 
-  CL_CHECK(clEnqueueReadBuffer((cl_command_queue) glb_cmd_queue, bufred_d,
-                               CL_TRUE, 0, nb * sizeof(real), bufred, 1,
+  CL_CHECK(clEnqueueReadBuffer(cmd_queue, bufred_d, CL_TRUE, 0,
+                               nb * sizeof(real), bufred, 1,
                                &kern_wait, NULL));
 
   real res = 0.0;
@@ -971,7 +991,8 @@ real opencl_glsc3(void *a, void *b, void *c, int *n) {
  * Fortran wrapper for doing a reduction to an array
  * Weighted inner product \f$ w^T v(n,1:j) c \f$
  */
-void opencl_glsc3_many(real *h, void * w, void *v, void *mult, int *j, int *n){
+void opencl_glsc3_many(real *h, void * w, void *v, void *mult, int *j, int *n,
+                       cl_command_queue cmd_queue){
   int i, k;
   cl_int err;
   cl_event kern_wait;
@@ -1012,12 +1033,12 @@ void opencl_glsc3_many(real *h, void * w, void *v, void *mult, int *j, int *n){
   CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int), j));
   CL_CHECK(clSetKernelArg(kernel, 5, sizeof(int), n));
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 2,
-                                  NULL, global_item_size, local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 2, NULL,
+                                  global_item_size, local_item_size,
                                   0, NULL, &kern_wait));
 
-  CL_CHECK(clEnqueueReadBuffer((cl_command_queue) glb_cmd_queue,
-                               bufred_d, CL_TRUE, 0, (*j) * nb * sizeof(real),
+  CL_CHECK(clEnqueueReadBuffer(cmd_queue, bufred_d, CL_TRUE, 0,
+                               (*j) * nb * sizeof(real),
                                bufred, 1, &kern_wait, NULL));
 
   for (k = 0; k < (*j); k++) {
@@ -1035,7 +1056,7 @@ void opencl_glsc3_many(real *h, void * w, void *v, void *mult, int *j, int *n){
  * Fortran wrapper glsc2
  * Weighted inner product \f$ a^T b c \f$
  */
-real opencl_glsc2(void *a, void *b, int *n) {
+real opencl_glsc2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   cl_int err;
   cl_event kern_wait;
   int i;
@@ -1061,13 +1082,13 @@ real opencl_glsc2(void *a, void *b, int *n) {
   CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &buf_d));
   CL_CHECK(clSetKernelArg(kernel, 3, sizeof(int), n));
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, &kern_wait));
 
 
-  CL_CHECK(clEnqueueReadBuffer((cl_command_queue) glb_cmd_queue, buf_d, CL_TRUE,
-                               0, nb * sizeof(real), buf, 1, &kern_wait, NULL));
+  CL_CHECK(clEnqueueReadBuffer(cmd_queue, buf_d, CL_TRUE, 0,
+                               nb * sizeof(real), buf, 1, &kern_wait, NULL));
 
   real res = 0.0;
   for (i = 0; i < nb; i++) {
@@ -1084,7 +1105,7 @@ real opencl_glsc2(void *a, void *b, int *n) {
  * Fortran wrapper glsubnorm2
  * Weighted inner product \f$ a^T b c \f$
  */
-real opencl_glsubnorm2(void *a, void *b, int *n) {
+real opencl_glsubnorm2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   cl_int err;
   cl_event kern_wait;
   int i;
@@ -1110,13 +1131,13 @@ real opencl_glsubnorm2(void *a, void *b, int *n) {
   CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &buf_d));
   CL_CHECK(clSetKernelArg(kernel, 3, sizeof(int), n));
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, &kern_wait));
 
 
-  CL_CHECK(clEnqueueReadBuffer((cl_command_queue) glb_cmd_queue, buf_d, CL_TRUE,
-                               0, nb * sizeof(real), buf, 1, &kern_wait, NULL));
+  CL_CHECK(clEnqueueReadBuffer(cmd_queue, buf_d, CL_TRUE, 0,
+                               nb * sizeof(real), buf, 1, &kern_wait, NULL));
 
   real res = 0.0;
   for (i = 0; i < nb; i++) {
@@ -1133,7 +1154,7 @@ real opencl_glsubnorm2(void *a, void *b, int *n) {
  * Fortran wrapper glsum
  * Sum a vector of length n
  */
-real opencl_glsum(void *a, int *n) {
+real opencl_glsum(void *a, int *n, cl_command_queue cmd_queue) {
   cl_int err;
   cl_event kern_wait;
   int i;
@@ -1158,13 +1179,13 @@ real opencl_glsum(void *a, int *n) {
   CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &buf_d));
   CL_CHECK(clSetKernelArg(kernel, 2, sizeof(int), n));
 
-  CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
-                                  NULL, &global_item_size, &local_item_size,
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
                                   0, NULL, &kern_wait));
 
 
-  CL_CHECK(clEnqueueReadBuffer((cl_command_queue) glb_cmd_queue, buf_d, CL_TRUE,
-                               0, nb * sizeof(real), buf, 1, &kern_wait, NULL));
+  CL_CHECK(clEnqueueReadBuffer(cmd_queue, buf_d, CL_TRUE, 0,
+                               nb * sizeof(real), buf, 1, &kern_wait, NULL));
 
   real res = 0.0;
   for (i = 0; i < nb; i++) {

--- a/src/math/bcknd/device/opencl/opencl_math.f90
+++ b/src/math/bcknd/device/opencl/opencl_math.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2024, The Neko Authors
+! Copyright (c) 2024-2025, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -36,35 +36,35 @@ module opencl_math
   public
 
   interface
-     subroutine opencl_copy(a_d, b_d, n) &
+     subroutine opencl_copy(a_d, b_d, n, strm) &
           bind(c, name = 'opencl_copy')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine opencl_copy
 
-     subroutine opencl_masked_copy(a_d, b_d, mask_d, n, n_mask) &
+     subroutine opencl_masked_copy(a_d, b_d, mask_d, n, n_mask, strm) &
           bind(c, name = 'opencl_masked_copy')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d, mask_d
+       type(c_ptr), value :: a_d, b_d, mask_d, strm
        integer(c_int) :: n, n_mask
      end subroutine opencl_masked_copy
 
-     subroutine opencl_masked_gather_copy(a_d, b_d, mask_d, n, n_mask) &
+     subroutine opencl_masked_gather_copy(a_d, b_d, mask_d, n, n_mask, strm) &
           bind(c, name = 'opencl_masked_gather_copy')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d, mask_d
+       type(c_ptr), value :: a_d, b_d, mask_d, strm
        integer(c_int) :: n, n_mask
      end subroutine opencl_masked_gather_copy
 
-     subroutine opencl_masked_scatter_copy(a_d, b_d, mask_d, n, n_mask) &
+     subroutine opencl_masked_scatter_copy(a_d, b_d, mask_d, n, n_mask, strm) &
           bind(c, name = 'opencl_masked_scatter_copy')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d, b_d, mask_d
+       type(c_ptr), value :: a_d, b_d, mask_d, strm
        integer(c_int) :: n, n_mask
      end subroutine opencl_masked_scatter_copy
 
-     subroutine opencl_cfill_mask(a_d, c, n, mask_d, n_mask) &
+     subroutine opencl_cfill_mask(a_d, c, n, mask_d, n_mask, strm) &
           bind(c, name = 'opencl_cfill_mask')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
@@ -73,292 +73,298 @@ module opencl_math
        integer(c_int) :: n
        type(c_ptr), value :: mask_d
        integer(c_int) :: n_mask
+       type(c_ptr), value :: strm
      end subroutine opencl_cfill_mask
 
-     subroutine opencl_cmult(a_d, c, n) &
+     subroutine opencl_cmult(a_d, c, n, strm) &
           bind(c, name = 'opencl_cmult')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine opencl_cmult
 
-     subroutine opencl_cmult2(a_d, b_d, c, n) &
+     subroutine opencl_cmult2(a_d, b_d, c, n, strm) &
           bind(c, name = 'opencl_cmult2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine opencl_cmult2
 
-     subroutine opencl_cdiv(a_d, c, n) &
+     subroutine opencl_cdiv(a_d, c, n, strm) &
           bind(c, name = 'opencl_cdiv')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine opencl_cdiv
 
-     subroutine opencl_cdiv2(a_d, b_d, c, n) &
+     subroutine opencl_cdiv2(a_d, b_d, c, n, strm) &
           bind(c, name = 'opencl_cdiv2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine opencl_cdiv2
 
-     subroutine opencl_cadd(a_d, c, n) &
+     subroutine opencl_cadd(a_d, c, n, strm) &
           bind(c, name = 'opencl_cadd')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine opencl_cadd
 
-     subroutine opencl_cadd2(a_d, b_d, c, n) &
+     subroutine opencl_cadd2(a_d, b_d, c, n, strm) &
           bind(c, name = 'opencl_cadd2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
        type(c_ptr), value :: a_d
        type(c_ptr), value :: b_d
+       type(c_ptr), value :: strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine opencl_cadd2
 
-     subroutine opencl_cfill(a_d, c, n) &
+     subroutine opencl_cfill(a_d, c, n, strm) &
           bind(c, name = 'opencl_cfill')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
        type(c_ptr), value :: a_d
+       type(c_ptr), value :: strm
        real(c_rp) :: c
        integer(c_int) :: n
      end subroutine opencl_cfill
 
-     subroutine opencl_rzero(a_d, n) &
+     subroutine opencl_rzero(a_d, n, strm) &
           bind(c, name = 'opencl_rzero')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        integer(c_int) :: n
      end subroutine opencl_rzero
 
-     subroutine opencl_rone(a_d, n) &
+     subroutine opencl_rone(a_d, n, strm) &
           bind(c, name = 'opencl_rone')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        integer(c_int) :: n
      end subroutine opencl_rone
 
-     subroutine opencl_add2(a_d, b_d, n) &
+     subroutine opencl_add2(a_d, b_d, n, strm) &
           bind(c, name = 'opencl_add2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        implicit none
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine opencl_add2
 
-     subroutine opencl_add4(a_d, b_d, c_d, d_d, n) &
+     subroutine opencl_add4(a_d, b_d, c_d, d_d, n, strm) &
           bind(c, name = 'opencl_add4')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        implicit none
-       type(c_ptr), value :: a_d, b_d, c_d, d_d
+       type(c_ptr), value :: a_d, b_d, c_d, d_d, strm
        integer(c_int) :: n
      end subroutine opencl_add4
 
-     subroutine opencl_add2s1(a_d, b_d, c1, n) &
+     subroutine opencl_add2s1(a_d, b_d, c1, n, strm) &
           bind(c, name = 'opencl_add2s1')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
        implicit none
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c1
        integer(c_int) :: n
      end subroutine opencl_add2s1
 
-     subroutine opencl_add2s2(a_d, b_d, c1, n) &
+     subroutine opencl_add2s2(a_d, b_d, c1, n, strm) &
           bind(c, name = 'opencl_add2s2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
        implicit none
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c1
        integer(c_int) :: n
      end subroutine opencl_add2s2
 
-     subroutine opencl_add2s2_many(y_d, x_d_d, a_d, j, n) &
+     subroutine opencl_add2s2_many(y_d, x_d_d, a_d, j, n, strm) &
           bind(c, name = 'opencl_add2s2_many')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
        implicit none
-       type(c_ptr), value :: y_d, x_d_d, a_d
+       type(c_ptr), value :: y_d, x_d_d, a_d, strm
        integer(c_int) :: j, n
      end subroutine opencl_add2s2_many
 
-     subroutine opencl_addsqr2s2(a_d, b_d, c1, n) &
+     subroutine opencl_addsqr2s2(a_d, b_d, c1, n, strm) &
           bind(c, name = 'opencl_addsqr2s2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
        implicit none
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        real(c_rp) :: c1
        integer(c_int) :: n
      end subroutine opencl_addsqr2s2
 
-     subroutine opencl_add3s2(a_d, b_d, c_d, c1, c2, n) &
+     subroutine opencl_add3s2(a_d, b_d, c_d, c1, c2, n, strm) &
           bind(c, name = 'opencl_add3s2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
        implicit none
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        real(c_rp) :: c1, c2
        integer(c_int) :: n
      end subroutine opencl_add3s2
 
-     subroutine opencl_invcol1(a_d, n) &
+     subroutine opencl_invcol1(a_d, n, strm) &
           bind(c, name = 'opencl_invcol1')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        implicit none
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        integer(c_int) :: n
      end subroutine opencl_invcol1
 
-     subroutine opencl_invcol2(a_d, b_d, n) &
+     subroutine opencl_invcol2(a_d, b_d, n, strm) &
           bind(c, name = 'opencl_invcol2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        implicit none
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine opencl_invcol2
 
-     subroutine opencl_col2(a_d, b_d, n) &
+     subroutine opencl_col2(a_d, b_d, n, strm) &
           bind(c, name = 'opencl_col2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        implicit none
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine opencl_col2
 
-     subroutine opencl_col3(a_d, b_d, c_d, n) &
+     subroutine opencl_col3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'opencl_col3')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        implicit none
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine opencl_col3
 
-     subroutine opencl_subcol3(a_d, b_d, c_d, n) &
+     subroutine opencl_subcol3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'opencl_subcol3')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        implicit none
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine opencl_subcol3
 
-     subroutine opencl_sub2(a_d, b_d, n) &
+     subroutine opencl_sub2(a_d, b_d, n, strm) &
           bind(c, name = 'opencl_sub2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        implicit none
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end subroutine opencl_sub2
 
-     subroutine opencl_sub3(a_d, b_d, c_d, n) &
+     subroutine opencl_sub3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'opencl_sub3')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        implicit none
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine opencl_sub3
 
-     subroutine opencl_add3(a_d, b_d, c_d, n) &
+     subroutine opencl_add3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'opencl_add3')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        implicit none
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine opencl_add3
 
-     subroutine opencl_addcol3(a_d, b_d, c_d, n) &
+     subroutine opencl_addcol3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'opencl_addcol3')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        implicit none
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end subroutine opencl_addcol3
 
-     subroutine opencl_addcol4(a_d, b_d, c_d, d_d, n) &
+     subroutine opencl_addcol4(a_d, b_d, c_d, d_d, n, strm) &
           bind(c, name = 'opencl_addcol4')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        implicit none
-       type(c_ptr), value :: a_d, b_d, c_d, d_d
+       type(c_ptr), value :: a_d, b_d, c_d, d_d, strm
        integer(c_int) :: n
      end subroutine opencl_addcol4
 
-     subroutine opencl_vdot3(dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, n) &
+     subroutine opencl_vdot3(dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, &
+          n, strm) &
           bind(c, name = 'opencl_vdot3')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        implicit none
        type(c_ptr), value :: dot_d, u1_d, u2_d, u3_d, v1_d, v2_d, v3_d
+       type(c_ptr), value :: strm
        integer(c_int) :: n
      end subroutine opencl_vdot3
 
      subroutine opencl_vcross(u1_d, u2_d, u3_d, v1_d, v2_d, v3_d, &
-          w1_d, w2_d, w3_d, n) &
+          w1_d, w2_d, w3_d, n, strm) &
           bind(c, name = 'opencl_vcross')
        use, intrinsic :: iso_c_binding, only: c_int, c_ptr
        type(c_ptr), value :: u1_d, u2_d, u3_d
        type(c_ptr), value :: v1_d, v2_d, v3_d
        type(c_ptr), value :: w1_d, w2_d, w3_d
+       type(c_ptr), value :: strm
        integer(c_int) :: n
      end subroutine opencl_vcross
 
-     real(c_rp) function opencl_glsc3(a_d, b_d, c_d, n) &
+     real(c_rp) function opencl_glsc3(a_d, b_d, c_d, n, strm) &
           bind(c, name = 'opencl_glsc3')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
        implicit none
-       type(c_ptr), value :: a_d, b_d, c_d
+       type(c_ptr), value :: a_d, b_d, c_d, strm
        integer(c_int) :: n
      end function opencl_glsc3
 
-     subroutine opencl_glsc3_many(h, w_d, v_d_d, mult_d, j, n) &
+     subroutine opencl_glsc3_many(h, w_d, v_d_d, mult_d, j, n, strm) &
           bind(c, name = 'opencl_glsc3_many')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
        implicit none
        integer(c_int) :: j, n
-       type(c_ptr), value :: w_d, v_d_d, mult_d
+       type(c_ptr), value :: w_d, v_d_d, mult_d, strm
        real(c_rp) :: h(j)
      end subroutine opencl_glsc3_many
 
-     real(c_rp) function opencl_glsc2(a_d, b_d, n) &
+     real(c_rp) function opencl_glsc2(a_d, b_d, n, strm) &
           bind(c, name = 'opencl_glsc2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
        implicit none
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end function opencl_glsc2
 
-     real(c_rp) function opencl_glsubnorm2(a_d, b_d, n) &
+     real(c_rp) function opencl_glsubnorm2(a_d, b_d, n, strm) &
           bind(c, name = 'opencl_glsubnorm2')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
        implicit none
-       type(c_ptr), value :: a_d, b_d
+       type(c_ptr), value :: a_d, b_d, strm
        integer(c_int) :: n
      end function opencl_glsubnorm2
 
-     real(c_rp) function opencl_glsum(a_d, n) &
+     real(c_rp) function opencl_glsum(a_d, n, strm) &
           bind(c, name = 'opencl_glsum')
        use, intrinsic :: iso_c_binding, only: c_ptr, c_int
        import c_rp
        implicit none
-       type(c_ptr), value :: a_d
+       type(c_ptr), value :: a_d, strm
        integer(c_int) :: n
      end function opencl_glsum
   end interface


### PR DESCRIPTION
This adds the feature of running device math routines in optional streams, if no stream is provided, it will defaults to `glb_cmd_queue`.

Essentially this is the same as the closed PR #1100, but adapted for our interfaces