### PR TITLE
Cleanup example makefile

### DIFF
--- a/examples/api/c/Makefile
+++ b/examples/api/c/Makefile
@@ -16,7 +16,5 @@ clean:
 $(DEST): ${OBJ}
 	$(CC) $(CFLAGS) ${OBJ} -o $@  $(LIBS)
 
-%.o: %.f90
-	${CC} ${CFLAGS} -c $<
 
 


### PR DESCRIPTION
Cleanup C API example makefile, remove unused target (we only use C, and the implicit rules)
