### PR TITLE
Add configuration information to package

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -263,6 +263,17 @@ fi
 # Checks for OpenCL backend
 AX_OPENCL
 
+# Set the NEKO_BCKND variable
+if test "x${have_cuda}" = xyes; then
+   AC_SUBST(NEKO_BCKND, "CUDA")
+elif test "x${have_hip}" = xyes; then
+   AC_SUBST(NEKO_BCKND, "HIP")
+elif test "x${have_opencl}" = xyes; then
+   AC_SUBST(NEKO_BCKND, "OpenCL")
+else
+   AC_SUBST(NEKO_BCKND, "none")
+fi
+
 # Check if device aware MPI is requested
 if (test "x${have_cuda}" = xyes ||
     test "x${have_hip}" = xyes  ||

--- a/neko.pc.in
+++ b/neko.pc.in
@@ -5,6 +5,10 @@ includedir=${prefix}/include
 includedir_pkg=${prefix}/include/neko
 compiler=@FC@
 
+# A couple of custom variables to communicate with consumers of the package
+precision=@NEKO_REAL_TYPE@
+backend=@NEKO_BCKND@
+
 Name: NEKO
 Version: @PACKAGE_VERSION@
 Description:


### PR DESCRIPTION
- Real precision.
- Backend supported.

This helps consuming packages know how neko was compiled. Specificly the backend information makes configuration of external packages much easier.