### PR TITLE
Change the definition of the elementwise_average les delta field

### DIFF
--- a/src/les/les_model.f90
+++ b/src/les/les_model.f90
@@ -313,8 +313,10 @@ contains
           do k = 1, this%coef%Xh%lx * this%coef%Xh%ly * this%coef%Xh%lz
              volume_element = volume_element + this%coef%B(k, 1, 1, e)
           end do
-          this%delta%x(:,:,:,e) = (volume_element / this%coef%Xh%lx &
-               / this%coef%Xh%ly / this%coef%Xh%lz)**(1.0_rp / 3.0_rp)
+          this%delta%x(:,:,:,e) = (volume_element / &
+                (this%coef%Xh%lx - 1.0_rp) / &
+                (this%coef%Xh%ly - 1.0_rp) / &
+                (this%coef%Xh%lz - 1.0_rp) ) ** (1.0_rp / 3.0_rp)
        end do
     else if (this%delta_type .eq. "pointwise") then
        do e = 1, this%coef%msh%nelv


### PR DESCRIPTION
The original option is directly ported from [Ntoukas et. al.](https://pdf.sciencedirectassets.com/320278/1-s2.0-S2590123024X00055/1-s2.0-S2590123025005043/main.pdf?X-Amz-Security-Token=IQoJb3JpZ2luX2VjEFYaCXVzLWVhc3QtMSJHMEUCIFjSlZhtLKnLAI4JCf2ZM%2F5dzBXFqkTzIEt6HB6uL0Y9AiEAmRw800qFb6xwpTU0TMKgCA0BciVEKGqRkeOh1NnF7zkquwUIj%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARAFGgwwNTkwMDM1NDY4NjUiDKe91XX0an4alDp6DyqPBbSu0pueiUE7YBXULjs4bmqEwIi0%2F3TE%2BFACTsIljTTANFzt0L%2B05aYK26GXV3chHAchv396KZ1lffMANbhGdr%2Fi4yDgAhl%2BQe9nUEbRXVf5AN%2Bu7r14lXrBEtKKZY92FMfjybCDFprRDHzj1KqUEHsTg8l5DqcKZub2slpzomn7JFKLQ%2F%2BYkCiE0yV8y0liY2L6%2B6vz344bDLXdg8mX5yQ%2FMf5JvMQEt0YYyUUOCZBo3kkQNUkZE6TQVHvxMiWS9AxtZpXhrKXh6vDTFOZC64nZUHzoQ4Gr0a0H0idR7V5Tem6BVvdBZRc6ctAkt6AnyCB%2FU3VkK8YtlknsxBQP7mNab0NJ0KRczBkq6g%2BFszkk1G9UWH3Ia%2Bvo4%2BevJwT4iS6KXW%2FdlYR1T18gCb3BkZCkRkYTI4LdBtuXWzwQJD8BMELcV30y0lDNA4cEi2okk%2BcGLttn8zLJi3yKPWJe1sll8xabuFljyXRilN5pPK%2FrVaRY3hDIMCixTwdxPeeFF4z2bQLXRz3BzNxUGFiEd%2FoeCRFHvSxiPXmNcEBuUcuRuK4HEYynD8GvWhJtVsRE7NGzQhW%2BLT5uHmkBrYPTYweoEtL7PNyrV2IeFIhJw4VMAJqbgRSZDbMrftHjk%2FIvbEnL0YlUv2IxdJabpGYI3TaJ6IRuqTG0ZqWwhcqLS7fluec9mvYhG03zLsv2hhl%2FU4%2BUJuNbo9fNK6SAb3M0wOt87kSic8JT%2B2h0ThDdj9JHRCMBmgXsz70N6lYcgj%2FHxfFIfSSRBowlQPn%2BG%2BR%2BOnHDPP7OBbn4kPZ%2BKSV%2Fg6qmnQ0tKdymHcO9ypAibjBCABBNg4WRx1pv8%2BLC9zmEMh7FqZXTedu3IiRMGHlWJLUw6t%2FSxAY6sQGU1Hu8u8ivUmTLSeCzCLPkQCMgPOuNZXdE%2BTQVDMxSdzoFkW6caJw8uiJjQ6pFZ9iCeK7UoN8mCPtiiFASedeeLzpvrYdivoq7PO3R8S7MqkfeY0E%2BF7VjEN4q%2Bj58%2BWMxKhUy4oLVUydWK%2BdWC60hjk3pJ3gqhsmV6at8O3m8YR1LAuS5sZry3mkoUFiexQwwXsNIZ4MBDhxTdE5Wo4FpekXKZ2drB%2Fe79bRUYMf3wLo%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20250807T151214Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=ASIAQ3PHCVTY3DGJL5OQ%2F20250807%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=730f6fe4526fca74ea9e8a640d07474fd04d7370ad88291ebdd3e3c6bfc67897&hash=feebd1f4d70a21179345df23d9e83635b0f2b9c2bde28083988bdcf314fcfd4b&host=68042c943591013ac2b2430a89b270f6af2c76d8dfd086a07176afe7c76c2c61&pii=S2590123025005043&tid=spdf-f9f26539-f8e5-4871-a4c7-885077ce7ad9&sid=cff09cef7f7d32482d49aa044a4ac46259cdgxrqa&type=client&tsoh=d3d3LnNjaWVuY2VkaXJlY3QuY29t&rh=d3d3LnNjaWVuY2VkaXJlY3QuY29t&ua=0b0c58560458045355&rr=96b7b6091a1edd4e&cc=hk). However, they used Gauss points which do not overlap on the elementary interfaces. In our case for GLL points, this setting is a bit questionable. So maybe we could change it to the average GLL spacing?