### PR TITLE
Allow user to set up mesh before load balancing

### DIFF
--- a/src/case.f90
+++ b/src/case.f90
@@ -181,9 +181,6 @@ contains
     call msh_file%init(string_val)
     call msh_file%read(this%msh)
 
-    ! Run user mesh motion routine
-    call this%user%mesh_setup(this%msh, this%time)
-
     !
     ! Load Balancing
     !
@@ -203,6 +200,9 @@ contains
 
        call neko_log%end_section()
     end if
+
+    ! Run user mesh motion routine
+    call this%user%mesh_setup(this%msh, this%time)
 
     !
     ! Time control


### PR DESCRIPTION
Enable users to configure the mesh prior to load balancing and the construction of point zones, improving the initialization process.