### PR TITLE
Remove json extract object

### DIFF
--- a/examples/programming/startup_and_json.f90
+++ b/examples/programming/startup_and_json.f90
@@ -7,7 +7,7 @@
 ! - Using the `user_startup` routine to inspect and manipulate the JSON
 !   parameter dictionary before the simulation starts.
 ! - Extracting parameters from the JSON file using `json_get` and
-!   `json_get_or_default`, and `json_extract_object`.
+!   `json_get_or_default`.
 ! - Printing JSON objects using the `print` method.
 ! - Adding or modifying parameters in the JSON file using the `add` method.
 ! - Saving the JSON parameter dictionary for later use in the module.
@@ -84,7 +84,7 @@ contains
     call json_get_or_default(params, "case.fluid.Re", some_real, 100.0_rp)
 
     ! Extract the object with the velocity initial conditions.
-    call json_extract_object(params, "case.fluid.initial_condition", &
+    call json_get(params, "case.fluid.initial_condition", &
          some_json_object)
 
     ! We can print the contents to the console.
@@ -100,7 +100,7 @@ contains
     call params%add("case.end_time", 0.0_rp)
 
     ! Show the updated part of the JSON file.
-    call json_extract_object(params, "case.fluid.initial_condition", &
+    call json_get(params, "case.fluid.initial_condition", &
          some_json_object)
     call some_json_object%print()
 

--- a/src/case.f90
+++ b/src/case.f90
@@ -57,7 +57,7 @@ module case
   use scalar_scheme, only : scalar_scheme_t
   use time_state, only : time_state_t
   use json_module, only : json_file
-  use json_utils, only : json_get, json_get_or_default, json_extract_object, json_extract_item, json_no_defaults
+  use json_utils, only : json_get, json_get_or_default, json_extract_item, json_no_defaults
   use scratch_registry, only : scratch_registry_t, neko_scratch_registry
   use point_zone_registry, only: neko_point_zone_registry
   use scalars, only : scalars_t
@@ -204,7 +204,7 @@ contains
     !
     ! Time control
     !
-    call json_extract_object(this%params, 'case.time', json_subdict)
+    call json_get(this%params, 'case.time', json_subdict)
     call this%time%init(json_subdict)
 
     !
@@ -215,7 +215,7 @@ contains
     ! Run user mesh motion routine
     call this%user%mesh_setup(this%msh, this%time)
 
-    call json_extract_object(this%params, 'case.numerics', numerics_params)
+    call json_get(this%params, 'case.numerics', numerics_params)
 
     !
     ! Setup fluid scheme
@@ -257,14 +257,14 @@ contains
        allocate(this%scalars)
        if (this%params%valid_path('case.scalar')) then
           ! For backward compatibility
-          call json_extract_object(this%params, 'case.scalar', scalar_params)
+          call json_get(this%params, 'case.scalar', scalar_params)
           call this%scalars%init(this%msh, this%fluid%c_Xh, this%fluid%gs_Xh, &
                scalar_params, numerics_params, this%user, this%chkp, this%fluid%ulag, &
                this%fluid%vlag, this%fluid%wlag, this%fluid%ext_bdf, &
                this%fluid%rho)
        else
           ! Multiple scalars
-          call json_extract_object(this%params, 'case.scalars', json_subdict)
+          call json_get(this%params, 'case.scalars', json_subdict)
           call this%scalars%init(n_scalars, this%msh, this%fluid%c_Xh, this%fluid%gs_Xh, &
                json_subdict, numerics_params, this%user, this%chkp, this%fluid%ulag, &
                this%fluid%vlag, this%fluid%wlag, this%fluid%ext_bdf, &
@@ -277,7 +277,7 @@ contains
     !
     call json_get(this%params, 'case.fluid.initial_condition.type', &
          string_val)
-    call json_extract_object(this%params, 'case.fluid.initial_condition', &
+    call json_get(this%params, 'case.fluid.initial_condition', &
          json_subdict)
 
     call neko_log%section("Fluid initial condition ")
@@ -310,12 +310,12 @@ contains
 
        if (this%params%valid_path('case.restart_file')) then
           call neko_log%message("Restart file specified, " // &
-                "initial conditions ignored")
+               "initial conditions ignored")
        else if (this%params%valid_path('case.scalar')) then
           ! For backward compatibility with single scalar
           call json_get(this%params, 'case.scalar.initial_condition.type', &
                string_val)
-          call json_extract_object(this%params, &
+          call json_get(this%params, &
                'case.scalar.initial_condition', json_subdict)
 
           if (trim(string_val) .ne. 'user') then
@@ -337,7 +337,7 @@ contains
              call json_extract_item(this%params, 'case.scalars', i, &
                   scalar_params)
              call json_get(scalar_params, 'initial_condition.type', string_val)
-             call json_extract_object(scalar_params, 'initial_condition', &
+             call json_get(scalar_params, 'initial_condition', &
                   json_subdict)
 
              if (trim(string_val) .ne. 'user') then

--- a/src/common/json_utils.f90
+++ b/src/common/json_utils.f90
@@ -257,21 +257,23 @@ contains
   subroutine json_get_subdict(json, key, output)
     type(json_file), intent(inout) :: json
     character(len=*), intent(in) :: key
-    type(json_file), intent(out) :: output
+    type(json_file), intent(inout) :: output
 
-    type(json_value), pointer :: child
-    logical :: valid
+    type(json_value), pointer :: ptr
+    type(json_core) :: core
+    logical :: found
+    character(len=:), allocatable :: buffer
 
-    valid = .false.
-    call json%get(key, child, valid)
-    if (.not. valid) then
-       call neko_error('Parameter "' // &
-            trim(key) // '" missing from the case file')
+    call json%get_core(core)
+    call json%get(key, ptr, found)
+
+    if (.not. found) then
+       call neko_error("Parameter " // &
+            trim(key) // " missing from the case file")
     end if
 
-    call output%initialize()
-    call output%add(child)
-    nullify(child)
+    call core%print_to_string(ptr, buffer)
+    call output%load_from_string(buffer)
 
   end subroutine json_get_subdict
 

--- a/src/common/json_utils.f90
+++ b/src/common/json_utils.f90
@@ -39,7 +39,7 @@ module json_utils
   private
 
   public :: json_get, json_get_or_default, json_extract_item, &
-       json_extract_object, json_no_defaults
+       json_no_defaults
 
   !> If true, the json_get_or_default routines will not add missing parameters
   logical :: json_no_defaults = .false.
@@ -434,31 +434,5 @@ contains
     call item%load_from_string(buffer)
 
   end subroutine json_extract_item_from_name
-
-  !> Extract object as a separate  JSON dictionary.
-  !! @param[inout] json The JSON with the object to be extracted.
-  !! @param[in] name The name of the object to extract.
-  !! @param[inout] object The extracted JSON object.
-  subroutine json_extract_object(json, name, object)
-    type(json_file), intent(inout) :: json
-    character(len=*), intent(in) :: name
-    type(json_file), intent(inout) :: object
-
-    type(json_value), pointer :: ptr
-    type(json_core) :: core
-    logical :: found
-    character(len=:), allocatable :: buffer
-
-    call json%get_core(core)
-    call json%get(name, ptr, found)
-
-    if (.not. found) then
-       call neko_error("Object " // name // " missing from the case file")
-    end if
-
-    call core%print_to_string(ptr, buffer)
-    call object%load_from_string(buffer)
-
-  end subroutine json_extract_object
 
 end module json_utils

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -56,8 +56,7 @@ module fluid_pnpn
   use advection, only : advection_t, advection_factory
   use profiler, only : profiler_start_region, profiler_end_region
   use json_module, only : json_file, json_core, json_value
-  use json_utils, only : json_get, json_get_or_default, json_extract_item, &
-       json_extract_object
+  use json_utils, only : json_get, json_get_or_default, json_extract_item
   use json_module, only : json_file
   use ax_product, only : ax_t, ax_helm_factory
   use field, only : field_t
@@ -384,7 +383,7 @@ contains
     call json_get(params, 'case.fluid.pressure_solver.type', solver_type)
     call json_get(params, 'case.fluid.pressure_solver.preconditioner.type', &
          precon_type)
-    call json_extract_object(params, &
+    call json_get(params, &
          'case.fluid.pressure_solver.preconditioner', precon_params)
     call json_get(params, 'case.fluid.pressure_solver.absolute_tolerance', &
          abs_tol)
@@ -404,7 +403,7 @@ contains
 
     ! Initialize the advection factory
     call json_get_or_default(params, 'case.fluid.advection', advection, .true.)
-    call json_extract_object(params, 'case.numerics', numerics_params)
+    call json_get(params, 'case.numerics', numerics_params)
     call advection_factory(this%adv, numerics_params, this%c_Xh, &
          this%ulag, this%vlag, this%wlag, &
          chkp%dtlag, chkp%tlag, this%ext_bdf, &

--- a/src/fluid/fluid_scheme_incompressible.f90
+++ b/src/fluid/fluid_scheme_incompressible.f90
@@ -58,7 +58,7 @@ module fluid_scheme_incompressible
   use operators, only : cfl
   use logger, only : neko_log, LOG_SIZE, NEKO_LOG_VERBOSE
   use field_registry, only : neko_field_registry
-  use json_utils, only : json_get, json_get_or_default, json_extract_object
+  use json_utils, only : json_get, json_get_or_default
   use json_module, only : json_file
   use scratch_registry, only : scratch_registry_t
   use user_intf, only : user_t, dummy_user_material_properties, &
@@ -283,7 +283,7 @@ contains
        call json_get(params, 'case.fluid.velocity_solver.type', string_val1)
        call json_get(params, 'case.fluid.velocity_solver.preconditioner.type', &
             string_val2)
-       call json_extract_object(params, &
+       call json_get(params, &
             'case.fluid.velocity_solver.preconditioner', json_subdict)
        call json_get(params, 'case.fluid.velocity_solver.absolute_tolerance', &
             real_val)

--- a/src/les/dynamic_smagorinsky.f90
+++ b/src/les/dynamic_smagorinsky.f90
@@ -36,7 +36,7 @@ module dynamic_smagorinsky
   use field, only : field_t
   use fluid_scheme_base, only : fluid_scheme_base_t
   use les_model, only : les_model_t
-  use json_utils, only : json_get_or_default, json_get, json_extract_object
+  use json_utils, only : json_get, json_get_or_default
   use json_module, only : json_file
   use utils, only : neko_error
   use neko_config, only : NEKO_BCKND_DEVICE
@@ -100,7 +100,7 @@ contains
 
       call this%free()
       call this%init_base(fluid, nut_name, delta_type, if_ext)
-      call json_extract_object(json, "test_filter", json_subdict)
+      call json_get(json, "test_filter", json_subdict)
       call this%test_filter%init(json_subdict, coef)
       if (json%valid_path('filter.transfer_function')) then
          call neko_error("Dynamic Smagorinsky model does not support " // &

--- a/src/neko.f90
+++ b/src/neko.f90
@@ -126,8 +126,7 @@ module neko
   use field_dirichlet_vector, only : field_dirichlet_vector_t
   use runtime_stats, only : neko_rt_stats
   use json_module, only : json_file
-  use json_utils, only : json_get, json_get_or_default, json_extract_item, &
-       json_extract_object
+  use json_utils, only : json_get, json_get_or_default, json_extract_item
   use bc_list, only : bc_list_t
   use les_model, only : les_model_t, les_model_allocate, register_les_model, &
        les_model_factory, les_model_allocator
@@ -234,7 +233,7 @@ contains
     type(json_file) :: dt_params
     real(kind=dp) :: tstep_loop_start_time
 
-    call json_extract_object(C%params, 'case.time', dt_params)
+    call json_get(C%params, 'case.time', dt_params)
     call dt_controller%init(dt_params)
 
     call C%time%reset()

--- a/src/scalar/scalar_scheme.f90
+++ b/src/scalar/scalar_scheme.f90
@@ -57,8 +57,7 @@ module scalar_scheme
   use time_scheme_controller, only : time_scheme_controller_t
   use logger, only : neko_log, LOG_SIZE, NEKO_LOG_VERBOSE
   use field_registry, only : neko_field_registry
-  use json_utils, only : json_get, json_get_or_default, json_extract_item, &
-       json_extract_object
+  use json_utils, only : json_get, json_get_or_default, json_extract_item
   use json_module, only : json_file
   use user_intf, only : user_t, dummy_user_material_properties, &
        user_material_properties_intf
@@ -270,7 +269,7 @@ contains
     call json_get(params, 'solver.type', solver_type)
     call json_get(params, 'solver.preconditioner.type', &
          solver_precon)
-    call json_extract_object(params, 'solver.preconditioner', precon_params)
+    call json_get(params, 'solver.preconditioner', precon_params)
     call json_get(params, 'solver.absolute_tolerance', &
          solver_abstol)
 

--- a/src/scalar/scalars.f90
+++ b/src/scalar/scalars.f90
@@ -43,8 +43,7 @@ module scalars
   use time_scheme_controller, only: time_scheme_controller_t
   use time_step_controller, only: time_step_controller_t
   use json_module, only: json_file
-  use json_utils, only: json_get, json_get_or_default, json_extract_object, &
-       json_extract_item
+  use json_utils, only: json_get, json_get_or_default, json_extract_item
   use field, only: field_t
   use field_list, only: field_list_t
   use field_series, only: field_series_t

--- a/src/simulation_components/simcomp_executor.f90
+++ b/src/simulation_components/simcomp_executor.f90
@@ -36,8 +36,7 @@ module simcomp_executor
   use simulation_component, only : simulation_component_t, &
        simulation_component_wrapper_t, simulation_component_factory
   use json_module, only : json_file
-  use json_utils, only : json_get, json_get_or_default, json_extract_item, &
-       json_extract_object
+  use json_utils, only : json_get, json_get_or_default, json_extract_item
   use case, only : case_t
   use time_state, only : time_state_t
   use utils, only : neko_error


### PR DESCRIPTION
I have observed that the object extraction invalidates the original json file object.

Also it have been superseeded by the `json_get_subdict` which is available through the `json_get` interface. The `json_get_subdict` does not show the same issues.