### PR TITLE
Make the rt statistics support the timestep region. Was opened without ID and closed with no name or ID.

### DIFF
--- a/src/common/profiler.F90
+++ b/src/common/profiler.F90
@@ -123,9 +123,7 @@ contains
     end if
 #endif
 
-    if (present(name)) then
-       call neko_rt_stats%end_region(name, region_id)
-    end if
+    call neko_rt_stats%end_region(name, region_id)
 
   end subroutine profiler_end_region
 


### PR DESCRIPTION
It gave very strange results since the Time-Step region was closed with no inputs. Meaning it was never closed at all.