### PR TITLE
Fix OpenCL memory leak: add missing clReleaseKernel calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
 ltmain.sh
+*.cl.h
 
 # Ignore installation files
 lib/*

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -644,7 +644,8 @@ CLEANFILES += \
 	scalar/bcknd/device/opencl/*.cl.h\
 	sem/bcknd/device/opencl/*.cl.h\
 	source_terms/bcknd/device/opencl/*.cl.h\
-	filter/bcknd/device/opencl/*.cl.h
+	filter/bcknd/device/opencl/*.cl.h\
+	common/bcknd/device/opencl/*.cl.h
 endif
 
 if ENABLE_MAKEDEPF90

--- a/src/bc/bcknd/device/opencl/dirichlet.c
+++ b/src/bc/bcknd/device/opencl/dirichlet.c
@@ -73,6 +73,7 @@ void opencl_dirichlet_apply_scalar(void *msk, void *x,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));  
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** 
@@ -104,4 +105,5 @@ void opencl_dirichlet_apply_vector(void *msk, void *x, void *y,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/bc/bcknd/device/opencl/dong_outflow.c
+++ b/src/bc/bcknd/device/opencl/dong_outflow.c
@@ -81,5 +81,6 @@ void opencl_dong_outflow_apply_scalar(void *msk, void *x, void *normal_x,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));  
+  CL_CHECK(clReleaseKernel(kernel));
 }
 

--- a/src/bc/bcknd/device/opencl/facet_normal.c
+++ b/src/bc/bcknd/device/opencl/facet_normal.c
@@ -87,4 +87,5 @@ void opencl_facet_normal_apply_surfvec(void *msk, void *facet,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/bc/bcknd/device/opencl/inflow.c
+++ b/src/bc/bcknd/device/opencl/inflow.c
@@ -83,4 +83,5 @@ void opencl_inflow_apply_vector(void *msk, void *x, void *y,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/bc/bcknd/device/opencl/inhom_dirichlet.c
+++ b/src/bc/bcknd/device/opencl/inhom_dirichlet.c
@@ -79,6 +79,7 @@ void opencl_inhom_dirichlet_apply_vector(void *msk,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 
@@ -112,4 +113,5 @@ void opencl_inhom_dirichlet_apply_scalar(void *msk,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/bc/bcknd/device/opencl/neumann.c
+++ b/src/bc/bcknd/device/opencl/neumann.c
@@ -78,6 +78,7 @@ void opencl_neumann_apply_scalar(void *msk, void *facet,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -117,4 +118,5 @@ void opencl_neumann_apply_vector(void *msk, void *facet,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/bc/bcknd/device/opencl/symmetry.c
+++ b/src/bc/bcknd/device/opencl/symmetry.c
@@ -83,4 +83,5 @@ void opencl_symmetry_apply_vector(void *xmsk, void *ymsk, void *zmsk,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/bc/bcknd/device/opencl/zero_dirichlet.c
+++ b/src/bc/bcknd/device/opencl/zero_dirichlet.c
@@ -72,6 +72,7 @@ void opencl_zero_dirichlet_apply_scalar(void *msk, void *x, int *m,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -102,5 +103,5 @@ void opencl_zero_dirichlet_apply_vector(void *msk, void *x, void *y,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
-
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/common/bcknd/device/opencl/rhs_maker.c
+++ b/src/common/bcknd/device/opencl/rhs_maker.c
@@ -84,6 +84,7 @@ void rhs_maker_sumab_opencl(void *u, void *v, void *w,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void rhs_maker_ext_opencl(void *abx1, void *aby1, void *abz1,
@@ -121,6 +122,7 @@ void rhs_maker_ext_opencl(void *abx1, void *aby1, void *abz1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void scalar_rhs_maker_ext_opencl(void *fs_lag, void *fs_laglag, void *fs,
@@ -151,6 +153,7 @@ void scalar_rhs_maker_ext_opencl(void *fs_lag, void *fs_laglag, void *fs,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void rhs_maker_bdf_opencl(void *ulag1, void *ulag2, void *vlag1,
@@ -196,6 +199,7 @@ void rhs_maker_bdf_opencl(void *ulag1, void *ulag2, void *vlag1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void scalar_rhs_maker_bdf_opencl(void *s_lag, void *s_laglag, void *fs,
@@ -231,6 +235,7 @@ void scalar_rhs_maker_bdf_opencl(void *s_lag, void *s_laglag, void *fs,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void rhs_maker_oifs_opencl(void *phi_x, void *phi_y, void *phi_z,
@@ -262,6 +267,7 @@ void rhs_maker_oifs_opencl(void *phi_x, void *phi_y, void *phi_z,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void scalar_rhs_maker_oifs_opencl(void *phi_s, void *bf_s,
@@ -288,4 +294,5 @@ void scalar_rhs_maker_oifs_opencl(void *phi_s, void *bf_s,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/filter/bcknd/device/opencl/mappings.c
+++ b/src/filter/bcknd/device/opencl/mappings.c
@@ -75,6 +75,7 @@ void opencl_smooth_step(void* x, real* edge0, real* edge1, int* n) {
     CL_CHECK(clEnqueueNDRangeKernel(
         (cl_command_queue)glb_cmd_queue, kernel, 1, NULL, &global_item_size,
         &local_item_size, 0, NULL, NULL));
+    CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for step function
@@ -113,6 +114,7 @@ void opencl_step_function(
     CL_CHECK(clEnqueueNDRangeKernel(
         (cl_command_queue)glb_cmd_queue, kernel, 1, NULL, &global_item_size,
         &local_item_size, 0, NULL, NULL));
+    CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for the permeability mapping
@@ -146,4 +148,5 @@ void opencl_permeability(void* x, real* k_0, real* k_1, real* q, int* n) {
     CL_CHECK(clEnqueueNDRangeKernel(
         (cl_command_queue)glb_cmd_queue, kernel, 1, NULL, &global_item_size,
         &local_item_size, 0, NULL, NULL));
+    CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/fluid/bcknd/device/opencl/compressible_ops_compute_entropy.c
+++ b/src/fluid/bcknd/device/opencl/compressible_ops_compute_entropy.c
@@ -53,10 +53,12 @@ void opencl_compute_entropy(void *S_d,
   cl_int err;
   
   if (compressible_ops_compute_entropy_program == NULL)
-    opencl_kernel_jit(compressible_ops_compute_entropy_kernel, (cl_program *) &compressible_ops_compute_entropy_program);
+    opencl_kernel_jit(compressible_ops_compute_entropy_kernel,
+                      (cl_program *) &compressible_ops_compute_entropy_program);
 
-  cl_kernel kernel = clCreateKernel((cl_program) compressible_ops_compute_entropy_program, 
-                                    "compute_entropy_kernel", &err);
+  cl_kernel kernel =
+    clCreateKernel((cl_program) compressible_ops_compute_entropy_program, 
+                   "compute_entropy_kernel", &err);
   CL_CHECK(err);
 
   CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &S_d));

--- a/src/fluid/bcknd/device/opencl/compressible_ops_compute_max_wave_speed.c
+++ b/src/fluid/bcknd/device/opencl/compressible_ops_compute_max_wave_speed.c
@@ -74,4 +74,5 @@ void opencl_compute_max_wave_speed(void *max_wave_speed, void *u, void *v, void 
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 } 

--- a/src/fluid/bcknd/device/opencl/compressible_ops_compute_max_wave_speed.c
+++ b/src/fluid/bcknd/device/opencl/compressible_ops_compute_max_wave_speed.c
@@ -46,16 +46,19 @@
 
 #include "compressible_ops_compute_max_wave_speed_kernel.cl.h"
 
-void opencl_compute_max_wave_speed(void *max_wave_speed, void *u, void *v, void *w,
-                                   real gamma, void *p, void *rho, int n) {
+void opencl_compute_max_wave_speed(void *max_wave_speed, void *u, void *v,
+                                   void *w, real gamma, void *p, void *rho,
+                                   int n) {
 
   cl_int err;
 
   if (compressible_ops_compute_max_wave_speed_program == NULL)
-    opencl_kernel_jit(compressible_ops_compute_max_wave_speed_kernel, (cl_program *) &compressible_ops_compute_max_wave_speed_program);
+    opencl_kernel_jit(compressible_ops_compute_max_wave_speed_kernel,
+                      (cl_program *) &compressible_ops_compute_max_wave_speed_program);
 
-  cl_kernel kernel = clCreateKernel((cl_program) compressible_ops_compute_max_wave_speed_program, 
-                                    "compute_max_wave_speed_kernel", &err);
+  cl_kernel kernel =
+    clCreateKernel((cl_program) compressible_ops_compute_max_wave_speed_program, 
+                   "compute_max_wave_speed_kernel", &err);
   CL_CHECK(err);
 
   CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &max_wave_speed));

--- a/src/fluid/bcknd/device/opencl/euler_res.c
+++ b/src/fluid/bcknd/device/opencl/euler_res.c
@@ -1,18 +1,23 @@
 /*
  Copyright (c) 2025, The Neko Authors
  All rights reserved.
+
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
+
    * Redistributions of source code must retain the above copyright
      notice, this list of conditions and the following disclaimer.
+
    * Redistributions in binary form must reproduce the above
      copyright notice, this list of conditions and the following
      disclaimer in the documentation and/or other materials provided
      with the distribution.
+
    * Neither the name of the authors nor the names of its
      contributors may be used to endorse or promote products derived
      from this software without specific prior written permission.
+
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS

--- a/src/fluid/bcknd/device/opencl/euler_res.c
+++ b/src/fluid/bcknd/device/opencl/euler_res.c
@@ -66,6 +66,7 @@ void euler_res_part_visc_opencl(void *rhs_u, void *Binv, void *lap_sol,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));  
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void euler_res_part_mx_flux_opencl(void *f_x, void *f_y, void *f_z,
@@ -97,6 +98,7 @@ void euler_res_part_mx_flux_opencl(void *f_x, void *f_y, void *f_z,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));  
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void euler_res_part_my_flux_opencl(void *f_x, void *f_y, void *f_z,
@@ -128,6 +130,7 @@ void euler_res_part_my_flux_opencl(void *f_x, void *f_y, void *f_z,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));  
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void euler_res_part_mz_flux_opencl(void *f_x, void *f_y, void *f_z,
@@ -159,6 +162,7 @@ void euler_res_part_mz_flux_opencl(void *f_x, void *f_y, void *f_z,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));  
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void euler_res_part_E_flux_opencl(void *f_x, void *f_y, void *f_z,
@@ -191,6 +195,7 @@ void euler_res_part_E_flux_opencl(void *f_x, void *f_y, void *f_z,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));  
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void euler_res_part_coef_mult_opencl(void *rhs_rho, void *rhs_m_x,
@@ -220,6 +225,7 @@ void euler_res_part_coef_mult_opencl(void *rhs_rho, void *rhs_m_x,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));  
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void euler_res_part_rk_sum_opencl(void *rho, void *m_x, void *m_y, void *m_z,
@@ -256,4 +262,5 @@ void euler_res_part_rk_sum_opencl(void *rho, void *m_x, void *m_y, void *m_z,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));  
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/fluid/bcknd/device/opencl/pnpn_res.c
+++ b/src/fluid/bcknd/device/opencl/pnpn_res.c
@@ -1,18 +1,23 @@
 /*
- Copyright (c) 2022, The Neko Authors
+ Copyright (c) 2025, The Neko Authors
  All rights reserved.
+
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
+
    * Redistributions of source code must retain the above copyright
      notice, this list of conditions and the following disclaimer.
+
    * Redistributions in binary form must reproduce the above
      copyright notice, this list of conditions and the following
      disclaimer in the documentation and/or other materials provided
      with the distribution.
+
    * Neither the name of the authors nor the names of its
      contributors may be used to endorse or promote products derived
      from this software without specific prior written permission.
+
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS

--- a/src/fluid/bcknd/device/opencl/pnpn_res.c
+++ b/src/fluid/bcknd/device/opencl/pnpn_res.c
@@ -77,6 +77,7 @@ void pnpn_prs_res_part1_opencl(void *ta1, void *ta2, void *ta3,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));  
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void pnpn_prs_res_part2_opencl(void *p_res, void *wa1, void *wa2,
@@ -103,6 +104,7 @@ void pnpn_prs_res_part2_opencl(void *p_res, void *wa1, void *wa2,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));  
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void pnpn_prs_res_part3_opencl(void *p_res, void *ta1, void *ta2,
@@ -130,6 +132,7 @@ void pnpn_prs_res_part3_opencl(void *p_res, void *ta1, void *ta2,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void pnpn_vel_res_update_opencl(void *u_res, void *v_res, void *w_res,
@@ -162,4 +165,5 @@ void pnpn_vel_res_update_opencl(void *u_res, void *v_res, void *w_res,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/fluid/stress_formulation/bcknd/device/opencl/pnpn_stress_res.c
+++ b/src/fluid/stress_formulation/bcknd/device/opencl/pnpn_stress_res.c
@@ -92,6 +92,7 @@ void pnpn_prs_stress_res_part1_opencl(void *ta1, void *ta2, void *ta3,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void pnpn_prs_stress_res_part3_opencl(void *p_res, void *ta1, void *ta2,
@@ -127,4 +128,5 @@ void pnpn_prs_stress_res_part3_opencl(void *p_res, void *ta1, void *ta2,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
 
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/gs/bcknd/device/opencl/gs.c
+++ b/src/gs/bcknd/device/opencl/gs.c
@@ -89,6 +89,7 @@ void opencl_gather_kernel(void *v, int *m, int *o, void *dg,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) cmd_queue, kernel,
                                       1, NULL, &global_item_size,
                                       &local_item_size, 0, NULL, NULL));
+      CL_CHECK(clReleaseKernel(kernel));
     }
     break;
   case GS_OP_MUL:
@@ -111,6 +112,7 @@ void opencl_gather_kernel(void *v, int *m, int *o, void *dg,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) cmd_queue, kernel,
                                       1, NULL, &global_item_size,
                                       &local_item_size, 0, NULL, NULL));
+      CL_CHECK(clReleaseKernel(kernel));
     }
     break;
   case GS_OP_MIN:
@@ -133,6 +135,7 @@ void opencl_gather_kernel(void *v, int *m, int *o, void *dg,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) cmd_queue, kernel,
                                       1, NULL, &global_item_size,
                                       &local_item_size, 0, NULL, NULL));
+      CL_CHECK(clReleaseKernel(kernel));
     }
     break;
   case GS_OP_MAX:
@@ -155,6 +158,7 @@ void opencl_gather_kernel(void *v, int *m, int *o, void *dg,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) cmd_queue, kernel,
                                       1, NULL, &global_item_size,
                                       &local_item_size, 0, NULL, NULL));
+      CL_CHECK(clReleaseKernel(kernel));
     }
     break;
   }
@@ -191,4 +195,5 @@ void opencl_scatter_kernel(void *v, int *m, void *dg,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/krylov/bcknd/device/opencl/pc_jacobi.c
+++ b/src/krylov/bcknd/device/opencl/pc_jacobi.c
@@ -87,6 +87,7 @@ void opencl_jacobi_update(void *d,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,        \
 				      kernel, 1, NULL, &global_item_size,      \
 				      &local_item_size, 0, NULL, NULL));       \
+      CL_CHECK(clReleaseKernel(kernel));                                       \
     }                                                                          \
     break
 

--- a/src/math/bcknd/device/opencl/ax_helm.c
+++ b/src/math/bcknd/device/opencl/ax_helm.c
@@ -105,7 +105,7 @@ void opencl_ax_helm(void *w, void *u, void *dx, void *dy, void *dz,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
                                      kernel, 1, NULL, &global_item_size,        \
                                      &local_item_size, 0, NULL, EVENT));        \
-                                                                                \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }
 
 
@@ -131,7 +131,7 @@ void opencl_ax_helm(void *w, void *u, void *dx, void *dy, void *dz,
      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                  \
                                      kernel, 2, NULL, global_kstep,             \
                                      local_kstep, 0, NULL, EVENT));             \
-                                                                                \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }
 
 
@@ -304,7 +304,7 @@ void opencl_ax_helm_vector(void *au, void *av, void *aw,
      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,          \
                                      kernel, 2, NULL, global_kstep,             \
                                      local_kstep, 0, NULL, NULL));              \
-                                                                                \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }                                                                           \
     break
 

--- a/src/math/bcknd/device/opencl/ax_helm_full.c
+++ b/src/math/bcknd/device/opencl/ax_helm_full.c
@@ -108,7 +108,7 @@ void opencl_ax_helm_stress_vector(void *au, void *av, void *aw,
      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,         \
                                      kernel, 2, NULL, global_kstep,            \
                                      local_kstep, 0, NULL, NULL));             \
-      CL_CHECK(clReleaseKernel(kernel));                                       \
+     CL_CHECK(clReleaseKernel(kernel));                                        \
     }                                                                          \
     break
 
@@ -152,7 +152,7 @@ void opencl_ax_helm_stress_vector_part2(void *au, void *av, void *aw,
   cl_kernel kernel = clCreateKernel(ax_helm_full_program,
                                     "ax_helm_stress_kernel_vector_part2", &err);
   CL_CHECK(err);
-  
+
   CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &au));
   CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &av));
   CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &aw));

--- a/src/math/bcknd/device/opencl/ax_helm_full.c
+++ b/src/math/bcknd/device/opencl/ax_helm_full.c
@@ -108,7 +108,7 @@ void opencl_ax_helm_stress_vector(void *au, void *av, void *aw,
      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,         \
                                      kernel, 2, NULL, global_kstep,            \
                                      local_kstep, 0, NULL, NULL));             \
-                                                                               \
+      CL_CHECK(clReleaseKernel(kernel));                                       \
     }                                                                          \
     break
 
@@ -170,5 +170,5 @@ void opencl_ax_helm_stress_vector_part2(void *au, void *av, void *aw,
   CL_CHECK(clEnqueueNDRangeKernel(glb_cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
- 
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/math/bcknd/device/opencl/fdm.c
+++ b/src/math/bcknd/device/opencl/fdm.c
@@ -72,6 +72,7 @@ void opencl_fdm_do_fast(void *e, void *r, void *s, void *d, int *nl, int *nel,
       CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel,                       \
                                       1, NULL, &global_item_size,              \
                                       &local_item_size, 0, NULL, NULL));       \
+      CL_CHECK(clReleaseKernel(kernel));                                       \
     }                                                                          \
    break
 

--- a/src/math/bcknd/device/opencl/math.c
+++ b/src/math/bcknd/device/opencl/math.c
@@ -175,7 +175,7 @@ void opencl_cfill_mask(void* a, void* c, int* size, void* mask, int* mask_size,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
   CL_CHECK(clReleaseKernel(kernel));
-  }
+}
 
 /** Fortran wrapper for rzero
  * Zero a real vector
@@ -1103,7 +1103,6 @@ real opencl_glsc3(void *a, void *b, void *c, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, &kern_wait));
-  CL_CHECK(clReleaseKernel(kernel));
 
   CL_CHECK(clEnqueueReadBuffer(cmd_queue, bufred_d, CL_TRUE, 0,
                                nb * sizeof(real), bufred, 1,
@@ -1113,6 +1112,8 @@ real opencl_glsc3(void *a, void *b, void *c, int *n,
   for (i = 0; i < nb; i++) {
     res += bufred[i];
   }
+
+  CL_CHECK(clReleaseKernel(kernel));
 
   return res;
 }
@@ -1166,7 +1167,6 @@ void opencl_glsc3_many(real *h, void * w, void *v, void *mult, int *j, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 2, NULL,
                                   global_item_size, local_item_size,
                                   0, NULL, &kern_wait));
-  CL_CHECK(clReleaseKernel(kernel));
 
   CL_CHECK(clEnqueueReadBuffer(cmd_queue, bufred_d, CL_TRUE, 0,
                                (*j) * nb * sizeof(real),
@@ -1181,6 +1181,8 @@ void opencl_glsc3_many(real *h, void * w, void *v, void *mult, int *j, int *n,
         h[k] += bufred[i*(*j)+k];
     }
   }
+
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -1216,8 +1218,6 @@ real opencl_glsc2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, &kern_wait));
-  CL_CHECK(clReleaseKernel(kernel));
-
 
   CL_CHECK(clEnqueueReadBuffer(cmd_queue, buf_d, CL_TRUE, 0,
                                nb * sizeof(real), buf, 1, &kern_wait, NULL));
@@ -1229,6 +1229,7 @@ real opencl_glsc2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
 
   free(buf);
   CL_CHECK(clReleaseMemObject(buf_d));
+  CL_CHECK(clReleaseKernel(kernel));
 
   return res;
 }
@@ -1266,8 +1267,6 @@ real opencl_glsubnorm2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, &kern_wait));
-  CL_CHECK(clReleaseKernel(kernel));
-
 
   CL_CHECK(clEnqueueReadBuffer(cmd_queue, buf_d, CL_TRUE, 0,
                                nb * sizeof(real), buf, 1, &kern_wait, NULL));
@@ -1279,6 +1278,7 @@ real opencl_glsubnorm2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
 
   free(buf);
   CL_CHECK(clReleaseMemObject(buf_d));
+  CL_CHECK(clReleaseKernel(kernel));
 
   return res;
 }
@@ -1315,8 +1315,6 @@ real opencl_glsum(void *a, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, &kern_wait));
-  CL_CHECK(clReleaseKernel(kernel));
-
 
   CL_CHECK(clEnqueueReadBuffer(cmd_queue, buf_d, CL_TRUE, 0,
                                nb * sizeof(real), buf, 1, &kern_wait, NULL));
@@ -1328,6 +1326,7 @@ real opencl_glsum(void *a, int *n, cl_command_queue cmd_queue) {
 
   free(buf);
   CL_CHECK(clReleaseMemObject(buf_d));
+  CL_CHECK(clReleaseKernel(kernel));
 
   return res;
 }

--- a/src/math/bcknd/device/opencl/math.c
+++ b/src/math/bcknd/device/opencl/math.c
@@ -82,6 +82,7 @@ void opencl_masked_copy(void *a, void *b, void *mask, int *n, int *m,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 
 }
 
@@ -112,6 +113,7 @@ void opencl_masked_gather_copy(void *a, void *b, void *mask, int *n, int *m,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 
 }
 
@@ -142,6 +144,7 @@ void opencl_masked_scatter_copy(void *a, void *b, void *mask, int *n, int *m,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 
 }
 
@@ -171,6 +174,7 @@ void opencl_cfill_mask(void* a, void* c, int* size, void* mask, int* mask_size,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
   }
 
 /** Fortran wrapper for rzero
@@ -220,6 +224,7 @@ void opencl_cmult(void *a, real *c, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for cmult2
@@ -247,6 +252,7 @@ void opencl_cmult2(void *a, void *b, real *c, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for cdiv
@@ -272,6 +278,7 @@ void opencl_cdiv(void *a, real *c, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for cdiv2
@@ -299,6 +306,7 @@ void opencl_cdiv2(void *a, void *b, real *c, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for cadd
@@ -324,6 +332,7 @@ void opencl_radd(void *a, real *c, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for cadd
@@ -351,6 +360,7 @@ void opencl_cadd2(void *a, void *b, real *c, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for cfill
@@ -376,6 +386,7 @@ void opencl_cfill(void *a, real *c, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -402,6 +413,7 @@ void opencl_add2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -430,6 +442,7 @@ void opencl_add3(void *a, void *b, void *c, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -459,6 +472,7 @@ void opencl_add4(void *a, void *b, void *c, void *d, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -488,6 +502,7 @@ void opencl_add2s1(void *a, void *b, real *c1, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -517,6 +532,7 @@ void opencl_add2s2(void *a, void *b, real *c1, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -548,6 +564,7 @@ void opencl_add2s2_many(void *x, void *p, void *alpha, int *j, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 
 }
 
@@ -578,6 +595,7 @@ void opencl_addsqr2s2(void *a, void *b, real *c1, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -608,6 +626,7 @@ void opencl_add3s2(void *a, void *b, void * c, real *c1, real *c2, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -640,6 +659,7 @@ void opencl_add4s3(void *a, void *b, void * c, void * d, real *c1, real *c2,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -675,6 +695,7 @@ void opencl_add5s4(void *a, void *b, void * c, void * d, void * e, real *c1,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -700,6 +721,7 @@ void opencl_invcol1(void *a, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -726,6 +748,7 @@ void opencl_invcol2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -752,6 +775,7 @@ void opencl_col2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -780,6 +804,7 @@ void opencl_col3(void *a, void *b, void *c, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -808,6 +833,7 @@ void opencl_subcol3(void *a, void *b, void *c, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -834,6 +860,7 @@ void opencl_sub2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -862,6 +889,7 @@ void opencl_sub3(void *a, void *b, void *c, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -890,6 +918,7 @@ void opencl_addcol3(void *a, void *b, void *c, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -919,6 +948,7 @@ void opencl_addcol4(void *a, void *b, void *c, void *d, int *n,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -948,6 +978,7 @@ void opencl_addcol3s2(void *a, void *b, void *c, real *s, int *n,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -982,6 +1013,7 @@ void opencl_vdot3(void *dot, void *u1, void *u2, void *u3,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /**
@@ -1020,6 +1052,7 @@ void opencl_vcross(void *u1, void *u2, void *u3,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 
 }
 
@@ -1070,6 +1103,7 @@ real opencl_glsc3(void *a, void *b, void *c, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, &kern_wait));
+  CL_CHECK(clReleaseKernel(kernel));
 
   CL_CHECK(clEnqueueReadBuffer(cmd_queue, bufred_d, CL_TRUE, 0,
                                nb * sizeof(real), bufred, 1,
@@ -1132,6 +1166,7 @@ void opencl_glsc3_many(real *h, void * w, void *v, void *mult, int *j, int *n,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 2, NULL,
                                   global_item_size, local_item_size,
                                   0, NULL, &kern_wait));
+  CL_CHECK(clReleaseKernel(kernel));
 
   CL_CHECK(clEnqueueReadBuffer(cmd_queue, bufred_d, CL_TRUE, 0,
                                (*j) * nb * sizeof(real),
@@ -1181,6 +1216,7 @@ real opencl_glsc2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, &kern_wait));
+  CL_CHECK(clReleaseKernel(kernel));
 
 
   CL_CHECK(clEnqueueReadBuffer(cmd_queue, buf_d, CL_TRUE, 0,
@@ -1230,6 +1266,7 @@ real opencl_glsubnorm2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, &kern_wait));
+  CL_CHECK(clReleaseKernel(kernel));
 
 
   CL_CHECK(clEnqueueReadBuffer(cmd_queue, buf_d, CL_TRUE, 0,
@@ -1278,6 +1315,7 @@ real opencl_glsum(void *a, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, &kern_wait));
+  CL_CHECK(clReleaseKernel(kernel));
 
 
   CL_CHECK(clEnqueueReadBuffer(cmd_queue, buf_d, CL_TRUE, 0,
@@ -1318,6 +1356,7 @@ void opencl_iadd(void *a, int *c, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for pwmax_vec2
@@ -1344,6 +1383,7 @@ void opencl_pwmax_vec2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for pwmax_vec3
@@ -1372,6 +1412,7 @@ void opencl_pwmax_vec3(void *a, void *b, void *c,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for pwmax_sca2
@@ -1398,6 +1439,7 @@ void opencl_pwmax_sca2(void *a, real *c, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for pwmax_sca3
@@ -1426,6 +1468,7 @@ void opencl_pwmax_sca3(void *a, void *b, real *c,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for pwmin_vec2
@@ -1452,6 +1495,7 @@ void opencl_pwmin_vec2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for pwmin_vec3
@@ -1480,6 +1524,7 @@ void opencl_pwmin_vec3(void *a, void *b, void *c,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for pwmin_sca2
@@ -1506,6 +1551,7 @@ void opencl_pwmin_sca2(void *a, real *c, int *n, cl_command_queue cmd_queue) {
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for pwmin_sca3
@@ -1534,4 +1580,5 @@ void opencl_pwmin_sca3(void *a, void *b, real *c,
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/math/bcknd/device/opencl/mathops.c
+++ b/src/math/bcknd/device/opencl/mathops.c
@@ -69,6 +69,7 @@ void opencl_opchsign(void *a1, void *a2, void *a3, int *gdim, int *n) {
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
 				  NULL, &global_item_size, &local_item_size,
 				  0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for opcolv \f$ a = a * c \f$ */
@@ -95,6 +96,7 @@ void opencl_opcolv(void *a1, void *a2, void *a3, void *c, int *gdim, int *n) {
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
 				  NULL, &global_item_size, &local_item_size,
 				  0, NULL, NULL));   
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for opcolv3c \f$ a(i) = b(i) * c(i) * d \f$ */
@@ -127,6 +129,7 @@ void opencl_opcolv3c(void *a1, void *a2, void *a3,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
 				  NULL, &global_item_size, &local_item_size,
 				  0, NULL, NULL));   
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for opadd2cm \f$ a(i) = a + b(i) * c \f$ */
@@ -158,6 +161,7 @@ void opencl_opadd2cm(void *a1, void *a2, void *a3,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
 				  NULL, &global_item_size, &local_item_size,
 				  0, NULL, NULL));  
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 /** Fortran wrapper for opadd2col \f$ a(i) = a + b(i) * c(i) \f$ */
@@ -189,4 +193,5 @@ void opencl_opadd2col(void *a1, void *a2, void *a3,
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
 				  NULL, &global_item_size, &local_item_size,
 				  0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/math/bcknd/device/opencl/opr_cdtp.c
+++ b/src/math/bcknd/device/opencl/opr_cdtp.c
@@ -98,6 +98,7 @@ void opencl_cdtp(void *dtx, void *x,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
                                       kernel, 1, NULL, &global_item_size,       \
                                       &local_item_size, 0, NULL, EVENT));       \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }
 
 
@@ -120,6 +121,7 @@ void opencl_cdtp(void *dtx, void *x,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
                                       kernel, 2, NULL, global_kstep,            \
                                       local_kstep, 0, NULL, EVENT));            \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }
 
 

--- a/src/math/bcknd/device/opencl/opr_cfl.c
+++ b/src/math/bcknd/device/opencl/opr_cfl.c
@@ -101,6 +101,7 @@ real opencl_cfl(real *dt, void *u, void *v, void *w,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,         \
                                       kernel, 1, NULL, &global_item_size,       \
                                       &local_item_size, 0, NULL, &kern_wait));  \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }                                                                           \
     break
     

--- a/src/math/bcknd/device/opencl/opr_conv1.c
+++ b/src/math/bcknd/device/opencl/opr_conv1.c
@@ -110,6 +110,7 @@ void opencl_conv1(void *du, void *u,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
                                       kernel, 1, NULL, &global_item_size,       \
                                       &local_item_size, 0, NULL, EVENT));       \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }
 
 #define CASE_KSTEP(LX, QUEUE, EVENT)                                            \
@@ -140,6 +141,7 @@ void opencl_conv1(void *du, void *u,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
                                       kernel, 2, NULL, global_kstep,            \
                                       local_kstep, 0, NULL, EVENT));            \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }
 
 

--- a/src/math/bcknd/device/opencl/opr_convect_scalar.c
+++ b/src/math/bcknd/device/opencl/opr_convect_scalar.c
@@ -81,6 +81,7 @@ void opencl_convect_scalar(void *du, void *u,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,         \
                                       kernel, 1, NULL, &global_item_size,       \
                                       &local_item_size, 0, NULL, NULL));        \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }                                                                           \
     break
 

--- a/src/math/bcknd/device/opencl/opr_dudxyz.c
+++ b/src/math/bcknd/device/opencl/opr_dudxyz.c
@@ -98,6 +98,7 @@ void opencl_dudxyz(void *du, void *u,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
                                       kernel, 1, NULL, &global_item_size,       \
                                       &local_item_size, 0, NULL, EVENT));       \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }
 
 #define CASE_KSTEP(LX, QUEUE, EVENT)                                            \
@@ -119,6 +120,7 @@ void opencl_dudxyz(void *du, void *u,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
                                       kernel, 2, NULL, global_kstep,            \
                                       local_kstep, 0, NULL, EVENT));            \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }
 
 #define CASE(LX)                                                                \

--- a/src/math/bcknd/device/opencl/opr_lambda2.c
+++ b/src/math/bcknd/device/opencl/opr_lambda2.c
@@ -93,7 +93,7 @@ void opencl_lambda2(void *lambda2, void *u, void *v, void *w,
      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,          \
                                      kernel, 1, NULL, &global_item_size,        \
                                      &local_item_size, 0, NULL, NULL));         \
-                                                                                \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }                                                                           \
     break
 

--- a/src/math/bcknd/device/opencl/opr_opgrad.c
+++ b/src/math/bcknd/device/opencl/opr_opgrad.c
@@ -108,6 +108,7 @@ void opencl_opgrad(void *ux, void *uy, void *uz, void *u,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
                                       kernel, 1, NULL, &global_item_size,       \
                                       &local_item_size,0, NULL, EVENT));        \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }
 
 #define CASE_KSTEP(LX, QUEUE, EVENT)                                            \
@@ -137,6 +138,7 @@ void opencl_opgrad(void *ux, void *uy, void *uz, void *u,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) QUEUE,                 \
                                       kernel, 2, NULL, global_kstep,            \
                                       local_kstep, 0, NULL, EVENT));            \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }
 
 

--- a/src/math/bcknd/device/opencl/schwarz.c
+++ b/src/math/bcknd/device/opencl/schwarz.c
@@ -79,6 +79,7 @@ void opencl_schwarz_extrude(void *arr1, int *l1, real *f1,
       CL_CHECK(clEnqueueNDRangeKernel(command_queue, kernel, 1, NULL,          \
                                       &global_item_size,                       \
                                       &local_item_size, 0, NULL, NULL));       \
+      CL_CHECK(clReleaseKernel(kernel));                                       \
      }                                                                         \
     break
 
@@ -122,6 +123,7 @@ void opencl_schwarz_toext3d(void *a, void *b, int *nx, int *nel,
   CL_CHECK(clEnqueueNDRangeKernel(command_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }
 
 void opencl_schwarz_toreg3d(void *b, void *a, int *nx, int *nel,
@@ -145,4 +147,5 @@ void opencl_schwarz_toreg3d(void *b, void *a, int *nx, int *nel,
   CL_CHECK(clEnqueueNDRangeKernel(command_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/math/bcknd/device/opencl/set_convect_rst.c
+++ b/src/math/bcknd/device/opencl/set_convect_rst.c
@@ -92,6 +92,7 @@ void opencl_set_convect_rst(void *cr, void *cs, void *ct,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,         \
                                       kernel, 1, NULL, &global_item_size,       \
                                       &local_item_size,0, NULL, NULL));         \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }                                                                           \
     break
 

--- a/src/math/bcknd/device/opencl/tensor.c
+++ b/src/math/bcknd/device/opencl/tensor.c
@@ -78,6 +78,7 @@ void opencl_tnsr3d(void *v, int *nv, void *u, int *nu,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel,\
                                       1, NULL, &global_item_size,              \
                                       &local_item_size, 0, NULL, NULL));       \
+      CL_CHECK(clReleaseKernel(kernel));                                       \
     }                                                                          \
    break
 
@@ -131,6 +132,7 @@ void opencl_tnsr3d_el_list(void *v, int *nv, void *u, int *nu,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel,\
                                       1, NULL, &global_item_size,              \
                                       &local_item_size, 0, NULL, NULL));       \
+      CL_CHECK(clReleaseKernel(kernel));                                       \
     }                                                                          \
    break
 

--- a/src/scalar/bcknd/device/opencl/scalar_residual.c
+++ b/src/scalar/bcknd/device/opencl/scalar_residual.c
@@ -63,4 +63,5 @@ void scalar_residual_update_opencl(void *s_res, void *f_s, int *n) {
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue, kernel, 1,
                                   NULL, &global_item_size, &local_item_size,
                                   0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/sem/bcknd/device/opencl/coef.c
+++ b/src/sem/bcknd/device/opencl/coef.c
@@ -97,6 +97,7 @@ void opencl_coef_generate_geo(void *G11, void *G12, void *G13,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,         \
                                       kernel, 1, NULL, &global_item_size,       \
                                       &local_item_size, 0, NULL, NULL));        \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }                                                                           \
     break
     
@@ -170,6 +171,7 @@ void opencl_coef_generate_dxyzdrst(void *drdx, void *drdy, void *drdz,
       CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,         \
                                       kernel, 1, NULL, &global_item_size_dxyz,  \
                                       &local_item_size, 0, NULL, NULL));        \
+      CL_CHECK(clReleaseKernel(kernel));                                        \
     }                                                                           \
     break
     
@@ -219,5 +221,6 @@ void opencl_coef_generate_dxyzdrst(void *drdx, void *drdy, void *drdz,
   
   CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,         
                                   kernel, 1, NULL, &global_item_size_drst,  
-                                  &local_item_size, 0, NULL, NULL));   
+                                  &local_item_size, 0, NULL, NULL));
+  CL_CHECK(clReleaseKernel(kernel));
 }

--- a/src/sem/bcknd/device/opencl/local_interpolation.c
+++ b/src/sem/bcknd/device/opencl/local_interpolation.c
@@ -97,7 +97,7 @@ void opencl_find_rst_legendre(void *rst,
      CL_CHECK(clEnqueueNDRangeKernel((cl_command_queue) glb_cmd_queue,         \
                                      kernel, 2, NULL, global_kstep,            \
                                      local_kstep, 0, NULL, NULL));             \
-                                                                               \
+      CL_CHECK(clReleaseKernel(kernel));                                       \
     }                                                                          \
     break
 


### PR DESCRIPTION
## Context

- The OpenCL backend had a memory leak where `cl_kernel` objects created with `clCreateKernel()` were never released

## Steps to reproduce

- I observed this on a macbook pro m4
  - `--with-opencl --enable-real=sp`
  - gfortran - GNU Fortran (Homebrew GCC 14.2.0_1) 14.2.0
  - gcc - Apple Clang 17.0.0
- Run the `examples/tgv` case with longer end time and observe the host memory (RAM) increases over time

## Changes

- Added `clReleaseKernel(kernel)` after every `clEnqueueNDRangeKernel()` call