### PR TITLE
Fix the Makefile in c api example

### DIFF
--- a/examples/api/c/Makefile
+++ b/examples/api/c/Makefile
@@ -1,22 +1,21 @@
 CFLAGS  = `pkg-config --cflags jansson,neko`
 LIBS    = `pkg-config --libs jansson,neko`
-CC      = mpicc
+CC      = mpicc       # for compiling C code
+FC      = mpifort     # for linking (Fortran libs need this)
 
 DEST    = cylinder
-SRC	= cylinder.c
-OBJ	= ${SRC:.c=.o}
+SRC     = cylinder.c
+OBJ     = ${SRC:.c=.o}
 
 all: $(DEST)
-
-install:
 
 clean:
 	-rm -f *.o core *.core $(OBJ) $(DEST)
 
 $(DEST): ${OBJ}
-	$(CC) $(CFLAGS) ${OBJ} -o $@  $(LIBS)
+	$(FC) $(CFLAGS) ${OBJ} -o $@ $(LIBS)
 
-%.o: %.f90
-	${CC} ${CFLAGS} -c $<
+%.o: %.c
+	$(CC) $(CFLAGS) -c $<
 
 


### PR DESCRIPTION
One needs mpifort to link the neko library