### PR TITLE
Fix: missing multi-scalar output when no temperature output

### DIFF
--- a/doc/pages/user-guide/user-file.md
+++ b/doc/pages/user-guide/user-file.md
@@ -329,12 +329,14 @@ is shown below.
        call field_rzero(v)
        call field_rzero(w)
     else !scalar
-       s => fields%get("s")
-       do i = 1, s%dof%size()
-          x = s%dof%x(i,1,1,1)
-          y = s%dof%y(i,1,1,1)
-          s%x(i,1,1,1) = sin(x)
-       end do
+       s => fields%get(scheme_name)
+       if (scheme_name .eq. 's1') then
+          do i = 1, s%dof%size()
+             x = s%dof%x(i,1,1,1)
+             y = s%dof%y(i,1,1,1)
+             s%x(i,1,1,1) = sin(x)
+          end do
+       end if
     end if
   end subroutine initial_conditions
 
@@ -344,8 +346,9 @@ Not again the usage of `scheme_name` to distinguish between the fluid and the
 scalar. Depending on the scheme, the contents of the field list `fields`
 changes, and we extract individual fields via field pointers accordingly.
 The incompressible fluid solver always generates solution fields, `u`, `v` and
-`w`. For the scalar, the name of the field coinside with `scheme_name`, both
-defaulting to `s`.
+`w`. For the scalar, the name of the field coincides with `scheme_name`. For single
+scalar cases, this defaults to `s`. For multiple scalar cases, the field name is
+set to the scalar name specified in the JSON configuration (e.g., "s1", "s2", etc.).
 
 @note Notice that the code for the scalar runs on the CPU. There is no need to
 add the transfer to GPU memory in this user routine, it will be done under the

--- a/src/io/bp_file.F90
+++ b/src/io/bp_file.F90
@@ -188,15 +188,27 @@ contains
           u%ptr => data%items(2)%ptr%x(:,1,1,1)
           v%ptr => data%items(3)%ptr%x(:,1,1,1)
           w%ptr => data%items(4)%ptr%x(:,1,1,1)
-          tem%ptr => data%items(5)%ptr%x(:,1,1,1)
-          n_scalar_fields = data%size() - 5
-          allocate(scalar_fields(n_scalar_fields))
-          do i = 1, n_scalar_fields
-             scalar_fields(i)%ptr => data%items(i+5)%ptr%x(:,1,1,1)
-          end do
+          ! Check if position 5 is a temperature field by name
+          if (trim(data%name(5)) .eq. 'temperature') then
+             ! Position 5 is temperature, remaining fields are scalars
+             tem%ptr => data%items(5)%ptr%x(:,1,1,1)
+             n_scalar_fields = data%size() - 5
+             allocate(scalar_fields(n_scalar_fields))
+             do i = 1, n_scalar_fields
+                scalar_fields(i)%ptr => data%items(i+5)%ptr%x(:,1,1,1)
+             end do
+             write_temperature = .true.
+          else
+             ! All remaining fields are scalars (no temperature field)
+             n_scalar_fields = data%size() - 4
+             allocate(scalar_fields(n_scalar_fields))
+             do i = 1, n_scalar_fields
+                scalar_fields(i)%ptr => data%items(i+4)%ptr%x(:,1,1,1)
+             end do
+             write_temperature = .false.
+          end if
           write_pressure = .true.
           write_velocity = .true.
-          write_temperature = .true.
        case default
           call neko_error('This many fields not supported yet, bp_file')
        end select

--- a/src/io/fld_file.f90
+++ b/src/io/fld_file.f90
@@ -213,15 +213,27 @@ contains
           u%ptr => data%items(2)%ptr%x(:,1,1,1)
           v%ptr => data%items(3)%ptr%x(:,1,1,1)
           w%ptr => data%items(4)%ptr%x(:,1,1,1)
-          tem%ptr => data%items(5)%ptr%x(:,1,1,1)
-          n_scalar_fields = data%size() - 5
-          allocate(scalar_fields(n_scalar_fields))
-          do i = 1, n_scalar_fields
-             scalar_fields(i)%ptr => data%items(i+5)%ptr%x(:,1,1,1)
-          end do
+          ! Check if position 5 is a temperature field by name
+          if (trim(data%name(5)) .eq. 'temperature') then
+             ! Position 5 is temperature, remaining fields are scalars
+             tem%ptr => data%items(5)%ptr%x(:,1,1,1)
+             n_scalar_fields = data%size() - 5
+             allocate(scalar_fields(n_scalar_fields))
+             do i = 1, n_scalar_fields
+                scalar_fields(i)%ptr => data%items(i+5)%ptr%x(:,1,1,1)
+             end do
+             write_temperature = .true.
+          else
+             ! All remaining fields are scalars (no temperature field)
+             n_scalar_fields = data%size() - 4
+             allocate(scalar_fields(n_scalar_fields))
+             do i = 1, n_scalar_fields
+                scalar_fields(i)%ptr => data%items(i+4)%ptr%x(:,1,1,1)
+             end do
+             write_temperature = .false.
+          end if
           write_pressure = .true.
           write_velocity = .true.
-          write_temperature = .true.
        case default
           call neko_error('This many fields not supported yet, fld_file')
        end select


### PR DESCRIPTION
## Problem

For example if there're 4 scalars, only 3 of them are written to the output file because fld_file.f90 assumes there's always temperature at the 5th position.