### PR TITLE
Fix invalid poly. declaration

### DIFF
--- a/src/io/mean_field_output.f90
+++ b/src/io/mean_field_output.f90
@@ -84,7 +84,7 @@ contains
        coef, avg_dir, name, path)
     class(mean_field_output_t), intent(inout):: this
     integer, intent(in) :: n_fields
-    class(mean_field_t), intent(inout), target :: mean_fields(n_fields)
+    type(mean_field_t), intent(inout), target :: mean_fields(n_fields)
     type(coef_t), intent(inout) :: coef
     character(len=*), intent(in) :: avg_dir
     character(len=*), intent(in), optional :: name


### PR DESCRIPTION
Fixes the following issue deteced by NAG

Error: io/mean_field_output.f90, line 87: Polymorphic array MEAN_FIELDS that is not deferred-shape, assumed-shape, or assumed-rank, is not yet supported
