### PR TITLE
Add kstep versions of kernels and add autotuner

### DIFF
--- a/src/device/device.F90
+++ b/src/device/device.F90
@@ -53,6 +53,11 @@ module device
   !> Aux command queue
   type(c_ptr), public, bind(c) :: aux_cmd_queue = C_NULL_PTR
 
+#ifdef HAVE_OPENCL
+  !> Profiling command queue
+  type(c_ptr), public, bind(c) :: prf_cmd_queue = C_NULL_PTR
+#endif
+
   !> Event for the global command queue
   type(c_ptr), public, bind(c) :: glb_cmd_event
 
@@ -128,7 +133,7 @@ contains
 #elif HAVE_CUDA
     call cuda_init(glb_cmd_queue, aux_cmd_queue, STRM_HIGH_PRIO, STRM_LOW_PRIO)
 #elif HAVE_OPENCL
-    call opencl_init(glb_cmd_queue, aux_cmd_queue)
+    call opencl_init(glb_cmd_queue, aux_cmd_queue, prf_cmd_queue)
 #endif
     call device_event_create(glb_cmd_event, 2)
 #endif
@@ -151,7 +156,7 @@ contains
     call cuda_finalize(glb_cmd_queue, aux_cmd_queue)
 #elif HAVE_OPENCL
     call opencl_prgm_lib_release
-    call opencl_finalize(glb_cmd_queue, aux_cmd_queue)
+    call opencl_finalize(glb_cmd_queue, aux_cmd_queue, prf_cmd_queue)
 #endif
     call device_event_destroy(glb_cmd_event)
 #endif

--- a/src/device/device_config.h.in
+++ b/src/device/device_config.h.in
@@ -16,4 +16,11 @@ extern void *glb_ctx;
 extern void *glb_cmd_queue;
 extern void *glb_device_id;
 
+#ifdef HAVE_OPENCL
+/** 
+ * OpenCL queue with profiling enabled
+ */
+extern void *prf_cmd_queue;
+#endif
+
 #endif // __DEVICE_DEVICE_CONFIG__

--- a/src/device/opencl_intf.F90
+++ b/src/device/opencl_intf.F90
@@ -421,7 +421,7 @@ contains
     end if
 
     if (clGetDeviceIDs(platform_id, CL_DEVICE_TYPE_GPU, 1, &
-                       c_loc(glb_device_id), num_devices) .ne. CL_SUCCESS) then
+         c_loc(glb_device_id), num_devices) .ne. CL_SUCCESS) then
        call neko_error('Failed to get a device id')
     end if
 
@@ -432,7 +432,7 @@ contains
     end if
 
     glb_ctx = clCreateContext(C_NULL_PTR, num_devices, c_loc(glb_device_id), &
-                              C_NULL_FUNPTR, C_NULL_PTR, ierr)
+         C_NULL_FUNPTR, C_NULL_PTR, ierr)
 
     if (ierr .ne. CL_SUCCESS) then
        call neko_error('Failed to create an OpenCL context')
@@ -444,20 +444,20 @@ contains
        end if
     end if
 
-    glb_cmd_queue = clCreateCommandQueue(glb_ctx, glb_device_id, queue_props, &
-                                         ierr)
+    glb_cmd_queue = clCreateCommandQueue(glb_ctx, glb_device_id, &
+         queue_props, ierr)
     if (ierr .ne. CL_SUCCESS) then
        call neko_error('Failed to create a command queue')
     end if
 
-    aux_cmd_queue = clCreateCommandQueue(glb_ctx, glb_device_id, queue_props, &
-                                         ierr)
+    aux_cmd_queue = clCreateCommandQueue(glb_ctx, glb_device_id, &
+         queue_props, ierr)
     if (ierr .ne. CL_SUCCESS) then
        call neko_error('Failed to create a command queue')
     end if
 
     prf_cmd_queue = clCreateCommandQueue(glb_ctx, glb_device_id, &
-                                         CL_QUEUE_PROFILING_ENABLE, ierr)
+         CL_QUEUE_PROFILING_ENABLE, ierr)
     if (ierr .ne. CL_SUCCESS) then
        call neko_error('Failed to create a command queue')
     end if
@@ -511,7 +511,7 @@ contains
     integer(c_size_t), target :: name_len
 
     if (clGetDeviceInfo(glb_device_id, CL_DEVICE_NAME, int(1024, i8), &
-                        c_loc(c_name), c_loc(name_len)) .ne. CL_SUCCESS) then
+         c_loc(c_name), c_loc(name_len)) .ne. CL_SUCCESS) then
        call neko_error('Failed to query device')
     end if
 
@@ -524,13 +524,13 @@ contains
     type(c_ptr), target :: platform_id
     integer(c_int) :: num_platforms, num_devices
 
-    if (clGetPlatformIDs(1, c_loc(platform_id), &
-                         num_platforms) .ne. CL_SUCCESS) then
+    if (clGetPlatformIDs(1, c_loc(platform_id), num_platforms) &
+         .ne. CL_SUCCESS) then
        call neko_error('Failed to get a platform id')
     end if
 
     if (clGetDeviceIDs(platform_id, CL_DEVICE_TYPE_GPU, 0, &
-                       C_NULL_PTR, num_devices) .ne. CL_SUCCESS) then
+         C_NULL_PTR, num_devices) .ne. CL_SUCCESS) then
        call neko_error('Failed to get a device id')
     end if
 

--- a/src/math/bcknd/device/opencl/ax_helm.c
+++ b/src/math/bcknd/device/opencl/ax_helm.c
@@ -163,14 +163,13 @@ void opencl_ax_helm(void *w, void *u, void *dx, void *dy, void *dz,
         else {                                                                  \
           CL_CHECK(clFinish(glb_cmd_queue));                                    \
           cl_event perf_event, sync_event;                                      \
+          cl_ulong start, end;                                                  \
           CL_CHECK(clEnqueueMarker(glb_cmd_queue, &sync_event));                \
           CL_CHECK(clEnqueueBarrier(prf_cmd_queue));                            \
           CL_CHECK(clEnqueueWaitForEvents(prf_cmd_queue, 1, &sync_event));      \
                                                                                 \
           double elapsed1 = 0.0;                                                \
           for(int i = 0; i < 100; i++) {                                        \
-            cl_ulong start = 0;                                                 \
-            cl_ulong end = 0;                                                   \
             CASE_1D(LX, prf_cmd_queue, &perf_event);                            \
             CL_CHECK(clWaitForEvents(1, &perf_event));                          \
             CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
@@ -181,11 +180,9 @@ void opencl_ax_helm(void *w, void *u, void *dx, void *dy, void *dz,
                                              sizeof(cl_ulong), &end, NULL));    \
             elapsed1 += (end - start)*1.0e-6;                                   \
           }                                                                     \
-          printf("Took: %g\n", elapsed1);                                       \
+                                                                                \
           double elapsed2 = 0.0;                                                \
           for(int i = 0; i < 100; i++) {                                        \
-            cl_ulong start = 0;                                                 \
-            cl_ulong end = 0;                                                   \
             CASE_KSTEP(LX, prf_cmd_queue, &perf_event);                         \
             CL_CHECK(clWaitForEvents(1, &perf_event));                          \
             CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
@@ -196,7 +193,7 @@ void opencl_ax_helm(void *w, void *u, void *dx, void *dy, void *dz,
                                              sizeof(cl_ulong), &end, NULL));    \
             elapsed2 += (end - start)*1.0e-6;                                   \
           }                                                                     \
-          printf("Took: %g\n", elapsed2);                                       \
+                                                                                \
           CL_CHECK(clFinish(prf_cmd_queue));                                    \
           CL_CHECK(clEnqueueMarker(prf_cmd_queue, &sync_event));                \
           int krnl_strtgy = (elapsed1 < elapsed2 ? 1 : 2);                      \

--- a/src/math/bcknd/device/opencl/ax_helm.c
+++ b/src/math/bcknd/device/opencl/ax_helm.c
@@ -182,9 +182,8 @@ void opencl_ax_helm(void *w, void *u, void *dx, void *dy, void *dz,
             elapsed1 += (end - start)*1.0e-6;                                   \
           }                                                                     \
           printf("Took: %g\n", elapsed1);                                       \
-          CL_CHECK(clFinish(prf_cmd_queue));                                    \
           double elapsed2 = 0.0;                                                \
-          for(int i = 0; i < 0; i++) {                                          \
+          for(int i = 0; i < 100; i++) {                                        \
             cl_ulong start = 0;                                                 \
             cl_ulong end = 0;                                                   \
             CASE_KSTEP(LX, prf_cmd_queue, &perf_event);                         \

--- a/src/math/bcknd/device/opencl/ax_helm.c
+++ b/src/math/bcknd/device/opencl/ax_helm.c
@@ -31,7 +31,7 @@
  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  POSSIBILITY OF SUCH DAMAGE.
 */
-#define CL_SILENCE_DEPRECATION
+
 #ifdef __APPLE__
 #include <OpenCL/cl.h>
 #else
@@ -230,7 +230,6 @@ void opencl_ax_helm(void *w, void *u, void *dx, void *dy, void *dz,
       exit(1);
     }
   }
-
 }
 
 /**

--- a/src/math/bcknd/device/opencl/ax_helm.c
+++ b/src/math/bcknd/device/opencl/ax_helm.c
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2022, The Neko Authors
+ Copyright (c) 2021-2025, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -40,14 +40,18 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <device/device_config.h>
 #include <device/opencl/jit.h>
 #include <device/opencl/prgm_lib.h>
 #include <device/opencl/check.h>
+#include <common/neko_log.h>
 
 #include "ax_helm_kernel.cl.h"
 
-/** 
+int *autotune_ax_helm = NULL;
+
+/**
  * Fortran wrapper for device OpenCL Ax
  */
 void opencl_ax_helm(void *w, void *u, void *dx, void *dy, void *dz,
@@ -56,16 +60,27 @@ void opencl_ax_helm(void *w, void *u, void *dx, void *dy, void *dz,
                     void *g13, void *g23, int *nelv, int *lx) {
 
   cl_int err;
-  
+
   if (ax_helm_program == NULL)
       opencl_kernel_jit(ax_helm_kernel, (cl_program *) &ax_helm_program);
-  
+
   const size_t global_item_size = 256 * (*nelv);
-  const size_t local_item_size = 256;    
+  const size_t local_item_size = 256;
+
+  size_t global_kstep[2];
+  size_t local_kstep[2];
+  local_kstep[0] = (*lx);
+  local_kstep[1] = (*lx);
+  global_kstep[0] = (*nelv) * (*lx);
+  global_kstep[1] = (*lx);
+
+  if (autotune_ax_helm == NULL) {
+    autotune_ax_helm = malloc(13 * sizeof(int));
+    memset(autotune_ax_helm, 0, 13 * sizeof(int));
+  }
 
 #define STR(X) #X
-#define CASE(LX)                                                                \
-  case LX:                                                                      \
+#define CASE_1D(LX)                                                             \
     {                                                                           \
       cl_kernel kernel = clCreateKernel(ax_helm_program,                        \
                                         STR(ax_helm_kernel_lx##LX), &err);      \
@@ -91,8 +106,67 @@ void opencl_ax_helm(void *w, void *u, void *dx, void *dy, void *dz,
                                      kernel, 1, NULL, &global_item_size,        \
                                      &local_item_size, 0, NULL, NULL));         \
                                                                                 \
-    }                                                                           \
-    break
+    }
+
+
+#define CASE_KSTEP(LX)                                                          \
+    {                                                                           \
+      cl_kernel kernel = clCreateKernel(ax_helm_program,                        \
+                                        STR(ax_helm_kernel_kstep_lx##LX), &err);\
+      CL_CHECK(err);                                                            \
+                                                                                \
+      CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &w));         \
+      CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &u));         \
+      CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &dx));        \
+      CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &dy));        \
+      CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), (void *) &dz));        \
+      CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_mem), (void *) &h1));        \
+      CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_mem), (void *) &g11));       \
+      CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_mem), (void *) &g22));       \
+      CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_mem), (void *) &g33));       \
+      CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_mem), (void *) &g12));       \
+      CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_mem), (void *) &g13));      \
+      CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_mem), (void *) &g23));      \
+                                                                                \
+     CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,          \
+                                     kernel, 2, NULL, global_kstep,             \
+                                     local_kstep, 0, NULL, NULL));              \
+                                                                                \
+    }
+
+
+#define CASE(LX)                                                                \
+  case LX:                                                                      \
+      if(autotune_ax_helm[LX] == 0 ) {                                          \
+        char *env_value = NULL;                                                 \
+        char neko_log_buf[80];                                                  \
+        env_value = getenv("NEKO_AUTOTUNE");                                    \
+                                                                                \
+        sprintf(neko_log_buf, "Autotune Ax helm (lx: %d)", *lx);                \
+        log_section(neko_log_buf);                                              \
+        if(env_value) {                                                         \
+          if( !strcmp(env_value,"1D") ) {                                       \
+            CASE_1D(LX);                                                        \
+            sprintf(neko_log_buf,"Set by env : 1 (1D)");                        \
+            log_message(neko_log_buf);                                          \
+            autotune_ax_helm[LX] = 1;                                           \
+          } else if( !strcmp(env_value,"KSTEP") ) {                             \
+            CASE_KSTEP(LX);                                                     \
+            sprintf(neko_log_buf,"Set by env : 2 (KSTEP)");                     \
+            log_message(neko_log_buf);                                          \
+            autotune_ax_helm[LX] = 2;                                           \
+          } else {                                                              \
+            sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");       \
+            log_error(neko_log_buf);                                            \
+          }                                                                     \
+        }                                                                       \
+        log_end_section();                                                      \
+      } else if (autotune_ax_helm[LX] == 1 ) {                                  \
+          CASE_1D(LX);                                                          \
+      } else if (autotune_ax_helm[LX] == 2 ) {                                  \
+          CASE_KSTEP(LX);                                                       \
+      }                                                                         \
+      break
 
   switch(*lx) {
     CASE(2);
@@ -112,4 +186,84 @@ void opencl_ax_helm(void *w, void *u, void *dx, void *dy, void *dz,
       exit(1);
     }
   }
+
+}
+
+/**
+ * Fortran wrapper for device OpenCL Ax (vector version)
+ */
+void opencl_ax_helm_vector(void *au, void *av, void *aw,
+                           void *u, void *v, void *w,
+                           void *dx, void *dy, void *dz,
+                           void *dxt, void *dyt, void *dzt, void *h1,
+                           void *g11, void *g22, void *g33, void *g12,
+                           void *g13, void *g23, int *nelv, int *lx) {
+
+  cl_int err;
+
+  if (ax_helm_program == NULL)
+      opencl_kernel_jit(ax_helm_kernel, (cl_program *) &ax_helm_program);
+
+  size_t * global_kstep = (size_t *) malloc(sizeof(size_t) * 2);
+  size_t * local_kstep = (size_t *) malloc(sizeof(size_t) * 2);
+  local_kstep[0] = (*lx);
+  local_kstep[1] = (*lx);
+  global_kstep[0] = (*nelv) * (*lx);
+  global_kstep[1] = (*lx);
+
+
+#define STR(X) #X
+#define CASE_VECTOR(LX)                                                         \
+  case LX:                                                                      \
+    {                                                                           \
+      cl_kernel kernel =                                                        \
+        clCreateKernel(ax_helm_program,                                         \
+                       STR(ax_helm_kernel_vector_kstep_lx##LX), &err);          \
+      CL_CHECK(err);                                                            \
+                                                                                \
+      CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &au));        \
+      CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &av));        \
+      CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &aw));        \
+      CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &u));         \
+      CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), (void *) &v));         \
+      CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_mem), (void *) &w));         \
+      CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_mem), (void *) &dx));        \
+      CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_mem), (void *) &dy));        \
+      CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_mem), (void *) &dz));        \
+      CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_mem), (void *) &h1));        \
+      CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_mem), (void *) &g11));      \
+      CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_mem), (void *) &g22));      \
+      CL_CHECK(clSetKernelArg(kernel, 12, sizeof(cl_mem), (void *) &g33));      \
+      CL_CHECK(clSetKernelArg(kernel, 13, sizeof(cl_mem), (void *) &g12));      \
+      CL_CHECK(clSetKernelArg(kernel, 14, sizeof(cl_mem), (void *) &g13));      \
+      CL_CHECK(clSetKernelArg(kernel, 15, sizeof(cl_mem), (void *) &g23));      \
+                                                                                \
+     CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,          \
+                                     kernel, 2, NULL, global_kstep,             \
+                                     local_kstep, 0, NULL, NULL));              \
+                                                                                \
+    }                                                                           \
+    break
+
+  switch(*lx) {
+    CASE_VECTOR(2);
+    CASE_VECTOR(3);
+    CASE_VECTOR(4);
+    CASE_VECTOR(5);
+    CASE_VECTOR(6);
+    CASE_VECTOR(7);
+    CASE_VECTOR(8);
+    CASE_VECTOR(9);
+    CASE_VECTOR(10);
+    CASE_VECTOR(11);
+    CASE_VECTOR(12);
+  default:
+    {
+      fprintf(stderr, __FILE__ ": size not supported: %d\n", *lx);
+      exit(1);
+    }
+  }
+
+  free(global_kstep);
+  free(local_kstep);
 }

--- a/src/math/bcknd/device/opencl/ax_helm_kernel.cl
+++ b/src/math/bcknd/device/opencl/ax_helm_kernel.cl
@@ -144,7 +144,6 @@ __kernel void ax_helm_kernel_lx##LX(__global real * __restrict__ w,            \
   }                                                                            \
 }
 
-DEFINE_AX_HELM_KERNEL(1, 256)
 DEFINE_AX_HELM_KERNEL(2, 256)
 DEFINE_AX_HELM_KERNEL(3, 256)
 DEFINE_AX_HELM_KERNEL(4, 256)
@@ -157,5 +156,313 @@ DEFINE_AX_HELM_KERNEL(10, 256)
 DEFINE_AX_HELM_KERNEL(11, 256)
 DEFINE_AX_HELM_KERNEL(12, 256)
 
+
+#define DEFINE_AX_HELM_KERNEL_KSTEP(LX)                                        \
+__kernel                                                                       \
+void ax_helm_kernel_kstep_lx##LX(__global real * __restrict__ w,               \
+                                 __global const real * __restrict__ u,         \
+                                 __global const real * __restrict__ dx,        \
+                                 __global const real * __restrict__ dy,        \
+                                 __global const real * __restrict__ dz,        \
+                                 __global const real * __restrict__ h1,        \
+                                 __global const real * __restrict__ g11,       \
+                                 __global const real * __restrict__ g22,       \
+                                 __global const real * __restrict__ g33,       \
+                                 __global const real * __restrict__ g12,       \
+                                 __global const real * __restrict__ g13,       \
+                                 __global const real * __restrict__ g23) {     \
+                                                                               \
+  __local real shdx[LX * LX];                                                  \
+  __local real shdy[LX * LX];                                                  \
+  __local real shdz[LX * LX];                                                  \
+                                                                               \
+  __local real shu[LX * LX];                                                   \
+  __local real shur[LX * LX];                                                  \
+  __local real shus[LX * LX];                                                  \
+                                                                               \
+  real ru[LX];                                                                 \
+  real rw[LX];                                                                 \
+  real rut;                                                                    \
+                                                                               \
+  const int e = get_group_id(0);                                               \
+  const int j = get_local_id(1);                                               \
+  const int i = get_local_id(0);                                               \
+  const int ij = i + j*LX;                                                     \
+  const int ele = e*LX*LX*LX;                                                  \
+                                                                               \
+  shdx[ij] = dx[ij];                                                           \
+  shdy[ij] = dy[ij];                                                           \
+  shdz[ij] = dz[ij];                                                           \
+                                                                               \
+  for(int k = 0; k < LX; ++k){                                                 \
+    ru[k] = u[ij + k*LX*LX + ele];                                             \
+    rw[k] = 0.0;                                                               \
+  }                                                                            \
+                                                                               \
+  barrier(CLK_LOCAL_MEM_FENCE);                                                \
+                                                                               \
+  for (int k = 0; k < LX; ++k){                                                \
+    const int ijk = ij + k*LX*LX;                                              \
+    const real G00 = g11[ijk+ele];                                             \
+    const real G11 = g22[ijk+ele];                                             \
+    const real G22 = g33[ijk+ele];                                             \
+    const real G01 = g12[ijk+ele];                                             \
+    const real G02 = g13[ijk+ele];                                             \
+    const real G12 = g23[ijk+ele];                                             \
+    const real H1  = h1[ijk+ele];                                              \
+    real ttmp = 0.0;                                                           \
+    shu[ij] = ru[k];                                                           \
+    for (int l = 0; l < LX; l++){                                              \
+      ttmp += shdz[k+l*LX] * ru[l];                                            \
+    }                                                                          \
+    barrier(CLK_LOCAL_MEM_FENCE);                                              \
+                                                                               \
+    real rtmp = 0.0;                                                           \
+    real stmp = 0.0;                                                           \
+                                                                               \
+    for (int l = 0; l < LX; l++){                                              \
+      rtmp += shdx[i+l*LX] * shu[l+j*LX];                                      \
+      stmp += shdy[j+l*LX] * shu[i+l*LX];                                      \
+    }                                                                          \
+    shur[ij] = H1                                                              \
+             * (G00 * rtmp                                                     \
+                + G01 * stmp                                                   \
+                + G02 * ttmp);                                                 \
+    shus[ij] = H1                                                              \
+             * (G01 * rtmp                                                     \
+                + G11 * stmp                                                   \
+                + G12 * ttmp);                                                 \
+    rut      = H1                                                              \
+             * (G02 * rtmp                                                     \
+                + G12 * stmp                                                   \
+                + G22 * ttmp);                                                 \
+                                                                               \
+    barrier(CLK_LOCAL_MEM_FENCE);                                              \
+                                                                               \
+    real wijke = 0.0;                                                          \
+                                                                               \
+    for (int l = 0; l < LX; l++){                                              \
+      wijke += shur[l+j*LX] * shdx[l+i*LX];                                    \
+      rw[l] += rut * shdz[k+l*LX];                                             \
+      wijke += shus[i+l*LX] * shdy[l + j*LX];                                  \
+    }                                                                          \
+    rw[k] += wijke;                                                            \
+  }                                                                            \
+                                                                               \
+  for (int k = 0; k < LX; ++k){                                                \
+    w[ij + k*LX*LX + ele] = rw[k];                                             \
+  }                                                                            \
+}
+
+DEFINE_AX_HELM_KERNEL_KSTEP(2)
+DEFINE_AX_HELM_KERNEL_KSTEP(3)
+DEFINE_AX_HELM_KERNEL_KSTEP(4)
+DEFINE_AX_HELM_KERNEL_KSTEP(5)
+DEFINE_AX_HELM_KERNEL_KSTEP(6)
+DEFINE_AX_HELM_KERNEL_KSTEP(7)
+DEFINE_AX_HELM_KERNEL_KSTEP(8)
+DEFINE_AX_HELM_KERNEL_KSTEP(9)
+DEFINE_AX_HELM_KERNEL_KSTEP(10)
+DEFINE_AX_HELM_KERNEL_KSTEP(11)
+DEFINE_AX_HELM_KERNEL_KSTEP(12)
+
+/*
+ * Vector versions
+ */
+
+
+#define DEFINE_AX_HELM_KERNEL_VECTOR_KSTEP(LX)                                 \
+__kernel void                                                                  \
+ax_helm_kernel_vector_kstep_lx##LX(__global real * __restrict__ au,            \
+                                   __global real * __restrict__ av,            \
+                                   __global real * __restrict__ aw,            \
+                                   __global const real * __restrict__ u,       \
+                                   __global const real * __restrict__ v,       \
+                                   __global const real * __restrict__ w,       \
+                                   __global const real * __restrict__ dx,      \
+                                   __global const real * __restrict__ dy,      \
+                                   __global const real * __restrict__ dz,      \
+                                   __global const real * __restrict__ h1,      \
+                                   __global const real * __restrict__ g11,     \
+                                   __global const real * __restrict__ g22,     \
+                                   __global const real * __restrict__ g33,     \
+                                   __global const real * __restrict__ g12,     \
+                                   __global const real * __restrict__ g13,     \
+                                   __global const real * __restrict__ g23) {   \
+                                                                               \
+  __local real shdx[LX * LX];                                                  \
+  __local real shdy[LX * LX];                                                  \
+  __local real shdz[LX * LX];                                                  \
+                                                                               \
+  __local real shu[LX * LX];                                                   \
+  __local real shur[LX * LX];                                                  \
+  __local real shus[LX * LX];                                                  \
+                                                                               \
+  __local real shv[LX * LX];                                                   \
+  __local real shvr[LX * LX];                                                  \
+  __local real shvs[LX * LX];                                                  \
+                                                                               \
+  __local real shw[LX * LX];                                                   \
+  __local real shwr[LX * LX];                                                  \
+  __local real shws[LX * LX];                                                  \
+                                                                               \
+  real ru[LX];                                                                 \
+  real rv[LX];                                                                 \
+  real rw[LX];                                                                 \
+                                                                               \
+  real ruw[LX];                                                                \
+  real rvw[LX];                                                                \
+  real rww[LX];                                                                \
+                                                                               \
+  real rut;                                                                    \
+  real rvt;                                                                    \
+  real rwt;                                                                    \
+                                                                               \
+  const int e = get_group_id(0);                                               \
+  const int j = get_local_id(1);                                               \
+  const int i = get_local_id(0);                                               \
+  const int ij = i + j*LX;                                                     \
+  const int ele = e*LX*LX*LX;                                                  \
+                                                                               \
+  shdx[ij] = dx[ij];                                                           \
+  shdy[ij] = dy[ij];                                                           \
+  shdz[ij] = dz[ij];                                                           \
+                                                                               \
+  for(int k = 0; k < LX; ++k){                                                 \
+    ru[k] = u[ij + k*LX*LX + ele];                                             \
+    ruw[k] = 0.0;                                                              \
+                                                                               \
+    rv[k] = v[ij + k*LX*LX + ele];                                             \
+    rvw[k] = 0.0;                                                              \
+                                                                               \
+    rw[k] = w[ij + k*LX*LX + ele];                                             \
+    rww[k] = 0.0;                                                              \
+  }                                                                            \
+                                                                               \
+  barrier(CLK_LOCAL_MEM_FENCE);                                                \
+                                                                               \
+  for (int k = 0; k < LX; ++k){                                                \
+    const int ijk = ij + k*LX*LX;                                              \
+    const real G00 = g11[ijk+ele];                                             \
+    const real G11 = g22[ijk+ele];                                             \
+    const real G22 = g33[ijk+ele];                                             \
+    const real G01 = g12[ijk+ele];                                             \
+    const real G02 = g13[ijk+ele];                                             \
+    const real G12 = g23[ijk+ele];                                             \
+    const real H1  = h1[ijk+ele];                                              \
+    real uttmp = 0.0;                                                          \
+    real vttmp = 0.0;                                                          \
+    real wttmp = 0.0;                                                          \
+    shu[ij] = ru[k];                                                           \
+    shv[ij] = rv[k];                                                           \
+    shw[ij] = rw[k];                                                           \
+    for (int l = 0; l < LX; l++){                                              \
+      uttmp += shdz[k+l*LX] * ru[l];                                           \
+      vttmp += shdz[k+l*LX] * rv[l];                                           \
+      wttmp += shdz[k+l*LX] * rw[l];                                           \
+    }                                                                          \
+    barrier(CLK_LOCAL_MEM_FENCE);                                              \
+                                                                               \
+    real urtmp = 0.0;                                                          \
+    real ustmp = 0.0;                                                          \
+                                                                               \
+    real vrtmp = 0.0;                                                          \
+    real vstmp = 0.0;                                                          \
+                                                                               \
+    real wrtmp = 0.0;                                                          \
+    real wstmp = 0.0;                                                          \
+                                                                               \
+    for (int l = 0; l < LX; l++){                                              \
+      urtmp += shdx[i+l*LX] * shu[l+j*LX];                                     \
+      ustmp += shdy[j+l*LX] * shu[i+l*LX];                                     \
+                                                                               \
+      vrtmp += shdx[i+l*LX] * shv[l+j*LX];                                     \
+      vstmp += shdy[j+l*LX] * shv[i+l*LX];                                     \
+                                                                               \
+      wrtmp += shdx[i+l*LX] * shw[l+j*LX];                                     \
+      wstmp += shdy[j+l*LX] * shw[i+l*LX];                                     \
+    }                                                                          \
+                                                                               \
+    shur[ij] = H1                                                              \
+             * (G00 * urtmp                                                    \
+                + G01 * ustmp                                                  \
+                + G02 * uttmp);                                                \
+    shus[ij] = H1                                                              \
+             * (G01 * urtmp                                                    \
+                + G11 * ustmp                                                  \
+                + G12 * uttmp);                                                \
+    rut      = H1                                                              \
+             * (G02 * urtmp                                                    \
+                + G12 * ustmp                                                  \
+                + G22 * uttmp);                                                \
+                                                                               \
+    shvr[ij] = H1                                                              \
+             * (G00 * vrtmp                                                    \
+                + G01 * vstmp                                                  \
+                + G02 * vttmp);                                                \
+    shvs[ij] = H1                                                              \
+             * (G01 * vrtmp                                                    \
+                + G11 * vstmp                                                  \
+                + G12 * vttmp);                                                \
+    rvt      = H1                                                              \
+             * (G02 * vrtmp                                                    \
+                + G12 * vstmp                                                  \
+                + G22 * vttmp);                                                \
+                                                                               \
+    shwr[ij] = H1                                                              \
+             * (G00 * wrtmp                                                    \
+                + G01 * wstmp                                                  \
+                + G02 * wttmp);                                                \
+    shws[ij] = H1                                                              \
+             * (G01 * wrtmp                                                    \
+                + G11 * wstmp                                                  \
+                + G12 * wttmp);                                                \
+    rwt      = H1                                                              \
+             * (G02 * wrtmp                                                    \
+                + G12 * wstmp                                                  \
+                + G22 * wttmp);                                                \
+                                                                               \
+    barrier(CLK_LOCAL_MEM_FENCE);                                              \
+                                                                               \
+    real uwijke = 0.0;                                                         \
+    real vwijke = 0.0;                                                         \
+    real wwijke = 0.0;                                                         \
+                                                                               \
+    for (int l = 0; l < LX; l++){                                              \
+      uwijke += shur[l+j*LX] * shdx[l+i*LX];                                   \
+      ruw[l] += rut * shdz[k+l*LX];                                            \
+      uwijke += shus[i+l*LX] * shdy[l + j*LX];                                 \
+                                                                               \
+      vwijke += shvr[l+j*LX] * shdx[l+i*LX];                                   \
+      rvw[l] += rvt * shdz[k+l*LX];                                            \
+      vwijke += shvs[i+l*LX] * shdy[l + j*LX];                                 \
+                                                                               \
+      wwijke += shwr[l+j*LX] * shdx[l+i*LX];                                   \
+      rww[l] += rwt * shdz[k+l*LX];                                            \
+      wwijke += shws[i+l*LX] * shdy[l + j*LX];                                 \
+    }                                                                          \
+    ruw[k] += uwijke;                                                          \
+    rvw[k] += vwijke;                                                          \
+    rww[k] += wwijke;                                                          \
+  }                                                                            \
+                                                                               \
+  for (int k = 0; k < LX; ++k){                                                \
+   au[ij + k*LX*LX + ele] = ruw[k];                                            \
+   av[ij + k*LX*LX + ele] = rvw[k];                                            \
+   aw[ij + k*LX*LX + ele] = rww[k];                                            \
+  }                                                                            \
+}
+
+DEFINE_AX_HELM_KERNEL_VECTOR_KSTEP(2)
+DEFINE_AX_HELM_KERNEL_VECTOR_KSTEP(3)
+DEFINE_AX_HELM_KERNEL_VECTOR_KSTEP(4)
+DEFINE_AX_HELM_KERNEL_VECTOR_KSTEP(5)
+DEFINE_AX_HELM_KERNEL_VECTOR_KSTEP(6)
+DEFINE_AX_HELM_KERNEL_VECTOR_KSTEP(7)
+DEFINE_AX_HELM_KERNEL_VECTOR_KSTEP(8)
+DEFINE_AX_HELM_KERNEL_VECTOR_KSTEP(9)
+DEFINE_AX_HELM_KERNEL_VECTOR_KSTEP(10)
+DEFINE_AX_HELM_KERNEL_VECTOR_KSTEP(11)
+DEFINE_AX_HELM_KERNEL_VECTOR_KSTEP(12)
 
 #endif // __MATH_AX_HELM_KERNEL_CL__

--- a/src/math/bcknd/device/opencl/cdtp_kernel.cl
+++ b/src/math/bcknd/device/opencl/cdtp_kernel.cl
@@ -1,7 +1,7 @@
 #ifndef __MATH_CDTP_KERNEL_CL__
 #define __MATH_CDTP_KERNEL_CL__
 /*
- Copyright (c) 2021-2024, The Neko Authors
+ Copyright (c) 2021-2025, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -103,7 +103,7 @@ __kernel void cdtp_kernel_lx##LX(__global real * __restrict__ dtx,             \
                                                                                \
     }                                                                          \
   }                                                                            \
-}                                                                              
+}
 
 DEFINE_CDTP_KERNEL(2, 256)
 DEFINE_CDTP_KERNEL(3, 256)
@@ -118,7 +118,83 @@ DEFINE_CDTP_KERNEL(11, 256)
 DEFINE_CDTP_KERNEL(12, 256)
 DEFINE_CDTP_KERNEL(13, 256)
 
+#define DEFINE_CDTP_KERNEL_KSTEP(LX)                                           \
+__kernel void cdtp_kernel_kstep_lx##LX(__global real * __restrict__ dtx,       \
+                                       __global const real * __restrict__ x,   \
+                                       __global const real * __restrict__ dr,  \
+                                       __global const real * __restrict__ ds,  \
+                                       __global const real * __restrict__ dt,  \
+                                       __global const real * __restrict__ dxt, \
+                                       __global const real * __restrict__ dyt, \
+                                       __global const real * __restrict__ dzt, \
+                                       __global const real * __restrict__ w3) {\
+                                                                               \
+  __local real shdxt[LX * LX];                                                 \
+  __local real shdyt[LX * LX];                                                 \
+  __local real shdzt[LX * LX];                                                 \
+                                                                               \
+  __local real shtar[LX * LX];                                                 \
+  __local real shtas[LX * LX];                                                 \
+                                                                               \
+  real rtar[LX];                                                               \
+  real rtas[LX];                                                               \
+  real rtat[LX];                                                               \
+                                                                               \
+  const int e = get_group_id(0);                                               \
+  const int j = get_local_id(1);                                               \
+  const int i = get_local_id(0);                                               \
+  const int ij = i + j * LX;                                                   \
+  const int ele = e*LX*LX*LX;                                                  \
+                                                                               \
+  shdxt[ij] = dxt[ij];                                                         \
+  shdyt[ij] = dyt[ij];                                                         \
+  shdzt[ij] = dzt[ij];                                                         \
+                                                                               \
+  for (int k = 0; k < LX; ++k) {                                               \
+    real wx = x[ij + k*LX*LX + ele] * w3[ij + k*LX*LX];                        \
+                                                                               \
+    rtar[k] = wx *dr[ij + k*LX*LX + ele];                                      \
+    rtas[k] = wx *ds[ij + k*LX*LX + ele];                                      \
+    rtat[k] = wx *dt[ij + k*LX*LX + ele];                                      \
+  }                                                                            \
+                                                                               \
+  barrier(CLK_LOCAL_MEM_FENCE);                                                \
+                                                                               \
+  for (int k = 0; k < LX; ++k) {                                               \
+    const int ijk = ij + k*LX*LX;                                              \
+    real ttmp = 0.0;                                                           \
+    shtar[ij] = rtar[k];                                                       \
+    shtas[ij] = rtas[k];                                                       \
+    for (int l = 0; l < LX; l++) {                                             \
+      ttmp += shdzt[k+l*LX] * rtat[l];                                         \
+    }                                                                          \
+    barrier(CLK_LOCAL_MEM_FENCE);                                              \
+                                                                               \
+    real rtmp = 0.0;                                                           \
+    real stmp = 0.0;                                                           \
+                                                                               \
+    for (int l = 0; l < LX; l++) {                                             \
+      rtmp += shdxt[i+l*LX] * shtar[l+j*LX];                                   \
+      stmp += shdyt[j+l*LX] * shtas[i+l*LX];                                   \
+    }                                                                          \
+                                                                               \
+    dtx[ijk + ele] = ( rtmp + stmp + ttmp );                                   \
+                                                                               \
+    barrier(CLK_LOCAL_MEM_FENCE);                                              \
+  }                                                                            \
+}
 
-
+DEFINE_CDTP_KERNEL_KSTEP(2)
+DEFINE_CDTP_KERNEL_KSTEP(3)
+DEFINE_CDTP_KERNEL_KSTEP(4)
+DEFINE_CDTP_KERNEL_KSTEP(5)
+DEFINE_CDTP_KERNEL_KSTEP(6)
+DEFINE_CDTP_KERNEL_KSTEP(7)
+DEFINE_CDTP_KERNEL_KSTEP(8)
+DEFINE_CDTP_KERNEL_KSTEP(9)
+DEFINE_CDTP_KERNEL_KSTEP(10)
+DEFINE_CDTP_KERNEL_KSTEP(11)
+DEFINE_CDTP_KERNEL_KSTEP(12)
+DEFINE_CDTP_KERNEL_KSTEP(13)
 
 #endif // __MATH_CDTP_KERNEL_CL__

--- a/src/math/bcknd/device/opencl/conv1_kernel.cl
+++ b/src/math/bcknd/device/opencl/conv1_kernel.cl
@@ -1,7 +1,7 @@
 #ifndef __MATH_CONV1_KERNEL_CL__
 #define __MATH_CONV1_KERNEL_CL__
 /*
- Copyright (c) 2021-2022, The Neko Authors
+ Copyright (c) 2021-2025, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -139,5 +139,99 @@ DEFINE_CONV1_KERNEL(9, 256)
 DEFINE_CONV1_KERNEL(10, 256)
 DEFINE_CONV1_KERNEL(11, 256)
 
+#define DEFINE_CONV1_KERNEL_KSTEP(LX)                                          \
+__kernel                                                                       \
+void conv1_kernel_kstep_lx##LX(__global real * __restrict__ du,                \
+                               __global const real * __restrict__ u,           \
+                               __global const real * __restrict__ vx,          \
+                               __global const real * __restrict__ vy,          \
+                               __global const real * __restrict__ vz,          \
+                               __global const real * __restrict__ dx,          \
+                               __global const real * __restrict__ dy,          \
+                               __global const real * __restrict__ dz,          \
+                               __global const real * __restrict__ drdx,        \
+                               __global const real * __restrict__ dsdx,        \
+                               __global const real * __restrict__ dtdx,        \
+                               __global const real * __restrict__ drdy,        \
+                               __global const real * __restrict__ dsdy,        \
+                               __global const real * __restrict__ dtdy,        \
+                               __global const real * __restrict__ drdz,        \
+                               __global const real * __restrict__ dsdz,        \
+                               __global const real * __restrict__ dtdz,        \
+                               __global const real * __restrict__ jacinv) {    \
+                                                                               \
+  __local real shu[LX * LX];                                                   \
+                                                                               \
+  __local real shdx[LX*LX];                                                    \
+  __local real shdy[LX*LX];                                                    \
+  __local real shdz[LX*LX];                                                    \
+                                                                               \
+  const int e = get_group_id(0);                                               \
+  const int j = get_local_id(1);                                               \
+  const int i = get_local_id(0);                                               \
+  const int ij = i + j * LX;                                                   \
+  const int ele = e*LX*LX*LX;                                                  \
+                                                                               \
+  shdx[ij] = dx[ij];                                                           \
+  shdy[ij] = dy[ij];                                                           \
+  shdz[ij] = dz[ij];                                                           \
+                                                                               \
+  real ru[LX];                                                                 \
+  real rvx[LX];                                                                \
+  real rvy[LX];                                                                \
+  real rvz[LX];                                                                \
+  real rjacinv[LX];                                                            \
+                                                                               \
+  for (int k = 0; k < LX; ++k) {                                               \
+    ru[k] = u[ij + k*LX*LX + ele];                                             \
+    rvx[k] = vx[ij + k*LX*LX + ele];                                           \
+    rvy[k] = vy[ij + k*LX*LX + ele];                                           \
+    rvz[k] = vz[ij + k*LX*LX + ele];                                           \
+    rjacinv[k] = jacinv[ij + k*LX*LX + ele];                                   \
+  }                                                                            \
+                                                                               \
+  barrier(CLK_LOCAL_MEM_FENCE);                                                \
+                                                                               \
+  for (int k = 0; k < LX; ++k) {                                               \
+    const int ijk = ij + k*LX*LX;                                              \
+    real ttmp = 0.0;                                                           \
+    shu[ij] = ru[k];                                                           \
+    for (int l = 0; l < LX; l++) {                                             \
+      ttmp += shdz[k+l*LX] * ru[l];                                            \
+    }                                                                          \
+    barrier(CLK_LOCAL_MEM_FENCE);                                              \
+                                                                               \
+    real rtmp = 0.0;                                                           \
+    real stmp = 0.0;                                                           \
+                                                                               \
+    for (int l = 0; l < LX; l++) {                                             \
+      rtmp += shdx[i+l*LX] * shu[l+j*LX];                                      \
+      stmp += shdy[j+l*LX] * shu[i+l*LX];                                      \
+    }                                                                          \
+                                                                               \
+    du[ijk + ele] = rjacinv[k] *                                               \
+	(rvx[k] * (drdx[ijk + ele] * rtmp                                      \
+                   + dsdx[ijk + ele] * stmp                                    \
+                   + dtdx[ijk + ele] * ttmp)                                   \
+	 + rvy[k] * (drdy[ijk + ele] * rtmp                                    \
+                     + dsdy[ijk + ele] * stmp                                  \
+                     + dtdy[ijk + ele] * ttmp)                                 \
+	 + rvz[k] * (drdz[ijk + ele] * rtmp                                    \
+                     + dsdz[ijk + ele] * stmp                                  \
+                     + dtdz[ijk + ele] * ttmp));                               \
+    barrier(CLK_LOCAL_MEM_FENCE);                                              \
+  }                                                                            \
+}
+
+DEFINE_CONV1_KERNEL_KSTEP(2)
+DEFINE_CONV1_KERNEL_KSTEP(3)
+DEFINE_CONV1_KERNEL_KSTEP(4)
+DEFINE_CONV1_KERNEL_KSTEP(5)
+DEFINE_CONV1_KERNEL_KSTEP(6)
+DEFINE_CONV1_KERNEL_KSTEP(7)
+DEFINE_CONV1_KERNEL_KSTEP(8)
+DEFINE_CONV1_KERNEL_KSTEP(9)
+DEFINE_CONV1_KERNEL_KSTEP(10)
+DEFINE_CONV1_KERNEL_KSTEP(11)
 
 #endif // __MATH_CONV1_KERNEL_CL__

--- a/src/math/bcknd/device/opencl/dudxyz_kernel.cl
+++ b/src/math/bcknd/device/opencl/dudxyz_kernel.cl
@@ -1,7 +1,7 @@
 #ifndef __MATH_DUDXYZ_KERNEL_CL__
 #define __MATH_DUDXYZ_KERNEL_CL__
 /*
- Copyright (c) 2021-2022, The Neko Authors
+ Copyright (c) 2021-2025, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -35,9 +35,9 @@
 */
 
 /**
- * Device kernel for derivative 
+ * Device kernel for derivative
  */
-                                                              
+
 #define DEFINE_DUDXYZ_KERNEL(LX, CHUNKS)                                       \
 __kernel void dudxyz_kernel_lx##LX(__global real * __restrict__ du,            \
                                    __global const real * __restrict__ u,       \
@@ -106,7 +106,7 @@ __kernel void dudxyz_kernel_lx##LX(__global real * __restrict__ du,            \
                                                                                \
     }                                                                          \
   }                                                                            \
-}                                                                              
+}
 
 DEFINE_DUDXYZ_KERNEL(2, 256)
 DEFINE_DUDXYZ_KERNEL(3, 256)
@@ -118,6 +118,84 @@ DEFINE_DUDXYZ_KERNEL(8, 256)
 DEFINE_DUDXYZ_KERNEL(9, 256)
 DEFINE_DUDXYZ_KERNEL(10, 256)
 DEFINE_DUDXYZ_KERNEL(11, 256)
+
+#define DEFINE_DUDXYZ_KERNEL_KSTEP(LX)                                         \
+__kernel                                                                       \
+void dudxyz_kernel_kstep_lx##LX(__global real * __restrict__ du,               \
+                                __global const real * __restrict__ u,          \
+                                __global const real * __restrict__ dr,         \
+                                __global const real * __restrict__ ds,         \
+                                __global const real * __restrict__ dt,         \
+                                __global const real * __restrict__ dx,         \
+                                __global const real * __restrict__ dy,         \
+                                __global const real * __restrict__ dz,         \
+                                __global const real * __restrict__ jacinv) {   \
+                                                                               \
+  __local real shu[LX * LX];                                                   \
+                                                                               \
+  __local real shdx[LX * LX];                                                  \
+  __local real shdy[LX * LX];                                                  \
+  __local real shdz[LX * LX];                                                  \
+                                                                               \
+  const int e = get_group_id(0);                                               \
+  const int j = get_local_id(1);                                               \
+  const int i = get_local_id(0);                                               \
+  const int ij = i + j * LX;                                                   \
+  const int ele = e*LX*LX*LX;                                                  \
+                                                                               \
+  shdx[ij] = dx[ij];                                                           \
+  shdy[ij] = dy[ij];                                                           \
+  shdz[ij] = dz[ij];                                                           \
+                                                                               \
+  real ru[LX];                                                                 \
+  real rdr[LX];                                                                \
+  real rds[LX];                                                                \
+  real rdt[LX];                                                                \
+  real rjacinv[LX];                                                            \
+                                                                               \
+  for (int k = 0; k < LX; ++k) {                                               \
+    ru[k] = u[ij + k*LX*LX + ele];                                             \
+    rdr[k] = dr[ij + k*LX*LX + ele];                                           \
+    rds[k] = ds[ij + k*LX*LX + ele];                                           \
+    rdt[k] = dt[ij + k*LX*LX + ele];                                           \
+    rjacinv[k] = jacinv[ij + k*LX*LX + ele];                                   \
+  }                                                                            \
+                                                                               \
+  barrier(CLK_LOCAL_MEM_FENCE);                                                \
+                                                                               \
+  for (int k = 0; k < LX; ++k) {                                               \
+    const int ijk = ij + k*LX*LX;                                              \
+    real ttmp = 0.0;                                                           \
+    shu[ij] = ru[k];                                                           \
+    for (int l = 0; l < LX; l++) {                                             \
+      ttmp += shdz[k+l*LX] * ru[l];                                            \
+    }                                                                          \
+    barrier(CLK_LOCAL_MEM_FENCE);                                              \
+                                                                               \
+    real rtmp = 0.0;                                                           \
+    real stmp = 0.0;                                                           \
+                                                                               \
+    for (int l = 0; l < LX; l++) {                                             \
+      rtmp += shdx[i+l*LX] * shu[l+j*LX];                                      \
+      stmp += shdy[j+l*LX] * shu[i+l*LX];                                      \
+    }                                                                          \
+                                                                               \
+    du[ijk + ele] = rjacinv[k] * ((rtmp * rdr[k])                              \
+                                  + (stmp * rds[k])                            \
+                                  + (ttmp * rdt[k]));                          \
+    barrier(CLK_LOCAL_MEM_FENCE);                                              \
+  }                                                                            \
+}
+
+DEFINE_DUDXYZ_KERNEL_KSTEP(2)
+DEFINE_DUDXYZ_KERNEL_KSTEP(3)
+DEFINE_DUDXYZ_KERNEL_KSTEP(4)
+DEFINE_DUDXYZ_KERNEL_KSTEP(5)
+DEFINE_DUDXYZ_KERNEL_KSTEP(6)
+DEFINE_DUDXYZ_KERNEL_KSTEP(7)
+DEFINE_DUDXYZ_KERNEL_KSTEP(8)
+DEFINE_DUDXYZ_KERNEL_KSTEP(9)
+DEFINE_DUDXYZ_KERNEL_KSTEP(10)
 
 
 #endif // __MATH_DUDXYZ_KERNEL_CL__

--- a/src/math/bcknd/device/opencl/opgrad_kernel.cl
+++ b/src/math/bcknd/device/opencl/opgrad_kernel.cl
@@ -1,7 +1,7 @@
 #ifndef __MATH_OPGRAD_KERNEL_CL__
 #define __MATH_OPGRAD_KERNEL_CL__
 /*
- Copyright (c) 2021-2022, The Neko Authors
+ Copyright (c) 2021-2025, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -116,7 +116,7 @@ __kernel void opgrad_kernel_lx##LX(__global real * __restrict__ ux,            \
                                                                                \
     }                                                                          \
   }                                                                            \
-}                                                                              
+}
 
 DEFINE_OPGRAD_KERNEL(16, 256)
 DEFINE_OPGRAD_KERNEL(15, 256)
@@ -133,5 +133,98 @@ DEFINE_OPGRAD_KERNEL(5, 256)
 DEFINE_OPGRAD_KERNEL(4, 256)
 DEFINE_OPGRAD_KERNEL(3, 256)
 DEFINE_OPGRAD_KERNEL(2, 256)
+
+#define DEFINE_OPGRAD_KERNEL_KSTEP(LX)                                         \
+__kernel                                                                       \
+void opgrad_kernel_kstep_lx##LX(__global real * __restrict__ ux,               \
+                                __global real * __restrict__ uy,               \
+                                __global real * __restrict__ uz,               \
+                                __global const real * __restrict__ u,          \
+                                __global const real * __restrict__ dx,         \
+                                __global const real * __restrict__ dy,         \
+                                __global const real * __restrict__ dz,         \
+                                __global const real * __restrict__ drdx,       \
+                                __global const real * __restrict__ dsdx,       \
+                                __global const real * __restrict__ dtdx,       \
+                                __global const real * __restrict__ drdy,       \
+                                __global const real * __restrict__ dsdy,       \
+                                __global const real * __restrict__ dtdy,       \
+                                __global const real * __restrict__ drdz,       \
+                                __global const real * __restrict__ dsdz,       \
+                                __global const real * __restrict__ dtdz,       \
+                                __global const real * __restrict__ w3) {       \
+                                                                               \
+  __local real shu[LX * LX];                                                   \
+                                                                               \
+  __local real shdx[LX * LX];                                                  \
+  __local real shdy[LX * LX];                                                  \
+  __local real shdz[LX * LX];                                                  \
+                                                                               \
+  const int e = get_group_id(0);                                               \
+  const int j = get_local_id(1);                                               \
+  const int i = get_local_id(0);                                               \
+  const int ij = i + j * LX;                                                   \
+  const int ele = e*LX*LX*LX;                                                  \
+                                                                               \
+  shdx[ij] = dx[ij];                                                           \
+  shdy[ij] = dy[ij];                                                           \
+  shdz[ij] = dz[ij];                                                           \
+                                                                               \
+  real ru[LX];                                                                 \
+                                                                               \
+  for (int k = 0; k < LX; ++k) {                                               \
+    ru[k] = u[ij + k*LX*LX + ele];                                             \
+  }                                                                            \
+                                                                               \
+  barrier(CLK_LOCAL_MEM_FENCE);                                                \
+                                                                               \
+  for (int k = 0; k < LX; ++k) {                                               \
+    const int ijk = ij + k*LX*LX;                                              \
+    const real W3 = w3[ijk];                                                   \
+    real ttmp = 0.0;                                                           \
+    shu[ij] = ru[k];                                                           \
+    for (int l = 0; l < LX; l++) {                                             \
+      ttmp += shdz[k+l*LX] * ru[l];                                            \
+    }                                                                          \
+    barrier(CLK_LOCAL_MEM_FENCE);                                              \
+                                                                               \
+    real rtmp = 0.0;                                                           \
+    real stmp = 0.0;                                                           \
+                                                                               \
+    for (int l = 0; l < LX; l++) {                                             \
+      rtmp += shdx[i+l*LX] * shu[l+j*LX];                                      \
+      stmp += shdy[j+l*LX] * shu[i+l*LX];                                      \
+    }                                                                          \
+                                                                               \
+    ux[ijk + ele] = W3 * (drdx[ijk + ele] * rtmp                               \
+                          + dsdx[ijk + ele] * stmp                             \
+                          + dtdx[ijk + ele] * ttmp);                           \
+                                                                               \
+    uy[ijk + ele] = W3 * (drdy[ijk + ele] * rtmp                               \
+                          + dsdy[ijk + ele] * stmp                             \
+                          + dtdy[ijk + ele] * ttmp);                           \
+                                                                               \
+    uz[ijk + ele] = W3 * (drdz[ijk + ele] * rtmp                               \
+                          + dsdz[ijk + ele] * stmp                             \
+                          + dtdz[ijk + ele] * ttmp);                           \
+    barrier(CLK_LOCAL_MEM_FENCE);                                              \
+  }                                                                            \
+}
+
+DEFINE_OPGRAD_KERNEL_KSTEP(16)
+DEFINE_OPGRAD_KERNEL_KSTEP(15)
+DEFINE_OPGRAD_KERNEL_KSTEP(14)
+DEFINE_OPGRAD_KERNEL_KSTEP(13)
+DEFINE_OPGRAD_KERNEL_KSTEP(12)
+DEFINE_OPGRAD_KERNEL_KSTEP(11)
+DEFINE_OPGRAD_KERNEL_KSTEP(10)
+DEFINE_OPGRAD_KERNEL_KSTEP(9)
+DEFINE_OPGRAD_KERNEL_KSTEP(8)
+DEFINE_OPGRAD_KERNEL_KSTEP(7)
+DEFINE_OPGRAD_KERNEL_KSTEP(6)
+DEFINE_OPGRAD_KERNEL_KSTEP(5)
+DEFINE_OPGRAD_KERNEL_KSTEP(4)
+DEFINE_OPGRAD_KERNEL_KSTEP(3)
+DEFINE_OPGRAD_KERNEL_KSTEP(2)
 
 #endif // __MATH_OPGRAD_KERNEL_CL__

--- a/src/math/bcknd/device/opencl/opr_cdtp.c
+++ b/src/math/bcknd/device/opencl/opr_cdtp.c
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2024, The Neko Authors
+ Copyright (c) 2021-2025, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -40,12 +40,16 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <device/device_config.h>
 #include <device/opencl/jit.h>
 #include <device/opencl/prgm_lib.h>
 #include <device/opencl/check.h>
+#include <common/neko_log.h>
 
 #include "cdtp_kernel.cl.h"
+
+int *autotune_cdtp = NULL;
 
 /**
  * Fortran wrapper for device OpenCL \f$ D^T X \f$
@@ -62,9 +66,20 @@ void opencl_cdtp(void *dtx, void *x,
   const size_t global_item_size = 256 * (*nel);
   const size_t local_item_size = 256;
 
+  size_t global_kstep[2];
+  size_t local_kstep[2];
+  local_kstep[0] = (*lx);
+  local_kstep[1] = (*lx);
+  global_kstep[0] = (*nel) * (*lx);
+  global_kstep[1] = (*lx);
+
+  if (autotune_cdtp == NULL) {
+    autotune_cdtp = malloc(17 * sizeof(int));
+    memset(autotune_cdtp, 0, 17 * sizeof(int));
+  }
+
 #define STR(X) #X
-#define CASE(LX)                                                                \
-  case LX:                                                                      \
+#define CASE_1D(LX, QUEUE, EVENT)                                               \
     {                                                                           \
       cl_kernel kernel = clCreateKernel(cdtp_program,                           \
                                         STR(cdtp_kernel_lx##LX), &err);         \
@@ -80,11 +95,110 @@ void opencl_cdtp(void *dtx, void *x,
       CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_mem), (void *) &dzt));       \
       CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_mem), (void *) &w3));        \
                                                                                 \
-      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,         \
+      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
                                       kernel, 1, NULL, &global_item_size,       \
-                                      &local_item_size, 0, NULL, NULL));        \
-    }                                                                           \
-    break
+                                      &local_item_size, 0, NULL, EVENT));       \
+    }
+
+
+#define CASE_KSTEP(LX, QUEUE, EVENT)                                            \
+    {                                                                           \
+      cl_kernel kernel = clCreateKernel(cdtp_program,                           \
+                                        STR(cdtp_kernel_kstep_lx##LX), &err);   \
+      CL_CHECK(err);                                                            \
+                                                                                \
+      CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &dtx));       \
+      CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &x));         \
+      CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &dr));        \
+      CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &ds));        \
+      CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), (void *) &dt));        \
+      CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_mem), (void *) &dxt));       \
+      CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_mem), (void *) &dyt));       \
+      CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_mem), (void *) &dzt));       \
+      CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_mem), (void *) &w3));        \
+                                                                                \
+      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
+                                      kernel, 2, NULL, global_kstep,            \
+                                      local_kstep, 0, NULL, EVENT));            \
+    }
+
+
+#define CASE(LX)                                                                \
+  case LX:                                                                      \
+      if(autotune_cdtp[LX] == 0 ) {                                             \
+        char *env_value = NULL;                                                 \
+        char neko_log_buf[80];                                                  \
+        env_value = getenv("NEKO_AUTOTUNE");                                    \
+                                                                                \
+        sprintf(neko_log_buf, "Autotune cdtp (lx: %d)", *lx);                   \
+        log_section(neko_log_buf);                                              \
+        if(env_value) {                                                         \
+          if( !strcmp(env_value,"1D") ) {                                       \
+            CASE_1D(LX, glb_cmd_queue, NULL);                                   \
+            sprintf(neko_log_buf,"Set by env : 1 (1D)");                        \
+            log_message(neko_log_buf);                                          \
+            autotune_cdtp[LX] = 1;                                              \
+          } else if( !strcmp(env_value,"KSTEP") ) {                             \
+            CASE_KSTEP(LX, glb_cmd_queue, NULL);                                \
+            sprintf(neko_log_buf,"Set by env : 2 (KSTEP)");                     \
+            log_message(neko_log_buf);                                          \
+            autotune_cdtp[LX] = 2;                                              \
+          } else {                                                              \
+            sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");       \
+            log_error(neko_log_buf);                                            \
+          }                                                                     \
+        }                                                                       \
+        else {                                                                  \
+          CL_CHECK(clFinish(glb_cmd_queue));                                    \
+          cl_event perf_event, sync_event;                                      \
+          cl_ulong start, end;                                                  \
+          CL_CHECK(clEnqueueMarker(glb_cmd_queue, &sync_event));                \
+          CL_CHECK(clEnqueueBarrier(prf_cmd_queue));                            \
+          CL_CHECK(clEnqueueWaitForEvents(prf_cmd_queue, 1, &sync_event));      \
+                                                                                \
+          double elapsed1 = 0.0;                                                \
+          for(int i = 0; i < 100; i++) {                                        \
+            CASE_1D(LX, prf_cmd_queue, &perf_event);                            \
+            CL_CHECK(clWaitForEvents(1, &perf_event));                          \
+            CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
+                                             CL_PROFILING_COMMAND_START,        \
+                                             sizeof(cl_ulong), &start, NULL));  \
+            CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
+                                             CL_PROFILING_COMMAND_END,          \
+                                             sizeof(cl_ulong), &end, NULL));    \
+            elapsed1 += (end - start)*1.0e-6;                                   \
+          }                                                                     \
+                                                                                \
+          double elapsed2 = 0.0;                                                \
+          for(int i = 0; i < 100; i++) {                                        \
+            CASE_KSTEP(LX, prf_cmd_queue, &perf_event);                         \
+            CL_CHECK(clWaitForEvents(1, &perf_event));                          \
+            CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
+                                             CL_PROFILING_COMMAND_START,        \
+                                             sizeof(cl_ulong), &start, NULL));  \
+            CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
+                                             CL_PROFILING_COMMAND_END,          \
+                                             sizeof(cl_ulong), &end, NULL));    \
+            elapsed2 += (end - start)*1.0e-6;                                   \
+          }                                                                     \
+                                                                                \
+          CL_CHECK(clFinish(prf_cmd_queue));                                    \
+          CL_CHECK(clEnqueueMarker(prf_cmd_queue, &sync_event));                \
+          int krnl_strtgy = (elapsed1 < elapsed2 ? 1 : 2);                      \
+          sprintf(neko_log_buf, "Chose      : %d (%s)", krnl_strtgy,            \
+                  (krnl_strtgy > 1 ? "KSTEP" : "1D"));                          \
+          autotune_cdtp[LX] = krnl_strtgy;                                      \
+          log_message(neko_log_buf);                                            \
+          clEnqueueBarrier(glb_cmd_queue);                                      \
+          clEnqueueWaitForEvents(glb_cmd_queue, 1, &sync_event) ;               \
+        }                                                                       \
+        log_end_section();                                                      \
+      } else if (autotune_cdtp[LX] == 1 ) {                                     \
+        CASE_1D(LX, glb_cmd_queue, NULL);                                       \
+      } else if (autotune_cdtp[LX] == 2 ) {                                     \
+        CASE_KSTEP(LX, glb_cmd_queue, NULL);                                    \
+      }                                                                         \
+      break
 
   switch(*lx) {
     CASE(2);

--- a/src/math/bcknd/device/opencl/opr_conv1.c
+++ b/src/math/bcknd/device/opencl/opr_conv1.c
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2022, The Neko Authors
+ Copyright (c) 2021-2025, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -40,12 +40,16 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <device/device_config.h>
 #include <device/opencl/jit.h>
 #include <device/opencl/prgm_lib.h>
 #include <device/opencl/check.h>
+#include <common/neko_log.h>
 
 #include "conv1_kernel.cl.h"
+
+int *autotune_conv1 = NULL;
 
 /** 
  * Fortran wrapper for device OpenCL convective terms
@@ -63,11 +67,22 @@ void opencl_conv1(void *du, void *u,
     opencl_kernel_jit(conv1_kernel, (cl_program *) &conv1_program);
   
   const size_t global_item_size = 256 * (*nel);
-  const size_t local_item_size = 256;    
+  const size_t local_item_size = 256;
+
+  size_t global_kstep[2];
+  size_t local_kstep[2];
+  local_kstep[0] = (*lx);
+  local_kstep[1] = (*lx);
+  global_kstep[0] = (*nel) * (*lx);
+  global_kstep[1] = (*lx);
+
+  if (autotune_conv1 == NULL) {
+    autotune_conv1 = malloc(17 * sizeof(int));
+    memset(autotune_conv1, 0, 17 * sizeof(int));
+  }  
 
 #define STR(X) #X
-#define CASE(LX)                                                                \
-  case LX:                                                                      \
+#define CASE_1D(LX, QUEUE, EVENT)                                               \
     {                                                                           \
       cl_kernel kernel = clCreateKernel(conv1_program,                          \
                                         STR(conv1_kernel_lx##LX), &err);        \
@@ -92,12 +107,120 @@ void opencl_conv1(void *du, void *u,
       CL_CHECK(clSetKernelArg(kernel, 16, sizeof(cl_mem), (void *) &dtdz));     \
       CL_CHECK(clSetKernelArg(kernel, 17, sizeof(cl_mem), (void *) &jacinv));   \
                                                                                 \
-      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,         \
+      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
                                       kernel, 1, NULL, &global_item_size,       \
-                                      &local_item_size, 0, NULL, NULL));        \
-    }                                                                           \
-    break
-    
+                                      &local_item_size, 0, NULL, EVENT));       \
+    }                                                                           
+
+#define CASE_KSTEP(LX, QUEUE, EVENT)                                            \
+    {                                                                           \
+      cl_kernel kernel = clCreateKernel(conv1_program,                          \
+                                        STR(conv1_kernel_kstep_lx##LX), &err);  \
+      CL_CHECK(err);    							\
+                                                                                \
+      CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &du));        \
+      CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &u));         \
+      CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &vx));        \
+      CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &vy));        \
+      CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), (void *) &vz));        \
+      CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_mem), (void *) &dx));        \
+      CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_mem), (void *) &dy));        \
+      CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_mem), (void *) &dz));        \
+      CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_mem), (void *) &drdx));      \
+      CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_mem), (void *) &dsdx));      \
+      CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_mem), (void *) &dtdx));     \
+      CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_mem), (void *) &drdy));     \
+      CL_CHECK(clSetKernelArg(kernel, 12, sizeof(cl_mem), (void *) &dsdy));     \
+      CL_CHECK(clSetKernelArg(kernel, 13, sizeof(cl_mem), (void *) &dtdy));     \
+      CL_CHECK(clSetKernelArg(kernel, 14, sizeof(cl_mem), (void *) &drdz));     \
+      CL_CHECK(clSetKernelArg(kernel, 15, sizeof(cl_mem), (void *) &dsdz));     \
+      CL_CHECK(clSetKernelArg(kernel, 16, sizeof(cl_mem), (void *) &dtdz));     \
+      CL_CHECK(clSetKernelArg(kernel, 17, sizeof(cl_mem), (void *) &jacinv));   \
+                                                                                \
+      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
+                                      kernel, 2, NULL, global_kstep,            \
+                                      local_kstep, 0, NULL, EVENT));            \
+    }                                                                           
+  
+
+#define CASE(LX)                                                                \
+  case LX:                                                                      \
+      if(autotune_conv1[LX] == 0 ) {                                            \
+        char *env_value = NULL;                                                 \
+        char neko_log_buf[80];                                                  \
+        env_value = getenv("NEKO_AUTOTUNE");                                    \
+                                                                                \
+        sprintf(neko_log_buf, "Autotune conv1 (lx: %d)", *lx);                  \
+        log_section(neko_log_buf);                                              \
+        if(env_value) {                                                         \
+          if( !strcmp(env_value,"1D") ) {                                       \
+            CASE_1D(LX, glb_cmd_queue, NULL);                                   \
+            sprintf(neko_log_buf,"Set by env : 1 (1D)");                        \
+            log_message(neko_log_buf);                                          \
+            autotune_conv1[LX] = 1;                                             \
+          } else if( !strcmp(env_value,"KSTEP") ) {                             \
+            CASE_KSTEP(LX, glb_cmd_queue, NULL);                                \
+            sprintf(neko_log_buf,"Set by env : 2 (KSTEP)");                     \
+            log_message(neko_log_buf);                                          \
+            autotune_conv1[LX] = 2;                                             \
+          } else {                                                              \
+            sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");       \
+            log_error(neko_log_buf);                                            \
+          }                                                                     \
+        }                                                                       \
+        else {                                                                  \
+          CL_CHECK(clFinish(glb_cmd_queue));                                    \
+          cl_event perf_event, sync_event;                                      \
+          cl_ulong start, end;                                                  \
+          CL_CHECK(clEnqueueMarker(glb_cmd_queue, &sync_event));                \
+          CL_CHECK(clEnqueueBarrier(prf_cmd_queue));                            \
+          CL_CHECK(clEnqueueWaitForEvents(prf_cmd_queue, 1, &sync_event));      \
+                                                                                \
+          double elapsed1 = 0.0;                                                \
+          for(int i = 0; i < 100; i++) {                                        \
+            CASE_1D(LX, prf_cmd_queue, &perf_event);                            \
+            CL_CHECK(clWaitForEvents(1, &perf_event));                          \
+            CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
+                                             CL_PROFILING_COMMAND_START,        \
+                                             sizeof(cl_ulong), &start, NULL));  \
+            CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
+                                             CL_PROFILING_COMMAND_END,          \
+                                             sizeof(cl_ulong), &end, NULL));    \
+            elapsed1 += (end - start)*1.0e-6;                                   \
+          }                                                                     \
+                                                                                \
+          double elapsed2 = 0.0;                                                \
+          for(int i = 0; i < 100; i++) {                                        \
+            CASE_KSTEP(LX, prf_cmd_queue, &perf_event);                         \
+            CL_CHECK(clWaitForEvents(1, &perf_event));                          \
+            CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
+                                             CL_PROFILING_COMMAND_START,        \
+                                             sizeof(cl_ulong), &start, NULL));  \
+            CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
+                                             CL_PROFILING_COMMAND_END,          \
+                                             sizeof(cl_ulong), &end, NULL));    \
+            elapsed2 += (end - start)*1.0e-6;                                   \
+          }                                                                     \
+                                                                                \
+          CL_CHECK(clFinish(prf_cmd_queue));                                    \
+          CL_CHECK(clEnqueueMarker(prf_cmd_queue, &sync_event));                \
+          int krnl_strtgy = (elapsed1 < elapsed2 ? 1 : 2);                      \
+          sprintf(neko_log_buf, "Chose      : %d (%s)", krnl_strtgy,            \
+                  (krnl_strtgy > 1 ? "KSTEP" : "1D"));                          \
+          autotune_conv1[LX] = krnl_strtgy;                                     \
+          log_message(neko_log_buf);                                            \
+          clEnqueueBarrier(glb_cmd_queue);                                      \
+          clEnqueueWaitForEvents(glb_cmd_queue, 1, &sync_event) ;               \
+        }                                                                       \
+        log_end_section();                                                      \
+      } else if (autotune_conv1[LX] == 1 ) {                                    \
+        CASE_1D(LX, glb_cmd_queue, NULL);                                       \
+      } else if (autotune_conv1[LX] == 2 ) {                                    \
+        CASE_KSTEP(LX, glb_cmd_queue, NULL);                                    \
+      }                                                                         \
+      break
+
+  
   switch(*lx) {
     CASE(2);
     CASE(3);

--- a/src/math/bcknd/device/opencl/opr_dudxyz.c
+++ b/src/math/bcknd/device/opencl/opr_dudxyz.c
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2022, The Neko Authors
+ Copyright (c) 2021-2025, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -40,14 +40,18 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <device/device_config.h>
 #include <device/opencl/jit.h>
 #include <device/opencl/prgm_lib.h>
 #include <device/opencl/check.h>
+#include <common/neko_log.h>
 
 #include "dudxyz_kernel.cl.h"
 
-/** 
+int *autotune_dudxyz = NULL;
+
+/**
  * Fortran wrapper for device OpenCL derivative kernels
  */
 void opencl_dudxyz(void *du, void *u,
@@ -55,16 +59,27 @@ void opencl_dudxyz(void *du, void *u,
                    void *dx, void *dy, void *dz,
                    void *jacinv, int *nel, int *lx) {
   cl_int err;
-  
+
   if (dudxyz_program == NULL)
     opencl_kernel_jit(dudxyz_kernel, (cl_program *) &dudxyz_program);
-  
+
   const size_t global_item_size = 256 * (*nel);
   const size_t local_item_size = 256;
 
+  size_t global_kstep[2];
+  size_t local_kstep[2];
+  local_kstep[0] = (*lx);
+  local_kstep[1] = (*lx);
+  global_kstep[0] = (*nel) * (*lx);
+  global_kstep[1] = (*lx);
+
+  if (autotune_dudxyz == NULL) {
+    autotune_dudxyz = malloc(17 * sizeof(int));
+    memset(autotune_dudxyz, 0, 17 * sizeof(int));
+  }
+
 #define STR(X) #X
-#define CASE(LX)                                                                \
-  case LX:                                                                      \
+#define CASE_1D(LX, QUEUE, EVENT)                                               \
     {                                                                           \
       cl_kernel kernel = clCreateKernel(dudxyz_program,                         \
                                         STR(dudxyz_kernel_lx##LX), &err);       \
@@ -80,11 +95,108 @@ void opencl_dudxyz(void *du, void *u,
       CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_mem), (void *) &dz));        \
       CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_mem), (void *) &jacinv));    \
                                                                                 \
-      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,         \
+      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
                                       kernel, 1, NULL, &global_item_size,       \
-                                      &local_item_size, 0, NULL, NULL));        \
-    }                                                                           \
-    break                                
+                                      &local_item_size, 0, NULL, EVENT));       \
+    }
+
+#define CASE_KSTEP(LX, QUEUE, EVENT)                                            \
+    {                                                                           \
+      cl_kernel kernel = clCreateKernel(dudxyz_program,                         \
+                                        STR(dudxyz_kernel_kstep_lx##LX), &err); \
+      CL_CHECK(err);                                                            \
+                                                                                \
+      CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &du));        \
+      CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &u));         \
+      CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &dr));        \
+      CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &ds));        \
+      CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), (void *) &dt));        \
+      CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_mem), (void *) &dx));        \
+      CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_mem), (void *) &dy));        \
+      CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_mem), (void *) &dz));        \
+      CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_mem), (void *) &jacinv));    \
+                                                                                \
+      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
+                                      kernel, 2, NULL, global_kstep,            \
+                                      local_kstep, 0, NULL, EVENT));            \
+    }
+
+#define CASE(LX)                                                                \
+  case LX:                                                                      \
+      if(autotune_dudxyz[LX] == 0 ) {                                           \
+        char *env_value = NULL;                                                 \
+        char neko_log_buf[80];                                                  \
+        env_value = getenv("NEKO_AUTOTUNE");                                    \
+                                                                                \
+        sprintf(neko_log_buf, "Autotune dudxyz (lx: %d)", *lx);                 \
+        log_section(neko_log_buf);                                              \
+        if(env_value) {                                                         \
+          if( !strcmp(env_value,"1D") ) {                                       \
+            CASE_1D(LX, glb_cmd_queue, NULL);                                   \
+            sprintf(neko_log_buf,"Set by env : 1 (1D)");                        \
+            log_message(neko_log_buf);                                          \
+            autotune_dudxyz[LX] = 1;                                            \
+          } else if( !strcmp(env_value,"KSTEP") ) {                             \
+            CASE_KSTEP(LX, glb_cmd_queue, NULL);                                \
+            sprintf(neko_log_buf,"Set by env : 2 (KSTEP)");                     \
+            log_message(neko_log_buf);                                          \
+            autotune_dudxyz[LX] = 2;                                            \
+          } else {                                                              \
+            sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");       \
+            log_error(neko_log_buf);                                            \
+          }                                                                     \
+        }                                                                       \
+        else {                                                                  \
+          CL_CHECK(clFinish(glb_cmd_queue));                                    \
+          cl_event perf_event, sync_event;                                      \
+          cl_ulong start, end;                                                  \
+          CL_CHECK(clEnqueueMarker(glb_cmd_queue, &sync_event));                \
+          CL_CHECK(clEnqueueBarrier(prf_cmd_queue));                            \
+          CL_CHECK(clEnqueueWaitForEvents(prf_cmd_queue, 1, &sync_event));      \
+                                                                                \
+          double elapsed1 = 0.0;                                                \
+          for(int i = 0; i < 100; i++) {                                        \
+            CASE_1D(LX, prf_cmd_queue, &perf_event);                            \
+            CL_CHECK(clWaitForEvents(1, &perf_event));                          \
+            CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
+                                             CL_PROFILING_COMMAND_START,        \
+                                             sizeof(cl_ulong), &start, NULL));  \
+            CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
+                                             CL_PROFILING_COMMAND_END,          \
+                                             sizeof(cl_ulong), &end, NULL));    \
+            elapsed1 += (end - start)*1.0e-6;                                   \
+          }                                                                     \
+                                                                                \
+          double elapsed2 = 0.0;                                                \
+          for(int i = 0; i < 100; i++) {                                        \
+            CASE_KSTEP(LX, prf_cmd_queue, &perf_event);                         \
+            CL_CHECK(clWaitForEvents(1, &perf_event));                          \
+            CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
+                                             CL_PROFILING_COMMAND_START,        \
+                                             sizeof(cl_ulong), &start, NULL));  \
+            CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
+                                             CL_PROFILING_COMMAND_END,          \
+                                             sizeof(cl_ulong), &end, NULL));    \
+            elapsed2 += (end - start)*1.0e-6;                                   \
+          }                                                                     \
+                                                                                \
+          CL_CHECK(clFinish(prf_cmd_queue));                                    \
+          CL_CHECK(clEnqueueMarker(prf_cmd_queue, &sync_event));                \
+          int krnl_strtgy = (elapsed1 < elapsed2 ? 1 : 2);                      \
+          sprintf(neko_log_buf, "Chose      : %d (%s)", krnl_strtgy,            \
+                  (krnl_strtgy > 1 ? "KSTEP" : "1D"));                          \
+          autotune_dudxyz[LX] = krnl_strtgy;                                    \
+          log_message(neko_log_buf);                                            \
+          clEnqueueBarrier(glb_cmd_queue);                                      \
+          clEnqueueWaitForEvents(glb_cmd_queue, 1, &sync_event) ;               \
+        }                                                                       \
+        log_end_section();                                                      \
+      } else if (autotune_dudxyz[LX] == 1 ) {                                   \
+        CASE_1D(LX, glb_cmd_queue, NULL);                                       \
+      } else if (autotune_dudxyz[LX] == 2 ) {                                   \
+        CASE_KSTEP(LX, glb_cmd_queue, NULL);                                    \
+      }                                                                         \
+      break
 
   switch(*lx) {
     CASE(2);
@@ -103,5 +215,4 @@ void opencl_dudxyz(void *du, void *u,
       exit(1);
     }
   }
-} 
-
+}

--- a/src/math/bcknd/device/opencl/opr_opgrad.c
+++ b/src/math/bcknd/device/opencl/opr_opgrad.c
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2024, The Neko Authors
+ Copyright (c) 2021-2025, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -40,14 +40,18 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <device/device_config.h>
 #include <device/opencl/jit.h>
 #include <device/opencl/prgm_lib.h>
 #include <device/opencl/check.h>
+#include <common/neko_log.h>
 
 #include "opgrad_kernel.cl.h"
 
-/** 
+int *autotune_opgrad = NULL;
+
+/**
  * Fortran wrapper for device OpenCL gradients
  */
 void opencl_opgrad(void *ux, void *uy, void *uz, void *u,
@@ -57,16 +61,27 @@ void opencl_opgrad(void *ux, void *uy, void *uz, void *u,
                    void *drdz, void *dsdz, void *dtdz,
                    void *w3, int *nel, int *lx) {
   cl_int err;
-  
+
   if (opgrad_program == NULL)
     opencl_kernel_jit(opgrad_kernel, (cl_program *) &opgrad_program);
-  
+
   const size_t global_item_size = 256 * (*nel);
   const size_t local_item_size = 256;
 
+  size_t global_kstep[2];
+  size_t local_kstep[2];
+  local_kstep[0] = (*lx);
+  local_kstep[1] = (*lx);
+  global_kstep[0] = (*nel) * (*lx);
+  global_kstep[1] = (*lx);
+
+  if (autotune_opgrad == NULL) {
+    autotune_opgrad = malloc(17 * sizeof(int));
+    memset(autotune_opgrad, 0, 17 * sizeof(int));
+  }
+
 #define STR(X) #X
-#define CASE(LX)                                                                \
-  case LX:                                                                      \
+#define CASE_1D(LX, QUEUE, EVENT)                                               \
     {                                                                           \
       cl_kernel kernel = clCreateKernel(opgrad_program,                         \
                                         STR(opgrad_kernel_lx##LX), &err);       \
@@ -90,12 +105,118 @@ void opencl_opgrad(void *ux, void *uy, void *uz, void *u,
       CL_CHECK(clSetKernelArg(kernel, 15, sizeof(cl_mem), (void *) &dtdz));     \
       CL_CHECK(clSetKernelArg(kernel, 16, sizeof(cl_mem), (void *) &w3));       \
                                                                                 \
-      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,         \
+      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
                                       kernel, 1, NULL, &global_item_size,       \
-                                      &local_item_size,0, NULL, NULL));         \
-    }                                                                           \
-    break     
-  
+                                      &local_item_size,0, NULL, EVENT));        \
+    }
+
+#define CASE_KSTEP(LX, QUEUE, EVENT)                                            \
+    {                                                                           \
+      cl_kernel kernel = clCreateKernel(opgrad_program,                         \
+                                        STR(opgrad_kernel_kstep_lx##LX), &err); \
+      CL_CHECK(err);                                                            \
+                                                                                \
+      CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &ux));        \
+      CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &uy));        \
+      CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &uz));        \
+      CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &u));         \
+      CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), (void *) &dx));        \
+      CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_mem), (void *) &dy));        \
+      CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_mem), (void *) &dz));        \
+      CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_mem), (void *) &drdx));      \
+      CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_mem), (void *) &dsdx));      \
+      CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_mem), (void *) &dtdx));      \
+      CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_mem), (void *) &drdy));     \
+      CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_mem), (void *) &dsdy));     \
+      CL_CHECK(clSetKernelArg(kernel, 12, sizeof(cl_mem), (void *) &dtdy));     \
+      CL_CHECK(clSetKernelArg(kernel, 13, sizeof(cl_mem), (void *) &drdz));     \
+      CL_CHECK(clSetKernelArg(kernel, 14, sizeof(cl_mem), (void *) &dsdz));     \
+      CL_CHECK(clSetKernelArg(kernel, 15, sizeof(cl_mem), (void *) &dtdz));     \
+      CL_CHECK(clSetKernelArg(kernel, 16, sizeof(cl_mem), (void *) &w3));       \
+                                                                                \
+      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
+                                      kernel, 2, NULL, global_kstep,            \
+                                      local_kstep, 0, NULL, EVENT));            \
+    }
+
+
+#define CASE(LX)                                                                \
+  case LX:                                                                      \
+      if(autotune_opgrad[LX] == 0 ) {                                           \
+        char *env_value = NULL;                                                 \
+        char neko_log_buf[80];                                                  \
+        env_value = getenv("NEKO_AUTOTUNE");                                    \
+                                                                                \
+        sprintf(neko_log_buf, "Autotune opgrad (lx: %d)", *lx);                 \
+        log_section(neko_log_buf);                                              \
+        if(env_value) {                                                         \
+          if( !strcmp(env_value,"1D") ) {                                       \
+            CASE_1D(LX, glb_cmd_queue, NULL);                                   \
+            sprintf(neko_log_buf,"Set by env : 1 (1D)");                        \
+            log_message(neko_log_buf);                                          \
+            autotune_opgrad[LX] = 1;                                            \
+          } else if( !strcmp(env_value,"KSTEP") ) {                             \
+            CASE_KSTEP(LX, glb_cmd_queue, NULL);                                \
+            sprintf(neko_log_buf,"Set by env : 2 (KSTEP)");                     \
+            log_message(neko_log_buf);                                          \
+            autotune_opgrad[LX] = 2;                                            \
+          } else {                                                              \
+            sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");       \
+            log_error(neko_log_buf);                                            \
+          }                                                                     \
+        }                                                                       \
+        else {                                                                  \
+          CL_CHECK(clFinish(glb_cmd_queue));                                    \
+          cl_event perf_event, sync_event;                                      \
+          cl_ulong start, end;                                                  \
+          CL_CHECK(clEnqueueMarker(glb_cmd_queue, &sync_event));                \
+          CL_CHECK(clEnqueueBarrier(prf_cmd_queue));                            \
+          CL_CHECK(clEnqueueWaitForEvents(prf_cmd_queue, 1, &sync_event));      \
+                                                                                \
+          double elapsed1 = 0.0;                                                \
+          for(int i = 0; i < 100; i++) {                                        \
+            CASE_1D(LX, prf_cmd_queue, &perf_event);                            \
+            CL_CHECK(clWaitForEvents(1, &perf_event));                          \
+            CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
+                                             CL_PROFILING_COMMAND_START,        \
+                                             sizeof(cl_ulong), &start, NULL));  \
+            CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
+                                             CL_PROFILING_COMMAND_END,          \
+                                             sizeof(cl_ulong), &end, NULL));    \
+            elapsed1 += (end - start)*1.0e-6;                                   \
+          }                                                                     \
+                                                                                \
+          double elapsed2 = 0.0;                                                \
+          for(int i = 0; i < 100; i++) {                                        \
+            CASE_KSTEP(LX, prf_cmd_queue, &perf_event);                         \
+            CL_CHECK(clWaitForEvents(1, &perf_event));                          \
+            CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
+                                             CL_PROFILING_COMMAND_START,        \
+                                             sizeof(cl_ulong), &start, NULL));  \
+            CL_CHECK(clGetEventProfilingInfo(perf_event,                        \
+                                             CL_PROFILING_COMMAND_END,          \
+                                             sizeof(cl_ulong), &end, NULL));    \
+            elapsed2 += (end - start)*1.0e-6;                                   \
+          }                                                                     \
+                                                                                \
+          CL_CHECK(clFinish(prf_cmd_queue));                                    \
+          CL_CHECK(clEnqueueMarker(prf_cmd_queue, &sync_event));                \
+          int krnl_strtgy = (elapsed1 < elapsed2 ? 1 : 2);                      \
+          sprintf(neko_log_buf, "Chose      : %d (%s)", krnl_strtgy,            \
+                  (krnl_strtgy > 1 ? "KSTEP" : "1D"));                          \
+          autotune_opgrad[LX] = krnl_strtgy;                                    \
+          log_message(neko_log_buf);                                            \
+          clEnqueueBarrier(glb_cmd_queue);                                      \
+          clEnqueueWaitForEvents(glb_cmd_queue, 1, &sync_event) ;               \
+        }                                                                       \
+        log_end_section();                                                      \
+      } else if (autotune_opgrad[LX] == 1 ) {                                   \
+        CASE_1D(LX, glb_cmd_queue, NULL);                                       \
+      } else if (autotune_opgrad[LX] == 2 ) {                                   \
+        CASE_KSTEP(LX, glb_cmd_queue, NULL);                                    \
+      }                                                                         \
+      break
+
   switch(*lx) {
     CASE(2);
     CASE(3);
@@ -118,4 +239,4 @@ void opencl_opgrad(void *ux, void *uy, void *uz, void *u,
       exit(1);
     }
   }
-} 
+}


### PR DESCRIPTION
This adds the kstep formulation of key OpenCL kernels, including a similar autotuner as used for CUDA/HIP kernels.

