### PR TITLE
Add extra precision type to device 

### DIFF
--- a/src/device/device_config.h.in
+++ b/src/device/device_config.h.in
@@ -10,6 +10,7 @@
  * @note Set to the same C/C++ equivalent type as @a rp
  */
 typedef @NEKO_DEV_REAL_TYPE@ real;
+typedef @NEKO_DEV_XREAL_TYPE@ real_xp;
 
 extern void *glb_ctx;
 extern void *glb_cmd_queue;


### PR DESCRIPTION
Adds the extra precision type `real_xp` for usage in device kernels.

@njansson should this also be added to [src/api/neko.h.in](https://github.com/ExtremeFLOW/neko/blob/0d5f137f088fa1399b629bade601a73eea2d701d/src/api/neko.h.in#L7)?