### PR TITLE
Revert "Update CI to nvhpc 25.9"

### DIFF
--- a/.github/workflows/check_nvidia.yml
+++ b/.github/workflows/check_nvidia.yml
@@ -89,13 +89,13 @@ jobs:
 
       - name: Setup - Install NVIDIA HPC SDK
         run: |
-          sudo apt-get install -y nvhpc-25-9
+          sudo apt-get install -y nvhpc-25-7
 
       - name: Setup - Environment
         id: setup-env
         run: |
           export NVARCH=`uname -s`_`uname -m`
-          export NVVER=25.9
+          export NVVER=25.7
           export NVCOMPILERS=/opt/nvidia/hpc_sdk
           export PATH=$NVCOMPILERS/$NVARCH/$NVVER/compilers/bin:$PATH
           export PATH=$NVCOMPILERS/$NVARCH/$NVVER/comm_libs/mpi/bin:$PATH


### PR DESCRIPTION
Reverts ExtremeFLOW/neko#2110 due to `__cxa_` issues at link time... 