### PR TITLE
Revert new gs sync introduced in #2010

### DIFF
--- a/src/gs/bcknd/device/gs_device_mpi.F90
+++ b/src/gs/bcknd/device/gs_device_mpi.F90
@@ -417,11 +417,10 @@ contains
   end subroutine gs_device_mpi_nbrecv
 
   !> Wait for non-blocking operations
-  subroutine gs_device_mpi_nbwait(this, u, n, op, deps, strm)
+  subroutine gs_device_mpi_nbwait(this, u, n, op, strm)
     class(gs_device_mpi_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
-    type(c_ptr), intent(inout) :: deps
     type(c_ptr), intent(inout) :: strm
     integer :: op, done_req, i
     type(c_ptr) :: u_d
@@ -453,11 +452,6 @@ contains
        call device_sync(strm)
 
     else
-
-       ! Sync unpacking streams with deps.
-       do i = 1, size(this%recv_pe)
-          call device_stream_wait_event(this%stream(i), deps, 0)
-       end do
 
        do while(device_mpi_waitany(size(this%recv_pe), &
             this%recv_buf%reqs, done_req) .ne. 0)

--- a/src/gs/bcknd/device/gs_device_nccl.F90
+++ b/src/gs/bcknd/device/gs_device_nccl.F90
@@ -306,11 +306,10 @@ contains
   end subroutine gs_device_nccl_nbrecv
 
   !> Wait for non-blocking operations
-  subroutine gs_device_nccl_nbwait(this, u, n, op, deps, strm)
+  subroutine gs_device_nccl_nbwait(this, u, n, op, strm)
     class(gs_device_nccl_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
-    type(c_ptr), intent(inout) :: deps
     type(c_ptr), intent(inout) :: strm
     integer :: op, done_req, i
     type(c_ptr) :: u_d

--- a/src/gs/bcknd/device/gs_device_shmem.F90
+++ b/src/gs/bcknd/device/gs_device_shmem.F90
@@ -318,11 +318,10 @@ contains
   end subroutine gs_device_shmem_nbrecv
 
   !> Wait for non-blocking operations
-  subroutine gs_device_shmem_nbwait(this, u, n, op, deps, strm)
+  subroutine gs_device_shmem_nbwait(this, u, n, op, strm)
     class(gs_device_shmem_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
-    type(c_ptr), intent(inout) :: deps
     type(c_ptr), intent(inout) :: strm
     integer :: op, done_req, i
     type(c_ptr) :: u_d

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -1407,14 +1407,12 @@ contains
     call gs%bcknd%gather(gs%local_gs, m, lo, gs%local_dof_gs, u, n, &
          gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, op, .false.)
     call gs%bcknd%scatter(gs%local_gs, m, gs%local_dof_gs, u, n, &
-         gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, &
-         .false., gs%bcknd%scatter_event)
+         gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, .false., C_NULL_PTR)
     call profiler_end_region("gs_local", 12)
     ! Scatter shared dofs
     if (pe_size .gt. 1) then
        call profiler_start_region("gs_nbwait", 7)
-       call gs%comm%nbwait(gs%shared_gs, l, op, &
-            gs%bcknd%scatter_event, gs%bcknd%gs_stream)
+       call gs%comm%nbwait(gs%shared_gs, l, op, gs%bcknd%gs_stream)
        call profiler_end_region("gs_nbwait", 7)
        call profiler_start_region("gs_scatter_shared", 15)
        if (present(event)) then

--- a/src/gs/gs_comm.f90
+++ b/src/gs/gs_comm.f90
@@ -125,10 +125,9 @@ module gs_comm
   !! @param u, data to store operation into
   !! @param n, length of u (redundant)
   !! @param op, gather scatter operation to carry out
-  !! @param deps, (local) scatter_event (for device aware mpi)
   !! @param strm, device stream to execute this operation on
   abstract interface
-     subroutine gs_nbwait(this, u, n, op, deps, strm)
+     subroutine gs_nbwait(this, u, n, op, strm)
        import gs_comm_t
        import stack_i4_t
        import c_ptr
@@ -137,7 +136,6 @@ module gs_comm
        integer, intent(in) :: n
        real(kind=rp), dimension(n), intent(inout) :: u
        integer :: op
-       type(c_ptr), intent(inout) :: deps
        type(c_ptr), intent(inout) :: strm
      end subroutine gs_nbwait
   end interface

--- a/src/gs/gs_mpi.f90
+++ b/src/gs/gs_mpi.f90
@@ -185,11 +185,10 @@ contains
   end subroutine gs_nbrecv_mpi
 
   !> Wait for non-blocking operations
-  subroutine gs_nbwait_mpi(this, u, n, op, deps, strm)
+  subroutine gs_nbwait_mpi(this, u, n, op, strm)
     class(gs_mpi_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
-    type(c_ptr), intent(inout) :: deps
     type(c_ptr), intent(inout) :: strm
     integer :: i, j, src, ierr
     integer :: op


### PR DESCRIPTION
Revert new gs sync introduced in #2010, it did not solve any race, since both local and shared scatter operations is performed in the same stream, thus these can't overlap