### PR TITLE
Use POSIX-compliant test command in backend compilation script

### DIFF
--- a/makeneko.in
+++ b/makeneko.in
@@ -183,7 +183,7 @@ _ACEOF
 
 # Compile backend files
 USER_BCKND_OBJ=''
-if [[ ! -z "$USER_BCKND_FILES" ]]; then
+if [ ! -z "$USER_BCKND_FILES" ]; then
     for file in $USER_BCKND_FILES; do
         if [ $HAVE_CUDA_BCKND -eq 1 ]; then
             $NVCC -c $CUDA_ARCH $CUDA_CFLAGS -I$includedir_pkg -I./ "$file" -o "${file%.cu}.o"


### PR DESCRIPTION
Replace the `[[` test command with `[` for better compatibility across different shell environments.