### PR TITLE
Fix typo in makeneko or compiling with hip

### DIFF
--- a/makeneko.in
+++ b/makeneko.in
@@ -18,7 +18,7 @@ fi
 HAVE_HIP_BCKND=@hip_bcknd@
 if [ $HAVE_HIP_BCKND -eq 1 ]; then
     HIPCC=@HIPCC@
-    HIP_HIPCC_CFLAGS='@HIP_HIPCC_CFLAGS@'
+    HIP_HIPCC_FLAGS='@HIP_HIPCC_FLAGS@'
 fi
 
 printf "\n%s\n" 'N E K O build tool, Version @PACKAGE_VERSION@'


### PR DESCRIPTION
Small typo in makeneko for compiling on hip backends.

Probably good to cherry-pick into release as well!