### PR TITLE
Fix a potential race condition for gs strategy 3 and 4

### DIFF
--- a/src/gs/bcknd/device/gs_device_mpi.F90
+++ b/src/gs/bcknd/device/gs_device_mpi.F90
@@ -417,10 +417,11 @@ contains
   end subroutine gs_device_mpi_nbrecv
 
   !> Wait for non-blocking operations
-  subroutine gs_device_mpi_nbwait(this, u, n, op, strm)
+  subroutine gs_device_mpi_nbwait(this, u, n, op, deps, strm)
     class(gs_device_mpi_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
+    type(c_ptr), intent(inout) :: deps
     type(c_ptr), intent(inout) :: strm
     integer :: op, done_req, i
     type(c_ptr) :: u_d
@@ -452,6 +453,11 @@ contains
        call device_sync(strm)
 
     else
+
+       ! Sync unpacking streams with deps.
+       do i = 1, size(this%recv_pe)
+          call device_stream_wait_event(this%stream(i), deps, 0)
+       end do
 
        do while(device_mpi_waitany(size(this%recv_pe), &
             this%recv_buf%reqs, done_req) .ne. 0)

--- a/src/gs/bcknd/device/gs_device_nccl.F90
+++ b/src/gs/bcknd/device/gs_device_nccl.F90
@@ -306,10 +306,11 @@ contains
   end subroutine gs_device_nccl_nbrecv
 
   !> Wait for non-blocking operations
-  subroutine gs_device_nccl_nbwait(this, u, n, op, strm)
+  subroutine gs_device_nccl_nbwait(this, u, n, op, deps, strm)
     class(gs_device_nccl_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
+    type(c_ptr), intent(inout) :: deps
     type(c_ptr), intent(inout) :: strm
     integer :: op, done_req, i
     type(c_ptr) :: u_d

--- a/src/gs/bcknd/device/gs_device_shmem.F90
+++ b/src/gs/bcknd/device/gs_device_shmem.F90
@@ -318,10 +318,11 @@ contains
   end subroutine gs_device_shmem_nbrecv
 
   !> Wait for non-blocking operations
-  subroutine gs_device_shmem_nbwait(this, u, n, op, strm)
+  subroutine gs_device_shmem_nbwait(this, u, n, op, deps, strm)
     class(gs_device_shmem_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
+    type(c_ptr), intent(inout) :: deps
     type(c_ptr), intent(inout) :: strm
     integer :: op, done_req, i
     type(c_ptr) :: u_d

--- a/src/gs/gs_comm.f90
+++ b/src/gs/gs_comm.f90
@@ -125,9 +125,10 @@ module gs_comm
   !! @param u, data to store operation into
   !! @param n, length of u (redundant)
   !! @param op, gather scatter operation to carry out
+  !! @param deps, (local) scatter_event (for device aware mpi)
   !! @param strm, device stream to execute this operation on
   abstract interface
-     subroutine gs_nbwait(this, u, n, op, strm)
+     subroutine gs_nbwait(this, u, n, op, deps, strm)
        import gs_comm_t
        import stack_i4_t
        import c_ptr
@@ -136,6 +137,7 @@ module gs_comm
        integer, intent(in) :: n
        real(kind=rp), dimension(n), intent(inout) :: u
        integer :: op
+       type(c_ptr), intent(inout) :: deps
        type(c_ptr), intent(inout) :: strm
      end subroutine gs_nbwait
   end interface

--- a/src/gs/gs_mpi.f90
+++ b/src/gs/gs_mpi.f90
@@ -185,10 +185,11 @@ contains
   end subroutine gs_nbrecv_mpi
 
   !> Wait for non-blocking operations
-  subroutine gs_nbwait_mpi(this, u, n, op, strm)
+  subroutine gs_nbwait_mpi(this, u, n, op, deps, strm)
     class(gs_mpi_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
+    type(c_ptr), intent(inout) :: deps
     type(c_ptr), intent(inout) :: strm
     integer :: i, j, src, ierr
     integer :: op


### PR DESCRIPTION
This fixes a potential race condition between the gather/scatter stream and the unpack streams active for gs strategy 3 and 4.

The pr adds a dependecy event (recorded in the local scatter) preventing unpack operations to continue unless the local gather/scatter operation has finished.

For strategy 1 pack/unpack and gather-scatter streams are scheduled in the same stream, thus synced by the stream ordering. Strategy 2 is also fine since it's only uses multiple pack streams.

