### PR TITLE
Add vector kernels to neumann_t

### DIFF
--- a/src/bc/bcknd/device/cuda/neumann.cu
+++ b/src/bc/bcknd/device/cuda/neumann.cu
@@ -60,4 +60,31 @@ extern "C" {
     CUDA_CHECK(cudaGetLastError());
   }
 
+  /**
+   * Fortran wrapper for device neumann apply vector
+   */
+  void cuda_neumann_apply_vector(void *msk, void *facet,
+                                 void *x, void *y, void *z,
+                                 void *flux_x, void *flux_y, void *flux_z,
+                                 void *area, int *lx, int *m,
+                                 cudaStream_t strm) {
+
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks(((*m) + 1024 - 1)/ 1024, 1, 1);
+
+    neumann_apply_vector_kernel<real>
+      <<<nblcks, nthrds, 0, strm>>>((int *) msk,
+                                    (int *) facet,
+                                    (real *) x,
+                                    (real *) y,
+                                    (real *) z,
+                                    (real *) flux_x,
+                                    (real *) flux_y,
+                                    (real *) flux_z,
+                                    (real *) area,
+                                    *lx,
+                                    *m);
+    CUDA_CHECK(cudaGetLastError());
+  }
+
 }

--- a/src/bc/bcknd/device/cuda/neumann_kernel.h
+++ b/src/bc/bcknd/device/cuda/neumann_kernel.h
@@ -117,8 +117,8 @@ void neumann_apply_vector_kernel(const int * __restrict__ msk,
   const int str = blockDim.x * gridDim.x;
 
   for (int i = (idx + 1); i < m; i += str) {
-    const int k = (msk[i] - 1);
-    const int f = (facet[i]);
+    const int k = msk[i] - 1;
+    const int f = facet[i];
     nonlinear_index(msk[i], lx, index);
 
     switch(f) {

--- a/src/bc/bcknd/device/device_neumann.F90
+++ b/src/bc/bcknd/device/device_neumann.F90
@@ -46,6 +46,16 @@ module device_neumann
        integer(c_int) :: m, lx
        type(c_ptr), value :: msk, facet, x, flux, area, strm
      end subroutine hip_neumann_apply_scalar
+
+     subroutine hip_neumann_apply_vector(msk, facet, x, y, z, flux_x, flux_y,&
+          flux_z, area, lx, m, strm) &
+          bind(c, name='hip_neumann_apply_vector')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int) :: m, lx
+       type(c_ptr), value :: msk, facet, x, y, z, flux_x, flux_y, flux_z, &
+            area, strm
+     end subroutine hip_neumann_apply_vector
   end interface
 #elif HAVE_CUDA
   interface
@@ -57,6 +67,16 @@ module device_neumann
        integer(c_int) :: m, lx
        type(c_ptr), value :: msk, facet, x, flux, area, strm
      end subroutine cuda_neumann_apply_scalar
+
+     subroutine cuda_neumann_apply_vector(msk, facet, x, y, z, flux_x, flux_y, &
+          flux_z, area, lx, m, strm) &
+          bind(c, name='cuda_neumann_apply_vector')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int) :: m, lx
+       type(c_ptr), value :: msk, facet, x, y, z, flux_x, flux_y, flux_z, &
+            area, strm
+     end subroutine cuda_neumann_apply_vector
   end interface
 #elif HAVE_OPENCL
   interface
@@ -68,6 +88,15 @@ module device_neumann
        integer(c_int) :: m, lx
        type(c_ptr), value :: msk, facet, x, flux, area, strm
      end subroutine opencl_neumann_apply_scalar
+
+     subroutine opencl_neumann_apply_vector(msk, facet, x, y, z, flux_x, &
+          flux_y, flux_z, area, lx, m, strm) &
+          bind(c, name='opencl_neumann_apply_vector')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int) :: m, lx
+       type(c_ptr), value :: msk, facet, x, flux, area, strm
+     end subroutine opencl_neumann_apply_vector
   end interface
 #endif
 
@@ -91,5 +120,26 @@ contains
 #endif
 
   end subroutine device_neumann_apply_scalar
+
+  subroutine device_neumann_apply_vector(msk, facet, x, y, z, flux_x, flux_y, &
+       flux_z, area, lx, m, strm)
+    integer, intent(in) :: m, lx
+    type(c_ptr) :: msk, facet, x, y, z, flux_x, flux_y, flux_z, area, strm
+
+    if (m .lt. 1) return
+#ifdef HAVE_HIP
+    call hip_neumann_apply_vector(msk, facet, x, y, z, flux_x, flux_y, flux_z, &
+         area, lx, m, strm)
+#elif HAVE_CUDA
+    call cuda_neumann_apply_vector(msk, facet, x, y, z, flux_x, flux_y, &
+         flux_z, area, lx, m, strm)
+#elif HAVE_OPENCL
+    call opencl_neumann_apply_vector(msk, facet, x, y, z, flux_x, flux_y, &
+         flux_z, area, lx, m, strm)
+#else
+    call neko_error('No device backend configured')
+#endif
+
+  end subroutine device_neumann_apply_vector
 
 end module device_neumann

--- a/src/bc/bcknd/device/device_neumann.F90
+++ b/src/bc/bcknd/device/device_neumann.F90
@@ -95,7 +95,8 @@ module device_neumann
        use, intrinsic :: iso_c_binding
        implicit none
        integer(c_int) :: m, lx
-       type(c_ptr), value :: msk, facet, x, flux, area, strm
+       type(c_ptr), value :: msk, facet, x, y, z, flux_x, flux_y, flux_z, &
+            area, strm
      end subroutine opencl_neumann_apply_vector
   end interface
 #endif

--- a/src/bc/bcknd/device/device_neumann.F90
+++ b/src/bc/bcknd/device/device_neumann.F90
@@ -100,7 +100,7 @@ module device_neumann
   end interface
 #endif
 
-  public :: device_neumann_apply_scalar
+  public :: device_neumann_apply_scalar, device_neumann_apply_vector
 
 contains
 

--- a/src/bc/bcknd/device/hip/neumann.hip
+++ b/src/bc/bcknd/device/hip/neumann.hip
@@ -61,7 +61,7 @@ extern "C" {
   /**
    * Fortran wrapper for device neumann apply vector
    */
-  void hip_neumann_apply_scalar(void *msk, void *facet,
+  void hip_neumann_apply_vector(void *msk, void *facet,
                                 void *x, void *y, void *z,
                                 void *flux_x, void *flux_y, void *flux_z,
                                 void *area, int *lx, int *m,
@@ -70,7 +70,7 @@ extern "C" {
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*m) + 1024 - 1)/ 1024, 1, 1);
 
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(neumann_apply_scalar_kernel<real>),
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(neumann_apply_vector_kernel<real>),
                        nblcks, nthrds, 0, strm,
                        (int *) msk, (int *) facet,
                        (real *) x,

--- a/src/bc/bcknd/device/hip/neumann.hip
+++ b/src/bc/bcknd/device/hip/neumann.hip
@@ -39,7 +39,7 @@
 
 extern "C" {
 
-  /** 
+  /**
    * Fortran wrapper for device neumann apply scalar
    */
   void hip_neumann_apply_scalar(void *msk, void *facet,
@@ -58,4 +58,29 @@ extern "C" {
     HIP_CHECK(hipGetLastError());
   }
 
-} 
+  /**
+   * Fortran wrapper for device neumann apply vector
+   */
+  void hip_neumann_apply_scalar(void *msk, void *facet,
+                                void *x, void *y, void *z,
+                                void *flux_x, void *flux_y, void *flux_z,
+                                void *area, int *lx, int *m,
+                                hipStream_t strm) {
+
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks(((*m) + 1024 - 1)/ 1024, 1, 1);
+
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(neumann_apply_scalar_kernel<real>),
+                       nblcks, nthrds, 0, strm,
+                       (int *) msk, (int *) facet,
+                       (real *) x,
+                       (real *) y,
+                       (real *) z,
+                       (real *) flux_x,
+                       (real *) flux_y,
+                       (real *) flux_z,
+                       (real *) area, *lx, *m);
+    HIP_CHECK(hipGetLastError());
+  }
+
+}

--- a/src/bc/bcknd/device/hip/neumann_kernel.h
+++ b/src/bc/bcknd/device/hip/neumann_kernel.h
@@ -117,8 +117,8 @@ void neumann_apply_vector_kernel(const int * __restrict__ msk,
   const int str = blockDim.x * gridDim.x;
 
   for (int i = (idx + 1); i < m; i += str) {
-    const int k = (msk[i] - 1);
-    const int f = (facet[i]);
+    const int k = msk[i] - 1;
+    const int f = facet[i];
     nonlinear_index(msk[i], lx, index);
 
     switch(f) {

--- a/src/bc/bcknd/device/hip/neumann_kernel.h
+++ b/src/bc/bcknd/device/hip/neumann_kernel.h
@@ -96,4 +96,64 @@ void neumann_apply_scalar_kernel(const int * __restrict__ msk,
   }
 }
 
-#endif // __BC_NEUMANN_KERNEL__ 
+/**
+ * Device kernel for neumann vector boundary condition
+ */
+template< typename T >
+__global__
+void neumann_apply_vector_kernel(const int * __restrict__ msk,
+                                 const int * __restrict__ facet,
+                                 T * __restrict__ x,
+                                 T * __restrict__ y,
+                                 T * __restrict__ z,
+                                 const T * __restrict__ flux_x,
+                                 const T * __restrict__ flux_y,
+                                 const T * __restrict__ flux_z,
+                                 const T * __restrict__ area,
+                                 const int lx,
+                                 const int m) {
+  int index[4];
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  for (int i = (idx + 1); i < m; i += str) {
+    const int k = (msk[i] - 1);
+    const int f = (facet[i]);
+    nonlinear_index(msk[i], lx, index);
+
+    switch(f) {
+    case 1:
+    case 2:
+      {
+        const int na_idx = coef_normal_area_idx(index[1], index[2],
+                                                f, index[3], lx, 6);
+        x[k] += flux_x[i-1] * area[na_idx];
+        y[k] += flux_y[i-1] * area[na_idx];
+        z[k] += flux_z[i-1] * area[na_idx];
+        break;
+      }
+    case 3:
+    case 4:
+      {
+        const int na_idx = coef_normal_area_idx(index[0], index[2],
+                                                f, index[3], lx, 6);
+        x[k] += flux_x[i-1] * area[na_idx];
+        y[k] += flux_y[i-1] * area[na_idx];
+        z[k] += flux_z[i-1] * area[na_idx];
+        break;
+      }
+    case 5:
+    case 6:
+      {
+        const int na_idx = coef_normal_area_idx(index[0], index[1],
+                                                f, index[3], lx, 6);
+        x[k] += flux_x[i-1] * area[na_idx];
+        y[k] += flux_y[i-1] * area[na_idx];
+        z[k] += flux_z[i-1] * area[na_idx];
+        break;
+      }
+    }
+  }
+}
+
+#endif // __BC_NEUMANN_KERNEL__

--- a/src/bc/bcknd/device/opencl/neumann.c
+++ b/src/bc/bcknd/device/opencl/neumann.c
@@ -46,7 +46,7 @@
 
 #include "neumann_kernel.cl.h"
 
-/** 
+/**
  * Fortran wrapper for device neumann apply scalar
  */
 void opencl_neumann_apply_scalar(void *msk, void *facet,
@@ -55,10 +55,10 @@ void opencl_neumann_apply_scalar(void *msk, void *facet,
                                  cl_command_queue cmd_queue) {
 
   cl_int err;
-  
+
   if (neumann_program == NULL)
     opencl_kernel_jit(neumann_kernel, (cl_program *) &neumann_program);
-  
+
   cl_kernel kernel = clCreateKernel(neumann_program,
                                   "neumann_apply_scalar_kernel", &err);
   CL_CHECK(err);
@@ -70,7 +70,7 @@ void opencl_neumann_apply_scalar(void *msk, void *facet,
   CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), (void *) &area));
   CL_CHECK(clSetKernelArg(kernel, 5, sizeof(int), lx));
   CL_CHECK(clSetKernelArg(kernel, 6, sizeof(int), m));
-  
+
   const int nb = ((*m) + 256 - 1) / 256;
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
@@ -78,4 +78,43 @@ void opencl_neumann_apply_scalar(void *msk, void *facet,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
-} 
+}
+
+/**
+ * Fortran wrapper for device neumann apply vector
+ */
+void opencl_neumann_apply_vector(void *msk, void *facet,
+                                 void *x, void *y, void *z,
+                                 void *flux_x, void *flux_y, void *flux_z,
+                                 void *area, int *lx, int *m,
+                                 cl_command_queue cmd_queue) {
+
+  cl_int err;
+
+  if (neumann_program == NULL)
+    opencl_kernel_jit(neumann_kernel, (cl_program *) &neumann_program);
+
+  cl_kernel kernel = clCreateKernel(neumann_program,
+                                  "neumann_apply_vector_kernel", &err);
+  CL_CHECK(err);
+
+  CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &msk));
+  CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &facet));
+  CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &x));
+  CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &y));
+  CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), (void *) &z));
+  CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_mem), (void *) &flux_x));
+  CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_mem), (void *) &flux_y));
+  CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_mem), (void *) &flux_z));
+  CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_mem), (void *) &area));
+  CL_CHECK(clSetKernelArg(kernel, 9, sizeof(int), lx));
+  CL_CHECK(clSetKernelArg(kernel, 10, sizeof(int), m));
+
+  const int nb = ((*m) + 256 - 1) / 256;
+  const size_t global_item_size = 256 * nb;
+  const size_t local_item_size = 256;
+
+  CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
+                                  &global_item_size, &local_item_size,
+                                  0, NULL, NULL));
+}

--- a/src/bc/bcknd/device/opencl/neumann_kernel.cl
+++ b/src/bc/bcknd/device/opencl/neumann_kernel.cl
@@ -127,8 +127,8 @@ void neumann_apply_vector_kernel(__global const int *msk,
   const int str = get_global_size(0);
 
   for (int i = (idx + 1); i < m; i += str) {
-    const int k = (msk[i] - 1);
-    const int f = (facet[i]);
+    const int k = msk[i] - 1;
+    const int f = facet[i];
     nonlinear_index(msk[i], lx, index);
 
     switch(f) {

--- a/src/bc/bcknd/device/opencl/neumann_kernel.cl
+++ b/src/bc/bcknd/device/opencl/neumann_kernel.cl
@@ -107,4 +107,63 @@ void neumann_apply_scalar_kernel(__global const int *msk,
   }
 }
 
+/**
+ * Device kernel for neumann vector boundary condition
+ */
+__kernel
+void neumann_apply_vector_kernel(__global const int *msk,
+                                 __global const int *facet,
+                                 __global real *x,
+                                 __global real *y,
+                                 __global real *z,
+                                 __global const real *flux_x,
+                                 __global const real *flux_y,
+                                 __global const real *flux_z,
+                                 __global const real *area,
+                                 const int lx,
+                                 const int m) {
+  int index[4];
+  const int idx = get_global_id(0);
+  const int str = get_global_size(0);
+
+  for (int i = (idx + 1); i < m; i += str) {
+    const int k = (msk[i] - 1);
+    const int f = (facet[i]);
+    nonlinear_index(msk[i], lx, index);
+
+    switch(f) {
+    case 1:
+    case 2:
+      {
+        const int na_idx = coef_normal_area_idx(index[1], index[2],
+                                              f, index[3], lx, 6);
+        x[k] += flux_x[i-1] * area[na_idx];
+        y[k] += flux_y[i-1] * area[na_idx];
+        z[k] += flux_z[i-1] * area[na_idx];
+        break;
+      }
+    case 3:
+    case 4:
+      {
+        const int na_idx = coef_normal_area_idx(index[0], index[2],
+                                              f, index[3], lx, 6);
+        x[k] += flux_x[i-1] * area[na_idx];
+        y[k] += flux_y[i-1] * area[na_idx];
+        z[k] += flux_z[i-1] * area[na_idx];
+        break;
+      }
+    case 5:
+    case 6:
+      {
+        const int na_idx = coef_normal_area_idx(index[0], index[1],
+                                              f, index[3], lx, 6);
+        x[k] += flux_x[i-1] * area[na_idx];
+        y[k] += flux_y[i-1] * area[na_idx];
+        z[k] += flux_z[i-1] * area[na_idx];
+        break;
+      }
+    }
+  }
+}
+
 #endif

--- a/src/bc/neumann.f90
+++ b/src/bc/neumann.f90
@@ -370,9 +370,9 @@ contains
     end if
 
     this%flux_(comp) = flux
-
-    ! Once a flux is set explicitly, we no longer assume it is uniform zero.
-    this%uniform_0 = .false.
+    ! If we were uniform zero before, and this comp is set to zero, we are still
+    ! uniform zero
+    this%uniform_0 = abscmp(flux, 0.0_rp) .and. this%uniform_0
 
   end subroutine neumann_set_flux_scalar
 

--- a/src/bc/shear_stress.f90
+++ b/src/bc/shear_stress.f90
@@ -249,9 +249,9 @@ contains
     real(kind=rp), intent(in) :: tau_z
 
     ! Calls finalize and allocates the flux arrays
-    call this%neumann_x%set_flux(tau_x)
-    call this%neumann_y%set_flux(tau_y)
-    call this%neumann_z%set_flux(tau_z)
+    call this%neumann_x%set_flux(tau_x, 1)
+    call this%neumann_y%set_flux(tau_y, 1)
+    call this%neumann_z%set_flux(tau_z, 1)
 
 
   end subroutine shear_stress_set_stress_scalar
@@ -266,9 +266,9 @@ contains
     type(vector_t), intent(in) :: tau_y
     type(vector_t), intent(in) :: tau_z
 
-    call this%neumann_x%set_flux(tau_x)
-    call this%neumann_y%set_flux(tau_y)
-    call this%neumann_z%set_flux(tau_z)
+    call this%neumann_x%set_flux(tau_x, 1)
+    call this%neumann_y%set_flux(tau_y, 1)
+    call this%neumann_z%set_flux(tau_z, 1)
 
   end subroutine shear_stress_set_stress_array
 


### PR DESCRIPTION
Adds support for the vector apply for neumann_t.

As a consequence, the flux is an array of vector_t (should be 1 or 3), holding the fluxes.

I removed the badly implemented flux getter and renamed the flux_ component to just flux. It is not private, so a getter is not really needed.