### PR TITLE
enable initialisation and destruction of a neko field registry from api

### DIFF
--- a/src/api/neko.h.in
+++ b/src/api/neko.h.in
@@ -17,6 +17,12 @@ void neko_finalize();
 /* Display job information */
 void neko_job_info();
 
+/* Initialise a Neko field registry */
+void neko_field_registry_init();
+
+/* Destroy a Neko field registry */
+void neko_field_registry_free();
+
 /* Allocate memory for a Neko case */
 void neko_case_allocate(int **case_iptr);
 

--- a/src/api/neko_api.f90
+++ b/src/api/neko_api.f90
@@ -108,6 +108,20 @@ contains
 
   end subroutine neko_api_job_info
 
+  !> Initialise a Neko field registry
+  subroutine neko_api_field_registry_init() bind(c, name="neko_field_registry_init")
+
+    call neko_field_registry%init()
+
+  end subroutine neko_api_field_registry_init
+
+  !> Destroy a Neko field registry
+  subroutine neko_api_field_registry_free() bind(c, name="neko_field_registry_free")
+
+    call neko_field_registry%free()
+
+  end subroutine neko_api_field_registry_free
+
   !> Allocate memory for a Neko case
   !! @param case_iptr Opaque pointer for the created Neko case
   subroutine neko_api_case_allocate(case_iptr) &

--- a/src/python/pyneko/intf.py.in
+++ b/src/python/pyneko/intf.py.in
@@ -36,6 +36,10 @@ libneko.neko_init.resType = None
 libneko.neko_finalize.resType = None
 libneko.neko_job_info.resType = None
 
+libneko.neko_field_registry_init.restype = None
+libneko.neko_field_registry_free.restype = None
+
+
 libneko.neko_case_allocate.argtypes = [POINTER(c_int)]
 libneko.neko_case_allocate.restype = None
 
@@ -245,6 +249,14 @@ def finalize():
 def job_info():
     """ Display job information. """
     libneko.neko_job_info()
+
+def field_registry_init():
+    """ Initialise a field registry. """
+    libneko.neko_field_registry_init()
+
+def field_registry_free():
+    """ Destroy a field registry. """
+    libneko.neko_field_registry_free()
 
 def case_init(case_json,
               cb_initial_condition = initial_condition(0),


### PR DESCRIPTION
The purpose of this PR is to allow for loops to run cases in API. When the users are intended to launch runs by for loops, they need to initialise the field registry at the begining and destruct it at the end of each for-loop iteration.