### PR TITLE
Update advection_fctry.f90

### DIFF
--- a/src/fluid/advection_fctry.f90
+++ b/src/fluid/advection_fctry.f90
@@ -93,7 +93,7 @@ contains
     call json_get_or_default(json, 'dealiased_polynomial_order', &
          lxd, ( 3 * (order + 1) ) / 2)
 
-    call json_get_or_default(json, 'target_cfl', ctarget, 1.9_rp)
+    call json_get_or_default(json, 'oifs_target_cfl', ctarget, 1.9_rp)
 
 
     if (oifs) then


### PR DESCRIPTION
In respect to OIFS, I changed the parameter target_cfl to oifs_target_cfl, which has to be set in the "numerics" section of the json.case file, to avoid any confusion with the "true" or already established target_cfl related to the time-stepping, which has to be set within the "time" section of the json file. 