### PR TITLE
add the missing link

### DIFF
--- a/src/io/file.f90
+++ b/src/io/file.f90
@@ -275,6 +275,8 @@ contains
     character(len=80) :: suffix
 
     select type (ft => this%file_type)
+    type is (csv_file_t)
+       call ft%set_overwrite(overwrite)
     class default
        call filename_suffix(this%file_type%fname, suffix)
        call neko_warning("No set_overwrite defined for " // trim(suffix) // &


### PR DESCRIPTION
## Problem

This is not currently overriding the csv file but appending

```fortran
call file%init("output.csv", overwrite=.true.)
```

## Changes

Fix the problem.