### PR TITLE
Add linter rule for .eqv. boolean comparisons

### DIFF
--- a/flinter_rc.yml
+++ b/flinter_rc.yml
@@ -142,6 +142,12 @@ regexp-rules:
     replacement: null
     active: true
 
+  not-recommended-equivalent-post:
+    message: Equivalent boolean comparison to true/false are not recommended
+    regexp: (\.eqv\.\s*(\.true\.|\.false\.))|((\.true\.|\.false\.)\s*\.eqv\.)
+    replacement: null
+    active: true
+
   # -------------------------------------------------------------------------- #
   # Formatting and code style rules
 


### PR DESCRIPTION
Introduce a new linter rule to flag the use of equivalent boolean comparisons with .eqv. to promote better coding practices.