### PR TITLE
Use 'nobase' installation for all headers except fortran modules

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -582,9 +582,7 @@ neko_LDADD= libneko.la
 endif
 
 pkginclude_HEADERS = \
-	$(wildcard *.mod)\
-	device/device_config.h\
-	common/neko_log.h
+	$(wildcard *.mod)
 
 if ENABLE_HIP
 pkginclude_HEADERS += device/hip/check.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -584,19 +584,6 @@ endif
 pkginclude_HEADERS = \
 	$(wildcard *.mod)
 
-if ENABLE_HIP
-pkginclude_HEADERS += device/hip/check.h
-endif
-
-if ENABLE_CUDA
-pkginclude_HEADERS += device/cuda/check.h
-endif
-
-if ENABLE_OPENCL
-pkginclude_HEADERS += device/opencl/check.h
-endif
-
-
 CLEANFILES = *.mod\
 	     *.smod
 


### PR DESCRIPTION
This will put all headers installed by Neko under `prefix/include/neko/<internal_path>/`, instead of some of them being placed under `prefix/include`. Fortran modules will still be installed under the base include path.
