### PR TITLE
Only check for layout for BP files

### DIFF
--- a/src/io/file.f90
+++ b/src/io/file.f90
@@ -137,7 +137,7 @@ contains
        call this%set_precision(precision)
     end if
 
-    if (present(layout)) then
+    if (present(layout).and. (suffix .eq. "bp")) then
        call this%set_layout(layout)
     end if
 


### PR DESCRIPTION
Revert layout changes added by #2307, causing unnecessary warnings to be thrown