### PR TITLE
Remove size check during vector allocation

### DIFF
--- a/src/math/vector.f90
+++ b/src/math/vector.f90
@@ -97,7 +97,6 @@ contains
     class(vector_t), intent(inout) :: a
     integer, intent(in) :: n
 
-    if (n .eq. 0) call neko_error('Vector cannot have size 0')
 
     if (a%n .eq. n) return
     call a%free()


### PR DESCRIPTION
Don't throw an error for zero sized vector allocations. This fixes #2062 (and probably more places after #2026).

Note: there's still enough checks in vector to avoid invalid launch configurations on devices for zero sized vectors.