### PR TITLE
Modernize the `speclib`

### DIFF
--- a/src/sem/speclib.f90
+++ b/src/sem/speclib.f90
@@ -159,8 +159,8 @@ contains
   !! @param NP Number of quadrature points.
   subroutine ZWGL (Z,W,NP)
     real(kind=rp) Z(1),W(1), ALPHA, BETA
-    ALPHA = 0.
-    BETA = 0.
+    ALPHA = 0.0_rp
+    BETA = 0.0_rp
     call ZWGJ (Z,W,NP,ALPHA,BETA)
   end subroutine ZWGL
 
@@ -175,8 +175,8 @@ contains
 !
 !--------------------------------------------------------------------
     real(kind=rp) Z(1),W(1), ALPHA, BETA
-    ALPHA = 0.
-    BETA = 0.
+    ALPHA = 0.0_rp
+    BETA = 0.0_rp
     call ZWGLJ (Z,W,NP,ALPHA,BETA)
   end subroutine ZWGLL
 
@@ -204,7 +204,7 @@ contains
     ALPHAD = ALPHA
     BETAD = BETA
     call ZWGJD (ZD,WD,NP,ALPHAD,BETAD)
-    do I=1,NP
+    do I = 1, NP
        Z(I) = ZD(I)
        W(I) = WD(I)
     end do
@@ -255,7 +255,7 @@ contains
     FAC3 = FAC2+ONE
     FNORM = PNORMJ(NP1,ALPHA,BETA)
     RCOEF = (FNORM*FAC2*FAC3)/(TWO*FAC1*DNP2)
-    do I=1,NP
+    do I = 1, NP
        call JACOBF (P,PD,PM1,PDM1,PM2,PDM2,NP2,ALPHA,BETA,Z(I))
        W(I) = -RCOEF/(P*PDM1)
     end do
@@ -285,7 +285,7 @@ contains
     ALPHAD = ALPHA
     BETAD = BETA
     call ZWGLJD (ZD,WD,NP,ALPHAD,BETAD)
-    do I=1,NP
+    do I = 1, NP
        Z(I) = ZD(I)
        W(I) = WD(I)
     end do
@@ -325,7 +325,7 @@ contains
     end if
     Z(1) = -ONE
     Z(NP) = ONE
-    do I=2,NP-1
+    do I = 2, NP-1
        W(I) = W(I)/(ONE-Z(I)**2)
     end do
     call JACOBF (P,PD,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(1))
@@ -364,7 +364,7 @@ contains
        ENDW1 = F2
        return
     end if
-    do I=3,N
+    do I = 3, N
        DI = ((I-1))
        ABN = ALPHA+BETA+DI
        ABNN = ABN+DI
@@ -407,7 +407,7 @@ contains
        ENDW2 = F2
        return
     end if
-    do I=3,N
+    do I = 3, N
        DI = ((I-1))
        ABN = ALPHA+BETA+DI
        ABNN = ABN+DI
@@ -461,7 +461,7 @@ contains
     PROD = PROD/(TWO*(ONE+CONST)*GAMMAF(CONST+ONE))
     PROD = PROD*(ONE+ALPHA)*(TWO+ALPHA)
     PROD = PROD*(ONE+BETA)*(TWO+BETA)
-    do I=3,N
+    do I = 3, N
        DINDX = ((I))
        FRAC = (DINDX+ALPHA)*(DINDX+BETA)/(DINDX*(DINDX+ALPHA+BETA))
        PROD = PROD*FRAC
@@ -487,7 +487,7 @@ contains
     N = NP-1
     one = 1.
     DTH = 4.*atan(one)/(2.*((N))+2.)
-    do J=1,NP
+    do J = 1, NP
        if (J .eq. 1) then
           X = cos((2.*(((J))-1.)+1.)*DTH)
        else
@@ -495,11 +495,11 @@ contains
           X2 = XLAST
           X = (X1+X2)/2.
        end if
-       do K=1,KSTOP
+       do K = 1, KSTOP
           call JACOBF (P,PD,PM1,PDM1,PM2,PDM2,NP,ALPHA,BETA,X)
           RECSUM = 0.
           JM = J-1
-          do I=1,JM
+          do I = 1, JM
              RECSUM = RECSUM+1./(X-XJAC(NP-I+1))
           end do
           DELX = -P/(PD-RECSUM*P)
@@ -510,9 +510,9 @@ contains
        XJAC(NP-J+1) = X
        XLAST = X
     end do
-    do I=1,NP
+    do I = 1, NP
        XMIN = 2.
-       do J=I,NP
+       do J = I, NP
           if (XJAC(J) .lt. XMIN) then
              XMIN = XJAC(J)
              JMIN = J
@@ -543,7 +543,7 @@ contains
     POLY = (ALP-BET+(APB+2.)*X)/2.
     PDER = (APB+2.)/2.
     if (N .eq. 1) return
-    do K=2,N
+    do K = 2, N
        DK = ((K))
        A1 = 2.*DK*(DK+APB)*(2.*DK+APB-2.)
        A2 = (2.*DK+APB-1.)*(ALP**2-BET**2)
@@ -585,7 +585,7 @@ contains
        call neko_error
     end if
     ZD = Z
-    do I=1,NP
+    do I = 1, NP
        ZGJD(I) = ZGJ(I)
     end do
     ALPHAD = ALPHA
@@ -636,7 +636,7 @@ contains
        call neko_error
     end if
     ZD = Z
-    do I=1,NP
+    do I = 1, NP
        ZGLJD(I) = ZGLJ(I)
     end do
     ALPHAD = ALPHA
@@ -702,12 +702,12 @@ contains
     end if
     ALPHAD = ALPHA
     BETAD = BETA
-    do I=1,NZ
+    do I = 1, NZ
        ZD(I) = Z(I)
     end do
     call DGJD (DD,DTD,ZD,NZ,NZDD,ALPHAD,BETAD)
-    do I=1,NZ
-       do J=1,NZ
+    do I = 1, NZ
+       do J = 1, NZ
           D(I,J) = DD(I,J)
           DT(I,J) = DTD(I,J)
        end do
@@ -740,8 +740,8 @@ contains
        call neko_error
     end if
 
-    do I=1,NZ
-       do J=1,NZ
+    do I = 1, NZ
+       do J = 1, NZ
           call JACOBF (PI,PDI,PM1,PDM1,PM2,PDM2,NZ,ALPHA,BETA,Z(I))
           call JACOBF (PJ,PDJ,PM1,PDM1,PM2,PDM2,NZ,ALPHA,BETA,Z(J))
           if (I.NE.J) D(I,J) = PDI/(PDJ*(Z(I)-Z(J)))
@@ -783,12 +783,12 @@ contains
     end if
     ALPHAD = ALPHA
     BETAD = BETA
-    do I=1,NZ
+    do I = 1, NZ
        ZD(I) = Z(I)
     end do
     call DGLJD (DD,DTD,ZD,NZ,NZDD,ALPHAD,BETAD)
-    do I=1,NZ
-       do J=1,NZ
+    do I = 1, NZ
+       do J = 1, NZ
           D(I,J) = DD(I,J)
           DT(I,J) = DTD(I,J)
        end do
@@ -822,19 +822,19 @@ contains
        call neko_error
     end if
 
-    do I=1,NZ
-       do J=1,NZ
+    do I = 1, NZ
+       do J = 1, NZ
           call JACOBF (PI,PDI,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(I))
           call JACOBF (PJ,PDJ,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(J))
           CI = EIGVAL*PI-(BETA*(ONE-Z(I))-ALPHA*(ONE+Z(I)))*PDI
           CJ = EIGVAL*PJ-(BETA*(ONE-Z(J))-ALPHA*(ONE+Z(J)))*PDJ
           if (I.NE.J) D(I,J) = CI/(CJ*(Z(I)-Z(J)))
-          if ((I .eq. J).AND.(I.NE.1).AND.(I.NE.NZ)) &
+          if ((I .eq. J) .and. (I.NE.1) .and. (I.NE.NZ)) &
                D(I,J) = (ALPHA*(ONE+Z(I))-BETA*(ONE-Z(I)))/ &
                (TWO*(ONE-Z(I)**2))
-          if ((I .eq. J).AND.(I .eq. 1)) &
+          if ((I .eq. J) .and. (I .eq. 1)) &
                D(I,J) = (EIGVAL+ALPHA)/(TWO*(BETA+TWO))
-          if ((I .eq. J).AND.(I .eq. NZ)) &
+          if ((I .eq. J) .and. (I .eq. NZ)) &
                D(I,J) = -(EIGVAL+BETA)/(TWO*(ALPHA+TWO))
           DT(J,I) = D(I,J)
        end do
@@ -865,13 +865,13 @@ contains
     end if
     FN = (N)
     d0 = FN*(FN+1.)/4.
-    do I=1,NZ
-       do J=1,NZ
-          D(I,J) = 0.
+    do I = 1, NZ
+       do J = 1, NZ
+          D(I,J) = 0.0_rp
           if (I.NE.J) D(I,J) = PNLEG(real(Z(I),xp),N)/ &
                (PNLEG(real(Z(J),xp),N)*(Z(I)-Z(J)))
-          if ((I .eq. J).AND.(I .eq. 1)) D(I,J) = -d0
-          if ((I .eq. J).AND.(I .eq. NZ)) D(I,J) = d0
+          if ((I .eq. J) .and. (I .eq. 1)) D(I,J) = -d0
+          if ((I .eq. J) .and. (I .eq. NZ)) D(I,J) = d0
           DT(J,I) = D(I,J)
        end do
     end do
@@ -961,7 +961,7 @@ contains
     if (N .eq. 0) return
     L(1) = x
 
-    do j=1, N-1
+    do j = 1, N-1
        L(j+1) = ( (2.0_xp * real(j, xp) + 1.0_xp) * x * L(j) &
             - real(j, xp) * L(j-1) ) / (real(j, xp) + 1.0_xp)
     end do
@@ -1020,7 +1020,7 @@ contains
        do JQ = 1, NZM1
           ZP = ZM2(IP)
           ZQ = ZM1(JQ)
-          if ((abs(ZP) .lt. EPS).AND.(abs(ZQ) .lt. EPS)) then
+          if ((abs(ZP) .lt. EPS) .and. (abs(ZQ) .lt. EPS)) then
              D(IP,JQ) = 0.
           else
              D(IP,JQ) = (PNLEG(ZP,NM1)/PNLEG(ZQ,NM1) &
@@ -1068,18 +1068,18 @@ contains
 
     ALPHAD = ALPHA
     BETAD = BETA
-    do I=1,NPG
+    do I = 1, NPG
        ZGD(I) = ZG(I)
-       do J=1,NPGL
+       do J = 1, NPGL
           IGLGD(I,J) = IGLG(I,J)
        end do
     end do
-    do I=1,NPGL
+    do I = 1, NPGL
        ZGLD(I) = ZGL(I)
     end do
     call DGLJGJD (DD,DTD,ZGLD,ZGD,IGLGD,NPGL,NPG,NDD,NDD,ALPHAD,BETAD)
-    do I=1,NPG
-       do J=1,NPGL
+    do I = 1, NPG
+       do J = 1, NPGL
           D(I,J) = DD(I,J)
           DT(J,I) = DTD(J,I)
        end do
@@ -1119,8 +1119,8 @@ contains
     DN = ((NGL))
     EIGVAL = -DN*(DN+ALPHA+BETA+ONE)
 
-    do I=1,NPG
-       do J=1,NPGL
+    do I = 1, NPG
+       do J = 1, NPGL
           DZ = abs(ZG(I)-ZGL(J))
           if (DZ .lt. EPS) then
              D(I,J) = (ALPHA*(ONE+ZG(I))-BETA*(ONE-ZG(I)))/ &
@@ -1155,9 +1155,9 @@ contains
        IT12(1,1) = 1.
        return
     end if
-    do I=1,NZ2
+    do I = 1, NZ2
        ZI = Z2(I)
-       do J=1,NZ1
+       do J = 1, NZ1
           I12 (I,J) = HGL(J,ZI,Z1,NZ1)
           IT12(J,I) = I12(I,J)
        end do
@@ -1180,9 +1180,9 @@ contains
        IT12(1,1) = 1.
        return
     end if
-    do I=1,NZ2
+    do I = 1, NZ2
        ZI = Z2(I)
-       do J=1,NZ1
+       do J = 1, NZ1
           I12 (I,J) = HGLL(J,ZI,Z1,NZ1)
           IT12(J,I) = I12(I,J)
        end do
@@ -1206,9 +1206,9 @@ contains
        IT12(1,1) = 1.
        return
     end if
-    do I=1,NZ2
+    do I = 1, NZ2
        ZI = Z2(I)
-       do J=1,NZ1
+       do J = 1, NZ1
           I12 (I,J) = HGJ(J,ZI,Z1,NZ1,ALPHA,BETA)
           IT12(J,I) = I12(I,J)
        end do
@@ -1232,9 +1232,9 @@ contains
        IT12(1,1) = 1.
        return
     end if
-    do I=1,NZ2
+    do I = 1, NZ2
        ZI = Z2(I)
-       do J=1,NZ1
+       do J = 1, NZ1
           I12 (I,J) = HGLJ(J,ZI,Z1,NZ1,ALPHA,BETA)
           IT12(J,I) = I12(I,J)
        end do

--- a/src/sem/speclib.f90
+++ b/src/sem/speclib.f90
@@ -204,10 +204,10 @@ contains
     ALPHAD = ALPHA
     BETAD = BETA
     call ZWGJD (ZD,WD,NP,ALPHAD,BETAD)
-    do 100 I=1,NP
+    do I=1,NP
        Z(I) = ZD(I)
        W(I) = WD(I)
-100 continue
+    end do
   end subroutine ZWGJ
 
   subroutine ZWGJD (Z,W,NP,ALPHA,BETA)
@@ -255,10 +255,10 @@ contains
     FAC3 = FAC2+ONE
     FNORM = PNORMJ(NP1,ALPHA,BETA)
     RCOEF = (FNORM*FAC2*FAC3)/(TWO*FAC1*DNP2)
-    do 100 I=1,NP
+    do I=1,NP
        call JACOBF (P,PD,PM1,PDM1,PM2,PDM2,NP2,ALPHA,BETA,Z(I))
        W(I) = -RCOEF/(P*PDM1)
-100 continue
+    end do
   end subroutine ZWGJD
 
   subroutine ZWGLJ (Z,W,NP,ALPHA,BETA)
@@ -285,10 +285,10 @@ contains
     ALPHAD = ALPHA
     BETAD = BETA
     call ZWGLJD (ZD,WD,NP,ALPHAD,BETAD)
-    do 100 I=1,NP
+    do I=1,NP
        Z(I) = ZD(I)
        W(I) = WD(I)
-100 continue
+    end do
   end subroutine ZWGLJ
 
   subroutine ZWGLJD (Z,W,NP,ALPHA,BETA)
@@ -325,9 +325,9 @@ contains
     end if
     Z(1) = -ONE
     Z(NP) = ONE
-    do 100 I=2,NP-1
+    do I=2,NP-1
        W(I) = W(I)/(ONE-Z(I)**2)
-100 continue
+    end do
     call JACOBF (P,PD,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(1))
     W(1) = ENDW1 (N,ALPHA,BETA)/(TWO*PD)
     call JACOBF (P,PD,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(NP))
@@ -364,7 +364,7 @@ contains
        ENDW1 = F2
        return
     end if
-    do 100 I=3,N
+    do I=3,N
        DI = ((I-1))
        ABN = ALPHA+BETA+DI
        ABNN = ABN+DI
@@ -374,7 +374,7 @@ contains
        F3 = -(A2*F2+A1*F1)/A3
        F1 = F2
        F2 = F3
-100 continue
+    end do
     ENDW1 = F3
   end function ENDW1
 
@@ -407,7 +407,7 @@ contains
        ENDW2 = F2
        return
     end if
-    do 100 I=3,N
+    do I=3,N
        DI = ((I-1))
        ABN = ALPHA+BETA+DI
        ABNN = ABN+DI
@@ -417,7 +417,7 @@ contains
        F3 = -(A2*F2+A1*F1)/A3
        F1 = F2
        F2 = F3
-100 continue
+    end do
     ENDW2 = F3
   end function ENDW2
 
@@ -461,11 +461,11 @@ contains
     PROD = PROD/(TWO*(ONE+CONST)*GAMMAF(CONST+ONE))
     PROD = PROD*(ONE+ALPHA)*(TWO+ALPHA)
     PROD = PROD*(ONE+BETA)*(TWO+BETA)
-    do 100 I=3,N
+    do I=3,N
        DINDX = ((I))
        FRAC = (DINDX+ALPHA)*(DINDX+BETA)/(DINDX*(DINDX+ALPHA+BETA))
        PROD = PROD*FRAC
-100 continue
+    end do
     PNORMJ = PROD * TWO**CONST/(TWO*DN+CONST)
   end function PNORMJ
 
@@ -487,7 +487,7 @@ contains
     N = NP-1
     one = 1.
     DTH = 4.*ATAN(one)/(2.*((N))+2.)
-    do 40 J=1,NP
+    do J=1,NP
        if (J .eq. 1) then
           X = COS((2.*(((J))-1.)+1.)*DTH)
        else
@@ -495,35 +495,35 @@ contains
           X2 = XLAST
           X = (X1+X2)/2.
        end if
-       do 30 K=1,KSTOP
+       do K=1,KSTOP
           call JACOBF (P,PD,PM1,PDM1,PM2,PDM2,NP,ALPHA,BETA,X)
           RECSUM = 0.
           JM = J-1
-          do 29 I=1,JM
+          do I=1,JM
              RECSUM = RECSUM+1./(X-XJAC(NP-I+1))
-29        continue
+          end do
           DELX = -P/(PD-RECSUM*P)
           X = X+DELX
-          if (ABS(DELX) .LT. EPS) GOTO 31
-30     continue
-31     continue
+          if (ABS(DELX) .LT. EPS) exit
+       end do
+
        XJAC(NP-J+1) = X
        XLAST = X
-40  continue
-    do 200 I=1,NP
+    end do
+    do I=1,NP
        XMIN = 2.
-       do 100 J=I,NP
+       do J=I,NP
           if (XJAC(J).LT.XMIN) then
              XMIN = XJAC(J)
              JMIN = J
           end if
-100    continue
+       end do
        if (JMIN.NE.I) then
           SWAP = XJAC(I)
           XJAC(I) = XJAC(JMIN)
           XJAC(JMIN) = SWAP
        end if
-200 continue
+    end do
   end subroutine JACG
 
   subroutine JACOBF (POLY,PDER,POLYM1,PDERM1,POLYM2,PDERM2,N,ALP,BET,X)
@@ -543,7 +543,7 @@ contains
     POLY = (ALP-BET+(APB+2.)*X)/2.
     PDER = (APB+2.)/2.
     if (N .eq. 1) return
-    do 20 K=2,N
+    do K=2,N
        DK = ((K))
        A1 = 2.*DK*(DK+APB)*(2.*DK+APB-2.)
        A2 = (2.*DK+APB-1.)*(ALP**2-BET**2)
@@ -558,7 +558,7 @@ contains
        POLY = POLYN
        PDERL = PDER
        PDER = PDERN
-20  continue
+    end do
     POLYM1 = POLYL
     PDERM1 = PDERL
     POLYM2 = PSAVE
@@ -585,9 +585,9 @@ contains
        call neko_error
     end if
     ZD = Z
-    do 100 I=1,NP
+    do I=1,NP
        ZGJD(I) = ZGJ(I)
-100 continue
+    end do
     ALPHAD = ALPHA
     BETAD = BETA
     HGJ = HGJD (II,ZD,ZGJD,NP,ALPHAD,BETAD)
@@ -636,9 +636,9 @@ contains
        call neko_error
     end if
     ZD = Z
-    do 100 I=1,NP
+    do I=1,NP
        ZGLJD(I) = ZGLJ(I)
-100 continue
+    end do
     ALPHAD = ALPHA
     BETAD = BETA
     HGLJ = HGLJD (II,ZD,ZGLJD,NP,ALPHAD,BETAD)
@@ -702,9 +702,9 @@ contains
     end if
     ALPHAD = ALPHA
     BETAD = BETA
-    do 100 I=1,NZ
+    do I=1,NZ
        ZD(I) = Z(I)
-100 continue
+    end do
     call DGJD (DD,DTD,ZD,NZ,NZDD,ALPHAD,BETAD)
     do I=1,NZ
        do J=1,NZ
@@ -783,9 +783,9 @@ contains
     end if
     ALPHAD = ALPHA
     BETAD = BETA
-    do 100 I=1,NZ
+    do I=1,NZ
        ZD(I) = Z(I)
-100 continue
+    end do
     call DGLJD (DD,DTD,ZD,NZ,NZDD,ALPHAD,BETAD)
     do I=1,NZ
        do J=1,NZ
@@ -940,12 +940,12 @@ contains
     end if
     P2 = Z
     P3 = P2
-    do 10 K = 1, N-1
+    do K = 1, N-1
        FK = (K)
        P3 = ((2.0_rp*FK+1.0_rp)*Z*P2 - FK*P1)/(FK+1.0_rp)
        P1 = P2
        P2 = P3
-10  continue
+    end do
     PNLEG = P3
     if (n .eq. 0) pnleg = 1.
   end function PNLEG
@@ -982,7 +982,7 @@ contains
     P1D = 0.
     P2D = 1.
     P3D = 1.
-    do 10 K = 1, N-1
+    do K = 1, N-1
        FK = (K)
        P3 = ((2.*FK+1.)*Z*P2 - FK*P1)/(FK+1.)
        P3D = ((2.*FK+1.)*P2 + (2.*FK+1.)*Z*P2D - FK*P1D)/(FK+1.)
@@ -990,7 +990,7 @@ contains
        P2 = P3
        P1D = P2D
        P2D = P3D
-10  continue
+    end do
     PNDLEG = P3D
     if (N .eq. 0) pndleg = 0.
   end function PNDLEG
@@ -1074,9 +1074,9 @@ contains
           IGLGD(I,J) = IGLG(I,J)
        end do
     end do
-    do 200 I=1,NPGL
+    do I=1,NPGL
        ZGLD(I) = ZGL(I)
-200 continue
+    end do
     call DGLJGJD (DD,DTD,ZGLD,ZGD,IGLGD,NPGL,NPG,NDD,NDD,ALPHAD,BETAD)
     do I=1,NPG
        do J=1,NPGL

--- a/src/sem/speclib.f90
+++ b/src/sem/speclib.f90
@@ -160,7 +160,7 @@ contains
   SUBROUTINE ZWGL (Z,W,NP)
     REAL(KIND=RP) Z(1),W(1), ALPHA, BETA
     ALPHA = 0.
-    BETA  = 0.
+    BETA = 0.
     CALL ZWGJ (Z,W,NP,ALPHA,BETA)
     RETURN
   end subroutine ZWGL
@@ -177,7 +177,7 @@ contains
 !--------------------------------------------------------------------
     REAL(KIND=RP) Z(1),W(1), ALPHA, BETA
     ALPHA = 0.
-    BETA  = 0.
+    BETA = 0.
     CALL ZWGLJ (Z,W,NP,ALPHA,BETA)
     RETURN
   end subroutine ZWGLL
@@ -193,7 +193,7 @@ contains
 !--------------------------------------------------------------------
     PARAMETER (NMAX=84)
     PARAMETER (NZD = NMAX)
-    REAL(KIND=XP)  ZD(NZD),WD(NZD),ALPHAD,BETAD
+    REAL(KIND=XP) ZD(NZD),WD(NZD),ALPHAD,BETAD
     REAL(KIND=RP) Z(1),W(1),ALPHA,BETA
 
     NPMAX = NZD
@@ -204,7 +204,7 @@ contains
        call neko_error
     ENDIF
     ALPHAD = ALPHA
-    BETAD  = BETA
+    BETAD = BETA
     CALL ZWGJD (ZD,WD,NP,ALPHAD,BETAD)
     DO 100 I=1,NP
        Z(I) = ZD(I)
@@ -222,14 +222,14 @@ contains
 !     Double precision version.
 !
 !--------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
-    REAL(KIND=XP)  Z(1),W(1),ALPHA,BETA
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
+    REAL(KIND=XP) Z(1),W(1),ALPHA,BETA
 
-    N     = NP-1
-    DN    = ((N))
-    ONE   = 1.
-    TWO   = 2.
-    APB   = ALPHA+BETA
+    N = NP-1
+    DN = ((N))
+    ONE = 1.
+    TWO = 2.
+    APB = ALPHA+BETA
 
     IF (NP.LE.0) THEN
        WRITE (6,*) 'ZWGJD: Minimum number of Gauss points is 1',np
@@ -243,19 +243,19 @@ contains
     IF (NP.EQ.1) THEN
        Z(1) = (BETA-ALPHA)/(APB+TWO)
        W(1) = GAMMAF(ALPHA+ONE)*GAMMAF(BETA+ONE)/GAMMAF(APB+TWO) &
-              * TWO**(APB+ONE)
+            * TWO**(APB+ONE)
        RETURN
     ENDIF
 
     CALL JACG (Z,NP,ALPHA,BETA)
 
-    NP1   = N+1
-    NP2   = N+2
-    DNP1  = ((NP1))
-    DNP2  = ((NP2))
-    FAC1  = DNP1+ALPHA+BETA+ONE
-    FAC2  = FAC1+DNP1
-    FAC3  = FAC2+ONE
+    NP1 = N+1
+    NP2 = N+2
+    DNP1 = ((NP1))
+    DNP2 = ((NP2))
+    FAC1 = DNP1+ALPHA+BETA+ONE
+    FAC2 = FAC1+DNP1
+    FAC3 = FAC2+ONE
     FNORM = PNORMJ(NP1,ALPHA,BETA)
     RCOEF = (FNORM*FAC2*FAC3)/(TWO*FAC1*DNP2)
     DO 100 I=1,NP
@@ -276,7 +276,7 @@ contains
 !--------------------------------------------------------------------
     PARAMETER (NMAX=84)
     PARAMETER (NZD = NMAX)
-    REAL(KIND=XP)  ZD(NZD),WD(NZD),ALPHAD,BETAD
+    REAL(KIND=XP) ZD(NZD),WD(NZD),ALPHAD,BETAD
     REAL(KIND=RP) Z(1),W(1),ALPHA,BETA
 
     NPMAX = NZD
@@ -287,7 +287,7 @@ contains
        call neko_error
     ENDIF
     ALPHAD = ALPHA
-    BETAD  = BETA
+    BETAD = BETA
     CALL ZWGLJD (ZD,WD,NP,ALPHAD,BETAD)
     DO 100 I=1,NP
        Z(I) = ZD(I)
@@ -305,13 +305,13 @@ contains
 !     Double precision version.
 !
 !--------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
-    REAL(KIND=XP)  Z(NP),W(NP),ALPHA,BETA
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
+    REAL(KIND=XP) Z(NP),W(NP),ALPHA,BETA
 
-    N     = NP-1
-    NM1   = N-1
-    ONE   = 1.
-    TWO   = 2.
+    N = NP-1
+    NM1 = N-1
+    ONE = 1.
+    TWO = 2.
 
     IF (NP.LE.1) THEN
        WRITE (6,*) 'ZWGLJD: Minimum number of Gauss-Lobatto points is 2'
@@ -324,38 +324,38 @@ contains
     ENDIF
 
     IF (NM1.GT.0) THEN
-       ALPG  = ALPHA+ONE
-       BETG  = BETA+ONE
+       ALPG = ALPHA+ONE
+       BETG = BETA+ONE
        CALL ZWGJD (Z(2),W(2),NM1,ALPG,BETG)
     ENDIF
-    Z(1)  = -ONE
-    Z(NP) =  ONE
-    DO 100  I=2,NP-1
+    Z(1) = -ONE
+    Z(NP) = ONE
+    DO 100 I=2,NP-1
        W(I) = W(I)/(ONE-Z(I)**2)
 100 CONTINUE
     CALL JACOBF (P,PD,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(1))
-    W(1)  = ENDW1 (N,ALPHA,BETA)/(TWO*PD)
+    W(1) = ENDW1 (N,ALPHA,BETA)/(TWO*PD)
     CALL JACOBF (P,PD,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(NP))
     W(NP) = ENDW2 (N,ALPHA,BETA)/(TWO*PD)
 
 !      RETURN
   end subroutine ZWGLJD
 
-  REAL(KIND=XP)  FUNCTION ENDW1 (N,ALPHA,BETA)
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
-    REAL(KIND=XP)  ALPHA,BETA
-    ZERO  = 0.
-    ONE   = 1.
-    TWO   = 2.
+  REAL(KIND=XP) FUNCTION ENDW1 (N,ALPHA,BETA)
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
+    REAL(KIND=XP) ALPHA,BETA
+    ZERO = 0.
+    ONE = 1.
+    TWO = 2.
     THREE = 3.
-    FOUR  = 4.
-    APB   = ALPHA+BETA
+    FOUR = 4.
+    APB = ALPHA+BETA
     IF (N.EQ.0) THEN
        ENDW1 = ZERO
        RETURN
     ENDIF
-    F1   = GAMMAF(ALPHA+TWO)*GAMMAF(BETA+ONE)/GAMMAF(APB+THREE)
-    F1   = F1*(APB+TWO)*TWO**(APB+TWO)/TWO
+    F1 = GAMMAF(ALPHA+TWO)*GAMMAF(BETA+ONE)/GAMMAF(APB+THREE)
+    F1 = F1*(APB+TWO)*TWO**(APB+TWO)/TWO
     IF (N.EQ.1) THEN
        ENDW1 = F1
        RETURN
@@ -364,42 +364,42 @@ contains
     FINT1 = FINT1*TWO**(APB+TWO)
     FINT2 = GAMMAF(ALPHA+TWO)*GAMMAF(BETA+TWO)/GAMMAF(APB+FOUR)
     FINT2 = FINT2*TWO**(APB+THREE)
-    F2    = (-TWO*(BETA+TWO)*FINT1 + (APB+FOUR)*FINT2) &
-           * (APB+THREE)/FOUR
+    F2 = (-TWO*(BETA+TWO)*FINT1 + (APB+FOUR)*FINT2) &
+         * (APB+THREE)/FOUR
     IF (N.EQ.2) THEN
        ENDW1 = F2
        RETURN
     ENDIF
     DO 100 I=3,N
-       DI   = ((I-1))
-       ABN  = ALPHA+BETA+DI
+       DI = ((I-1))
+       ABN = ALPHA+BETA+DI
        ABNN = ABN+DI
-       A1   = -(TWO*(DI+ALPHA)*(DI+BETA))/(ABN*ABNN*(ABNN+ONE))
-       A2   =  (TWO*(ALPHA-BETA))/(ABNN*(ABNN+TWO))
-       A3   =  (TWO*(ABN+ONE))/((ABNN+TWO)*(ABNN+ONE))
-       F3   =  -(A2*F2+A1*F1)/A3
-       F1   = F2
-       F2   = F3
+       A1 = -(TWO*(DI+ALPHA)*(DI+BETA))/(ABN*ABNN*(ABNN+ONE))
+       A2 = (TWO*(ALPHA-BETA))/(ABNN*(ABNN+TWO))
+       A3 = (TWO*(ABN+ONE))/((ABNN+TWO)*(ABNN+ONE))
+       F3 = -(A2*F2+A1*F1)/A3
+       F1 = F2
+       F2 = F3
 100 CONTINUE
-    ENDW1  = F3
+    ENDW1 = F3
     RETURN
   end function ENDW1
 
-  REAL(KIND=XP)  FUNCTION ENDW2 (N,ALPHA,BETA)
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
-    REAL(KIND=XP)  ALPHA,BETA
-    ZERO  = 0.
-    ONE   = 1.
-    TWO   = 2.
+  REAL(KIND=XP) FUNCTION ENDW2 (N,ALPHA,BETA)
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
+    REAL(KIND=XP) ALPHA,BETA
+    ZERO = 0.
+    ONE = 1.
+    TWO = 2.
     THREE = 3.
-    FOUR  = 4.
-    APB   = ALPHA+BETA
+    FOUR = 4.
+    APB = ALPHA+BETA
     IF (N.EQ.0) THEN
        ENDW2 = ZERO
        RETURN
     ENDIF
-    F1   = GAMMAF(ALPHA+ONE)*GAMMAF(BETA+TWO)/GAMMAF(APB+THREE)
-    F1   = F1*(APB+TWO)*TWO**(APB+TWO)/TWO
+    F1 = GAMMAF(ALPHA+ONE)*GAMMAF(BETA+TWO)/GAMMAF(APB+THREE)
+    F1 = F1*(APB+TWO)*TWO**(APB+TWO)/TWO
     IF (N.EQ.1) THEN
        ENDW2 = F1
        RETURN
@@ -408,72 +408,72 @@ contains
     FINT1 = FINT1*TWO**(APB+TWO)
     FINT2 = GAMMAF(ALPHA+TWO)*GAMMAF(BETA+TWO)/GAMMAF(APB+FOUR)
     FINT2 = FINT2*TWO**(APB+THREE)
-    F2    = (TWO*(ALPHA+TWO)*FINT1 - (APB+FOUR)*FINT2) &
-           * (APB+THREE)/FOUR
+    F2 = (TWO*(ALPHA+TWO)*FINT1 - (APB+FOUR)*FINT2) &
+         * (APB+THREE)/FOUR
     IF (N.EQ.2) THEN
        ENDW2 = F2
        RETURN
     ENDIF
     DO 100 I=3,N
-       DI   = ((I-1))
-       ABN  = ALPHA+BETA+DI
+       DI = ((I-1))
+       ABN = ALPHA+BETA+DI
        ABNN = ABN+DI
-       A1   =  -(TWO*(DI+ALPHA)*(DI+BETA))/(ABN*ABNN*(ABNN+ONE))
-       A2   =  (TWO*(ALPHA-BETA))/(ABNN*(ABNN+TWO))
-       A3   =  (TWO*(ABN+ONE))/((ABNN+TWO)*(ABNN+ONE))
-       F3   =  -(A2*F2+A1*F1)/A3
-       F1   = F2
-       F2   = F3
+       A1 = -(TWO*(DI+ALPHA)*(DI+BETA))/(ABN*ABNN*(ABNN+ONE))
+       A2 = (TWO*(ALPHA-BETA))/(ABNN*(ABNN+TWO))
+       A3 = (TWO*(ABN+ONE))/((ABNN+TWO)*(ABNN+ONE))
+       F3 = -(A2*F2+A1*F1)/A3
+       F1 = F2
+       F2 = F3
 100 CONTINUE
-    ENDW2  = F3
+    ENDW2 = F3
     RETURN
   end function ENDW2
 
-  REAL(KIND=XP)  FUNCTION GAMMAF (X)
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
-    REAL(KIND=XP)  X
+  REAL(KIND=XP) FUNCTION GAMMAF (X)
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
+    REAL(KIND=XP) X
     ZERO = 0.0
     HALF = 0.5
-    ONE  = 1.0
-    TWO  = 2.0
+    ONE = 1.0
+    TWO = 2.0
     FOUR = 4.0
-    PI   = FOUR*ATAN(ONE)
+    PI = FOUR*ATAN(ONE)
     GAMMAF = ONE
     IF (X.EQ.-HALF) GAMMAF = -TWO*SQRT(PI)
-    IF (X.EQ. HALF) GAMMAF =  SQRT(PI)
-    IF (X.EQ. ONE ) GAMMAF =  ONE
-    IF (X.EQ. TWO ) GAMMAF =  ONE
-    IF (X.EQ. 1.5  ) GAMMAF =  SQRT(PI)/2.
-    IF (X.EQ. 2.5) GAMMAF =  1.5*SQRT(PI)/2.
-    IF (X.EQ. 3.5) GAMMAF =  0.5*(2.5*(1.5*SQRT(PI)))
-    IF (X.EQ. 3. ) GAMMAF =  2.
+    IF (X.EQ. HALF) GAMMAF = SQRT(PI)
+    IF (X.EQ. ONE ) GAMMAF = ONE
+    IF (X.EQ. TWO ) GAMMAF = ONE
+    IF (X.EQ. 1.5 ) GAMMAF = SQRT(PI)/2.
+    IF (X.EQ. 2.5) GAMMAF = 1.5*SQRT(PI)/2.
+    IF (X.EQ. 3.5) GAMMAF = 0.5*(2.5*(1.5*SQRT(PI)))
+    IF (X.EQ. 3. ) GAMMAF = 2.
     IF (X.EQ. 4. ) GAMMAF = 6.
     IF (X.EQ. 5. ) GAMMAF = 24.
     IF (X.EQ. 6. ) GAMMAF = 120.
     RETURN
   end function GAMMAF
 
-  REAL(KIND=XP)  FUNCTION PNORMJ (N,ALPHA,BETA)
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
-    REAL(KIND=XP)  ALPHA,BETA
-    ONE   = 1.
-    TWO   = 2.
-    DN    = ((N))
+  REAL(KIND=XP) FUNCTION PNORMJ (N,ALPHA,BETA)
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
+    REAL(KIND=XP) ALPHA,BETA
+    ONE = 1.
+    TWO = 2.
+    DN = ((N))
     CONST = ALPHA+BETA+ONE
     IF (N.LE.1) THEN
-       PROD   = GAMMAF(DN+ALPHA)*GAMMAF(DN+BETA)
-       PROD   = PROD/(GAMMAF(DN)*GAMMAF(DN+ALPHA+BETA))
+       PROD = GAMMAF(DN+ALPHA)*GAMMAF(DN+BETA)
+       PROD = PROD/(GAMMAF(DN)*GAMMAF(DN+ALPHA+BETA))
        PNORMJ = PROD * TWO**CONST/(TWO*DN+CONST)
        RETURN
     ENDIF
-    PROD  = GAMMAF(ALPHA+ONE)*GAMMAF(BETA+ONE)
-    PROD  = PROD/(TWO*(ONE+CONST)*GAMMAF(CONST+ONE))
-    PROD  = PROD*(ONE+ALPHA)*(TWO+ALPHA)
-    PROD  = PROD*(ONE+BETA)*(TWO+BETA)
+    PROD = GAMMAF(ALPHA+ONE)*GAMMAF(BETA+ONE)
+    PROD = PROD/(TWO*(ONE+CONST)*GAMMAF(CONST+ONE))
+    PROD = PROD*(ONE+ALPHA)*(TWO+ALPHA)
+    PROD = PROD*(ONE+BETA)*(TWO+BETA)
     DO 100 I=3,N
        DINDX = ((I))
-       FRAC  = (DINDX+ALPHA)*(DINDX+BETA)/(DINDX*(DINDX+ALPHA+BETA))
-       PROD  = PROD*FRAC
+       FRAC = (DINDX+ALPHA)*(DINDX+BETA)/(DINDX*(DINDX+ALPHA+BETA))
+       PROD = PROD*FRAC
 100 CONTINUE
     PNORMJ = PROD * TWO**CONST/(TWO*DN+CONST)
     RETURN
@@ -490,11 +490,11 @@ contains
 !     ALPHA = BETA = -0.5  ->  Chebyshev points
 !
 !--------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
-    REAL(KIND=XP)  XJAC(1)
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
+    REAL(KIND=XP) XJAC(1)
     DATA KSTOP /10/
     DATA EPS/1.0e-12_RP/
-    N   = NP-1
+    N = NP-1
     one = 1.
     DTH = 4.*ATAN(one)/(2.*((N))+2.)
     DO 40 J=1,NP
@@ -503,7 +503,7 @@ contains
        ELSE
           X1 = COS((2.*(((J))-1.)+1.)*DTH)
           X2 = XLAST
-          X  = (X1+X2)/2.
+          X = (X1+X2)/2.
        ENDIF
        DO 30 K=1,KSTOP
           CALL JACOBF (P,PD,PM1,PDM1,PM2,PDM2,NP,ALPHA,BETA,X)
@@ -513,12 +513,12 @@ contains
              RECSUM = RECSUM+1./(X-XJAC(NP-I+1))
 29        CONTINUE
           DELX = -P/(PD-RECSUM*P)
-          X    = X+DELX
+          X = X+DELX
           IF (ABS(DELX) .LT. EPS) GOTO 31
 30     CONTINUE
 31     CONTINUE
        XJAC(NP-J+1) = X
-       XLAST        = X
+       XLAST = X
 40  CONTINUE
     DO 200 I=1,NP
        XMIN = 2.
@@ -544,15 +544,15 @@ contains
 !     of degree N at X.
 !
 !--------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
-    APB  = ALP+BET
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
+    APB = ALP+BET
     POLY = 1.
     PDER = 0.
     IF (N .EQ. 0) RETURN
     POLYL = POLY
     PDERL = PDER
-    POLY  = (ALP-BET+(APB+2.)*X)/2.
-    PDER  = (APB+2.)/2.
+    POLY = (ALP-BET+(APB+2.)*X)/2.
+    PDER = (APB+2.)/2.
     IF (N .EQ. 1) RETURN
     DO 20 K=2,N
        DK = ((K))
@@ -561,14 +561,14 @@ contains
        B3 = (2.*DK+APB-2.)
        A3 = B3*(B3+1.)*(B3+2.)
        A4 = 2.*(DK+ALP-1.)*(DK+BET-1.)*(2.*DK+APB)
-       POLYN  = ((A2+A3*X)*POLY-A4*POLYL)/A1
-       PDERN  = ((A2+A3*X)*PDER-A4*PDERL+A3*POLY)/A1
-       PSAVE  = POLYL
+       POLYN = ((A2+A3*X)*POLY-A4*POLYL)/A1
+       PDERN = ((A2+A3*X)*PDER-A4*PDERL+A3*POLY)/A1
+       PSAVE = POLYL
        PDSAVE = PDERL
-       POLYL  = POLY
-       POLY   = POLYN
-       PDERL  = PDER
-       PDER   = PDERN
+       POLYL = POLY
+       POLY = POLYN
+       PDERL = PDER
+       PDER = PDERN
 20  CONTINUE
     POLYM1 = POLYL
     PDERM1 = PDERL
@@ -587,8 +587,8 @@ contains
 !---------------------------------------------------------------------
     PARAMETER (NMAX=84)
     PARAMETER (NZD = NMAX)
-    REAL(KIND=XP)  ZD,ZGJD(NZD),ALPHAD,BETAD
-    REAL(KIND=XP)  Z,ZGJ(1),ALPHA,BETA
+    REAL(KIND=XP) ZD,ZGJD(NZD),ALPHAD,BETAD
+    REAL(KIND=XP) Z,ZGJ(1),ALPHA,BETA
     NPMAX = NZD
     IF (NP.GT.NPMAX) THEN
        WRITE (6,*) 'Too large polynomial degree in HGJ'
@@ -601,12 +601,12 @@ contains
        ZGJD(I) = ZGJ(I)
 100 CONTINUE
     ALPHAD = ALPHA
-    BETAD  = BETA
-    HGJ    = HGJD (II,ZD,ZGJD,NP,ALPHAD,BETAD)
+    BETAD = BETA
+    HGJ = HGJD (II,ZD,ZGJD,NP,ALPHAD,BETAD)
     RETURN
   end function HGJ
 
-  REAL(KIND=XP)  FUNCTION HGJD (II,Z,ZGJ,NP,ALPHA,BETA)
+  REAL(KIND=XP) FUNCTION HGJD (II,Z,ZGJ,NP,ALPHA,BETA)
 !---------------------------------------------------------------------
 !
 !     Compute the value of the Lagrangian interpolant HGJD through
@@ -614,19 +614,19 @@ contains
 !     Double precision version.
 !
 !---------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
-    REAL(KIND=XP)  Z,ZGJ(1),ALPHA,BETA
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
+    REAL(KIND=XP) Z,ZGJ(1),ALPHA,BETA
     EPS = 1.e-5
     ONE = 1.
-    ZI  = ZGJ(II)
-    DZ  = Z-ZI
+    ZI = ZGJ(II)
+    DZ = Z-ZI
     IF (ABS(DZ).LT.EPS) THEN
        HGJD = ONE
        RETURN
     ENDIF
     CALL JACOBF (PZI,PDZI,PM1,PDM1,PM2,PDM2,NP,ALPHA,BETA,ZI)
     CALL JACOBF (PZ,PDZ,PM1,PDM1,PM2,PDM2,NP,ALPHA,BETA,Z)
-    HGJD  = PZ/(PDZI*(Z-ZI))
+    HGJD = PZ/(PDZI*(Z-ZI))
     RETURN
   end function HGJD
 
@@ -640,8 +640,8 @@ contains
 !---------------------------------------------------------------------
     PARAMETER (NMAX=84)
     PARAMETER (NZD = NMAX)
-    REAL(KIND=XP)  ZD,ZGLJD(NZD),ALPHAD,BETAD
-    REAL(KIND=XP)  Z,ZGLJ(1),ALPHA,BETA
+    REAL(KIND=XP) ZD,ZGLJD(NZD),ALPHAD,BETAD
+    REAL(KIND=XP) Z,ZGLJ(1),ALPHA,BETA
     NPMAX = NZD
     IF (NP.GT.NPMAX) THEN
        WRITE (6,*) 'Too large polynomial degree in HGLJ'
@@ -654,12 +654,12 @@ contains
        ZGLJD(I) = ZGLJ(I)
 100 CONTINUE
     ALPHAD = ALPHA
-    BETAD  = BETA
-    HGLJ   = HGLJD (II,ZD,ZGLJD,NP,ALPHAD,BETAD)
+    BETAD = BETA
+    HGLJ = HGLJD (II,ZD,ZGLJD,NP,ALPHAD,BETAD)
     RETURN
   end function HGLJ
 
-  REAL(KIND=XP)  FUNCTION HGLJD (I,Z,ZGLJ,NP,ALPHA,BETA)
+  REAL(KIND=XP) FUNCTION HGLJD (I,Z,ZGLJ,NP,ALPHA,BETA)
 !---------------------------------------------------------------------
 !
 !     Compute the value of the Lagrangian interpolant HGLJD through
@@ -667,23 +667,23 @@ contains
 !     Double precision version.
 !
 !---------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
-    REAL(KIND=XP)  Z,ZGLJ(1),ALPHA,BETA
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
+    REAL(KIND=XP) Z,ZGLJ(1),ALPHA,BETA
     EPS = 1.e-5
     ONE = 1.
-    ZI  = ZGLJ(I)
-    DZ  = Z-ZI
+    ZI = ZGLJ(I)
+    DZ = Z-ZI
     IF (ABS(DZ).LT.EPS) THEN
        HGLJD = ONE
        RETURN
     ENDIF
-    N      = NP-1
-    DN     = ((N))
+    N = NP-1
+    DN = ((N))
     EIGVAL = -DN*(DN+ALPHA+BETA+ONE)
     CALL JACOBF (PI,PDI,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,ZI)
-    CONST  = EIGVAL*PI+ALPHA*(ONE+ZI)*PDI-BETA*(ONE-ZI)*PDI
+    CONST = EIGVAL*PI+ALPHA*(ONE+ZI)*PDI-BETA*(ONE-ZI)*PDI
     CALL JACOBF (P,PD,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z)
-    HGLJD  = (ONE-Z**2)*PD/(CONST*(Z-ZI))
+    HGLJD = (ONE-Z**2)*PD/(CONST*(Z-ZI))
     RETURN
   end function HGLJD
 
@@ -699,7 +699,7 @@ contains
 !-----------------------------------------------------------------
     PARAMETER (NMAX=84)
     PARAMETER (NZDD = NMAX)
-    REAL(KIND=XP)  DD(NZDD,NZDD),DTD(NZDD,NZDD),ZD(NZDD),ALPHAD,BETAD
+    REAL(KIND=XP) DD(NZDD,NZDD),DTD(NZDD,NZDD),ZD(NZDD),ALPHAD,BETAD
     REAL(KIND=XP) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
 
     IF (NZ.LE.0) THEN
@@ -717,14 +717,14 @@ contains
        call neko_error
     ENDIF
     ALPHAD = ALPHA
-    BETAD  = BETA
+    BETAD = BETA
     DO 100 I=1,NZ
        ZD(I) = Z(I)
 100 CONTINUE
     CALL DGJD (DD,DTD,ZD,NZ,NZDD,ALPHAD,BETAD)
     DO I=1,NZ
        DO J=1,NZ
-          D(I,J)  = DD(I,J)
+          D(I,J) = DD(I,J)
           DT(I,J) = DTD(I,J)
        END DO
     END DO
@@ -741,12 +741,12 @@ contains
 !     Double precision version.
 !
 !-----------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
-    REAL(KIND=XP)  D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
-    N    = NZ-1
-    DN   = ((N))
-    ONE  = 1.
-    TWO  = 2.
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
+    REAL(KIND=XP) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
+    N = NZ-1
+    DN = ((N))
+    ONE = 1.
+    TWO = 2.
 
     IF (NZ.LE.1) THEN
        WRITE (6,*) 'DGJD: Minimum number of Gauss-Lobatto points is 2'
@@ -763,7 +763,7 @@ contains
           CALL JACOBF (PJ,PDJ,PM1,PDM1,PM2,PDM2,NZ,ALPHA,BETA,Z(J))
           IF (I.NE.J) D(I,J) = PDI/(PDJ*(Z(I)-Z(J)))
           IF (I.EQ.J) D(I,J) = ((ALPHA+BETA+TWO)*Z(I)+ALPHA-BETA)/ &
-              (TWO*(ONE-Z(I)**2))
+               (TWO*(ONE-Z(I)**2))
           DT(J,I) = D(I,J)
        END DO
     END DO
@@ -782,7 +782,7 @@ contains
 !-----------------------------------------------------------------
     PARAMETER (NMAX=84)
     PARAMETER (NZDD = NMAX)
-    REAL(KIND=XP)  DD(NZDD,NZDD),DTD(NZDD,NZDD),ZD(NZDD),ALPHAD,BETAD
+    REAL(KIND=XP) DD(NZDD,NZDD),DTD(NZDD,NZDD),ZD(NZDD),ALPHAD,BETAD
     REAL(KIND=XP) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
 
     IF (NZ.LE.1) THEN
@@ -800,14 +800,14 @@ contains
        call neko_error
     ENDIF
     ALPHAD = ALPHA
-    BETAD  = BETA
+    BETAD = BETA
     DO 100 I=1,NZ
        ZD(I) = Z(I)
 100 CONTINUE
     CALL DGLJD (DD,DTD,ZD,NZ,NZDD,ALPHAD,BETAD)
     DO I=1,NZ
        DO J=1,NZ
-          D(I,J)  = DD(I,J)
+          D(I,J) = DD(I,J)
           DT(I,J) = DTD(I,J)
        END DO
     END DO
@@ -824,12 +824,12 @@ contains
 !     Double precision version.
 !
 !-----------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
-    REAL(KIND=XP)  D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
-    N    = NZ-1
-    DN   = ((N))
-    ONE  = 1.
-    TWO  = 2.
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
+    REAL(KIND=XP) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
+    N = NZ-1
+    DN = ((N))
+    ONE = 1.
+    TWO = 2.
     EIGVAL = -DN*(DN+ALPHA+BETA+ONE)
 
     IF (NZ.LE.1) THEN
@@ -849,12 +849,12 @@ contains
           CJ = EIGVAL*PJ-(BETA*(ONE-Z(J))-ALPHA*(ONE+Z(J)))*PDJ
           IF (I.NE.J) D(I,J) = CI/(CJ*(Z(I)-Z(J)))
           IF ((I.EQ.J).AND.(I.NE.1).AND.(I.NE.NZ)) &
-              D(I,J) = (ALPHA*(ONE+Z(I))-BETA*(ONE-Z(I)))/ &
-              (TWO*(ONE-Z(I)**2))
+               D(I,J) = (ALPHA*(ONE+Z(I))-BETA*(ONE-Z(I)))/ &
+               (TWO*(ONE-Z(I)**2))
           IF ((I.EQ.J).AND.(I.EQ.1)) &
-              D(I,J) =  (EIGVAL+ALPHA)/(TWO*(BETA+TWO))
+               D(I,J) = (EIGVAL+ALPHA)/(TWO*(BETA+TWO))
           IF ((I.EQ.J).AND.(I.EQ.NZ)) &
-              D(I,J) = -(EIGVAL+BETA)/(TWO*(ALPHA+TWO))
+               D(I,J) = -(EIGVAL+BETA)/(TWO*(ALPHA+TWO))
           DT(J,I) = D(I,J)
        END DO
     END DO
@@ -870,10 +870,10 @@ contains
 !     Note: D and DT are square matrices.
 !
 !-----------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
     PARAMETER (NMAX=84)
     REAL(KIND=RP) D(NZD,NZD),DT(NZD,NZD),Z(1)
-    N  = NZ-1
+    N = NZ-1
     IF (NZ .GT. NMAX) THEN
        WRITE (6,*) 'Subroutine DGLL'
        WRITE (6,*) 'Maximum polynomial degree =',NMAX
@@ -888,10 +888,10 @@ contains
     DO I=1,NZ
        DO J=1,NZ
           D(I,J) = 0.
-          IF  (I.NE.J) D(I,J) = PNLEG(real(Z(I),xp),N)/ &
-                             (PNLEG(real(Z(J),xp),N)*(Z(I)-Z(J)))
-          IF ((I.EQ.J).AND.(I.EQ.1))  D(I,J) = -d0
-          IF ((I.EQ.J).AND.(I.EQ.NZ)) D(I,J) =  d0
+          IF (I.NE.J) D(I,J) = PNLEG(real(Z(I),xp),N)/ &
+               (PNLEG(real(Z(J),xp),N)*(Z(I)-Z(J)))
+          IF ((I.EQ.J).AND.(I.EQ.1)) D(I,J) = -d0
+          IF ((I.EQ.J).AND.(I.EQ.NZ)) D(I,J) = d0
           DT(J,I) = D(I,J)
        END DO
     END DO
@@ -905,7 +905,7 @@ contains
 !     the NZ Gauss-Lobatto Legendre points ZGLL at the point Z.
 !
 !---------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
     REAL(KIND=XP) ZGLL(1), EPS, DZ, Z
     EPS = 1.E-5
     DZ = Z - ZGLL(I)
@@ -916,7 +916,7 @@ contains
     N = NZ - 1
     ALFAN = (N)*((N)+1.)
     HGLL = - (1.-Z*Z)*PNDLEG(Z,N)/ &
-           (ALFAN*PNLEG(ZGLL(I),N)*(Z-ZGLL(I)))
+         (ALFAN*PNLEG(ZGLL(I),N)*(Z-ZGLL(I)))
     RETURN
   end function HGLL
 
@@ -951,29 +951,29 @@ contains
 !     This next statement is to overcome the underflow bug in the i860.
 !     It can be removed at a later date.  11 Aug 1990   pff.
 !
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
     REAL(KIND=XP) Z, P1, P2, P3
-    IF(ABS(Z) .LT. 1.0E-25) Z = 0.0
+    !IF(ABS(Z) .LT. 1.0E-25) Z = 0.0
 
 
-    P1   = 1.
+    P1 = 1.
     IF (N.EQ.0) THEN
        PNLEG = P1
        RETURN
     ENDIF
-    P2   = Z
-    P3   = P2
+    P2 = Z
+    P3 = P2
     DO 10 K = 1, N-1
-       FK  = (K)
-       P3  = ((2.*FK+1.)*Z*P2 - FK*P1)/(FK+1.)
-       P1  = P2
-       P2  = P3
+       FK = (K)
+       P3 = ((2.0_rp*FK+1.0_rp)*Z*P2 - FK*P1)/(FK+1.0_rp)
+       P1 = P2
+       P2 = P3
 10  CONTINUE
     PNLEG = P3
     if (n.eq.0) pnleg = 1.
     RETURN
   end function PNLEG
-   
+
   !> Evaluate Legendre polynomials of degrees 0-N at point x
   !! and store in array L
   subroutine legendre_poly(L, x, N)
@@ -987,7 +987,7 @@ contains
 
     do j=1, N-1
        L(j+1) = ( (2.0_xp * real(j, xp) + 1.0_xp) * x * L(j) &
-            - real(j, xp) * L(j-1) ) / (real(j, xp) + 1.0_xp) 
+            - real(j, xp) * L(j-1) ) / (real(j, xp) + 1.0_xp)
     end do
   end subroutine legendre_poly
 
@@ -999,19 +999,19 @@ contains
 !     Based on the recursion formula for the Legendre polynomials.
 !
 !----------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
     REAL(KIND=XP) P1, P2, P1D, P2D, P3D, Z
-    P1   = 1.
-    P2   = Z
-    P1D  = 0.
-    P2D  = 1.
-    P3D  = 1.
+    P1 = 1.
+    P2 = Z
+    P1D = 0.
+    P2D = 1.
+    P3D = 1.
     DO 10 K = 1, N-1
-       FK  = (K)
-       P3  = ((2.*FK+1.)*Z*P2 - FK*P1)/(FK+1.)
+       FK = (K)
+       P3 = ((2.*FK+1.)*Z*P2 - FK*P1)/(FK+1.)
        P3D = ((2.*FK+1.)*P2 + (2.*FK+1.)*Z*P2D - FK*P1D)/(FK+1.)
-       P1  = P2
-       P2  = P3
+       P1 = P2
+       P2 = P3
        P1D = P2D
        P2D = P3D
 10  CONTINUE
@@ -1049,7 +1049,7 @@ contains
              D(IP,JQ) = 0.
           ELSE
              D(IP,JQ) = (PNLEG(ZP,NM1)/PNLEG(ZQ,NM1) &
-                     -IM12(IP,JQ))/(ZP-ZQ)
+                  -IM12(IP,JQ))/(ZP-ZQ)
           ENDIF
           DT(JQ,IP) = D(IP,JQ)
        END DO
@@ -1073,9 +1073,9 @@ contains
     REAL(KIND=XP) D(ND2,ND1), DT(ND1,ND2), ZGL(ND1), ZG(ND2), IGLG(ND2,ND1)
     PARAMETER (NMAX=84)
     PARAMETER (NDD = NMAX)
-    REAL(KIND=XP)  DD(NDD,NDD), DTD(NDD,NDD)
-    REAL(KIND=XP)  ZGD(NDD), ZGLD(NDD), IGLGD(NDD,NDD)
-    REAL(KIND=XP)  ALPHAD, BETAD
+    REAL(KIND=XP) DD(NDD,NDD), DTD(NDD,NDD)
+    REAL(KIND=XP) ZGD(NDD), ZGLD(NDD), IGLGD(NDD,NDD)
+    REAL(KIND=XP) ALPHAD, BETAD
 
     IF (NPGL.LE.1) THEN
        WRITE(6,*) 'DGLJGJ: Minimum number of Gauss-Lobatto points is 2'
@@ -1093,7 +1093,7 @@ contains
     ENDIF
 
     ALPHAD = ALPHA
-    BETAD  = BETA
+    BETAD = BETA
     DO I=1,NPG
        ZGD(I) = ZG(I)
        DO J=1,NPGL
@@ -1106,7 +1106,7 @@ contains
     CALL DGLJGJD (DD,DTD,ZGLD,ZGD,IGLGD,NPGL,NPG,NDD,NDD,ALPHAD,BETAD)
     DO I=1,NPG
        DO J=1,NPGL
-          D(I,J)  = DD(I,J)
+          D(I,J) = DD(I,J)
           DT(J,I) = DTD(J,I)
        END DO
     END DO
@@ -1126,9 +1126,9 @@ contains
 !     Double precision version.
 !
 !-----------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP)  (A-H,O-Z)
-    REAL(KIND=XP)  D(ND2,ND1), DT(ND1,ND2), ZGL(ND1), ZG(ND2)
-    REAL(KIND=XP)  IGLG(ND2,ND1), ALPHA, BETA
+    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
+    REAL(KIND=XP) D(ND2,ND1), DT(ND1,ND2), ZGL(ND1), ZG(ND2)
+    REAL(KIND=XP) IGLG(ND2,ND1), ALPHA, BETA
 
     IF (NPGL.LE.1) THEN
        WRITE(6,*) 'DGLJGJD: Minimum number of Gauss-Lobatto points is 2'
@@ -1139,11 +1139,11 @@ contains
        call neko_error
     ENDIF
 
-    EPS    = 1.e-6
-    ONE    = 1.
-    TWO    = 2.
-    NGL    = NPGL-1
-    DN     = ((NGL))
+    EPS = 1.e-6
+    ONE = 1.
+    TWO = 2.
+    NGL = NPGL-1
+    DN = ((NGL))
     EIGVAL = -DN*(DN+ALPHA+BETA+ONE)
 
     DO I=1,NPG
@@ -1151,15 +1151,15 @@ contains
           DZ = ABS(ZG(I)-ZGL(J))
           IF (DZ.LT.EPS) THEN
              D(I,J) = (ALPHA*(ONE+ZG(I))-BETA*(ONE-ZG(I)))/ &
-                 (TWO*(ONE-ZG(I)**2))
+                  (TWO*(ONE-ZG(I)**2))
           ELSE
              CALL JACOBF (PI,PDI,PM1,PDM1,PM2,PDM2,NGL,ALPHA,BETA,ZG(I))
              CALL JACOBF (PJ,PDJ,PM1,PDM1,PM2,PDM2,NGL,ALPHA,BETA,ZGL(J))
-             FACI   = ALPHA*(ONE+ZG(I))-BETA*(ONE-ZG(I))
-             FACJ   = ALPHA*(ONE+ZGL(J))-BETA*(ONE-ZGL(J))
-             CONST  = EIGVAL*PJ+FACJ*PDJ
+             FACI = ALPHA*(ONE+ZG(I))-BETA*(ONE-ZG(I))
+             FACJ = ALPHA*(ONE+ZGL(J))-BETA*(ONE-ZGL(J))
+             CONST = EIGVAL*PJ+FACJ*PDJ
              D(I,J) = ((EIGVAL*PI+FACI*PDI)*(ZG(I)-ZGL(J)) &
-                 -(ONE-ZG(I)**2)*PDI)/(CONST*(ZG(I)-ZGL(J))**2)
+                  -(ONE-ZG(I)**2)*PDI)/(CONST*(ZG(I)-ZGL(J))**2)
           ENDIF
           DT(J,I) = D(I,J)
        END DO

--- a/src/sem/speclib.f90
+++ b/src/sem/speclib.f90
@@ -29,10 +29,10 @@
 ! ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 ! SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
 ! TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-! DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! data, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 ! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 ! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+! OF THIS SOFTWARE, EVEN if ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 !
 ! Additional BSD Notice
 ! ---------------------
@@ -157,15 +157,15 @@ contains
   !! @param Z Quadrature points.
   !! @param W Quadrature weights.
   !! @param NP Number of quadrature points.
-  SUBROUTINE ZWGL (Z,W,NP)
-    REAL(KIND=RP) Z(1),W(1), ALPHA, BETA
+  subroutine ZWGL (Z,W,NP)
+    real(kind=rp) Z(1),W(1), ALPHA, BETA
     ALPHA = 0.
     BETA = 0.
-    CALL ZWGJ (Z,W,NP,ALPHA,BETA)
-    RETURN
+    call ZWGJ (Z,W,NP,ALPHA,BETA)
+    return
   end subroutine ZWGL
 
-  SUBROUTINE ZWGLL (Z,W,NP)
+  subroutine ZWGLL (Z,W,NP)
 !--------------------------------------------------------------------
 !
 !     Generate NP Gauss-Lobatto Legendre points (Z) and weights (W)
@@ -175,14 +175,14 @@ contains
 !     operations are done in double precision.
 !
 !--------------------------------------------------------------------
-    REAL(KIND=RP) Z(1),W(1), ALPHA, BETA
+    real(kind=rp) Z(1),W(1), ALPHA, BETA
     ALPHA = 0.
     BETA = 0.
-    CALL ZWGLJ (Z,W,NP,ALPHA,BETA)
-    RETURN
+    call ZWGLJ (Z,W,NP,ALPHA,BETA)
+    return
   end subroutine ZWGLL
 
-  SUBROUTINE ZWGJ (Z,W,NP,ALPHA,BETA)
+  subroutine ZWGJ (Z,W,NP,ALPHA,BETA)
 !--------------------------------------------------------------------
 !
 !     Generate NP GAUSS JACOBI points (Z) and weights (W)
@@ -191,29 +191,29 @@ contains
 !     Single precision version.
 !
 !--------------------------------------------------------------------
-    PARAMETER (NMAX=84)
-    PARAMETER (NZD = NMAX)
-    REAL(KIND=XP) ZD(NZD),WD(NZD),ALPHAD,BETAD
-    REAL(KIND=RP) Z(1),W(1),ALPHA,BETA
+    parameter (NMAX=84)
+    parameter (NZD = NMAX)
+    real(kind=xp) ZD(NZD),WD(NZD),ALPHAD,BETAD
+    real(kind=rp) Z(1),W(1),ALPHA,BETA
 
     NPMAX = NZD
-    IF (NP.GT.NPMAX) THEN
-       WRITE (6,*) 'Too large polynomial degree in ZWGJ'
-       WRITE (6,*) 'Maximum polynomial degree is',NMAX
-       WRITE (6,*) 'Here NP=',NP
+    if (NP .gt. NPMAX) then
+       write (6,*) 'Too large polynomial degree in ZWGJ'
+       write (6,*) 'Maximum polynomial degree is',NMAX
+       write (6,*) 'Here NP=',NP
        call neko_error
-    ENDIF
+    end if
     ALPHAD = ALPHA
     BETAD = BETA
-    CALL ZWGJD (ZD,WD,NP,ALPHAD,BETAD)
-    DO 100 I=1,NP
+    call ZWGJD (ZD,WD,NP,ALPHAD,BETAD)
+    do 100 I=1,NP
        Z(I) = ZD(I)
        W(I) = WD(I)
-100 CONTINUE
-    RETURN
+100 continue
+    return
   end subroutine ZWGJ
 
-  SUBROUTINE ZWGJD (Z,W,NP,ALPHA,BETA)
+  subroutine ZWGJD (Z,W,NP,ALPHA,BETA)
 !--------------------------------------------------------------------
 !
 !     Generate NP GAUSS JACOBI points (Z) and weights (W)
@@ -222,8 +222,8 @@ contains
 !     Double precision version.
 !
 !--------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
-    REAL(KIND=XP) Z(1),W(1),ALPHA,BETA
+    implicit real(kind=xp) (A-H,O-Z)
+    real(kind=xp) Z(1),W(1),ALPHA,BETA
 
     N = NP-1
     DN = ((N))
@@ -231,23 +231,23 @@ contains
     TWO = 2.
     APB = ALPHA+BETA
 
-    IF (NP.LE.0) THEN
-       WRITE (6,*) 'ZWGJD: Minimum number of Gauss points is 1',np
+    if (NP .le. 0) then
+       write (6,*) 'ZWGJD: Minimum number of Gauss points is 1',np
        call neko_error
-    ENDIF
-    IF ((ALPHA.LE.-ONE).OR.(BETA.LE.-ONE)) THEN
-       WRITE (6,*) 'ZWGJD: Alpha and Beta must be greater than -1'
+    end if
+    if ((ALPHA .le. -ONE) .or. (BETA .le. -ONE)) then
+       write (6,*) 'ZWGJD: Alpha and Beta must be greater than -1'
        call neko_error
-    ENDIF
+    end if
 
-    IF (NP.EQ.1) THEN
+    if (NP .eq. 1) then
        Z(1) = (BETA-ALPHA)/(APB+TWO)
        W(1) = GAMMAF(ALPHA+ONE)*GAMMAF(BETA+ONE)/GAMMAF(APB+TWO) &
             * TWO**(APB+ONE)
-       RETURN
-    ENDIF
+       return
+    end if
 
-    CALL JACG (Z,NP,ALPHA,BETA)
+    call JACG (Z,NP,ALPHA,BETA)
 
     NP1 = N+1
     NP2 = N+2
@@ -258,14 +258,14 @@ contains
     FAC3 = FAC2+ONE
     FNORM = PNORMJ(NP1,ALPHA,BETA)
     RCOEF = (FNORM*FAC2*FAC3)/(TWO*FAC1*DNP2)
-    DO 100 I=1,NP
-       CALL JACOBF (P,PD,PM1,PDM1,PM2,PDM2,NP2,ALPHA,BETA,Z(I))
+    do 100 I=1,NP
+       call JACOBF (P,PD,PM1,PDM1,PM2,PDM2,NP2,ALPHA,BETA,Z(I))
        W(I) = -RCOEF/(P*PDM1)
-100 CONTINUE
-    RETURN
+100 continue
+    return
   end subroutine ZWGJD
 
-  SUBROUTINE ZWGLJ (Z,W,NP,ALPHA,BETA)
+  subroutine ZWGLJ (Z,W,NP,ALPHA,BETA)
 !--------------------------------------------------------------------
 !
 !     Generate NP GAUSS LOBATTO JACOBI points (Z) and weights (W)
@@ -274,29 +274,29 @@ contains
 !     Single precision version.
 !
 !--------------------------------------------------------------------
-    PARAMETER (NMAX=84)
-    PARAMETER (NZD = NMAX)
-    REAL(KIND=XP) ZD(NZD),WD(NZD),ALPHAD,BETAD
-    REAL(KIND=RP) Z(1),W(1),ALPHA,BETA
+    parameter (NMAX=84)
+    parameter (NZD = NMAX)
+    real(kind=xp) ZD(NZD),WD(NZD),ALPHAD,BETAD
+    real(kind=rp) Z(1),W(1),ALPHA,BETA
 
     NPMAX = NZD
-    IF (NP.GT.NPMAX) THEN
-       WRITE (6,*) 'Too large polynomial degree in ZWGLJ'
-       WRITE (6,*) 'Maximum polynomial degree is',NMAX
-       WRITE (6,*) 'Here NP=',NP
+    if (NP .gt. NPMAX) then
+       write (6,*) 'Too large polynomial degree in ZWGLJ'
+       write (6,*) 'Maximum polynomial degree is',NMAX
+       write (6,*) 'Here NP=',NP
        call neko_error
-    ENDIF
+    end if
     ALPHAD = ALPHA
     BETAD = BETA
-    CALL ZWGLJD (ZD,WD,NP,ALPHAD,BETAD)
-    DO 100 I=1,NP
+    call ZWGLJD (ZD,WD,NP,ALPHAD,BETAD)
+    do 100 I=1,NP
        Z(I) = ZD(I)
        W(I) = WD(I)
-100 CONTINUE
-    RETURN
+100 continue
+    return
   end subroutine ZWGLJ
 
-  SUBROUTINE ZWGLJD (Z,W,NP,ALPHA,BETA)
+  subroutine ZWGLJD (Z,W,NP,ALPHA,BETA)
 !--------------------------------------------------------------------
 !
 !     Generate NP GAUSS LOBATTO JACOBI points (Z) and weights (W)
@@ -305,72 +305,72 @@ contains
 !     Double precision version.
 !
 !--------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
-    REAL(KIND=XP) Z(NP),W(NP),ALPHA,BETA
+    implicit real(kind=xp) (A-H,O-Z)
+    real(kind=xp) Z(NP),W(NP),ALPHA,BETA
 
     N = NP-1
     NM1 = N-1
     ONE = 1.
     TWO = 2.
 
-    IF (NP.LE.1) THEN
-       WRITE (6,*) 'ZWGLJD: Minimum number of Gauss-Lobatto points is 2'
-       WRITE (6,*) 'ZWGLJD: alpha,beta:',alpha,beta,np
+    if (NP .le. 1) then
+       write (6,*) 'ZWGLJD: Minimum number of Gauss-Lobatto points is 2'
+       write (6,*) 'ZWGLJD: alpha,beta:',alpha,beta,np
        call neko_error
-    ENDIF
-    IF ((ALPHA.LE.-ONE).OR.(BETA.LE.-ONE)) THEN
-       WRITE (6,*) 'ZWGLJD: Alpha and Beta must be greater than -1'
+    end if
+    if ((ALPHA .le. -ONE) .or. (BETA .le. -ONE)) then
+       write (6,*) 'ZWGLJD: Alpha and Beta must be greater than -1'
        call neko_error
-    ENDIF
+    end if
 
-    IF (NM1.GT.0) THEN
+    if (NM1 .gt. 0) then
        ALPG = ALPHA+ONE
        BETG = BETA+ONE
-       CALL ZWGJD (Z(2),W(2),NM1,ALPG,BETG)
-    ENDIF
+       call ZWGJD (Z(2),W(2),NM1,ALPG,BETG)
+    end if
     Z(1) = -ONE
     Z(NP) = ONE
-    DO 100 I=2,NP-1
+    do 100 I=2,NP-1
        W(I) = W(I)/(ONE-Z(I)**2)
-100 CONTINUE
-    CALL JACOBF (P,PD,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(1))
+100 continue
+    call JACOBF (P,PD,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(1))
     W(1) = ENDW1 (N,ALPHA,BETA)/(TWO*PD)
-    CALL JACOBF (P,PD,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(NP))
+    call JACOBF (P,PD,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(NP))
     W(NP) = ENDW2 (N,ALPHA,BETA)/(TWO*PD)
 
-!      RETURN
+!      return
   end subroutine ZWGLJD
 
-  REAL(KIND=XP) FUNCTION ENDW1 (N,ALPHA,BETA)
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
-    REAL(KIND=XP) ALPHA,BETA
+  real(kind=xp) function ENDW1 (N,ALPHA,BETA)
+    implicit real(kind=xp) (A-H,O-Z)
+    real(kind=xp) ALPHA,BETA
     ZERO = 0.
     ONE = 1.
     TWO = 2.
     THREE = 3.
     FOUR = 4.
     APB = ALPHA+BETA
-    IF (N.EQ.0) THEN
+    if (N .eq. 0) then
        ENDW1 = ZERO
-       RETURN
-    ENDIF
+       return
+    end if
     F1 = GAMMAF(ALPHA+TWO)*GAMMAF(BETA+ONE)/GAMMAF(APB+THREE)
     F1 = F1*(APB+TWO)*TWO**(APB+TWO)/TWO
-    IF (N.EQ.1) THEN
+    if (N .eq. 1) then
        ENDW1 = F1
-       RETURN
-    ENDIF
+       return
+    end if
     FINT1 = GAMMAF(ALPHA+TWO)*GAMMAF(BETA+ONE)/GAMMAF(APB+THREE)
     FINT1 = FINT1*TWO**(APB+TWO)
     FINT2 = GAMMAF(ALPHA+TWO)*GAMMAF(BETA+TWO)/GAMMAF(APB+FOUR)
     FINT2 = FINT2*TWO**(APB+THREE)
     F2 = (-TWO*(BETA+TWO)*FINT1 + (APB+FOUR)*FINT2) &
          * (APB+THREE)/FOUR
-    IF (N.EQ.2) THEN
+    if (N .eq. 2) then
        ENDW1 = F2
-       RETURN
-    ENDIF
-    DO 100 I=3,N
+       return
+    end if
+    do 100 I=3,N
        DI = ((I-1))
        ABN = ALPHA+BETA+DI
        ABNN = ABN+DI
@@ -380,41 +380,41 @@ contains
        F3 = -(A2*F2+A1*F1)/A3
        F1 = F2
        F2 = F3
-100 CONTINUE
+100 continue
     ENDW1 = F3
-    RETURN
+    return
   end function ENDW1
 
-  REAL(KIND=XP) FUNCTION ENDW2 (N,ALPHA,BETA)
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
-    REAL(KIND=XP) ALPHA,BETA
+  real(kind=xp) function ENDW2 (N,ALPHA,BETA)
+    implicit real(kind=xp) (A-H,O-Z)
+    real(kind=xp) ALPHA,BETA
     ZERO = 0.
     ONE = 1.
     TWO = 2.
     THREE = 3.
     FOUR = 4.
     APB = ALPHA+BETA
-    IF (N.EQ.0) THEN
+    if (N .eq. 0) then
        ENDW2 = ZERO
-       RETURN
-    ENDIF
+       return
+    end if
     F1 = GAMMAF(ALPHA+ONE)*GAMMAF(BETA+TWO)/GAMMAF(APB+THREE)
     F1 = F1*(APB+TWO)*TWO**(APB+TWO)/TWO
-    IF (N.EQ.1) THEN
+    if (N .eq. 1) then
        ENDW2 = F1
-       RETURN
-    ENDIF
+       return
+    end if
     FINT1 = GAMMAF(ALPHA+ONE)*GAMMAF(BETA+TWO)/GAMMAF(APB+THREE)
     FINT1 = FINT1*TWO**(APB+TWO)
     FINT2 = GAMMAF(ALPHA+TWO)*GAMMAF(BETA+TWO)/GAMMAF(APB+FOUR)
     FINT2 = FINT2*TWO**(APB+THREE)
     F2 = (TWO*(ALPHA+TWO)*FINT1 - (APB+FOUR)*FINT2) &
          * (APB+THREE)/FOUR
-    IF (N.EQ.2) THEN
+    if (N .eq. 2) then
        ENDW2 = F2
-       RETURN
-    ENDIF
-    DO 100 I=3,N
+       return
+    end if
+    do 100 I=3,N
        DI = ((I-1))
        ABN = ALPHA+BETA+DI
        ABNN = ABN+DI
@@ -424,14 +424,14 @@ contains
        F3 = -(A2*F2+A1*F1)/A3
        F1 = F2
        F2 = F3
-100 CONTINUE
+100 continue
     ENDW2 = F3
-    RETURN
+    return
   end function ENDW2
 
-  REAL(KIND=XP) FUNCTION GAMMAF (X)
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
-    REAL(KIND=XP) X
+  real(kind=xp) function GAMMAF (X)
+    implicit real(kind=xp) (A-H,O-Z)
+    real(kind=xp) X
     ZERO = 0.0
     HALF = 0.5
     ONE = 1.0
@@ -439,47 +439,47 @@ contains
     FOUR = 4.0
     PI = FOUR*ATAN(ONE)
     GAMMAF = ONE
-    IF (X.EQ.-HALF) GAMMAF = -TWO*SQRT(PI)
-    IF (X.EQ. HALF) GAMMAF = SQRT(PI)
-    IF (X.EQ. ONE ) GAMMAF = ONE
-    IF (X.EQ. TWO ) GAMMAF = ONE
-    IF (X.EQ. 1.5 ) GAMMAF = SQRT(PI)/2.
-    IF (X.EQ. 2.5) GAMMAF = 1.5*SQRT(PI)/2.
-    IF (X.EQ. 3.5) GAMMAF = 0.5*(2.5*(1.5*SQRT(PI)))
-    IF (X.EQ. 3. ) GAMMAF = 2.
-    IF (X.EQ. 4. ) GAMMAF = 6.
-    IF (X.EQ. 5. ) GAMMAF = 24.
-    IF (X.EQ. 6. ) GAMMAF = 120.
-    RETURN
+    if (X .eq. -HALF) GAMMAF = -TWO*SQRT(PI)
+    if (X .eq. HALF) GAMMAF = SQRT(PI)
+    if (X .eq. ONE ) GAMMAF = ONE
+    if (X .eq. TWO ) GAMMAF = ONE
+    if (X .eq. 1.5 ) GAMMAF = SQRT(PI)/2.
+    if (X .eq. 2.5) GAMMAF = 1.5*SQRT(PI)/2.
+    if (X .eq. 3.5) GAMMAF = 0.5*(2.5*(1.5*SQRT(PI)))
+    if (X .eq. 3. ) GAMMAF = 2.
+    if (X .eq. 4. ) GAMMAF = 6.
+    if (X .eq. 5. ) GAMMAF = 24.
+    if (X .eq. 6. ) GAMMAF = 120.
+    return
   end function GAMMAF
 
-  REAL(KIND=XP) FUNCTION PNORMJ (N,ALPHA,BETA)
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
-    REAL(KIND=XP) ALPHA,BETA
+  real(kind=xp) function PNORMJ (N,ALPHA,BETA)
+    implicit real(kind=xp) (A-H,O-Z)
+    real(kind=xp) ALPHA,BETA
     ONE = 1.
     TWO = 2.
     DN = ((N))
     CONST = ALPHA+BETA+ONE
-    IF (N.LE.1) THEN
+    if (N .le. 1) then
        PROD = GAMMAF(DN+ALPHA)*GAMMAF(DN+BETA)
        PROD = PROD/(GAMMAF(DN)*GAMMAF(DN+ALPHA+BETA))
        PNORMJ = PROD * TWO**CONST/(TWO*DN+CONST)
-       RETURN
-    ENDIF
+       return
+    end if
     PROD = GAMMAF(ALPHA+ONE)*GAMMAF(BETA+ONE)
     PROD = PROD/(TWO*(ONE+CONST)*GAMMAF(CONST+ONE))
     PROD = PROD*(ONE+ALPHA)*(TWO+ALPHA)
     PROD = PROD*(ONE+BETA)*(TWO+BETA)
-    DO 100 I=3,N
+    do 100 I=3,N
        DINDX = ((I))
        FRAC = (DINDX+ALPHA)*(DINDX+BETA)/(DINDX*(DINDX+ALPHA+BETA))
        PROD = PROD*FRAC
-100 CONTINUE
+100 continue
     PNORMJ = PROD * TWO**CONST/(TWO*DN+CONST)
-    RETURN
+    return
   end function PNORMJ
 
-  SUBROUTINE JACG (XJAC,NP,ALPHA,BETA)
+  subroutine JACG (XJAC,NP,ALPHA,BETA)
 !--------------------------------------------------------------------
 !
 !     Compute NP Gauss points XJAC, which are the zeros of the
@@ -490,71 +490,71 @@ contains
 !     ALPHA = BETA = -0.5  ->  Chebyshev points
 !
 !--------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
-    REAL(KIND=XP) XJAC(1)
-    DATA KSTOP /10/
-    DATA EPS/1.0e-12_RP/
+    implicit real(kind=xp) (A-H,O-Z)
+    real(kind=xp) XJAC(1)
+    data KSTOP /10/
+    data EPS/1.0e-12_RP/
     N = NP-1
     one = 1.
     DTH = 4.*ATAN(one)/(2.*((N))+2.)
-    DO 40 J=1,NP
-       IF (J.EQ.1) THEN
+    do 40 J=1,NP
+       if (J .eq. 1) then
           X = COS((2.*(((J))-1.)+1.)*DTH)
-       ELSE
+       else
           X1 = COS((2.*(((J))-1.)+1.)*DTH)
           X2 = XLAST
           X = (X1+X2)/2.
-       ENDIF
-       DO 30 K=1,KSTOP
-          CALL JACOBF (P,PD,PM1,PDM1,PM2,PDM2,NP,ALPHA,BETA,X)
+       end if
+       do 30 K=1,KSTOP
+          call JACOBF (P,PD,PM1,PDM1,PM2,PDM2,NP,ALPHA,BETA,X)
           RECSUM = 0.
           JM = J-1
-          DO 29 I=1,JM
+          do 29 I=1,JM
              RECSUM = RECSUM+1./(X-XJAC(NP-I+1))
-29        CONTINUE
+29        continue
           DELX = -P/(PD-RECSUM*P)
           X = X+DELX
-          IF (ABS(DELX) .LT. EPS) GOTO 31
-30     CONTINUE
-31     CONTINUE
+          if (ABS(DELX) .LT. EPS) GOTO 31
+30     continue
+31     continue
        XJAC(NP-J+1) = X
        XLAST = X
-40  CONTINUE
-    DO 200 I=1,NP
+40  continue
+    do 200 I=1,NP
        XMIN = 2.
-       DO 100 J=I,NP
-          IF (XJAC(J).LT.XMIN) THEN
+       do 100 J=I,NP
+          if (XJAC(J).LT.XMIN) then
              XMIN = XJAC(J)
              JMIN = J
-          ENDIF
-100    CONTINUE
-       IF (JMIN.NE.I) THEN
+          end if
+100    continue
+       if (JMIN.NE.I) then
           SWAP = XJAC(I)
           XJAC(I) = XJAC(JMIN)
           XJAC(JMIN) = SWAP
-       ENDIF
-200 CONTINUE
-    RETURN
+       end if
+200 continue
+    return
   end subroutine JACG
 
-  SUBROUTINE JACOBF (POLY,PDER,POLYM1,PDERM1,POLYM2,PDERM2,N,ALP,BET,X)
+  subroutine JACOBF (POLY,PDER,POLYM1,PDERM1,POLYM2,PDERM2,N,ALP,BET,X)
 !--------------------------------------------------------------------
 !
 !     Computes the Jacobi polynomial (POLY) and its derivative (PDER)
 !     of degree N at X.
 !
 !--------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
+    implicit real(kind=xp) (A-H,O-Z)
     APB = ALP+BET
     POLY = 1.
     PDER = 0.
-    IF (N .EQ. 0) RETURN
+    if (N .eq. 0) return
     POLYL = POLY
     PDERL = PDER
     POLY = (ALP-BET+(APB+2.)*X)/2.
     PDER = (APB+2.)/2.
-    IF (N .EQ. 1) RETURN
-    DO 20 K=2,N
+    if (N .eq. 1) return
+    do 20 K=2,N
        DK = ((K))
        A1 = 2.*DK*(DK+APB)*(2.*DK+APB-2.)
        A2 = (2.*DK+APB-1.)*(ALP**2-BET**2)
@@ -569,15 +569,15 @@ contains
        POLY = POLYN
        PDERL = PDER
        PDER = PDERN
-20  CONTINUE
+20  continue
     POLYM1 = POLYL
     PDERM1 = PDERL
     POLYM2 = PSAVE
     PDERM2 = PDSAVE
-    RETURN
+    return
   end subroutine JACOBF
 
-  REAL(KIND=XP) FUNCTION HGJ (II,Z,ZGJ,NP,ALPHA,BETA)
+  real(kind=xp) function HGJ (II,Z,ZGJ,NP,ALPHA,BETA)
 !---------------------------------------------------------------------
 !
 !     Compute the value of the Lagrangian interpolant HGJ through
@@ -585,28 +585,28 @@ contains
 !     Single precision version.
 !
 !---------------------------------------------------------------------
-    PARAMETER (NMAX=84)
-    PARAMETER (NZD = NMAX)
-    REAL(KIND=XP) ZD,ZGJD(NZD),ALPHAD,BETAD
-    REAL(KIND=XP) Z,ZGJ(1),ALPHA,BETA
+    parameter (NMAX=84)
+    parameter (NZD = NMAX)
+    real(kind=xp) ZD,ZGJD(NZD),ALPHAD,BETAD
+    real(kind=xp) Z,ZGJ(1),ALPHA,BETA
     NPMAX = NZD
-    IF (NP.GT.NPMAX) THEN
-       WRITE (6,*) 'Too large polynomial degree in HGJ'
-       WRITE (6,*) 'Maximum polynomial degree is',NMAX
-       WRITE (6,*) 'Here NP=',NP
+    if (NP .gt. NPMAX) then
+       write (6,*) 'Too large polynomial degree in HGJ'
+       write (6,*) 'Maximum polynomial degree is',NMAX
+       write (6,*) 'Here NP=',NP
        call neko_error
-    ENDIF
+    end if
     ZD = Z
-    DO 100 I=1,NP
+    do 100 I=1,NP
        ZGJD(I) = ZGJ(I)
-100 CONTINUE
+100 continue
     ALPHAD = ALPHA
     BETAD = BETA
     HGJ = HGJD (II,ZD,ZGJD,NP,ALPHAD,BETAD)
-    RETURN
+    return
   end function HGJ
 
-  REAL(KIND=XP) FUNCTION HGJD (II,Z,ZGJ,NP,ALPHA,BETA)
+  real(kind=xp) function HGJD (II,Z,ZGJ,NP,ALPHA,BETA)
 !---------------------------------------------------------------------
 !
 !     Compute the value of the Lagrangian interpolant HGJD through
@@ -614,23 +614,23 @@ contains
 !     Double precision version.
 !
 !---------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
-    REAL(KIND=XP) Z,ZGJ(1),ALPHA,BETA
+    implicit real(kind=xp) (A-H,O-Z)
+    real(kind=xp) Z,ZGJ(1),ALPHA,BETA
     EPS = 1.e-5
     ONE = 1.
     ZI = ZGJ(II)
     DZ = Z-ZI
-    IF (ABS(DZ).LT.EPS) THEN
+    if (ABS(DZ).LT.EPS) then
        HGJD = ONE
-       RETURN
-    ENDIF
-    CALL JACOBF (PZI,PDZI,PM1,PDM1,PM2,PDM2,NP,ALPHA,BETA,ZI)
-    CALL JACOBF (PZ,PDZ,PM1,PDM1,PM2,PDM2,NP,ALPHA,BETA,Z)
+       return
+    end if
+    call JACOBF (PZI,PDZI,PM1,PDM1,PM2,PDM2,NP,ALPHA,BETA,ZI)
+    call JACOBF (PZ,PDZ,PM1,PDM1,PM2,PDM2,NP,ALPHA,BETA,Z)
     HGJD = PZ/(PDZI*(Z-ZI))
-    RETURN
+    return
   end function HGJD
 
-  REAL(KIND=XP) FUNCTION HGLJ (II,Z,ZGLJ,NP,ALPHA,BETA)
+  real(kind=xp) function HGLJ (II,Z,ZGLJ,NP,ALPHA,BETA)
 !---------------------------------------------------------------------
 !
 !     Compute the value of the Lagrangian interpolant HGLJ through
@@ -638,28 +638,28 @@ contains
 !     Single precision version.
 !
 !---------------------------------------------------------------------
-    PARAMETER (NMAX=84)
-    PARAMETER (NZD = NMAX)
-    REAL(KIND=XP) ZD,ZGLJD(NZD),ALPHAD,BETAD
-    REAL(KIND=XP) Z,ZGLJ(1),ALPHA,BETA
+    parameter (NMAX=84)
+    parameter (NZD = NMAX)
+    real(kind=xp) ZD,ZGLJD(NZD),ALPHAD,BETAD
+    real(kind=xp) Z,ZGLJ(1),ALPHA,BETA
     NPMAX = NZD
-    IF (NP.GT.NPMAX) THEN
-       WRITE (6,*) 'Too large polynomial degree in HGLJ'
-       WRITE (6,*) 'Maximum polynomial degree is',NMAX
-       WRITE (6,*) 'Here NP=',NP
+    if (NP .gt. NPMAX) then
+       write (6,*) 'Too large polynomial degree in HGLJ'
+       write (6,*) 'Maximum polynomial degree is',NMAX
+       write (6,*) 'Here NP=',NP
        call neko_error
-    ENDIF
+    end if
     ZD = Z
-    DO 100 I=1,NP
+    do 100 I=1,NP
        ZGLJD(I) = ZGLJ(I)
-100 CONTINUE
+100 continue
     ALPHAD = ALPHA
     BETAD = BETA
     HGLJ = HGLJD (II,ZD,ZGLJD,NP,ALPHAD,BETAD)
-    RETURN
+    return
   end function HGLJ
 
-  REAL(KIND=XP) FUNCTION HGLJD (I,Z,ZGLJ,NP,ALPHA,BETA)
+  real(kind=xp) function HGLJD (I,Z,ZGLJ,NP,ALPHA,BETA)
 !---------------------------------------------------------------------
 !
 !     Compute the value of the Lagrangian interpolant HGLJD through
@@ -667,27 +667,27 @@ contains
 !     Double precision version.
 !
 !---------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
-    REAL(KIND=XP) Z,ZGLJ(1),ALPHA,BETA
+    implicit real(kind=xp) (A-H,O-Z)
+    real(kind=xp) Z,ZGLJ(1),ALPHA,BETA
     EPS = 1.e-5
     ONE = 1.
     ZI = ZGLJ(I)
     DZ = Z-ZI
-    IF (ABS(DZ).LT.EPS) THEN
+    if (ABS(DZ).LT.EPS) then
        HGLJD = ONE
-       RETURN
-    ENDIF
+       return
+    end if
     N = NP-1
     DN = ((N))
     EIGVAL = -DN*(DN+ALPHA+BETA+ONE)
-    CALL JACOBF (PI,PDI,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,ZI)
+    call JACOBF (PI,PDI,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,ZI)
     CONST = EIGVAL*PI+ALPHA*(ONE+ZI)*PDI-BETA*(ONE-ZI)*PDI
-    CALL JACOBF (P,PD,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z)
+    call JACOBF (P,PD,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z)
     HGLJD = (ONE-Z**2)*PD/(CONST*(Z-ZI))
-    RETURN
+    return
   end function HGLJD
 
-  SUBROUTINE DGJ (D,DT,Z,NZ,NZD,ALPHA,BETA)
+  subroutine DGJ (D,DT,Z,NZ,NZD,ALPHA,BETA)
 !-----------------------------------------------------------------
 !
 !     Compute the derivative matrix D and its transpose DT
@@ -697,41 +697,41 @@ contains
 !     Single precision version.
 !
 !-----------------------------------------------------------------
-    PARAMETER (NMAX=84)
-    PARAMETER (NZDD = NMAX)
-    REAL(KIND=XP) DD(NZDD,NZDD),DTD(NZDD,NZDD),ZD(NZDD),ALPHAD,BETAD
-    REAL(KIND=XP) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
+    parameter (NMAX=84)
+    parameter (NZDD = NMAX)
+    real(kind=xp) DD(NZDD,NZDD),DTD(NZDD,NZDD),ZD(NZDD),ALPHAD,BETAD
+    real(kind=xp) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
 
-    IF (NZ.LE.0) THEN
-       WRITE (6,*) 'DGJ: Minimum number of Gauss points is 1'
+    if (NZ .le. 0) then
+       write (6,*) 'DGJ: Minimum number of Gauss points is 1'
        call neko_error
-    ENDIF
-    IF (NZ .GT. NMAX) THEN
-       WRITE (6,*) 'Too large polynomial degree in DGJ'
-       WRITE (6,*) 'Maximum polynomial degree is',NMAX
-       WRITE (6,*) 'Here Nz=',Nz
+    end if
+    if (NZ .gt. NMAX) then
+       write (6,*) 'Too large polynomial degree in DGJ'
+       write (6,*) 'Maximum polynomial degree is',NMAX
+       write (6,*) 'Here Nz=',Nz
        call neko_error
-    ENDIF
-    IF ((ALPHA.LE.-1.).OR.(BETA.LE.-1.)) THEN
-       WRITE (6,*) 'DGJ: Alpha and Beta must be greater than -1'
+    end if
+    if ((ALPHA .le. -1.) .or. (BETA .le. -1.)) then
+       write (6,*) 'DGJ: Alpha and Beta must be greater than -1'
        call neko_error
-    ENDIF
+    end if
     ALPHAD = ALPHA
     BETAD = BETA
-    DO 100 I=1,NZ
+    do 100 I=1,NZ
        ZD(I) = Z(I)
-100 CONTINUE
-    CALL DGJD (DD,DTD,ZD,NZ,NZDD,ALPHAD,BETAD)
-    DO I=1,NZ
-       DO J=1,NZ
+100 continue
+    call DGJD (DD,DTD,ZD,NZ,NZDD,ALPHAD,BETAD)
+    do I=1,NZ
+       do J=1,NZ
           D(I,J) = DD(I,J)
           DT(I,J) = DTD(I,J)
-       END DO
-    END DO
-    RETURN
+       end do
+    end do
+    return
   end subroutine DGJ
 
-  SUBROUTINE DGJD (D,DT,Z,NZ,NZD,ALPHA,BETA)
+  subroutine DGJD (D,DT,Z,NZ,NZD,ALPHA,BETA)
 !-----------------------------------------------------------------
 !
 !     Compute the derivative matrix D and its transpose DT
@@ -741,36 +741,36 @@ contains
 !     Double precision version.
 !
 !-----------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
-    REAL(KIND=XP) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
+    implicit real(kind=xp) (A-H,O-Z)
+    real(kind=xp) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
     N = NZ-1
     DN = ((N))
     ONE = 1.
     TWO = 2.
 
-    IF (NZ.LE.1) THEN
-       WRITE (6,*) 'DGJD: Minimum number of Gauss-Lobatto points is 2'
+    if (NZ .le. 1) then
+       write (6,*) 'DGJD: Minimum number of Gauss-Lobatto points is 2'
        call neko_error
-    ENDIF
-    IF ((ALPHA.LE.-ONE).OR.(BETA.LE.-ONE)) THEN
-       WRITE (6,*) 'DGJD: Alpha and Beta must be greater than -1'
+    end if
+    if ((ALPHA .le. -ONE) .or. (BETA .le. -ONE)) then
+       write (6,*) 'DGJD: Alpha and Beta must be greater than -1'
        call neko_error
-    ENDIF
+    end if
 
-    DO I=1,NZ
-       DO J=1,NZ
-          CALL JACOBF (PI,PDI,PM1,PDM1,PM2,PDM2,NZ,ALPHA,BETA,Z(I))
-          CALL JACOBF (PJ,PDJ,PM1,PDM1,PM2,PDM2,NZ,ALPHA,BETA,Z(J))
-          IF (I.NE.J) D(I,J) = PDI/(PDJ*(Z(I)-Z(J)))
-          IF (I.EQ.J) D(I,J) = ((ALPHA+BETA+TWO)*Z(I)+ALPHA-BETA)/ &
+    do I=1,NZ
+       do J=1,NZ
+          call JACOBF (PI,PDI,PM1,PDM1,PM2,PDM2,NZ,ALPHA,BETA,Z(I))
+          call JACOBF (PJ,PDJ,PM1,PDM1,PM2,PDM2,NZ,ALPHA,BETA,Z(J))
+          if (I.NE.J) D(I,J) = PDI/(PDJ*(Z(I)-Z(J)))
+          if (I .eq. J) D(I,J) = ((ALPHA+BETA+TWO)*Z(I)+ALPHA-BETA)/ &
                (TWO*(ONE-Z(I)**2))
           DT(J,I) = D(I,J)
-       END DO
-    END DO
-    RETURN
+       end do
+    end do
+    return
   end subroutine DGJD
 
-  SUBROUTINE DGLJ (D,DT,Z,NZ,NZD,ALPHA,BETA)
+  subroutine DGLJ (D,DT,Z,NZ,NZD,ALPHA,BETA)
 !-----------------------------------------------------------------
 !
 !     Compute the derivative matrix D and its transpose DT
@@ -780,41 +780,41 @@ contains
 !     Single precision version.
 !
 !-----------------------------------------------------------------
-    PARAMETER (NMAX=84)
-    PARAMETER (NZDD = NMAX)
-    REAL(KIND=XP) DD(NZDD,NZDD),DTD(NZDD,NZDD),ZD(NZDD),ALPHAD,BETAD
-    REAL(KIND=XP) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
+    parameter (NMAX=84)
+    parameter (NZDD = NMAX)
+    real(kind=xp) DD(NZDD,NZDD),DTD(NZDD,NZDD),ZD(NZDD),ALPHAD,BETAD
+    real(kind=xp) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
 
-    IF (NZ.LE.1) THEN
-       WRITE (6,*) 'DGLJ: Minimum number of Gauss-Lobatto points is 2'
+    if (NZ .le. 1) then
+       write (6,*) 'DGLJ: Minimum number of Gauss-Lobatto points is 2'
        call neko_error
-    ENDIF
-    IF (NZ .GT. NMAX) THEN
-       WRITE (6,*) 'Too large polynomial degree in DGLJ'
-       WRITE (6,*) 'Maximum polynomial degree is',NMAX
-       WRITE (6,*) 'Here NZ=',NZ
+    end if
+    if (NZ .gt. NMAX) then
+       write (6,*) 'Too large polynomial degree in DGLJ'
+       write (6,*) 'Maximum polynomial degree is',NMAX
+       write (6,*) 'Here NZ=',NZ
        call neko_error
-    ENDIF
-    IF ((ALPHA.LE.-1.).OR.(BETA.LE.-1.)) THEN
-       WRITE (6,*) 'DGLJ: Alpha and Beta must be greater than -1'
+    end if
+    if ((ALPHA .le. -1.) .or. (BETA .le. -1.)) then
+       write (6,*) 'DGLJ: Alpha and Beta must be greater than -1'
        call neko_error
-    ENDIF
+    end if
     ALPHAD = ALPHA
     BETAD = BETA
-    DO 100 I=1,NZ
+    do 100 I=1,NZ
        ZD(I) = Z(I)
-100 CONTINUE
-    CALL DGLJD (DD,DTD,ZD,NZ,NZDD,ALPHAD,BETAD)
-    DO I=1,NZ
-       DO J=1,NZ
+100 continue
+    call DGLJD (DD,DTD,ZD,NZ,NZDD,ALPHAD,BETAD)
+    do I=1,NZ
+       do J=1,NZ
           D(I,J) = DD(I,J)
           DT(I,J) = DTD(I,J)
-       END DO
-    END DO
-    RETURN
+       end do
+    end do
+    return
   end subroutine DGLJ
 
-  SUBROUTINE DGLJD (D,DT,Z,NZ,NZD,ALPHA,BETA)
+  subroutine DGLJD (D,DT,Z,NZ,NZD,ALPHA,BETA)
 !-----------------------------------------------------------------
 !
 !     Compute the derivative matrix D and its transpose DT
@@ -824,44 +824,44 @@ contains
 !     Double precision version.
 !
 !-----------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
-    REAL(KIND=XP) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
+    implicit real(kind=xp) (A-H,O-Z)
+    real(kind=xp) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
     N = NZ-1
     DN = ((N))
     ONE = 1.
     TWO = 2.
     EIGVAL = -DN*(DN+ALPHA+BETA+ONE)
 
-    IF (NZ.LE.1) THEN
-       WRITE (6,*) 'DGLJD: Minimum number of Gauss-Lobatto points is 2'
+    if (NZ .le. 1) then
+       write (6,*) 'DGLJD: Minimum number of Gauss-Lobatto points is 2'
        call neko_error
-    ENDIF
-    IF ((ALPHA.LE.-ONE).OR.(BETA.LE.-ONE)) THEN
-       WRITE (6,*) 'DGLJD: Alpha and Beta must be greater than -1'
+    end if
+    if ((ALPHA .le. -ONE) .or. (BETA .le. -ONE)) then
+       write (6,*) 'DGLJD: Alpha and Beta must be greater than -1'
        call neko_error
-    ENDIF
+    end if
 
-    DO I=1,NZ
-       DO J=1,NZ
-          CALL JACOBF (PI,PDI,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(I))
-          CALL JACOBF (PJ,PDJ,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(J))
+    do I=1,NZ
+       do J=1,NZ
+          call JACOBF (PI,PDI,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(I))
+          call JACOBF (PJ,PDJ,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(J))
           CI = EIGVAL*PI-(BETA*(ONE-Z(I))-ALPHA*(ONE+Z(I)))*PDI
           CJ = EIGVAL*PJ-(BETA*(ONE-Z(J))-ALPHA*(ONE+Z(J)))*PDJ
-          IF (I.NE.J) D(I,J) = CI/(CJ*(Z(I)-Z(J)))
-          IF ((I.EQ.J).AND.(I.NE.1).AND.(I.NE.NZ)) &
+          if (I.NE.J) D(I,J) = CI/(CJ*(Z(I)-Z(J)))
+          if ((I .eq. J).AND.(I.NE.1).AND.(I.NE.NZ)) &
                D(I,J) = (ALPHA*(ONE+Z(I))-BETA*(ONE-Z(I)))/ &
                (TWO*(ONE-Z(I)**2))
-          IF ((I.EQ.J).AND.(I.EQ.1)) &
+          if ((I .eq. J).AND.(I .eq. 1)) &
                D(I,J) = (EIGVAL+ALPHA)/(TWO*(BETA+TWO))
-          IF ((I.EQ.J).AND.(I.EQ.NZ)) &
+          if ((I .eq. J).AND.(I .eq. NZ)) &
                D(I,J) = -(EIGVAL+BETA)/(TWO*(ALPHA+TWO))
           DT(J,I) = D(I,J)
-       END DO
-    END DO
-    RETURN
+       end do
+    end do
+    return
   end subroutine DGLJD
 
-  SUBROUTINE DGLL (D,DT,Z,NZ,NZD)
+  subroutine DGLL (D,DT,Z,NZ,NZD)
 !-----------------------------------------------------------------
 !
 !     Compute the derivative matrix D and its transpose DT
@@ -870,76 +870,76 @@ contains
 !     Note: D and DT are square matrices.
 !
 !-----------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
-    PARAMETER (NMAX=84)
-    REAL(KIND=RP) D(NZD,NZD),DT(NZD,NZD),Z(1)
+    implicit real(kind=xp) (A-H,O-Z)
+    parameter (NMAX=84)
+    real(kind=rp) D(NZD,NZD),DT(NZD,NZD),Z(1)
     N = NZ-1
-    IF (NZ .GT. NMAX) THEN
-       WRITE (6,*) 'Subroutine DGLL'
-       WRITE (6,*) 'Maximum polynomial degree =',NMAX
-       WRITE (6,*) 'Polynomial degree         =',NZ
-    ENDIF
-    IF (NZ .EQ. 1) THEN
+    if (NZ .gt. NMAX) then
+       write (6,*) 'Subroutine DGLL'
+       write (6,*) 'Maximum polynomial degree =',NMAX
+       write (6,*) 'Polynomial degree         =',NZ
+    end if
+    if (NZ .eq. 1) then
        D(1,1) = 0.
-       RETURN
-    ENDIF
+       return
+    end if
     FN = (N)
     d0 = FN*(FN+1.)/4.
-    DO I=1,NZ
-       DO J=1,NZ
+    do I=1,NZ
+       do J=1,NZ
           D(I,J) = 0.
-          IF (I.NE.J) D(I,J) = PNLEG(real(Z(I),xp),N)/ &
+          if (I.NE.J) D(I,J) = PNLEG(real(Z(I),xp),N)/ &
                (PNLEG(real(Z(J),xp),N)*(Z(I)-Z(J)))
-          IF ((I.EQ.J).AND.(I.EQ.1)) D(I,J) = -d0
-          IF ((I.EQ.J).AND.(I.EQ.NZ)) D(I,J) = d0
+          if ((I .eq. J).AND.(I .eq. 1)) D(I,J) = -d0
+          if ((I .eq. J).AND.(I .eq. NZ)) D(I,J) = d0
           DT(J,I) = D(I,J)
-       END DO
-    END DO
-    RETURN
+       end do
+    end do
+    return
   end subroutine DGLL
 
-  REAL(KIND=XP) FUNCTION HGLL (I,Z,ZGLL,NZ)
+  real(kind=xp) function HGLL (I,Z,ZGLL,NZ)
 !---------------------------------------------------------------------
 !
 !     Compute the value of the Lagrangian interpolant L through
 !     the NZ Gauss-Lobatto Legendre points ZGLL at the point Z.
 !
 !---------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
-    REAL(KIND=XP) ZGLL(1), EPS, DZ, Z
+    implicit real(kind=xp) (A-H,O-Z)
+    real(kind=xp) ZGLL(1), EPS, DZ, Z
     EPS = 1.E-5
     DZ = Z - ZGLL(I)
-    IF (ABS(DZ) .LT. EPS) THEN
+    if (ABS(DZ) .LT. EPS) then
        HGLL = 1.
-       RETURN
-    ENDIF
+       return
+    end if
     N = NZ - 1
     ALFAN = (N)*((N)+1.)
     HGLL = - (1.-Z*Z)*PNDLEG(Z,N)/ &
          (ALFAN*PNLEG(ZGLL(I),N)*(Z-ZGLL(I)))
-    RETURN
+    return
   end function HGLL
 
-  REAL(KIND=XP) FUNCTION HGL (I,Z,ZGL,NZ)
+  real(kind=xp) function HGL (I,Z,ZGL,NZ)
 !---------------------------------------------------------------------
 !
 !     Compute the value of the Lagrangian interpolant HGL through
 !     the NZ Gauss Legendre points ZGL at the point Z.
 !
 !---------------------------------------------------------------------
-    REAL(KIND=XP) ZGL(1), Z, EPS, DZ
+    real(kind=xp) ZGL(1), Z, EPS, DZ
     EPS = 1.E-5
     DZ = Z - ZGL(I)
-    IF (ABS(DZ) .LT. EPS) THEN
+    if (ABS(DZ) .LT. EPS) then
        HGL = 1.
-       RETURN
-    ENDIF
+       return
+    end if
     N = NZ-1
     HGL = PNLEG(Z,NZ)/(PNDLEG(ZGL(I),NZ)*(Z-ZGL(I)))
-    RETURN
+    return
   end function HGL
 
-  REAL(KIND=XP) FUNCTION PNLEG (Z,N)
+  real(kind=xp) function PNLEG (Z,N)
 !---------------------------------------------------------------------
 !
 !     Compute the value of the Nth order Legendre polynomial at Z.
@@ -951,27 +951,27 @@ contains
 !     This next statement is to overcome the underflow bug in the i860.
 !     It can be removed at a later date.  11 Aug 1990   pff.
 !
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
-    REAL(KIND=XP) Z, P1, P2, P3
-    !IF(ABS(Z) .LT. 1.0E-25) Z = 0.0
+    implicit real(kind=xp) (A-H,O-Z)
+    real(kind=xp) Z, P1, P2, P3
+    !if(ABS(Z) .LT. 1.0E-25) Z = 0.0
 
 
     P1 = 1.
-    IF (N.EQ.0) THEN
+    if (N .eq. 0) then
        PNLEG = P1
-       RETURN
-    ENDIF
+       return
+    end if
     P2 = Z
     P3 = P2
-    DO 10 K = 1, N-1
+    do 10 K = 1, N-1
        FK = (K)
        P3 = ((2.0_rp*FK+1.0_rp)*Z*P2 - FK*P1)/(FK+1.0_rp)
        P1 = P2
        P2 = P3
-10  CONTINUE
+10  continue
     PNLEG = P3
-    if (n.eq.0) pnleg = 1.
-    RETURN
+    if (n .eq. 0) pnleg = 1.
+    return
   end function PNLEG
 
   !> Evaluate Legendre polynomials of degrees 0-N at point x
@@ -991,7 +991,7 @@ contains
     end do
   end subroutine legendre_poly
 
-  REAL(KIND=XP) FUNCTION PNDLEG (Z,N)
+  real(kind=xp) function PNDLEG (Z,N)
 !----------------------------------------------------------------------
 !
 !     Compute the derivative of the Nth order Legendre polynomial at Z.
@@ -999,14 +999,14 @@ contains
 !     Based on the recursion formula for the Legendre polynomials.
 !
 !----------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
-    REAL(KIND=XP) P1, P2, P1D, P2D, P3D, Z
+    implicit real(kind=xp) (A-H,O-Z)
+    real(kind=xp) P1, P2, P1D, P2D, P3D, Z
     P1 = 1.
     P2 = Z
     P1D = 0.
     P2D = 1.
     P3D = 1.
-    DO 10 K = 1, N-1
+    do 10 K = 1, N-1
        FK = (K)
        P3 = ((2.*FK+1.)*Z*P2 - FK*P1)/(FK+1.)
        P3D = ((2.*FK+1.)*P2 + (2.*FK+1.)*Z*P2D - FK*P1D)/(FK+1.)
@@ -1014,13 +1014,13 @@ contains
        P2 = P3
        P1D = P2D
        P2D = P3D
-10  CONTINUE
+10  continue
     PNDLEG = P3D
-    IF (N.eq.0) pndleg = 0.
-    RETURN
+    if (N .eq. 0) pndleg = 0.
+    return
   end function PNDLEG
 
-  SUBROUTINE DGLLGL (D,DT,ZM1,ZM2,IM12,NZM1,NZM2,ND1,ND2)
+  subroutine DGLLGL (D,DT,ZM1,ZM2,IM12,NZM1,NZM2,ND1,ND2)
 !-----------------------------------------------------------------------
 !
 !     Compute the (one-dimensional) derivative matrix D and its
@@ -1032,32 +1032,32 @@ contains
 !     Note: D and DT are rectangular matrices.
 !
 !-----------------------------------------------------------------------
-    REAL(KIND=XP) D(ND2,ND1), DT(ND1,ND2), ZM1(ND1), ZM2(ND2), IM12(ND2,ND1)
-    REAL(KIND=XP) EPS, ZP, ZQ
-    IF (NZM1.EQ.1) THEN
+    real(kind=xp) D(ND2,ND1), DT(ND1,ND2), ZM1(ND1), ZM2(ND2), IM12(ND2,ND1)
+    real(kind=xp) EPS, ZP, ZQ
+    if (NZM1 .eq. 1) then
        D (1,1) = 0.
        DT(1,1) = 0.
-       RETURN
-    ENDIF
+       return
+    end if
     EPS = 1.E-6
     NM1 = NZM1-1
-    DO IP = 1, NZM2
-       DO JQ = 1, NZM1
+    do IP = 1, NZM2
+       do JQ = 1, NZM1
           ZP = ZM2(IP)
           ZQ = ZM1(JQ)
-          IF ((ABS(ZP) .LT. EPS).AND.(ABS(ZQ) .LT. EPS)) THEN
+          if ((ABS(ZP) .LT. EPS).AND.(ABS(ZQ) .LT. EPS)) then
              D(IP,JQ) = 0.
-          ELSE
+          else
              D(IP,JQ) = (PNLEG(ZP,NM1)/PNLEG(ZQ,NM1) &
                   -IM12(IP,JQ))/(ZP-ZQ)
-          ENDIF
+          end if
           DT(JQ,IP) = D(IP,JQ)
-       END DO
-    END DO
-    RETURN
+       end do
+    end do
+    return
   end subroutine DGLLGL
 
-  SUBROUTINE DGLJGJ (D,DT,ZGL,ZG,IGLG,NPGL,NPG,ND1,ND2,ALPHA,BETA)
+  subroutine DGLJGJ (D,DT,ZGL,ZG,IGLG,NPGL,NPG,ND1,ND2,ALPHA,BETA)
 !-----------------------------------------------------------------------
 !
 !     Compute the (one-dimensional) derivative matrix D and its
@@ -1070,50 +1070,50 @@ contains
 !     Single precision version.
 !
 !-----------------------------------------------------------------------
-    REAL(KIND=XP) D(ND2,ND1), DT(ND1,ND2), ZGL(ND1), ZG(ND2), IGLG(ND2,ND1)
-    PARAMETER (NMAX=84)
-    PARAMETER (NDD = NMAX)
-    REAL(KIND=XP) DD(NDD,NDD), DTD(NDD,NDD)
-    REAL(KIND=XP) ZGD(NDD), ZGLD(NDD), IGLGD(NDD,NDD)
-    REAL(KIND=XP) ALPHAD, BETAD
+    real(kind=xp) D(ND2,ND1), DT(ND1,ND2), ZGL(ND1), ZG(ND2), IGLG(ND2,ND1)
+    parameter (NMAX=84)
+    parameter (NDD = NMAX)
+    real(kind=xp) DD(NDD,NDD), DTD(NDD,NDD)
+    real(kind=xp) ZGD(NDD), ZGLD(NDD), IGLGD(NDD,NDD)
+    real(kind=xp) ALPHAD, BETAD
 
-    IF (NPGL.LE.1) THEN
-       WRITE(6,*) 'DGLJGJ: Minimum number of Gauss-Lobatto points is 2'
+    if (NPGL .le. 1) then
+       write(6,*) 'DGLJGJ: Minimum number of Gauss-Lobatto points is 2'
        call neko_error
-    ENDIF
-    IF (NPGL.GT.NMAX) THEN
-       WRITE(6,*) 'Polynomial degree too high in DGLJGJ'
-       WRITE(6,*) 'Maximum polynomial degree is',NMAX
-       WRITE(6,*) 'Here NPGL=',NPGL
+    end if
+    if (NPGL .gt. NMAX) then
+       write(6,*) 'Polynomial degree too high in DGLJGJ'
+       write(6,*) 'Maximum polynomial degree is',NMAX
+       write(6,*) 'Here NPGL=',NPGL
        call neko_error
-    ENDIF
-    IF ((ALPHA.LE.-1.).OR.(BETA.LE.-1.)) THEN
-       WRITE(6,*) 'DGLJGJ: Alpha and Beta must be greater than -1'
+    end if
+    if ((ALPHA .le. -1.) .or. (BETA .le. -1.)) then
+       write(6,*) 'DGLJGJ: Alpha and Beta must be greater than -1'
        call neko_error
-    ENDIF
+    end if
 
     ALPHAD = ALPHA
     BETAD = BETA
-    DO I=1,NPG
+    do I=1,NPG
        ZGD(I) = ZG(I)
-       DO J=1,NPGL
+       do J=1,NPGL
           IGLGD(I,J) = IGLG(I,J)
-       END DO
-    END DO
-    DO 200 I=1,NPGL
+       end do
+    end do
+    do 200 I=1,NPGL
        ZGLD(I) = ZGL(I)
-200 CONTINUE
-    CALL DGLJGJD (DD,DTD,ZGLD,ZGD,IGLGD,NPGL,NPG,NDD,NDD,ALPHAD,BETAD)
-    DO I=1,NPG
-       DO J=1,NPGL
+200 continue
+    call DGLJGJD (DD,DTD,ZGLD,ZGD,IGLGD,NPGL,NPG,NDD,NDD,ALPHAD,BETAD)
+    do I=1,NPG
+       do J=1,NPGL
           D(I,J) = DD(I,J)
           DT(J,I) = DTD(J,I)
-       END DO
-    END DO
-    RETURN
+       end do
+    end do
+    return
   end subroutine DGLJGJ
 
-  SUBROUTINE DGLJGJD (D,DT,ZGL,ZG,IGLG,NPGL,NPG,ND1,ND2,ALPHA,BETA)
+  subroutine DGLJGJD (D,DT,ZGL,ZG,IGLG,NPGL,NPG,ND1,ND2,ALPHA,BETA)
 !-----------------------------------------------------------------------
 !
 !     Compute the (one-dimensional) derivative matrix D and its
@@ -1126,18 +1126,18 @@ contains
 !     Double precision version.
 !
 !-----------------------------------------------------------------------
-    IMPLICIT REAL(KIND=XP) (A-H,O-Z)
-    REAL(KIND=XP) D(ND2,ND1), DT(ND1,ND2), ZGL(ND1), ZG(ND2)
-    REAL(KIND=XP) IGLG(ND2,ND1), ALPHA, BETA
+    implicit real(kind=xp) (A-H,O-Z)
+    real(kind=xp) D(ND2,ND1), DT(ND1,ND2), ZGL(ND1), ZG(ND2)
+    real(kind=xp) IGLG(ND2,ND1), ALPHA, BETA
 
-    IF (NPGL.LE.1) THEN
-       WRITE(6,*) 'DGLJGJD: Minimum number of Gauss-Lobatto points is 2'
+    if (NPGL .le. 1) then
+       write(6,*) 'DGLJGJD: Minimum number of Gauss-Lobatto points is 2'
        call neko_error
-    ENDIF
-    IF ((ALPHA.LE.-1.).OR.(BETA.LE.-1.)) THEN
-       WRITE(6,*) 'DGLJGJD: Alpha and Beta must be greater than -1'
+    end if
+    if ((ALPHA .le. -1.) .or. (BETA .le. -1.)) then
+       write(6,*) 'DGLJGJD: Alpha and Beta must be greater than -1'
        call neko_error
-    ENDIF
+    end if
 
     EPS = 1.e-6
     ONE = 1.
@@ -1146,28 +1146,28 @@ contains
     DN = ((NGL))
     EIGVAL = -DN*(DN+ALPHA+BETA+ONE)
 
-    DO I=1,NPG
-       DO J=1,NPGL
+    do I=1,NPG
+       do J=1,NPGL
           DZ = ABS(ZG(I)-ZGL(J))
-          IF (DZ.LT.EPS) THEN
+          if (DZ.LT.EPS) then
              D(I,J) = (ALPHA*(ONE+ZG(I))-BETA*(ONE-ZG(I)))/ &
                   (TWO*(ONE-ZG(I)**2))
-          ELSE
-             CALL JACOBF (PI,PDI,PM1,PDM1,PM2,PDM2,NGL,ALPHA,BETA,ZG(I))
-             CALL JACOBF (PJ,PDJ,PM1,PDM1,PM2,PDM2,NGL,ALPHA,BETA,ZGL(J))
+          else
+             call JACOBF (PI,PDI,PM1,PDM1,PM2,PDM2,NGL,ALPHA,BETA,ZG(I))
+             call JACOBF (PJ,PDJ,PM1,PDM1,PM2,PDM2,NGL,ALPHA,BETA,ZGL(J))
              FACI = ALPHA*(ONE+ZG(I))-BETA*(ONE-ZG(I))
              FACJ = ALPHA*(ONE+ZGL(J))-BETA*(ONE-ZGL(J))
              CONST = EIGVAL*PJ+FACJ*PDJ
              D(I,J) = ((EIGVAL*PI+FACI*PDI)*(ZG(I)-ZGL(J)) &
                   -(ONE-ZG(I)**2)*PDI)/(CONST*(ZG(I)-ZGL(J))**2)
-          ENDIF
+          end if
           DT(J,I) = D(I,J)
-       END DO
-    END DO
-    RETURN
+       end do
+    end do
+    return
   end subroutine DGLJGJD
 
-  SUBROUTINE IGLM (I12,IT12,Z1,Z2,NZ1,NZ2,ND1,ND2)
+  subroutine IGLM (I12,IT12,Z1,Z2,NZ1,NZ2,ND1,ND2)
 !----------------------------------------------------------------------
 !
 !     Compute the one-dimensional interpolation operator (matrix) I12
@@ -1177,23 +1177,23 @@ contains
 !     Z2 : NZ2 points on mesh M.
 !
 !--------------------------------------------------------------------
-    REAL(KIND=XP) I12(ND2,ND1),IT12(ND1,ND2),Z1(ND1),Z2(ND2), ZI
-    IF (NZ1 .EQ. 1) THEN
+    real(kind=xp) I12(ND2,ND1),IT12(ND1,ND2),Z1(ND1),Z2(ND2), ZI
+    if (NZ1 .eq. 1) then
        I12 (1,1) = 1.
        IT12(1,1) = 1.
-       RETURN
-    ENDIF
-    DO I=1,NZ2
+       return
+    end if
+    do I=1,NZ2
        ZI = Z2(I)
-       DO J=1,NZ1
+       do J=1,NZ1
           I12 (I,J) = HGL(J,ZI,Z1,NZ1)
           IT12(J,I) = I12(I,J)
-       END DO
-    END DO
-    RETURN
+       end do
+    end do
+    return
   end subroutine IGLM
 
-  SUBROUTINE IGLLM (I12,IT12,Z1,Z2,NZ1,NZ2,ND1,ND2)
+  subroutine IGLLM (I12,IT12,Z1,Z2,NZ1,NZ2,ND1,ND2)
 !----------------------------------------------------------------------
 !
 !     Compute the one-dimensional interpolation operator (matrix) I12
@@ -1203,23 +1203,23 @@ contains
 !     Z2 : NZ2 points on mesh M.
 !
 !--------------------------------------------------------------------
-    REAL(KIND=XP) I12(ND2,ND1),IT12(ND1,ND2),Z1(ND1),Z2(ND2),ZI
-    IF (NZ1 .EQ. 1) THEN
+    real(kind=xp) I12(ND2,ND1),IT12(ND1,ND2),Z1(ND1),Z2(ND2),ZI
+    if (NZ1 .eq. 1) then
        I12 (1,1) = 1.
        IT12(1,1) = 1.
-       RETURN
-    ENDIF
-    DO I=1,NZ2
+       return
+    end if
+    do I=1,NZ2
        ZI = Z2(I)
-       DO J=1,NZ1
+       do J=1,NZ1
           I12 (I,J) = HGLL(J,ZI,Z1,NZ1)
           IT12(J,I) = I12(I,J)
-       END DO
-    END DO
-    RETURN
+       end do
+    end do
+    return
   end subroutine IGLLM
 
-  SUBROUTINE IGJM (I12,IT12,Z1,Z2,NZ1,NZ2,ND1,ND2,ALPHA,BETA)
+  subroutine IGJM (I12,IT12,Z1,Z2,NZ1,NZ2,ND1,ND2,ALPHA,BETA)
 !----------------------------------------------------------------------
 !
 !     Compute the one-dimensional interpolation operator (matrix) I12
@@ -1230,23 +1230,23 @@ contains
 !     Single precision version.
 !
 !--------------------------------------------------------------------
-    REAL(KIND=XP) I12(ND2,ND1),IT12(ND1,ND2),Z1(ND1),Z2(ND2),ZI,ALPHA,BETA
-    IF (NZ1 .EQ. 1) THEN
+    real(kind=xp) I12(ND2,ND1),IT12(ND1,ND2),Z1(ND1),Z2(ND2),ZI,ALPHA,BETA
+    if (NZ1 .eq. 1) then
        I12 (1,1) = 1.
        IT12(1,1) = 1.
-       RETURN
-    ENDIF
-    DO I=1,NZ2
+       return
+    end if
+    do I=1,NZ2
        ZI = Z2(I)
-       DO J=1,NZ1
+       do J=1,NZ1
           I12 (I,J) = HGJ(J,ZI,Z1,NZ1,ALPHA,BETA)
           IT12(J,I) = I12(I,J)
-       END DO
-    END DO
-    RETURN
+       end do
+    end do
+    return
   end subroutine IGJM
 
-  SUBROUTINE IGLJM (I12,IT12,Z1,Z2,NZ1,NZ2,ND1,ND2,ALPHA,BETA)
+  subroutine IGLJM (I12,IT12,Z1,Z2,NZ1,NZ2,ND1,ND2,ALPHA,BETA)
 !----------------------------------------------------------------------
 !
 !     Compute the one-dimensional interpolation operator (matrix) I12
@@ -1257,19 +1257,19 @@ contains
 !     Single precision version.
 !
 !--------------------------------------------------------------------
-    REAL(KIND=XP) I12(ND2,ND1),IT12(ND1,ND2),Z1(ND1),Z2(ND2),ZI,ALPHA,BETA
-    IF (NZ1 .EQ. 1) THEN
+    real(kind=xp) I12(ND2,ND1),IT12(ND1,ND2),Z1(ND1),Z2(ND2),ZI,ALPHA,BETA
+    if (NZ1 .eq. 1) then
        I12 (1,1) = 1.
        IT12(1,1) = 1.
-       RETURN
-    ENDIF
-    DO I=1,NZ2
+       return
+    end if
+    do I=1,NZ2
        ZI = Z2(I)
-       DO J=1,NZ1
+       do J=1,NZ1
           I12 (I,J) = HGLJ(J,ZI,Z1,NZ1,ALPHA,BETA)
           IT12(J,I) = I12(I,J)
-       END DO
-    END DO
-    RETURN
+       end do
+    end do
+    return
   end subroutine IGLJM
 end module speclib

--- a/src/sem/speclib.f90
+++ b/src/sem/speclib.f90
@@ -162,7 +162,6 @@ contains
     ALPHA = 0.
     BETA = 0.
     call ZWGJ (Z,W,NP,ALPHA,BETA)
-    return
   end subroutine ZWGL
 
   subroutine ZWGLL (Z,W,NP)
@@ -179,7 +178,6 @@ contains
     ALPHA = 0.
     BETA = 0.
     call ZWGLJ (Z,W,NP,ALPHA,BETA)
-    return
   end subroutine ZWGLL
 
   subroutine ZWGJ (Z,W,NP,ALPHA,BETA)
@@ -210,7 +208,6 @@ contains
        Z(I) = ZD(I)
        W(I) = WD(I)
 100 continue
-    return
   end subroutine ZWGJ
 
   subroutine ZWGJD (Z,W,NP,ALPHA,BETA)
@@ -262,7 +259,6 @@ contains
        call JACOBF (P,PD,PM1,PDM1,PM2,PDM2,NP2,ALPHA,BETA,Z(I))
        W(I) = -RCOEF/(P*PDM1)
 100 continue
-    return
   end subroutine ZWGJD
 
   subroutine ZWGLJ (Z,W,NP,ALPHA,BETA)
@@ -293,7 +289,6 @@ contains
        Z(I) = ZD(I)
        W(I) = WD(I)
 100 continue
-    return
   end subroutine ZWGLJ
 
   subroutine ZWGLJD (Z,W,NP,ALPHA,BETA)
@@ -338,7 +333,6 @@ contains
     call JACOBF (P,PD,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(NP))
     W(NP) = ENDW2 (N,ALPHA,BETA)/(TWO*PD)
 
-!      return
   end subroutine ZWGLJD
 
   real(kind=xp) function ENDW1 (N,ALPHA,BETA)
@@ -382,7 +376,6 @@ contains
        F2 = F3
 100 continue
     ENDW1 = F3
-    return
   end function ENDW1
 
   real(kind=xp) function ENDW2 (N,ALPHA,BETA)
@@ -426,7 +419,6 @@ contains
        F2 = F3
 100 continue
     ENDW2 = F3
-    return
   end function ENDW2
 
   real(kind=xp) function GAMMAF (X)
@@ -450,7 +442,6 @@ contains
     if (X .eq. 4. ) GAMMAF = 6.
     if (X .eq. 5. ) GAMMAF = 24.
     if (X .eq. 6. ) GAMMAF = 120.
-    return
   end function GAMMAF
 
   real(kind=xp) function PNORMJ (N,ALPHA,BETA)
@@ -476,7 +467,6 @@ contains
        PROD = PROD*FRAC
 100 continue
     PNORMJ = PROD * TWO**CONST/(TWO*DN+CONST)
-    return
   end function PNORMJ
 
   subroutine JACG (XJAC,NP,ALPHA,BETA)
@@ -534,7 +524,6 @@ contains
           XJAC(JMIN) = SWAP
        end if
 200 continue
-    return
   end subroutine JACG
 
   subroutine JACOBF (POLY,PDER,POLYM1,PDERM1,POLYM2,PDERM2,N,ALP,BET,X)
@@ -574,7 +563,6 @@ contains
     PDERM1 = PDERL
     POLYM2 = PSAVE
     PDERM2 = PDSAVE
-    return
   end subroutine JACOBF
 
   real(kind=xp) function HGJ (II,Z,ZGJ,NP,ALPHA,BETA)
@@ -603,7 +591,6 @@ contains
     ALPHAD = ALPHA
     BETAD = BETA
     HGJ = HGJD (II,ZD,ZGJD,NP,ALPHAD,BETAD)
-    return
   end function HGJ
 
   real(kind=xp) function HGJD (II,Z,ZGJ,NP,ALPHA,BETA)
@@ -627,7 +614,6 @@ contains
     call JACOBF (PZI,PDZI,PM1,PDM1,PM2,PDM2,NP,ALPHA,BETA,ZI)
     call JACOBF (PZ,PDZ,PM1,PDM1,PM2,PDM2,NP,ALPHA,BETA,Z)
     HGJD = PZ/(PDZI*(Z-ZI))
-    return
   end function HGJD
 
   real(kind=xp) function HGLJ (II,Z,ZGLJ,NP,ALPHA,BETA)
@@ -656,7 +642,6 @@ contains
     ALPHAD = ALPHA
     BETAD = BETA
     HGLJ = HGLJD (II,ZD,ZGLJD,NP,ALPHAD,BETAD)
-    return
   end function HGLJ
 
   real(kind=xp) function HGLJD (I,Z,ZGLJ,NP,ALPHA,BETA)
@@ -684,7 +669,6 @@ contains
     CONST = EIGVAL*PI+ALPHA*(ONE+ZI)*PDI-BETA*(ONE-ZI)*PDI
     call JACOBF (P,PD,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z)
     HGLJD = (ONE-Z**2)*PD/(CONST*(Z-ZI))
-    return
   end function HGLJD
 
   subroutine DGJ (D,DT,Z,NZ,NZD,ALPHA,BETA)
@@ -728,7 +712,6 @@ contains
           DT(I,J) = DTD(I,J)
        end do
     end do
-    return
   end subroutine DGJ
 
   subroutine DGJD (D,DT,Z,NZ,NZD,ALPHA,BETA)
@@ -767,7 +750,6 @@ contains
           DT(J,I) = D(I,J)
        end do
     end do
-    return
   end subroutine DGJD
 
   subroutine DGLJ (D,DT,Z,NZ,NZD,ALPHA,BETA)
@@ -811,7 +793,6 @@ contains
           DT(I,J) = DTD(I,J)
        end do
     end do
-    return
   end subroutine DGLJ
 
   subroutine DGLJD (D,DT,Z,NZ,NZD,ALPHA,BETA)
@@ -858,7 +839,6 @@ contains
           DT(J,I) = D(I,J)
        end do
     end do
-    return
   end subroutine DGLJD
 
   subroutine DGLL (D,DT,Z,NZ,NZD)
@@ -895,7 +875,6 @@ contains
           DT(J,I) = D(I,J)
        end do
     end do
-    return
   end subroutine DGLL
 
   real(kind=xp) function HGLL (I,Z,ZGLL,NZ)
@@ -917,7 +896,6 @@ contains
     ALFAN = (N)*((N)+1.)
     HGLL = - (1.-Z*Z)*PNDLEG(Z,N)/ &
          (ALFAN*PNLEG(ZGLL(I),N)*(Z-ZGLL(I)))
-    return
   end function HGLL
 
   real(kind=xp) function HGL (I,Z,ZGL,NZ)
@@ -936,7 +914,6 @@ contains
     end if
     N = NZ-1
     HGL = PNLEG(Z,NZ)/(PNDLEG(ZGL(I),NZ)*(Z-ZGL(I)))
-    return
   end function HGL
 
   real(kind=xp) function PNLEG (Z,N)
@@ -971,7 +948,6 @@ contains
 10  continue
     PNLEG = P3
     if (n .eq. 0) pnleg = 1.
-    return
   end function PNLEG
 
   !> Evaluate Legendre polynomials of degrees 0-N at point x
@@ -1017,7 +993,6 @@ contains
 10  continue
     PNDLEG = P3D
     if (N .eq. 0) pndleg = 0.
-    return
   end function PNDLEG
 
   subroutine DGLLGL (D,DT,ZM1,ZM2,IM12,NZM1,NZM2,ND1,ND2)
@@ -1054,7 +1029,6 @@ contains
           DT(JQ,IP) = D(IP,JQ)
        end do
     end do
-    return
   end subroutine DGLLGL
 
   subroutine DGLJGJ (D,DT,ZGL,ZG,IGLG,NPGL,NPG,ND1,ND2,ALPHA,BETA)
@@ -1110,7 +1084,6 @@ contains
           DT(J,I) = DTD(J,I)
        end do
     end do
-    return
   end subroutine DGLJGJ
 
   subroutine DGLJGJD (D,DT,ZGL,ZG,IGLG,NPGL,NPG,ND1,ND2,ALPHA,BETA)
@@ -1164,7 +1137,6 @@ contains
           DT(J,I) = D(I,J)
        end do
     end do
-    return
   end subroutine DGLJGJD
 
   subroutine IGLM (I12,IT12,Z1,Z2,NZ1,NZ2,ND1,ND2)
@@ -1190,7 +1162,6 @@ contains
           IT12(J,I) = I12(I,J)
        end do
     end do
-    return
   end subroutine IGLM
 
   subroutine IGLLM (I12,IT12,Z1,Z2,NZ1,NZ2,ND1,ND2)
@@ -1216,7 +1187,6 @@ contains
           IT12(J,I) = I12(I,J)
        end do
     end do
-    return
   end subroutine IGLLM
 
   subroutine IGJM (I12,IT12,Z1,Z2,NZ1,NZ2,ND1,ND2,ALPHA,BETA)
@@ -1243,7 +1213,6 @@ contains
           IT12(J,I) = I12(I,J)
        end do
     end do
-    return
   end subroutine IGJM
 
   subroutine IGLJM (I12,IT12,Z1,Z2,NZ1,NZ2,ND1,ND2,ALPHA,BETA)
@@ -1270,6 +1239,5 @@ contains
           IT12(J,I) = I12(I,J)
        end do
     end do
-    return
   end subroutine IGLJM
 end module speclib

--- a/src/sem/speclib.f90
+++ b/src/sem/speclib.f90
@@ -189,8 +189,8 @@ contains
 !     Single precision version.
 !
 !--------------------------------------------------------------------
-    parameter (NMAX=84)
-    parameter (NZD = NMAX)
+    integer, parameter :: NMAX = 84
+    integer, parameter :: NZD = NMAX
     real(kind=xp) ZD(NZD),WD(NZD),ALPHAD,BETAD
     real(kind=rp) Z(1),W(1),ALPHA,BETA
 
@@ -248,8 +248,8 @@ contains
 
     NP1 = N+1
     NP2 = N+2
-    DNP1 = ((NP1))
-    DNP2 = ((NP2))
+    DNP1 = real(NP1, kind=xp)
+    DNP2 = real(NP2, kind=xp)
     FAC1 = DNP1+ALPHA+BETA+ONE
     FAC2 = FAC1+DNP1
     FAC3 = FAC2+ONE
@@ -270,8 +270,8 @@ contains
 !     Single precision version.
 !
 !--------------------------------------------------------------------
-    parameter (NMAX=84)
-    parameter (NZD = NMAX)
+    integer, parameter :: NMAX = 84
+    integer, parameter :: NZD = NMAX
     real(kind=xp) ZD(NZD),WD(NZD),ALPHAD,BETAD
     real(kind=rp) Z(1),W(1),ALPHA,BETA
 
@@ -573,8 +573,8 @@ contains
 !     Single precision version.
 !
 !---------------------------------------------------------------------
-    parameter (NMAX=84)
-    parameter (NZD = NMAX)
+    integer, parameter :: NMAX = 84
+    integer, parameter :: NZD = NMAX
     real(kind=xp) ZD,ZGJD(NZD),ALPHAD,BETAD
     real(kind=xp) Z,ZGJ(1),ALPHA,BETA
     NPMAX = NZD
@@ -624,8 +624,8 @@ contains
 !     Single precision version.
 !
 !---------------------------------------------------------------------
-    parameter (NMAX=84)
-    parameter (NZD = NMAX)
+    integer, parameter :: NMAX = 84
+    integer, parameter :: NZD = NMAX
     real(kind=xp) ZD,ZGLJD(NZD),ALPHAD,BETAD
     real(kind=xp) Z,ZGLJ(1),ALPHA,BETA
     NPMAX = NZD
@@ -681,8 +681,8 @@ contains
 !     Single precision version.
 !
 !-----------------------------------------------------------------
-    parameter (NMAX=84)
-    parameter (NZDD = NMAX)
+    integer, parameter :: NMAX = 84
+    integer, parameter :: NZDD = NMAX
     real(kind=xp) DD(NZDD,NZDD),DTD(NZDD,NZDD),ZD(NZDD),ALPHAD,BETAD
     real(kind=xp) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
 
@@ -762,8 +762,8 @@ contains
 !     Single precision version.
 !
 !-----------------------------------------------------------------
-    parameter (NMAX=84)
-    parameter (NZDD = NMAX)
+    integer, parameter :: NMAX = 84
+    integer, parameter :: NZDD = NMAX
     real(kind=xp) DD(NZDD,NZDD),DTD(NZDD,NZDD),ZD(NZDD),ALPHAD,BETAD
     real(kind=xp) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
 
@@ -851,7 +851,7 @@ contains
 !
 !-----------------------------------------------------------------
     implicit real(kind=xp) (A-H,O-Z)
-    parameter (NMAX=84)
+    integer, parameter :: NMAX = 84
     real(kind=rp) D(NZD,NZD),DT(NZD,NZD),Z(1)
     N = NZ-1
     if (NZ .gt. NMAX) then
@@ -1045,8 +1045,8 @@ contains
 !
 !-----------------------------------------------------------------------
     real(kind=xp) D(ND2,ND1), DT(ND1,ND2), ZGL(ND1), ZG(ND2), IGLG(ND2,ND1)
-    parameter (NMAX=84)
-    parameter (NDD = NMAX)
+    integer, parameter :: NMAX = 84
+    integer, parameter :: NDD = NMAX
     real(kind=xp) DD(NDD,NDD), DTD(NDD,NDD)
     real(kind=xp) ZGD(NDD), ZGLD(NDD), IGLGD(NDD,NDD)
     real(kind=xp) ALPHAD, BETAD

--- a/src/sem/speclib.f90
+++ b/src/sem/speclib.f90
@@ -158,7 +158,9 @@ contains
   !! @param W Quadrature weights.
   !! @param NP Number of quadrature points.
   subroutine ZWGL (Z,W,NP)
-    real(kind=rp) Z(1),W(1), ALPHA, BETA
+    real(kind=rp), intent(inout) :: Z(1), W(1)
+    integer, intent(in) :: NP
+    real(kind=rp) ALPHA, BETA
     ALPHA = 0.0_rp
     BETA = 0.0_rp
     call ZWGJ (Z,W,NP,ALPHA,BETA)
@@ -174,7 +176,9 @@ contains
 !     operations are done in double precision.
 !
 !--------------------------------------------------------------------
-    real(kind=rp) Z(1),W(1), ALPHA, BETA
+    real(kind=rp), intent(inout) :: Z(1), W(1)
+    integer, intent(in) :: NP
+    real(kind=rp) ALPHA, BETA
     ALPHA = 0.0_rp
     BETA = 0.0_rp
     call ZWGLJ (Z,W,NP,ALPHA,BETA)
@@ -191,8 +195,10 @@ contains
 !--------------------------------------------------------------------
     integer, parameter :: NMAX = 84
     integer, parameter :: NZD = NMAX
-    real(kind=xp) ZD(NZD),WD(NZD),ALPHAD,BETAD
-    real(kind=rp) Z(1),W(1),ALPHA,BETA
+    real(kind=rp), intent(inout) :: Z(1), W(1)
+    real(kind=rp), intent(in) :: ALPHA, BETA
+    integer, intent(in) :: NP
+    real(kind=xp) ZD(NZD), WD(NZD), ALPHAD, BETAD
 
     NPMAX = NZD
     if (NP .gt. NPMAX) then
@@ -201,8 +207,8 @@ contains
        write (stderr, *) 'Here NP=',NP
        call neko_error
     end if
-    ALPHAD = ALPHA
-    BETAD = BETA
+    ALPHAD = real(ALPHA, kind=xp)
+    BETAD = real(BETA, kind=xp)
     call ZWGJD (ZD,WD,NP,ALPHAD,BETAD)
     do I = 1, NP
        Z(I) = ZD(I)
@@ -219,8 +225,12 @@ contains
 !     Double precision version.
 !
 !--------------------------------------------------------------------
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
-    real(kind=xp) Z(1),W(1),ALPHA,BETA
+
+    real(kind=xp), intent(inout) :: Z(1), W(1)
+    real(kind=xp), intent(in) :: ALPHA, BETA
+    integer, intent(in) :: NP
 
     N = NP-1
     DN = real(N, kind=xp)
@@ -272,18 +282,20 @@ contains
 !--------------------------------------------------------------------
     integer, parameter :: NMAX = 84
     integer, parameter :: NZD = NMAX
-    real(kind=xp) ZD(NZD),WD(NZD),ALPHAD,BETAD
-    real(kind=rp) Z(1),W(1),ALPHA,BETA
+    real(kind=rp), intent(inout) :: Z(1), W(1)
+    real(kind=rp), intent(in) :: ALPHA, BETA
+    integer, intent(in) :: NP
+    real(kind=xp) ZD(NZD), WD(NZD), ALPHAD, BETAD
 
     NPMAX = NZD
     if (NP .gt. NPMAX) then
        write (stderr, *) 'Too large polynomial degree in ZWGLJ'
-       write (stderr, *) 'Maximum polynomial degree is',NMAX
-       write (stderr, *) 'Here NP=',NP
+       write (stderr, *) 'Maximum polynomial degree is', NMAX
+       write (stderr, *) 'Here NP=', NP
        call neko_error
     end if
-    ALPHAD = ALPHA
-    BETAD = BETA
+    ALPHAD = real(ALPHA, kind=xp)
+    BETAD = real(BETA, kind=xp)
     call ZWGLJD (ZD,WD,NP,ALPHAD,BETAD)
     do I = 1, NP
        Z(I) = ZD(I)
@@ -300,8 +312,13 @@ contains
 !     Double precision version.
 !
 !--------------------------------------------------------------------
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
-    real(kind=xp) Z(NP),W(NP),ALPHA,BETA
+
+    real(kind=xp), intent(inout) :: Z(NP), W(NP)
+    real(kind=xp), intent(in) :: ALPHA, BETA
+    integer, intent(in) :: NP
+
 
     N = NP-1
     NM1 = N-1
@@ -336,8 +353,12 @@ contains
   end subroutine ZWGLJD
 
   real(kind=xp) function ENDW1 (N,ALPHA,BETA)
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
-    real(kind=xp) ALPHA,BETA
+
+    integer, intent(in) :: N
+    real(kind=xp), intent(in) :: ALPHA, BETA
+
     ZERO = 0.
     ONE = 1.0_xp
     TWO = 2.0_xp
@@ -379,8 +400,12 @@ contains
   end function ENDW1
 
   real(kind=xp) function ENDW2 (N,ALPHA,BETA)
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
-    real(kind=xp) ALPHA,BETA
+
+    integer, intent(in) :: N
+    real(kind=xp), intent(in) :: ALPHA, BETA
+
     ZERO = 0.0_xp
     ONE = 1.0_xp
     TWO = 2.0_xp
@@ -422,8 +447,11 @@ contains
   end function ENDW2
 
   real(kind=xp) function GAMMAF (X)
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
-    real(kind=xp) X
+
+    real(kind=xp), intent(in) :: X
+
     ZERO = 0.0_xp
     HALF = 0.5_xp
     ONE = 1.0_xp
@@ -445,8 +473,12 @@ contains
   end function GAMMAF
 
   real(kind=xp) function PNORMJ (N,ALPHA,BETA)
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
-    real(kind=xp) ALPHA,BETA
+
+    real(kind=xp), intent(in) :: ALPHA, BETA
+    integer, intent(in) :: N
+
     ONE = 1.0_xp
     TWO = 2.0_xp
     DN = real(N, kind=xp)
@@ -480,10 +512,16 @@ contains
 !     ALPHA = BETA = -0.5  ->  Chebyshev points
 !
 !--------------------------------------------------------------------
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
-    real(kind=xp) XJAC(1)
-    data KSTOP /10/
-    data EPS/1.0e-12_RP/
+
+    real(kind=xp), intent(inout) :: XJAC(1)
+    integer, intent(in) :: NP
+    real(kind=xp), intent(in) :: ALPHA, BETA
+
+    integer, parameter :: KSTOP = 10
+    real(kind=rp), parameter :: EPS = 1.0e-12_rp
+
     N = NP-1
     one = 1.0_xp
     DTH = 4.0_xp*atan(one)/(2.0_xp*real(N, kind=xp) + 2.0_xp)
@@ -533,7 +571,14 @@ contains
 !     of degree N at X.
 !
 !--------------------------------------------------------------------
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
+
+    real(kind=xp), intent(inout) :: POLY, PDER, &
+         POLYM1, PDERM1, POLYM2, PDERM2
+    integer, intent(in) :: N
+    real(kind=xp), intent(in) :: ALP, BET, X
+
     APB = ALP+BET
     POLY = 1.0_xp
     PDER = 0.0_xp
@@ -575,8 +620,11 @@ contains
 !---------------------------------------------------------------------
     integer, parameter :: NMAX = 84
     integer, parameter :: NZD = NMAX
+    real(kind=xp), intent(in) :: Z, ZGJ(1), ALPHA, BETA
+    integer, intent(in) :: NP, II
+
     real(kind=xp) ZD,ZGJD(NZD),ALPHAD,BETAD
-    real(kind=xp) Z,ZGJ(1),ALPHA,BETA
+
     NPMAX = NZD
     if (NP .gt. NPMAX) then
        write (stderr, *) 'Too large polynomial degree in HGJ'
@@ -601,8 +649,12 @@ contains
 !     Double precision version.
 !
 !---------------------------------------------------------------------
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
-    real(kind=xp) Z,ZGJ(1),ALPHA,BETA
+
+    real(kind=xp), intent(in) :: Z, ZGJ(1), ALPHA, BETA
+    integer, intent(in) :: NP, II
+
     EPS = 1.0e-5_xp
     ONE = 1.0_xp
     ZI = ZGJ(II)
@@ -626,8 +678,11 @@ contains
 !---------------------------------------------------------------------
     integer, parameter :: NMAX = 84
     integer, parameter :: NZD = NMAX
+
+    real(kind=xp), intent(in) :: Z, ZGLJ(1), ALPHA, BETA
+    integer, intent(in) :: NP, II
     real(kind=xp) ZD,ZGLJD(NZD),ALPHAD,BETAD
-    real(kind=xp) Z,ZGLJ(1),ALPHA,BETA
+
     NPMAX = NZD
     if (NP .gt. NPMAX) then
        write (stderr, *) 'Too large polynomial degree in HGLJ'
@@ -652,8 +707,12 @@ contains
 !     Double precision version.
 !
 !---------------------------------------------------------------------
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
-    real(kind=xp) Z,ZGLJ(1),ALPHA,BETA
+
+    real(kind=xp), intent(in) :: Z, ZGLJ(1), ALPHA, BETA
+    integer, intent(in) :: NP, I
+
     EPS = 1.0e-5_xp
     ONE = 1.0_xp
     ZI = ZGLJ(I)
@@ -683,8 +742,11 @@ contains
 !-----------------------------------------------------------------
     integer, parameter :: NMAX = 84
     integer, parameter :: NZDD = NMAX
+    integer, intent(in) :: NZ, NZD
+    real(kind=xp), intent(inout) :: D(NZD,NZD), DT(NZD,NZD)
+    real(kind=xp), intent(in) :: Z(1), ALPHA, BETA
+
     real(kind=xp) DD(NZDD,NZDD),DTD(NZDD,NZDD),ZD(NZDD),ALPHAD,BETAD
-    real(kind=xp) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
 
     if (NZ .le. 0) then
        write (stderr, *) 'DGJ: Minimum number of Gauss points is 1'
@@ -724,8 +786,13 @@ contains
 !     Double precision version.
 !
 !-----------------------------------------------------------------
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
-    real(kind=xp) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
+
+    integer, intent(in) :: NZ, NZD
+    real(kind=xp), intent(inout) :: D(NZD,NZD), DT(NZD,NZD)
+    real(kind=xp), intent(in) :: Z(1), ALPHA, BETA
+
     N = NZ-1
     DN = real(N, kind=xp)
     ONE = 1.0_xp
@@ -805,8 +872,13 @@ contains
 !     Double precision version.
 !
 !-----------------------------------------------------------------
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
-    real(kind=xp) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
+
+    integer, intent(in) :: NZ, NZD
+    real(kind=xp), intent(inout) :: D(NZD,NZD), DT(NZD,NZD)
+    real(kind=xp), intent(in) :: Z(1), ALPHA, BETA
+
     N = NZ-1
     DN = real(N, kind=xp)
     ONE = 1.0_xp
@@ -850,9 +922,14 @@ contains
 !     Note: D and DT are square matrices.
 !
 !-----------------------------------------------------------------
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
+
     integer, parameter :: NMAX = 84
-    real(kind=rp) D(NZD,NZD),DT(NZD,NZD),Z(1)
+    integer, intent(in) :: NZ, NZD
+    real(kind=rp), intent(inout) :: D(NZD,NZD), DT(NZD,NZD)
+    real(kind=rp), intent(in) :: Z(1)
+
     N = NZ-1
     if (NZ .gt. NMAX) then
        write (stderr, *) 'Subroutine DGLL'
@@ -884,8 +961,13 @@ contains
 !     the NZ Gauss-Lobatto Legendre points ZGLL at the point Z.
 !
 !---------------------------------------------------------------------
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
-    real(kind=xp) ZGLL(1), EPS, DZ, Z
+
+    integer, intent(in) :: I, NZ
+    real(kind=xp), intent(in) :: ZGLL(1), Z
+    real(kind=xp) :: EPS, DZ
+
     EPS = 1.0e-5_xp
     DZ = Z - ZGLL(I)
     if (abs(DZ) .lt. EPS) then
@@ -905,7 +987,10 @@ contains
 !     the NZ Gauss Legendre points ZGL at the point Z.
 !
 !---------------------------------------------------------------------
-    real(kind=xp) ZGL(1), Z, EPS, DZ
+    integer, intent(in) :: I, NZ
+    real(kind=xp), intent(in) :: ZGL(1), Z
+    real(kind=xp) :: EPS, DZ
+
     EPS = 1.0e-5_xp
     DZ = Z - ZGL(I)
     if (abs(DZ) .lt. EPS) then
@@ -927,11 +1012,13 @@ contains
 !
 !     This next statement is to overcome the underflow bug in the i860.
 !     It can be removed at a later date.  11 Aug 1990   pff.
-!
+    !
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
-    real(kind=xp) Z, P1, P2, P3
-    !if(abs(Z)  .lt.  1.0E-25) Z = 0.0
 
+    real(kind=xp), intent(in) :: Z
+    integer, intent(in) :: N
+    real(kind=xp) :: P1, P2, P3
 
     P1 = 1.0_xp
     if (N .eq. 0) then
@@ -953,9 +1040,10 @@ contains
   !> Evaluate Legendre polynomials of degrees 0-N at point x
   !! and store in array L
   subroutine legendre_poly(L, x, N)
-    real(kind=rp), intent(inout):: L(0:N)
-    real(kind=rp) :: x
-    integer :: N, j
+    integer, intent(in) :: N
+    real(kind=rp), intent(inout) :: L(0:N)
+    real(kind=rp), intent(in) :: x
+    integer :: j
 
     L(0) = 1.0_rp
     if (N .eq. 0) return
@@ -975,8 +1063,13 @@ contains
 !     Based on the recursion formula for the Legendre polynomials.
 !
 !----------------------------------------------------------------------
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
-    real(kind=xp) P1, P2, P1D, P2D, P3D, Z
+
+    real(kind=xp), intent(in) :: Z
+    integer, intent(in) :: N
+    real(kind=xp) :: P1, P2, P1D, P2D, P3D
+
     P1 = 1.0_xp
     P2 = Z
     P1D = 0.0_xp
@@ -1007,8 +1100,11 @@ contains
 !     Note: D and DT are rectangular matrices.
 !
 !-----------------------------------------------------------------------
-    real(kind=xp) D(ND2,ND1), DT(ND1,ND2), ZM1(ND1), ZM2(ND2), IM12(ND2,ND1)
+    integer, intent(in) :: ND1, ND2
+    real(kind=xp), intent(inout) :: D(ND2,ND1), DT(ND1,ND2)
+    real(kind=xp), intent(in) :: ZM1(ND1), ZM2(ND2), IM12(ND2,ND1)
     real(kind=xp) EPS, ZP, ZQ
+
     if (NZM1 .eq. 1) then
        D (1,1) = 0.0_xp
        DT(1,1) = 0.0_xp
@@ -1044,9 +1140,12 @@ contains
 !     Single precision version.
 !
 !-----------------------------------------------------------------------
-    real(kind=xp) D(ND2,ND1), DT(ND1,ND2), ZGL(ND1), ZG(ND2), IGLG(ND2,ND1)
     integer, parameter :: NMAX = 84
     integer, parameter :: NDD = NMAX
+    integer, intent(in) :: NPGL, NPG, ND1, ND2
+    real(kind=xp), intent(inout) :: D(ND2,ND1), DT(ND1,ND2)
+    real(kind=xp), intent(in) :: ZGL(ND1), ZG(ND2), IGLG(ND2,ND1)
+
     real(kind=xp) DD(NDD,NDD), DTD(NDD,NDD)
     real(kind=xp) ZGD(NDD), ZGLD(NDD), IGLGD(NDD,NDD)
     real(kind=xp) ALPHAD, BETAD
@@ -1099,9 +1198,12 @@ contains
 !     Double precision version.
 !
 !-----------------------------------------------------------------------
+    ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
-    real(kind=xp) D(ND2,ND1), DT(ND1,ND2), ZGL(ND1), ZG(ND2)
-    real(kind=xp) IGLG(ND2,ND1), ALPHA, BETA
+
+    integer, intent(in) :: NPGL, NPG, ND1, ND2
+    real(kind=xp), intent(inout) :: D(ND2,ND1), DT(ND1,ND2)
+    real(kind=xp), intent(in) :: ZGL(ND1), ZG(ND2), IGLG(ND2,ND1), ALPHA, BETA
 
     if (NPGL .le. 1) then
        write(6,*) 'DGLJGJD: Minimum number of Gauss-Lobatto points is 2'
@@ -1149,7 +1251,11 @@ contains
 !     Z2 : NZ2 points on mesh M.
 !
 !--------------------------------------------------------------------
-    real(kind=xp) I12(ND2,ND1),IT12(ND1,ND2),Z1(ND1),Z2(ND2), ZI
+    integer, intent(in) :: NZ1, NZ2, ND1, ND2
+    real(kind=xp), intent(inout) :: I12(ND2,ND1), IT12(ND1,ND2)
+    real(kind=xp), intent(in) :: Z1(ND1),Z2(ND2)
+    real(kind=xp) :: ZI
+
     if (NZ1 .eq. 1) then
        I12 (1,1) = 1.0_xp
        IT12(1,1) = 1.0_xp
@@ -1174,7 +1280,11 @@ contains
 !     Z2 : NZ2 points on mesh M.
 !
 !--------------------------------------------------------------------
-    real(kind=xp) I12(ND2,ND1),IT12(ND1,ND2),Z1(ND1),Z2(ND2),ZI
+    integer, intent(in) :: NZ1, NZ2, ND1, ND2
+    real(kind=xp), intent(inout) :: I12(ND2,ND1), IT12(ND1,ND2)
+    real(kind=xp), intent(in) :: Z1(ND1), Z2(ND2)
+    real(kind=xp) :: ZI
+
     if (NZ1 .eq. 1) then
        I12 (1,1) = 1.0_xp
        IT12(1,1) = 1.0_xp
@@ -1200,7 +1310,11 @@ contains
 !     Single precision version.
 !
 !--------------------------------------------------------------------
-    real(kind=xp) I12(ND2,ND1),IT12(ND1,ND2),Z1(ND1),Z2(ND2),ZI,ALPHA,BETA
+    integer, intent(in) :: NZ1, NZ2, ND1, ND2
+    real(kind=xp), intent(inout) :: I12(ND2,ND1), IT12(ND1,ND2)
+    real(kind=xp), intent(in) :: Z1(ND1), Z2(ND2), ALPHA, BETA
+    real(kind=xp) :: ZI
+
     if (NZ1 .eq. 1) then
        I12 (1,1) = 1.0_xp
        IT12(1,1) = 1.0_xp
@@ -1226,7 +1340,11 @@ contains
 !     Single precision version.
 !
 !--------------------------------------------------------------------
-    real(kind=xp) I12(ND2,ND1),IT12(ND1,ND2),Z1(ND1),Z2(ND2),ZI,ALPHA,BETA
+    integer, intent(in) :: NZ1, NZ2, ND1, ND2
+    real(kind=xp), intent(inout) :: I12(ND2,ND1), IT12(ND1,ND2)
+    real(kind=xp), intent(in) :: Z1(ND1), Z2(ND2), ALPHA, BETA
+    real(kind=xp) :: ZI
+
     if (NZ1 .eq. 1) then
        I12 (1,1) = 1.0_xp
        IT12(1,1) = 1.0_xp

--- a/src/sem/speclib.f90
+++ b/src/sem/speclib.f90
@@ -148,7 +148,8 @@
 module speclib
   use num_types, only : rp, xp
   use utils, only : neko_error
-  use, intrinsic :: iso_fortran_env, only : stderr=>error_unit
+  use, intrinsic :: iso_fortran_env, only : stderr => error_unit
+  implicit none
 
 contains
   !> Generate `NP` Gauss Legendre points `Z` and weights `W`
@@ -199,6 +200,7 @@ contains
     real(kind=rp), intent(in) :: ALPHA, BETA
     integer, intent(in) :: NP
     real(kind=xp) ZD(NZD), WD(NZD), ALPHAD, BETAD
+    integer :: I, NPMAX
 
     NPMAX = NZD
     if (NP .gt. NPMAX) then
@@ -231,6 +233,7 @@ contains
     real(kind=xp), intent(inout) :: Z(1), W(1)
     real(kind=xp), intent(in) :: ALPHA, BETA
     integer, intent(in) :: NP
+    integer :: N, NP1, NP2, I
 
     N = NP-1
     DN = real(N, kind=xp)
@@ -286,6 +289,7 @@ contains
     real(kind=rp), intent(in) :: ALPHA, BETA
     integer, intent(in) :: NP
     real(kind=xp) ZD(NZD), WD(NZD), ALPHAD, BETAD
+    integer :: I, NPMAX
 
     NPMAX = NZD
     if (NP .gt. NPMAX) then
@@ -318,7 +322,7 @@ contains
     real(kind=xp), intent(inout) :: Z(NP), W(NP)
     real(kind=xp), intent(in) :: ALPHA, BETA
     integer, intent(in) :: NP
-
+    integer :: N, NM1, I
 
     N = NP-1
     NM1 = N-1
@@ -359,7 +363,9 @@ contains
     integer, intent(in) :: N
     real(kind=xp), intent(in) :: ALPHA, BETA
 
-    ZERO = 0.
+    integer :: I
+
+    ZERO = 0.0_xp
     ONE = 1.0_xp
     TWO = 2.0_xp
     THREE = 3.0_xp
@@ -405,6 +411,7 @@ contains
 
     integer, intent(in) :: N
     real(kind=xp), intent(in) :: ALPHA, BETA
+    integer :: I
 
     ZERO = 0.0_xp
     ONE = 1.0_xp
@@ -478,6 +485,7 @@ contains
 
     real(kind=xp), intent(in) :: ALPHA, BETA
     integer, intent(in) :: N
+    integer :: I
 
     ONE = 1.0_xp
     TWO = 2.0_xp
@@ -521,6 +529,7 @@ contains
 
     integer, parameter :: KSTOP = 10
     real(kind=rp), parameter :: EPS = 1.0e-12_rp
+    integer :: I, J, K, N, JM, JMIN
 
     N = NP-1
     one = 1.0_xp
@@ -578,6 +587,7 @@ contains
          POLYM1, PDERM1, POLYM2, PDERM2
     integer, intent(in) :: N
     real(kind=xp), intent(in) :: ALP, BET, X
+    integer :: K
 
     APB = ALP+BET
     POLY = 1.0_xp
@@ -623,7 +633,8 @@ contains
     real(kind=xp), intent(in) :: Z, ZGJ(1), ALPHA, BETA
     integer, intent(in) :: NP, II
 
-    real(kind=xp) ZD,ZGJD(NZD),ALPHAD,BETAD
+    real(kind=xp) ZD, ZGJD(NZD), ALPHAD, BETAD
+    integer :: I, NPMAX
 
     NPMAX = NZD
     if (NP .gt. NPMAX) then
@@ -681,7 +692,8 @@ contains
 
     real(kind=xp), intent(in) :: Z, ZGLJ(1), ALPHA, BETA
     integer, intent(in) :: NP, II
-    real(kind=xp) ZD,ZGLJD(NZD),ALPHAD,BETAD
+    real(kind=xp) ZD, ZGLJD(NZD), ALPHAD, BETAD
+    integer :: I, NPMAX
 
     NPMAX = NZD
     if (NP .gt. NPMAX) then
@@ -712,6 +724,7 @@ contains
 
     real(kind=xp), intent(in) :: Z, ZGLJ(1), ALPHA, BETA
     integer, intent(in) :: NP, I
+    integer :: N
 
     EPS = 1.0e-5_xp
     ONE = 1.0_xp
@@ -746,7 +759,8 @@ contains
     real(kind=xp), intent(inout) :: D(NZD,NZD), DT(NZD,NZD)
     real(kind=xp), intent(in) :: Z(1), ALPHA, BETA
 
-    real(kind=xp) DD(NZDD,NZDD),DTD(NZDD,NZDD),ZD(NZDD),ALPHAD,BETAD
+    real(kind=xp) DD(NZDD,NZDD), DTD(NZDD,NZDD), ZD(NZDD), ALPHAD, BETAD
+    integer :: I, J
 
     if (NZ .le. 0) then
        write (stderr, *) 'DGJ: Minimum number of Gauss points is 1'
@@ -792,6 +806,7 @@ contains
     integer, intent(in) :: NZ, NZD
     real(kind=xp), intent(inout) :: D(NZD,NZD), DT(NZD,NZD)
     real(kind=xp), intent(in) :: Z(1), ALPHA, BETA
+    integer :: I, J, N
 
     N = NZ-1
     DN = real(N, kind=xp)
@@ -831,8 +846,12 @@ contains
 !-----------------------------------------------------------------
     integer, parameter :: NMAX = 84
     integer, parameter :: NZDD = NMAX
-    real(kind=xp) DD(NZDD,NZDD),DTD(NZDD,NZDD),ZD(NZDD),ALPHAD,BETAD
-    real(kind=xp) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
+    integer, intent(in) :: NZ, NZD
+    real(kind=xp), intent(inout) :: D(NZD,NZD), DT(NZD,NZD)
+    real(kind=xp), intent(in) :: Z(1), ALPHA, BETA
+
+    real(kind=xp) :: DD(NZDD,NZDD), DTD(NZDD,NZDD), ZD(NZDD), ALPHAD, BETAD
+    integer :: I, J
 
     if (NZ .le. 1) then
        write (stderr, *) 'DGLJ: Minimum number of Gauss-Lobatto points is 2'
@@ -878,6 +897,8 @@ contains
     integer, intent(in) :: NZ, NZD
     real(kind=xp), intent(inout) :: D(NZD,NZD), DT(NZD,NZD)
     real(kind=xp), intent(in) :: Z(1), ALPHA, BETA
+
+    integer :: I, J, N
 
     N = NZ-1
     DN = real(N, kind=xp)
@@ -930,6 +951,8 @@ contains
     real(kind=rp), intent(inout) :: D(NZD,NZD), DT(NZD,NZD)
     real(kind=rp), intent(in) :: Z(1)
 
+    integer :: I, J, N
+
     N = NZ-1
     if (NZ .gt. NMAX) then
        write (stderr, *) 'Subroutine DGLL'
@@ -968,6 +991,8 @@ contains
     real(kind=xp), intent(in) :: ZGLL(1), Z
     real(kind=xp) :: EPS, DZ
 
+    integer :: N
+
     EPS = 1.0e-5_xp
     DZ = Z - ZGLL(I)
     if (abs(DZ) .lt. EPS) then
@@ -975,7 +1000,7 @@ contains
        return
     end if
     N = NZ - 1
-    ALFAN = (N)*(real(N, kind=xp) + 1.0_xp)
+    ALFAN = real(N, kind=xp)*(real(N, kind=xp) + 1.0_xp)
     HGLL = - (1.0_xp-Z*Z)*PNDLEG(Z,N)/ &
          (ALFAN*PNLEG(ZGLL(I),N)*(Z-ZGLL(I)))
   end function HGLL
@@ -990,6 +1015,8 @@ contains
     integer, intent(in) :: I, NZ
     real(kind=xp), intent(in) :: ZGL(1), Z
     real(kind=xp) :: EPS, DZ
+
+    integer :: N
 
     EPS = 1.0e-5_xp
     DZ = Z - ZGL(I)
@@ -1012,13 +1039,14 @@ contains
 !
 !     This next statement is to overcome the underflow bug in the i860.
 !     It can be removed at a later date.  11 Aug 1990   pff.
-    !
+!
     ! Bug: Remove implicit types
     implicit real(kind=xp) (A-H,O-Z)
 
     real(kind=xp), intent(in) :: Z
     integer, intent(in) :: N
     real(kind=xp) :: P1, P2, P3
+    integer :: K
 
     P1 = 1.0_xp
     if (N .eq. 0) then
@@ -1069,6 +1097,7 @@ contains
     real(kind=xp), intent(in) :: Z
     integer, intent(in) :: N
     real(kind=xp) :: P1, P2, P1D, P2D, P3D
+    integer :: K
 
     P1 = 1.0_xp
     P2 = Z
@@ -1100,10 +1129,11 @@ contains
 !     Note: D and DT are rectangular matrices.
 !
 !-----------------------------------------------------------------------
-    integer, intent(in) :: ND1, ND2
+    integer, intent(in) :: NZM1, NZM2, ND1, ND2
     real(kind=xp), intent(inout) :: D(ND2,ND1), DT(ND1,ND2)
     real(kind=xp), intent(in) :: ZM1(ND1), ZM2(ND2), IM12(ND2,ND1)
     real(kind=xp) EPS, ZP, ZQ
+    integer :: IP, JQ, NM1
 
     if (NZM1 .eq. 1) then
        D (1,1) = 0.0_xp
@@ -1144,11 +1174,12 @@ contains
     integer, parameter :: NDD = NMAX
     integer, intent(in) :: NPGL, NPG, ND1, ND2
     real(kind=xp), intent(inout) :: D(ND2,ND1), DT(ND1,ND2)
-    real(kind=xp), intent(in) :: ZGL(ND1), ZG(ND2), IGLG(ND2,ND1)
+    real(kind=xp), intent(in) :: ZGL(ND1), ZG(ND2), IGLG(ND2,ND1), ALPHA, BETA
 
     real(kind=xp) DD(NDD,NDD), DTD(NDD,NDD)
     real(kind=xp) ZGD(NDD), ZGLD(NDD), IGLGD(NDD,NDD)
     real(kind=xp) ALPHAD, BETAD
+    integer :: I, J
 
     if (NPGL .le. 1) then
        write(6,*) 'DGLJGJ: Minimum number of Gauss-Lobatto points is 2'
@@ -1204,6 +1235,7 @@ contains
     integer, intent(in) :: NPGL, NPG, ND1, ND2
     real(kind=xp), intent(inout) :: D(ND2,ND1), DT(ND1,ND2)
     real(kind=xp), intent(in) :: ZGL(ND1), ZG(ND2), IGLG(ND2,ND1), ALPHA, BETA
+    integer :: I, J, NGL
 
     if (NPGL .le. 1) then
        write(6,*) 'DGLJGJD: Minimum number of Gauss-Lobatto points is 2'
@@ -1253,8 +1285,9 @@ contains
 !--------------------------------------------------------------------
     integer, intent(in) :: NZ1, NZ2, ND1, ND2
     real(kind=xp), intent(inout) :: I12(ND2,ND1), IT12(ND1,ND2)
-    real(kind=xp), intent(in) :: Z1(ND1),Z2(ND2)
+    real(kind=xp), intent(in) :: Z1(ND1), Z2(ND2)
     real(kind=xp) :: ZI
+    integer :: I, J
 
     if (NZ1 .eq. 1) then
        I12 (1,1) = 1.0_xp
@@ -1284,6 +1317,7 @@ contains
     real(kind=xp), intent(inout) :: I12(ND2,ND1), IT12(ND1,ND2)
     real(kind=xp), intent(in) :: Z1(ND1), Z2(ND2)
     real(kind=xp) :: ZI
+    integer :: I, J
 
     if (NZ1 .eq. 1) then
        I12 (1,1) = 1.0_xp
@@ -1314,6 +1348,7 @@ contains
     real(kind=xp), intent(inout) :: I12(ND2,ND1), IT12(ND1,ND2)
     real(kind=xp), intent(in) :: Z1(ND1), Z2(ND2), ALPHA, BETA
     real(kind=xp) :: ZI
+    integer :: I, J
 
     if (NZ1 .eq. 1) then
        I12 (1,1) = 1.0_xp
@@ -1344,6 +1379,7 @@ contains
     real(kind=xp), intent(inout) :: I12(ND2,ND1), IT12(ND1,ND2)
     real(kind=xp), intent(in) :: Z1(ND1), Z2(ND2), ALPHA, BETA
     real(kind=xp) :: ZI
+    integer :: I, J
 
     if (NZ1 .eq. 1) then
        I12 (1,1) = 1.0_xp

--- a/src/sem/speclib.f90
+++ b/src/sem/speclib.f90
@@ -227,19 +227,22 @@ contains
 !     Double precision version.
 !
 !--------------------------------------------------------------------
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
 
     real(kind=xp), intent(inout) :: Z(1), W(1)
     real(kind=xp), intent(in) :: ALPHA, BETA
     integer, intent(in) :: NP
+
+    real(kind=xp) :: DN, ONE, TWO, APB
+    real(kind=xp) :: FAC1, FAC2, FAC3, FNORM
+    real(kind=xp) :: RCOEF, P, PD, PM1, PDM1, PM2, PDM2
+    real(kind=xp) :: DNP1, DNP2
     integer :: N, NP1, NP2, I
 
-    N = NP-1
+    N = NP - 1
     DN = real(N, kind=xp)
     ONE = 1.0_xp
     TWO = 2.0_xp
-    APB = ALPHA+BETA
+    APB = ALPHA + BETA
 
     if (NP .le. 0) then
        write (stderr, *) 'ZWGJD: Minimum number of Gauss points is 1',np
@@ -283,11 +286,14 @@ contains
 !     Single precision version.
 !
 !--------------------------------------------------------------------
-    integer, parameter :: NMAX = 84
-    integer, parameter :: NZD = NMAX
+
     real(kind=rp), intent(inout) :: Z(1), W(1)
     real(kind=rp), intent(in) :: ALPHA, BETA
     integer, intent(in) :: NP
+
+    integer, parameter :: NMAX = 84
+    integer, parameter :: NZD = NMAX
+
     real(kind=xp) ZD(NZD), WD(NZD), ALPHAD, BETAD
     integer :: I, NPMAX
 
@@ -316,12 +322,13 @@ contains
 !     Double precision version.
 !
 !--------------------------------------------------------------------
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
 
     real(kind=xp), intent(inout) :: Z(NP), W(NP)
     real(kind=xp), intent(in) :: ALPHA, BETA
     integer, intent(in) :: NP
+
+    real(kind=xp) :: ONE, TWO, ALPG, BETG
+    real(kind=xp) :: P, PD, PM1, PDM1, PM2, PDM2
     integer :: N, NM1, I
 
     N = NP-1
@@ -357,12 +364,13 @@ contains
   end subroutine ZWGLJD
 
   real(kind=xp) function ENDW1 (N,ALPHA,BETA)
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
 
-    integer, intent(in) :: N
     real(kind=xp), intent(in) :: ALPHA, BETA
+    integer, intent(in) :: N
 
+    real(kind=xp) :: ZERO, ONE, TWO, THREE, FOUR, APB
+    real(kind=xp) :: F1, F2, F3, FINT1, FINT2
+    real(kind=xp) :: A1, A2, A3, DI, ABN, ABNN
     integer :: I
 
     ZERO = 0.0_xp
@@ -406,11 +414,13 @@ contains
   end function ENDW1
 
   real(kind=xp) function ENDW2 (N,ALPHA,BETA)
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
 
-    integer, intent(in) :: N
     real(kind=xp), intent(in) :: ALPHA, BETA
+    integer, intent(in) :: N
+
+    real(kind=xp) :: ZERO, ONE, TWO, THREE, FOUR, APB
+    real(kind=xp) :: F1, F2, F3, FINT1, FINT2
+    real(kind=xp) :: A1, A2, A3, DI, ABN, ABNN
     integer :: I
 
     ZERO = 0.0_xp
@@ -454,10 +464,8 @@ contains
   end function ENDW2
 
   real(kind=xp) function GAMMAF (X)
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
-
     real(kind=xp), intent(in) :: X
+    real(kind=xp) :: ZERO, HALF, ONE, TWO, FOUR, PI
 
     ZERO = 0.0_xp
     HALF = 0.5_xp
@@ -480,11 +488,11 @@ contains
   end function GAMMAF
 
   real(kind=xp) function PNORMJ (N,ALPHA,BETA)
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
-
     real(kind=xp), intent(in) :: ALPHA, BETA
     integer, intent(in) :: N
+
+    real(kind=xp) :: ONE, TWO, DN, DINDX
+    real(kind=xp) :: CONST, PROD, FRAC
     integer :: I
 
     ONE = 1.0_xp
@@ -502,7 +510,7 @@ contains
     PROD = PROD*(ONE+ALPHA)*(TWO+ALPHA)
     PROD = PROD*(ONE+BETA)*(TWO+BETA)
     do I = 3, N
-       DINDX = ((I))
+       DINDX = real(I, kind=xp)
        FRAC = (DINDX+ALPHA)*(DINDX+BETA)/(DINDX*(DINDX+ALPHA+BETA))
        PROD = PROD*FRAC
     end do
@@ -520,15 +528,18 @@ contains
 !     ALPHA = BETA = -0.5  ->  Chebyshev points
 !
 !--------------------------------------------------------------------
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
+
 
     real(kind=xp), intent(inout) :: XJAC(1)
-    integer, intent(in) :: NP
     real(kind=xp), intent(in) :: ALPHA, BETA
+    integer, intent(in) :: NP
 
     integer, parameter :: KSTOP = 10
     real(kind=rp), parameter :: EPS = 1.0e-12_rp
+
+    real(kind=xp) :: one, DTH, X, X1, X2, XLAST, DELX, XMIN
+    real(kind=xp) :: P, PD, PM1, PDM1, PM2, PDM2
+    real(kind=xp) :: RECSUM, SWAP
     integer :: I, J, K, N, JM, JMIN
 
     N = NP-1
@@ -580,13 +591,15 @@ contains
 !     of degree N at X.
 !
 !--------------------------------------------------------------------
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
 
-    real(kind=xp), intent(inout) :: POLY, PDER, &
-         POLYM1, PDERM1, POLYM2, PDERM2
+    real(kind=xp), intent(inout) :: POLY, PDER, POLYM1, PDERM1, POLYM2, PDERM2
     integer, intent(in) :: N
     real(kind=xp), intent(in) :: ALP, BET, X
+
+    real(kind=xp) :: APB, POLYL, PDERL, POLYN, PDERN
+    real(kind=xp) :: PSAVE, PDSAVE
+    real(kind=xp) :: A1, A2, A3, A4, B3
+    real(kind=xp) :: DK
     integer :: K
 
     APB = ALP+BET
@@ -660,11 +673,12 @@ contains
 !     Double precision version.
 !
 !---------------------------------------------------------------------
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
 
     real(kind=xp), intent(in) :: Z, ZGJ(1), ALPHA, BETA
     integer, intent(in) :: NP, II
+
+    real(kind=xp) :: EPS, ONE, ZI, DZ
+    real(kind=xp) :: PZ, PDZ, PZI, PDZI, PM1, PDM1, PM2, PDM2
 
     EPS = 1.0e-5_xp
     ONE = 1.0_xp
@@ -719,11 +733,13 @@ contains
 !     Double precision version.
 !
 !---------------------------------------------------------------------
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
 
     real(kind=xp), intent(in) :: Z, ZGLJ(1), ALPHA, BETA
     integer, intent(in) :: NP, I
+
+    real(kind=xp) :: EPS, ONE, ZI, DZ, DN
+    real(kind=xp) :: P, PD, PI, PDI, PM1, PDM1, PM2, PDM2
+    real(kind=xp) :: EIGVAL, CONST
     integer :: N
 
     EPS = 1.0e-5_xp
@@ -759,7 +775,7 @@ contains
     real(kind=xp), intent(inout) :: D(NZD,NZD), DT(NZD,NZD)
     real(kind=xp), intent(in) :: Z(1), ALPHA, BETA
 
-    real(kind=xp) DD(NZDD,NZDD), DTD(NZDD,NZDD), ZD(NZDD), ALPHAD, BETAD
+    real(kind=xp) :: DD(NZDD,NZDD), DTD(NZDD,NZDD), ZD(NZDD), ALPHAD, BETAD
     integer :: I, J
 
     if (NZ .le. 0) then
@@ -800,12 +816,13 @@ contains
 !     Double precision version.
 !
 !-----------------------------------------------------------------
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
 
     integer, intent(in) :: NZ, NZD
     real(kind=xp), intent(inout) :: D(NZD,NZD), DT(NZD,NZD)
     real(kind=xp), intent(in) :: Z(1), ALPHA, BETA
+
+    real(kind=xp) :: DN, ONE, TWO
+    real(kind=xp) :: PDI, PDJ, PI, PJ, PM1, PDM1, PM2, PDM2
     integer :: I, J, N
 
     N = NZ-1
@@ -891,13 +908,14 @@ contains
 !     Double precision version.
 !
 !-----------------------------------------------------------------
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
 
     integer, intent(in) :: NZ, NZD
     real(kind=xp), intent(inout) :: D(NZD,NZD), DT(NZD,NZD)
     real(kind=xp), intent(in) :: Z(1), ALPHA, BETA
 
+    real(kind=xp) :: DN, ONE, TWO, EIGVAL
+    real(kind=xp) :: PDI, PDJ, PI, PJ, PM1, PDM1, PM2, PDM2
+    real(kind=xp) :: CI, CJ
     integer :: I, J, N
 
     N = NZ-1
@@ -943,14 +961,14 @@ contains
 !     Note: D and DT are square matrices.
 !
 !-----------------------------------------------------------------
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
 
-    integer, parameter :: NMAX = 84
     integer, intent(in) :: NZ, NZD
     real(kind=rp), intent(inout) :: D(NZD,NZD), DT(NZD,NZD)
     real(kind=rp), intent(in) :: Z(1)
 
+    integer, parameter :: NMAX = 84
+
+    real(kind=xp) :: d0, FN
     integer :: I, J, N
 
     N = NZ-1
@@ -963,8 +981,8 @@ contains
        D(1,1) = 0.0_rp
        return
     end if
-    FN = (N)
-    d0 = FN*(FN + 1.0_rp)/4.0_rp
+    FN = real(N, kind=xp)
+    d0 = FN*(FN + 1.0_xp)/4.0_xp
     do I = 1, NZ
        do J = 1, NZ
           D(I,J) = 0.0_rp
@@ -984,13 +1002,12 @@ contains
 !     the NZ Gauss-Lobatto Legendre points ZGLL at the point Z.
 !
 !---------------------------------------------------------------------
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
 
-    integer, intent(in) :: I, NZ
     real(kind=xp), intent(in) :: ZGLL(1), Z
-    real(kind=xp) :: EPS, DZ
+    integer, intent(in) :: I, NZ
 
+    real(kind=xp) :: EPS, DZ
+    real(kind=xp) :: ALFAN
     integer :: N
 
     EPS = 1.0e-5_xp
@@ -1040,12 +1057,11 @@ contains
 !     This next statement is to overcome the underflow bug in the i860.
 !     It can be removed at a later date.  11 Aug 1990   pff.
 !
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
 
     real(kind=xp), intent(in) :: Z
     integer, intent(in) :: N
-    real(kind=xp) :: P1, P2, P3
+
+    real(kind=xp) :: P1, P2, P3, FK
     integer :: K
 
     P1 = 1.0_xp
@@ -1071,6 +1087,7 @@ contains
     integer, intent(in) :: N
     real(kind=rp), intent(inout) :: L(0:N)
     real(kind=rp), intent(in) :: x
+
     integer :: j
 
     L(0) = 1.0_rp
@@ -1091,12 +1108,11 @@ contains
 !     Based on the recursion formula for the Legendre polynomials.
 !
 !----------------------------------------------------------------------
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
 
     real(kind=xp), intent(in) :: Z
     integer, intent(in) :: N
-    real(kind=xp) :: P1, P2, P1D, P2D, P3D
+
+    real(kind=xp) :: P1, P2, P3, P1D, P2D, P3D, FK
     integer :: K
 
     P1 = 1.0_xp
@@ -1105,7 +1121,7 @@ contains
     P2D = 1.0_xp
     P3D = 1.0_xp
     do K = 1, N-1
-       FK = (K)
+       FK = real(K, kind=xp)
        P3 = ((2.0_xp*FK+1.0_xp)*Z*P2 - FK*P1)/(FK+1.0_xp)
        P3D = ((2.0_xp*FK+1.0_xp)*P2 + (2.0_xp*FK+1.0_xp)*Z*P2D - FK*P1D)/(FK+1.0_xp)
        P1 = P2
@@ -1129,9 +1145,11 @@ contains
 !     Note: D and DT are rectangular matrices.
 !
 !-----------------------------------------------------------------------
+
     integer, intent(in) :: NZM1, NZM2, ND1, ND2
     real(kind=xp), intent(inout) :: D(ND2,ND1), DT(ND1,ND2)
     real(kind=xp), intent(in) :: ZM1(ND1), ZM2(ND2), IM12(ND2,ND1)
+
     real(kind=xp) EPS, ZP, ZQ
     integer :: IP, JQ, NM1
 
@@ -1229,12 +1247,14 @@ contains
 !     Double precision version.
 !
 !-----------------------------------------------------------------------
-    ! Bug: Remove implicit types
-    implicit real(kind=xp) (A-H,O-Z)
 
     integer, intent(in) :: NPGL, NPG, ND1, ND2
     real(kind=xp), intent(inout) :: D(ND2,ND1), DT(ND1,ND2)
     real(kind=xp), intent(in) :: ZGL(ND1), ZG(ND2), IGLG(ND2,ND1), ALPHA, BETA
+
+    real(kind=xp) :: EPS, ONE, TWO, EIGVAL, DN
+    real(kind=xp) :: PDI, PDJ, PI, PJ, PM1, PDM1, PM2, PDM2
+    real(kind=xp) :: DZ, FACI, FACJ, CONST
     integer :: I, J, NGL
 
     if (NPGL .le. 1) then
@@ -1250,7 +1270,7 @@ contains
     ONE = 1.0_xp
     TWO = 2.0_xp
     NGL = NPGL-1
-    DN = ((NGL))
+    DN = real(NGL, kind=xp)
     EIGVAL = -DN*(DN+ALPHA+BETA+ONE)
 
     do I = 1, NPG

--- a/src/sem/speclib.f90
+++ b/src/sem/speclib.f90
@@ -147,8 +147,8 @@
 !==============================================================================
 module speclib
   use num_types, only : rp, xp
-  use utils, only: neko_error
-
+  use utils, only : neko_error
+  use, intrinsic :: iso_fortran_env, only : stderr=>error_unit
 
 contains
   !> Generate `NP` Gauss Legendre points `Z` and weights `W`
@@ -196,9 +196,9 @@ contains
 
     NPMAX = NZD
     if (NP .gt. NPMAX) then
-       write (6,*) 'Too large polynomial degree in ZWGJ'
-       write (6,*) 'Maximum polynomial degree is',NMAX
-       write (6,*) 'Here NP=',NP
+       write (stderr, *) 'Too large polynomial degree in ZWGJ'
+       write (stderr, *) 'Maximum polynomial degree is',NMAX
+       write (stderr, *) 'Here NP=',NP
        call neko_error
     end if
     ALPHAD = ALPHA
@@ -229,11 +229,11 @@ contains
     APB = ALPHA+BETA
 
     if (NP .le. 0) then
-       write (6,*) 'ZWGJD: Minimum number of Gauss points is 1',np
+       write (stderr, *) 'ZWGJD: Minimum number of Gauss points is 1',np
        call neko_error
     end if
     if ((ALPHA .le. -ONE) .or. (BETA .le. -ONE)) then
-       write (6,*) 'ZWGJD: Alpha and Beta must be greater than -1'
+       write (stderr, *) 'ZWGJD: Alpha and Beta must be greater than -1'
        call neko_error
     end if
 
@@ -277,9 +277,9 @@ contains
 
     NPMAX = NZD
     if (NP .gt. NPMAX) then
-       write (6,*) 'Too large polynomial degree in ZWGLJ'
-       write (6,*) 'Maximum polynomial degree is',NMAX
-       write (6,*) 'Here NP=',NP
+       write (stderr, *) 'Too large polynomial degree in ZWGLJ'
+       write (stderr, *) 'Maximum polynomial degree is',NMAX
+       write (stderr, *) 'Here NP=',NP
        call neko_error
     end if
     ALPHAD = ALPHA
@@ -309,12 +309,12 @@ contains
     TWO = 2.0_xp
 
     if (NP .le. 1) then
-       write (6,*) 'ZWGLJD: Minimum number of Gauss-Lobatto points is 2'
-       write (6,*) 'ZWGLJD: alpha,beta:', alpha, beta, np
+       write (stderr, *) 'ZWGLJD: Minimum number of Gauss-Lobatto points is 2'
+       write (stderr, *) 'ZWGLJD: alpha,beta:', alpha, beta, np
        call neko_error
     end if
     if ((ALPHA .le. -ONE) .or. (BETA .le. -ONE)) then
-       write (6,*) 'ZWGLJD: Alpha and Beta must be greater than -1'
+       write (stderr, *) 'ZWGLJD: Alpha and Beta must be greater than -1'
        call neko_error
     end if
 
@@ -579,9 +579,9 @@ contains
     real(kind=xp) Z,ZGJ(1),ALPHA,BETA
     NPMAX = NZD
     if (NP .gt. NPMAX) then
-       write (6,*) 'Too large polynomial degree in HGJ'
-       write (6,*) 'Maximum polynomial degree is',NMAX
-       write (6,*) 'Here NP=',NP
+       write (stderr, *) 'Too large polynomial degree in HGJ'
+       write (stderr, *) 'Maximum polynomial degree is',NMAX
+       write (stderr, *) 'Here NP=',NP
        call neko_error
     end if
     ZD = Z
@@ -630,9 +630,9 @@ contains
     real(kind=xp) Z,ZGLJ(1),ALPHA,BETA
     NPMAX = NZD
     if (NP .gt. NPMAX) then
-       write (6,*) 'Too large polynomial degree in HGLJ'
-       write (6,*) 'Maximum polynomial degree is',NMAX
-       write (6,*) 'Here NP=',NP
+       write (stderr, *) 'Too large polynomial degree in HGLJ'
+       write (stderr, *) 'Maximum polynomial degree is',NMAX
+       write (stderr, *) 'Here NP=',NP
        call neko_error
     end if
     ZD = Z
@@ -687,17 +687,17 @@ contains
     real(kind=xp) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
 
     if (NZ .le. 0) then
-       write (6,*) 'DGJ: Minimum number of Gauss points is 1'
+       write (stderr, *) 'DGJ: Minimum number of Gauss points is 1'
        call neko_error
     end if
     if (NZ .gt. NMAX) then
-       write (6,*) 'Too large polynomial degree in DGJ'
-       write (6,*) 'Maximum polynomial degree is',NMAX
-       write (6,*) 'Here Nz=',Nz
+       write (stderr, *) 'Too large polynomial degree in DGJ'
+       write (stderr, *) 'Maximum polynomial degree is',NMAX
+       write (stderr, *) 'Here Nz=',Nz
        call neko_error
     end if
     if ((ALPHA .le. -1.0_xp) .or. (BETA .le. -1.0_xp)) then
-       write (6,*) 'DGJ: Alpha and Beta must be greater than -1'
+       write (stderr, *) 'DGJ: Alpha and Beta must be greater than -1'
        call neko_error
     end if
     ALPHAD = ALPHA
@@ -732,11 +732,11 @@ contains
     TWO = 2.0_xp
 
     if (NZ .le. 1) then
-       write (6,*) 'DGJD: Minimum number of Gauss-Lobatto points is 2'
+       write (stderr, *) 'DGJD: Minimum number of Gauss-Lobatto points is 2'
        call neko_error
     end if
     if ((ALPHA .le. -ONE) .or. (BETA .le. -ONE)) then
-       write (6,*) 'DGJD: Alpha and Beta must be greater than -1'
+       write (stderr, *) 'DGJD: Alpha and Beta must be greater than -1'
        call neko_error
     end if
 
@@ -768,17 +768,17 @@ contains
     real(kind=xp) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
 
     if (NZ .le. 1) then
-       write (6,*) 'DGLJ: Minimum number of Gauss-Lobatto points is 2'
+       write (stderr, *) 'DGLJ: Minimum number of Gauss-Lobatto points is 2'
        call neko_error
     end if
     if (NZ .gt. NMAX) then
-       write (6,*) 'Too large polynomial degree in DGLJ'
-       write (6,*) 'Maximum polynomial degree is',NMAX
-       write (6,*) 'Here NZ=',NZ
+       write (stderr, *) 'Too large polynomial degree in DGLJ'
+       write (stderr, *) 'Maximum polynomial degree is',NMAX
+       write (stderr, *) 'Here NZ=',NZ
        call neko_error
     end if
     if ((ALPHA .le. -1.) .or. (BETA .le. -1.)) then
-       write (6,*) 'DGLJ: Alpha and Beta must be greater than -1'
+       write (stderr, *) 'DGLJ: Alpha and Beta must be greater than -1'
        call neko_error
     end if
     ALPHAD = ALPHA
@@ -814,11 +814,11 @@ contains
     EIGVAL = -DN*(DN+ALPHA+BETA+ONE)
 
     if (NZ .le. 1) then
-       write (6,*) 'DGLJD: Minimum number of Gauss-Lobatto points is 2'
+       write (stderr, *) 'DGLJD: Minimum number of Gauss-Lobatto points is 2'
        call neko_error
     end if
     if ((ALPHA .le. -ONE) .or. (BETA .le. -ONE)) then
-       write (6,*) 'DGLJD: Alpha and Beta must be greater than -1'
+       write (stderr, *) 'DGLJD: Alpha and Beta must be greater than -1'
        call neko_error
     end if
 
@@ -855,9 +855,9 @@ contains
     real(kind=rp) D(NZD,NZD),DT(NZD,NZD),Z(1)
     N = NZ-1
     if (NZ .gt. NMAX) then
-       write (6,*) 'Subroutine DGLL'
-       write (6,*) 'Maximum polynomial degree =',NMAX
-       write (6,*) 'Polynomial degree         =',NZ
+       write (stderr, *) 'Subroutine DGLL'
+       write (stderr, *) 'Maximum polynomial degree =',NMAX
+       write (stderr, *) 'Polynomial degree         =',NZ
     end if
     if (NZ .eq. 1) then
        D(1,1) = 0.0_rp

--- a/src/sem/speclib.f90
+++ b/src/sem/speclib.f90
@@ -429,15 +429,15 @@ contains
     ONE = 1.0
     TWO = 2.0
     FOUR = 4.0
-    PI = FOUR*ATAN(ONE)
+    PI = FOUR*atan(ONE)
     GAMMAF = ONE
-    if (X .eq. -HALF) GAMMAF = -TWO*SQRT(PI)
-    if (X .eq. HALF) GAMMAF = SQRT(PI)
+    if (X .eq. -HALF) GAMMAF = -TWO*sqrt(PI)
+    if (X .eq. HALF) GAMMAF = sqrt(PI)
     if (X .eq. ONE ) GAMMAF = ONE
     if (X .eq. TWO ) GAMMAF = ONE
-    if (X .eq. 1.5 ) GAMMAF = SQRT(PI)/2.
-    if (X .eq. 2.5) GAMMAF = 1.5*SQRT(PI)/2.
-    if (X .eq. 3.5) GAMMAF = 0.5*(2.5*(1.5*SQRT(PI)))
+    if (X .eq. 1.5 ) GAMMAF = sqrt(PI)/2.
+    if (X .eq. 2.5) GAMMAF = 1.5*sqrt(PI)/2.
+    if (X .eq. 3.5) GAMMAF = 0.5*(2.5*(1.5*sqrt(PI)))
     if (X .eq. 3. ) GAMMAF = 2.
     if (X .eq. 4. ) GAMMAF = 6.
     if (X .eq. 5. ) GAMMAF = 24.
@@ -486,12 +486,12 @@ contains
     data EPS/1.0e-12_RP/
     N = NP-1
     one = 1.
-    DTH = 4.*ATAN(one)/(2.*((N))+2.)
+    DTH = 4.*atan(one)/(2.*((N))+2.)
     do J=1,NP
        if (J .eq. 1) then
-          X = COS((2.*(((J))-1.)+1.)*DTH)
+          X = cos((2.*(((J))-1.)+1.)*DTH)
        else
-          X1 = COS((2.*(((J))-1.)+1.)*DTH)
+          X1 = cos((2.*(((J))-1.)+1.)*DTH)
           X2 = XLAST
           X = (X1+X2)/2.
        end if
@@ -504,7 +504,7 @@ contains
           end do
           DELX = -P/(PD-RECSUM*P)
           X = X+DELX
-          if (ABS(DELX) .LT. EPS) exit
+          if (abs(DELX) .lt. EPS) exit
        end do
 
        XJAC(NP-J+1) = X
@@ -513,7 +513,7 @@ contains
     do I=1,NP
        XMIN = 2.
        do J=I,NP
-          if (XJAC(J).LT.XMIN) then
+          if (XJAC(J) .lt. XMIN) then
              XMIN = XJAC(J)
              JMIN = J
           end if
@@ -607,7 +607,7 @@ contains
     ONE = 1.
     ZI = ZGJ(II)
     DZ = Z-ZI
-    if (ABS(DZ).LT.EPS) then
+    if (abs(DZ) .lt. EPS) then
        HGJD = ONE
        return
     end if
@@ -658,7 +658,7 @@ contains
     ONE = 1.
     ZI = ZGLJ(I)
     DZ = Z-ZI
-    if (ABS(DZ).LT.EPS) then
+    if (abs(DZ) .lt. EPS) then
        HGLJD = ONE
        return
     end if
@@ -888,7 +888,7 @@ contains
     real(kind=xp) ZGLL(1), EPS, DZ, Z
     EPS = 1.E-5
     DZ = Z - ZGLL(I)
-    if (ABS(DZ) .LT. EPS) then
+    if (abs(DZ) .lt. EPS) then
        HGLL = 1.
        return
     end if
@@ -908,7 +908,7 @@ contains
     real(kind=xp) ZGL(1), Z, EPS, DZ
     EPS = 1.E-5
     DZ = Z - ZGL(I)
-    if (ABS(DZ) .LT. EPS) then
+    if (abs(DZ) .lt. EPS) then
        HGL = 1.
        return
     end if
@@ -930,7 +930,7 @@ contains
 !
     implicit real(kind=xp) (A-H,O-Z)
     real(kind=xp) Z, P1, P2, P3
-    !if(ABS(Z) .LT. 1.0E-25) Z = 0.0
+    !if(abs(Z)  .lt.  1.0E-25) Z = 0.0
 
 
     P1 = 1.
@@ -1020,7 +1020,7 @@ contains
        do JQ = 1, NZM1
           ZP = ZM2(IP)
           ZQ = ZM1(JQ)
-          if ((ABS(ZP) .LT. EPS).AND.(ABS(ZQ) .LT. EPS)) then
+          if ((abs(ZP) .lt. EPS).AND.(abs(ZQ) .lt. EPS)) then
              D(IP,JQ) = 0.
           else
              D(IP,JQ) = (PNLEG(ZP,NM1)/PNLEG(ZQ,NM1) &
@@ -1121,8 +1121,8 @@ contains
 
     do I=1,NPG
        do J=1,NPGL
-          DZ = ABS(ZG(I)-ZGL(J))
-          if (DZ.LT.EPS) then
+          DZ = abs(ZG(I)-ZGL(J))
+          if (DZ .lt. EPS) then
              D(I,J) = (ALPHA*(ONE+ZG(I))-BETA*(ONE-ZG(I)))/ &
                   (TWO*(ONE-ZG(I)**2))
           else

--- a/src/sem/speclib.f90
+++ b/src/sem/speclib.f90
@@ -223,9 +223,9 @@ contains
     real(kind=xp) Z(1),W(1),ALPHA,BETA
 
     N = NP-1
-    DN = ((N))
-    ONE = 1.
-    TWO = 2.
+    DN = real(N, kind=xp)
+    ONE = 1.0_xp
+    TWO = 2.0_xp
     APB = ALPHA+BETA
 
     if (NP .le. 0) then
@@ -305,12 +305,12 @@ contains
 
     N = NP-1
     NM1 = N-1
-    ONE = 1.
-    TWO = 2.
+    ONE = 1.0_xp
+    TWO = 2.0_xp
 
     if (NP .le. 1) then
        write (6,*) 'ZWGLJD: Minimum number of Gauss-Lobatto points is 2'
-       write (6,*) 'ZWGLJD: alpha,beta:',alpha,beta,np
+       write (6,*) 'ZWGLJD: alpha,beta:', alpha, beta, np
        call neko_error
     end if
     if ((ALPHA .le. -ONE) .or. (BETA .le. -ONE)) then
@@ -339,10 +339,10 @@ contains
     implicit real(kind=xp) (A-H,O-Z)
     real(kind=xp) ALPHA,BETA
     ZERO = 0.
-    ONE = 1.
-    TWO = 2.
-    THREE = 3.
-    FOUR = 4.
+    ONE = 1.0_xp
+    TWO = 2.0_xp
+    THREE = 3.0_xp
+    FOUR = 4.0_xp
     APB = ALPHA+BETA
     if (N .eq. 0) then
        ENDW1 = ZERO
@@ -381,11 +381,11 @@ contains
   real(kind=xp) function ENDW2 (N,ALPHA,BETA)
     implicit real(kind=xp) (A-H,O-Z)
     real(kind=xp) ALPHA,BETA
-    ZERO = 0.
-    ONE = 1.
-    TWO = 2.
-    THREE = 3.
-    FOUR = 4.
+    ZERO = 0.0_xp
+    ONE = 1.0_xp
+    TWO = 2.0_xp
+    THREE = 3.0_xp
+    FOUR = 4.0_xp
     APB = ALPHA+BETA
     if (N .eq. 0) then
        ENDW2 = ZERO
@@ -424,32 +424,32 @@ contains
   real(kind=xp) function GAMMAF (X)
     implicit real(kind=xp) (A-H,O-Z)
     real(kind=xp) X
-    ZERO = 0.0
-    HALF = 0.5
-    ONE = 1.0
-    TWO = 2.0
-    FOUR = 4.0
+    ZERO = 0.0_xp
+    HALF = 0.5_xp
+    ONE = 1.0_xp
+    TWO = 2.0_xp
+    FOUR = 4.0_xp
     PI = FOUR*atan(ONE)
     GAMMAF = ONE
     if (X .eq. -HALF) GAMMAF = -TWO*sqrt(PI)
     if (X .eq. HALF) GAMMAF = sqrt(PI)
     if (X .eq. ONE ) GAMMAF = ONE
     if (X .eq. TWO ) GAMMAF = ONE
-    if (X .eq. 1.5 ) GAMMAF = sqrt(PI)/2.
-    if (X .eq. 2.5) GAMMAF = 1.5*sqrt(PI)/2.
-    if (X .eq. 3.5) GAMMAF = 0.5*(2.5*(1.5*sqrt(PI)))
-    if (X .eq. 3. ) GAMMAF = 2.
-    if (X .eq. 4. ) GAMMAF = 6.
-    if (X .eq. 5. ) GAMMAF = 24.
-    if (X .eq. 6. ) GAMMAF = 120.
+    if (X .eq. 1.5_xp) GAMMAF = sqrt(PI) / 2.0_xp
+    if (X .eq. 2.5_xp) GAMMAF = 1.5_xp * sqrt(PI) / 2.0_xp
+    if (X .eq. 3.5_xp) GAMMAF = 0.5_xp * (2.5_xp * (1.5_xp * sqrt(PI)))
+    if (X .eq. 3.0_xp) GAMMAF = 2.0_xp
+    if (X .eq. 4.0_xp) GAMMAF = 6.0_xp
+    if (X .eq. 5.0_xp) GAMMAF = 24.0_xp
+    if (X .eq. 6.0_xp) GAMMAF = 120.0_xp
   end function GAMMAF
 
   real(kind=xp) function PNORMJ (N,ALPHA,BETA)
     implicit real(kind=xp) (A-H,O-Z)
     real(kind=xp) ALPHA,BETA
-    ONE = 1.
-    TWO = 2.
-    DN = ((N))
+    ONE = 1.0_xp
+    TWO = 2.0_xp
+    DN = real(N, kind=xp)
     CONST = ALPHA+BETA+ONE
     if (N .le. 1) then
        PROD = GAMMAF(DN+ALPHA)*GAMMAF(DN+BETA)
@@ -485,22 +485,22 @@ contains
     data KSTOP /10/
     data EPS/1.0e-12_RP/
     N = NP-1
-    one = 1.
-    DTH = 4.*atan(one)/(2.*((N))+2.)
+    one = 1.0_xp
+    DTH = 4.0_xp*atan(one)/(2.0_xp*real(N, kind=xp) + 2.0_xp)
     do J = 1, NP
        if (J .eq. 1) then
-          X = cos((2.*(((J))-1.)+1.)*DTH)
+          X = cos((2.0_xp*(real(J, kind=xp)-1.0_xp)+1.0_xp)*DTH)
        else
-          X1 = cos((2.*(((J))-1.)+1.)*DTH)
+          X1 = cos((2.0_xp*(real(J, kind=xp)-1.0_xp)+1.0_xp)*DTH)
           X2 = XLAST
-          X = (X1+X2)/2.
+          X = (X1+X2)/2.0_xp
        end if
        do K = 1, KSTOP
           call JACOBF (P,PD,PM1,PDM1,PM2,PDM2,NP,ALPHA,BETA,X)
-          RECSUM = 0.
+          RECSUM = 0.0_xp
           JM = J-1
           do I = 1, JM
-             RECSUM = RECSUM+1./(X-XJAC(NP-I+1))
+             RECSUM = RECSUM+1.0_xp/(X-XJAC(NP-I+1))
           end do
           DELX = -P/(PD-RECSUM*P)
           X = X+DELX
@@ -518,7 +518,7 @@ contains
              JMIN = J
           end if
        end do
-       if (JMIN.NE.I) then
+       if (JMIN .ne. I) then
           SWAP = XJAC(I)
           XJAC(I) = XJAC(JMIN)
           XJAC(JMIN) = SWAP
@@ -535,21 +535,21 @@ contains
 !--------------------------------------------------------------------
     implicit real(kind=xp) (A-H,O-Z)
     APB = ALP+BET
-    POLY = 1.
-    PDER = 0.
+    POLY = 1.0_xp
+    PDER = 0.0_xp
     if (N .eq. 0) return
     POLYL = POLY
     PDERL = PDER
-    POLY = (ALP-BET+(APB+2.)*X)/2.
-    PDER = (APB+2.)/2.
+    POLY = (ALP-BET+(APB+2.0_xp)*X)/2.0_xp
+    PDER = (APB+2.0_xp)/2.0_xp
     if (N .eq. 1) return
     do K = 2, N
        DK = ((K))
-       A1 = 2.*DK*(DK+APB)*(2.*DK+APB-2.)
-       A2 = (2.*DK+APB-1.)*(ALP**2-BET**2)
-       B3 = (2.*DK+APB-2.)
-       A3 = B3*(B3+1.)*(B3+2.)
-       A4 = 2.*(DK+ALP-1.)*(DK+BET-1.)*(2.*DK+APB)
+       A1 = 2.0_xp*DK*(DK+APB)*(2.0_xp*DK+APB-2.0_xp)
+       A2 = (2.0_xp*DK+APB-1.0_xp)*(ALP**2-BET**2)
+       B3 = (2.0_xp*DK+APB-2.0_xp)
+       A3 = B3*(B3+1.0_xp)*(B3+2.0_xp)
+       A4 = 2.0_xp*(DK+ALP-1.0_xp)*(DK+BET-1.0_xp)*(2.0_xp*DK+APB)
        POLYN = ((A2+A3*X)*POLY-A4*POLYL)/A1
        PDERN = ((A2+A3*X)*PDER-A4*PDERL+A3*POLY)/A1
        PSAVE = POLYL
@@ -603,8 +603,8 @@ contains
 !---------------------------------------------------------------------
     implicit real(kind=xp) (A-H,O-Z)
     real(kind=xp) Z,ZGJ(1),ALPHA,BETA
-    EPS = 1.e-5
-    ONE = 1.
+    EPS = 1.0e-5_xp
+    ONE = 1.0_xp
     ZI = ZGJ(II)
     DZ = Z-ZI
     if (abs(DZ) .lt. EPS) then
@@ -654,8 +654,8 @@ contains
 !---------------------------------------------------------------------
     implicit real(kind=xp) (A-H,O-Z)
     real(kind=xp) Z,ZGLJ(1),ALPHA,BETA
-    EPS = 1.e-5
-    ONE = 1.
+    EPS = 1.0e-5_xp
+    ONE = 1.0_xp
     ZI = ZGLJ(I)
     DZ = Z-ZI
     if (abs(DZ) .lt. EPS) then
@@ -663,7 +663,7 @@ contains
        return
     end if
     N = NP-1
-    DN = ((N))
+    DN = real(N, kind=xp)
     EIGVAL = -DN*(DN+ALPHA+BETA+ONE)
     call JACOBF (PI,PDI,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,ZI)
     CONST = EIGVAL*PI+ALPHA*(ONE+ZI)*PDI-BETA*(ONE-ZI)*PDI
@@ -696,7 +696,7 @@ contains
        write (6,*) 'Here Nz=',Nz
        call neko_error
     end if
-    if ((ALPHA .le. -1.) .or. (BETA .le. -1.)) then
+    if ((ALPHA .le. -1.0_xp) .or. (BETA .le. -1.0_xp)) then
        write (6,*) 'DGJ: Alpha and Beta must be greater than -1'
        call neko_error
     end if
@@ -727,9 +727,9 @@ contains
     implicit real(kind=xp) (A-H,O-Z)
     real(kind=xp) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
     N = NZ-1
-    DN = ((N))
-    ONE = 1.
-    TWO = 2.
+    DN = real(N, kind=xp)
+    ONE = 1.0_xp
+    TWO = 2.0_xp
 
     if (NZ .le. 1) then
        write (6,*) 'DGJD: Minimum number of Gauss-Lobatto points is 2'
@@ -744,7 +744,7 @@ contains
        do J = 1, NZ
           call JACOBF (PI,PDI,PM1,PDM1,PM2,PDM2,NZ,ALPHA,BETA,Z(I))
           call JACOBF (PJ,PDJ,PM1,PDM1,PM2,PDM2,NZ,ALPHA,BETA,Z(J))
-          if (I.NE.J) D(I,J) = PDI/(PDJ*(Z(I)-Z(J)))
+          if (I .ne. J) D(I,J) = PDI/(PDJ*(Z(I)-Z(J)))
           if (I .eq. J) D(I,J) = ((ALPHA+BETA+TWO)*Z(I)+ALPHA-BETA)/ &
                (TWO*(ONE-Z(I)**2))
           DT(J,I) = D(I,J)
@@ -808,9 +808,9 @@ contains
     implicit real(kind=xp) (A-H,O-Z)
     real(kind=xp) D(NZD,NZD),DT(NZD,NZD),Z(1),ALPHA,BETA
     N = NZ-1
-    DN = ((N))
-    ONE = 1.
-    TWO = 2.
+    DN = real(N, kind=xp)
+    ONE = 1.0_xp
+    TWO = 2.0_xp
     EIGVAL = -DN*(DN+ALPHA+BETA+ONE)
 
     if (NZ .le. 1) then
@@ -828,8 +828,8 @@ contains
           call JACOBF (PJ,PDJ,PM1,PDM1,PM2,PDM2,N,ALPHA,BETA,Z(J))
           CI = EIGVAL*PI-(BETA*(ONE-Z(I))-ALPHA*(ONE+Z(I)))*PDI
           CJ = EIGVAL*PJ-(BETA*(ONE-Z(J))-ALPHA*(ONE+Z(J)))*PDJ
-          if (I.NE.J) D(I,J) = CI/(CJ*(Z(I)-Z(J)))
-          if ((I .eq. J) .and. (I.NE.1) .and. (I.NE.NZ)) &
+          if (I .ne. J) D(I,J) = CI/(CJ*(Z(I)-Z(J)))
+          if ((I .eq. J) .and. (I .ne. 1) .and. (I .ne. NZ)) &
                D(I,J) = (ALPHA*(ONE+Z(I))-BETA*(ONE-Z(I)))/ &
                (TWO*(ONE-Z(I)**2))
           if ((I .eq. J) .and. (I .eq. 1)) &
@@ -860,15 +860,15 @@ contains
        write (6,*) 'Polynomial degree         =',NZ
     end if
     if (NZ .eq. 1) then
-       D(1,1) = 0.
+       D(1,1) = 0.0_rp
        return
     end if
     FN = (N)
-    d0 = FN*(FN+1.)/4.
+    d0 = FN*(FN + 1.0_rp)/4.0_rp
     do I = 1, NZ
        do J = 1, NZ
           D(I,J) = 0.0_rp
-          if (I.NE.J) D(I,J) = PNLEG(real(Z(I),xp),N)/ &
+          if (I .ne. J) D(I,J) = PNLEG(real(Z(I),xp),N)/ &
                (PNLEG(real(Z(J),xp),N)*(Z(I)-Z(J)))
           if ((I .eq. J) .and. (I .eq. 1)) D(I,J) = -d0
           if ((I .eq. J) .and. (I .eq. NZ)) D(I,J) = d0
@@ -886,15 +886,15 @@ contains
 !---------------------------------------------------------------------
     implicit real(kind=xp) (A-H,O-Z)
     real(kind=xp) ZGLL(1), EPS, DZ, Z
-    EPS = 1.E-5
+    EPS = 1.0e-5_xp
     DZ = Z - ZGLL(I)
     if (abs(DZ) .lt. EPS) then
-       HGLL = 1.
+       HGLL = 1.0_xp
        return
     end if
     N = NZ - 1
-    ALFAN = (N)*((N)+1.)
-    HGLL = - (1.-Z*Z)*PNDLEG(Z,N)/ &
+    ALFAN = (N)*(real(N, kind=xp) + 1.0_xp)
+    HGLL = - (1.0_xp-Z*Z)*PNDLEG(Z,N)/ &
          (ALFAN*PNLEG(ZGLL(I),N)*(Z-ZGLL(I)))
   end function HGLL
 
@@ -906,10 +906,10 @@ contains
 !
 !---------------------------------------------------------------------
     real(kind=xp) ZGL(1), Z, EPS, DZ
-    EPS = 1.E-5
+    EPS = 1.0e-5_xp
     DZ = Z - ZGL(I)
     if (abs(DZ) .lt. EPS) then
-       HGL = 1.
+       HGL = 1.0_xp
        return
     end if
     N = NZ-1
@@ -933,7 +933,7 @@ contains
     !if(abs(Z)  .lt.  1.0E-25) Z = 0.0
 
 
-    P1 = 1.
+    P1 = 1.0_xp
     if (N .eq. 0) then
        PNLEG = P1
        return
@@ -942,12 +942,12 @@ contains
     P3 = P2
     do K = 1, N-1
        FK = (K)
-       P3 = ((2.0_rp*FK+1.0_rp)*Z*P2 - FK*P1)/(FK+1.0_rp)
+       P3 = ((2.0_xp*FK+1.0_xp)*Z*P2 - FK*P1)/(FK+1.0_xp)
        P1 = P2
        P2 = P3
     end do
     PNLEG = P3
-    if (n .eq. 0) pnleg = 1.
+    if (n .eq. 0) pnleg = 1.0_xp
   end function PNLEG
 
   !> Evaluate Legendre polynomials of degrees 0-N at point x
@@ -957,13 +957,13 @@ contains
     real(kind=rp) :: x
     integer :: N, j
 
-    L(0) = 1.0_xp
+    L(0) = 1.0_rp
     if (N .eq. 0) return
     L(1) = x
 
     do j = 1, N-1
-       L(j+1) = ( (2.0_xp * real(j, xp) + 1.0_xp) * x * L(j) &
-            - real(j, xp) * L(j-1) ) / (real(j, xp) + 1.0_xp)
+       L(j+1) = real( ((2.0_xp * real(j,rp) + 1.0_xp) * x * L(j) &
+            - real(j, kind=xp) * L(j-1) ) / (real(j,kind=xp) + 1.0_xp), kind=rp)
     end do
   end subroutine legendre_poly
 
@@ -977,22 +977,22 @@ contains
 !----------------------------------------------------------------------
     implicit real(kind=xp) (A-H,O-Z)
     real(kind=xp) P1, P2, P1D, P2D, P3D, Z
-    P1 = 1.
+    P1 = 1.0_xp
     P2 = Z
-    P1D = 0.
-    P2D = 1.
-    P3D = 1.
+    P1D = 0.0_xp
+    P2D = 1.0_xp
+    P3D = 1.0_xp
     do K = 1, N-1
        FK = (K)
-       P3 = ((2.*FK+1.)*Z*P2 - FK*P1)/(FK+1.)
-       P3D = ((2.*FK+1.)*P2 + (2.*FK+1.)*Z*P2D - FK*P1D)/(FK+1.)
+       P3 = ((2.0_xp*FK+1.0_xp)*Z*P2 - FK*P1)/(FK+1.0_xp)
+       P3D = ((2.0_xp*FK+1.0_xp)*P2 + (2.0_xp*FK+1.0_xp)*Z*P2D - FK*P1D)/(FK+1.0_xp)
        P1 = P2
        P2 = P3
        P1D = P2D
        P2D = P3D
     end do
     PNDLEG = P3D
-    if (N .eq. 0) pndleg = 0.
+    if (N .eq. 0) pndleg = 0.0_xp
   end function PNDLEG
 
   subroutine DGLLGL (D,DT,ZM1,ZM2,IM12,NZM1,NZM2,ND1,ND2)
@@ -1010,18 +1010,18 @@ contains
     real(kind=xp) D(ND2,ND1), DT(ND1,ND2), ZM1(ND1), ZM2(ND2), IM12(ND2,ND1)
     real(kind=xp) EPS, ZP, ZQ
     if (NZM1 .eq. 1) then
-       D (1,1) = 0.
-       DT(1,1) = 0.
+       D (1,1) = 0.0_xp
+       DT(1,1) = 0.0_xp
        return
     end if
-    EPS = 1.E-6
+    EPS = 1.0E-6_xp
     NM1 = NZM1-1
     do IP = 1, NZM2
        do JQ = 1, NZM1
           ZP = ZM2(IP)
           ZQ = ZM1(JQ)
           if ((abs(ZP) .lt. EPS) .and. (abs(ZQ) .lt. EPS)) then
-             D(IP,JQ) = 0.
+             D(IP,JQ) = 0.0_xp
           else
              D(IP,JQ) = (PNLEG(ZP,NM1)/PNLEG(ZQ,NM1) &
                   -IM12(IP,JQ))/(ZP-ZQ)
@@ -1112,9 +1112,9 @@ contains
        call neko_error
     end if
 
-    EPS = 1.e-6
-    ONE = 1.
-    TWO = 2.
+    EPS = 1.0e-6_xp
+    ONE = 1.0_xp
+    TWO = 2.0_xp
     NGL = NPGL-1
     DN = ((NGL))
     EIGVAL = -DN*(DN+ALPHA+BETA+ONE)
@@ -1151,8 +1151,8 @@ contains
 !--------------------------------------------------------------------
     real(kind=xp) I12(ND2,ND1),IT12(ND1,ND2),Z1(ND1),Z2(ND2), ZI
     if (NZ1 .eq. 1) then
-       I12 (1,1) = 1.
-       IT12(1,1) = 1.
+       I12 (1,1) = 1.0_xp
+       IT12(1,1) = 1.0_xp
        return
     end if
     do I = 1, NZ2
@@ -1176,8 +1176,8 @@ contains
 !--------------------------------------------------------------------
     real(kind=xp) I12(ND2,ND1),IT12(ND1,ND2),Z1(ND1),Z2(ND2),ZI
     if (NZ1 .eq. 1) then
-       I12 (1,1) = 1.
-       IT12(1,1) = 1.
+       I12 (1,1) = 1.0_xp
+       IT12(1,1) = 1.0_xp
        return
     end if
     do I = 1, NZ2
@@ -1202,8 +1202,8 @@ contains
 !--------------------------------------------------------------------
     real(kind=xp) I12(ND2,ND1),IT12(ND1,ND2),Z1(ND1),Z2(ND2),ZI,ALPHA,BETA
     if (NZ1 .eq. 1) then
-       I12 (1,1) = 1.
-       IT12(1,1) = 1.
+       I12 (1,1) = 1.0_xp
+       IT12(1,1) = 1.0_xp
        return
     end if
     do I = 1, NZ2
@@ -1228,8 +1228,8 @@ contains
 !--------------------------------------------------------------------
     real(kind=xp) I12(ND2,ND1),IT12(ND1,ND2),Z1(ND1),Z2(ND2),ZI,ALPHA,BETA
     if (NZ1 .eq. 1) then
-       I12 (1,1) = 1.
-       IT12(1,1) = 1.
+       I12 (1,1) = 1.0_xp
+       IT12(1,1) = 1.0_xp
        return
     end if
     do I = 1, NZ2


### PR DESCRIPTION
This PR refactors the entire speclib module.

- Implicit variables are removed
- Explicit specification of precision are done for (hopefully) all variables.
- Attempt at eliminating implicit type casting.

This will require a high level of testing, I hope you can help me verify that this does not break stuff. Especially performance