### PR TITLE
Use math.f90 for cpu ops in vector

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -115,7 +115,7 @@ math/bcknd/cpu/fdm_cpu.lo : math/bcknd/cpu/fdm_cpu.f90 math/bcknd/cpu/tensor_cpu
 math/bcknd/sx/fdm_sx.lo : math/bcknd/sx/fdm_sx.f90 math/bcknd/sx/tensor_sx.lo config/num_types.lo 
 math/bcknd/xsmm/fdm_xsmm.lo : math/bcknd/xsmm/fdm_xsmm.f90 math/bcknd/xsmm/tensor_xsmm.lo config/num_types.lo 
 math/schwarz.lo : math/schwarz.f90 bc/bc_list.lo config/neko_config.lo device/device.lo math/fdm.lo math/bcknd/device/device_math.lo math/bcknd/device/device_schwarz.lo gs/gather_scatter.lo sem/dofmap.lo sem/space.lo mesh/mesh.lo math/math.lo config/num_types.lo 
-math/vector.lo : math/vector.f90 common/utils.lo math/bcknd/device/device_math.lo device/device.lo config/num_types.lo math/math.lo config/neko_config.lo 
+math/vector.lo : math/vector.f90 common/utils.lo math/bcknd/device/device_math.lo math/math.lo device/device.lo config/num_types.lo config/neko_config.lo 
 math/vector_math.lo : math/vector_math.f90 math/bcknd/device/device_math.lo math/math.lo device/device.lo math/vector.lo config/num_types.lo config/neko_config.lo 
 math/matrix.lo : math/matrix.f90 common/utils.lo math/bcknd/device/device_math.lo device/device.lo config/num_types.lo math/math.lo config/neko_config.lo 
 math/signed_distance.lo : math/signed_distance.f90 adt/stack.lo mesh/search_tree/aabb.lo mesh/point.lo common/utils.lo config/neko_config.lo device/device.lo mesh/aabb_tree.lo mesh/tri_mesh.lo mesh/tri.lo field/field.lo config/num_types.lo 

--- a/src/math/vector.f90
+++ b/src/math/vector.f90
@@ -33,13 +33,10 @@
 !> Defines a vector
 module vector
   use neko_config, only: NEKO_BCKND_DEVICE
-  use math, only: sub3, chsign, add3, cmult2, cadd2, cfill, copy, col3, cdiv2, &
-       col2, invcol3
   use num_types, only: rp
   use device, only: device_map, device_free
-  use device_math, only: device_copy, device_cfill, device_cmult, &
-       device_sub3, device_cmult2, device_add3, device_cadd2, device_col3, &
-       device_col2, device_invcol3, device_cdiv2
+  use math, only: cfill, copy
+  use device_math, only: device_copy, device_cfill
   use utils, only: neko_error
   use, intrinsic :: iso_c_binding
   implicit none
@@ -85,7 +82,7 @@ contains
     integer, intent(in) :: n
 
     call v%alloc(n)
-    v%x = 0.0_rp
+    call cfill(v%x, 0.0_rp, n)
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_cfill(v%x_d, 0.0_rp, n)
     end if
@@ -141,7 +138,7 @@ contains
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_copy(v%x_d, w%x_d, v%n)
     else
-       v%x = w%x
+       call copy(v%x, w%x, v%n)
     end if
 
   end subroutine vector_assign_vector
@@ -150,8 +147,6 @@ contains
   subroutine vector_assign_scalar(v, s)
     class(vector_t), intent(inout) :: v
     real(kind=rp), intent(in) :: s
-
-    if (v%n .eq. 0) call neko_error('Vector not allocated')
 
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_cfill(v%x_d, s, v%n)


### PR DESCRIPTION
For `vector_t`

* Removes size check in assignment.
* Use cfill and copy instead of intrinsic `=` so that it runs for zero-sized vectors.

Prompted by crash in the wall_model_bc_t as reported by Sachin on Zulip. See #2062, which still persists on develop.