### PR TITLE
Correct precision replacement

### DIFF
--- a/src/scripts/cltostring.sh.in
+++ b/src/scripts/cltostring.sh.in
@@ -3,6 +3,6 @@ IN=$(basename $1)
 NAME=${IN%.cl}
 
 echo "const char *"${NAME}" =" > $1.h
-$(SED) -e 's/\\/\\\\/g;s/"/\\"/g;s/^/"/;s/$/\\n"/;s/real/@NEKO_DEV_REAL_TYPE@/g' \
+@SED@ -e 's/\\/\\\\/g;s/"/\\"/g;s/^/"/;s/$/\\n"/;s/real/@NEKO_DEV_REAL_TYPE@/g' \
     $1 >> $1.h
 echo ";" >>$1.h


### PR DESCRIPTION
## Context

On Macbook, develop branch builds with opencl but I cannot run examples

## Solution

When generating `.cl.h`, it should replace all occurences of `real` in each line with correct `float` or `double`, not just the first one.