### PR TITLE
Change stream ordering in FDM compute

### DIFF
--- a/src/math/schwarz.f90
+++ b/src/math/schwarz.f90
@@ -96,7 +96,7 @@ module schwarz
      type(gs_t), pointer :: gs_h
      type(mesh_t), pointer :: msh
      type(c_ptr) :: event
-     logical :: local_gs
+     logical :: local_gs = .false.
    contains
      procedure, pass(this) :: init => schwarz_init
      procedure, pass(this) :: free => schwarz_free


### PR DESCRIPTION
Change how Schwarz is compute on devices, and fix a "false" stream dependency, which casused FDM to interfere with other streams (blocking them) for multithreaded runs.

With both math and bcs accepting optional stream arguments, we move all FDM computations to `aux_cmd_queue`, and remove false dependncy on `glb_cmd_queue` due to the usage of a shared gather-scatter from the coarse grid solver (passed down from hsmg).

For multithreaded runs, we are now creating a copy of the passed down gather-scatter such that we can use it in parallel with the coarse grid solver.