### PR TITLE
Add check for implicit integer conversion in json read

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -423,6 +423,7 @@ AC_CONFIG_FILES([tests/unit/stack/Makefile\
         tests/unit/time_scheme_controller/Makefile\
         tests/unit/runge_kutta_scheme/Makefile\
         tests/unit/time_based_controller/Makefile\
+        tests/unit/json_utils/Makefile\
         tests/unit/point_interpolation/Makefile])
 
 if test "x${enable_contrib}" = xyes; then
@@ -443,4 +444,3 @@ fi
 AC_CONFIG_FILES([doc/Doxyfile doc/Makefile])
 
 AC_OUTPUT
-

--- a/src/.depends
+++ b/src/.depends
@@ -18,7 +18,7 @@ common/datadist.lo : common/datadist.f90
 common/distdata.lo : common/distdata.f90 adt/uset.lo adt/tuple.lo adt/stack.lo 
 common/utils.lo : common/utils.f90 
 common/time_state.lo : common/time_state.f90 common/json_utils.lo common/checkpoint.lo common/log.lo config/num_types.lo 
-common/json_utils.lo : common/json_utils.f90 common/utils.lo config/num_types.lo 
+common/json_utils.lo : common/json_utils.f90 math/math.lo common/utils.lo config/num_types.lo 
 common/mask.lo : common/mask.f90 common/utils.lo math/bcknd/device/device_math.lo device/device.lo config/neko_config.lo 
 common/system.lo : common/system.f90 
 common/runtime_statistics.lo : common/runtime_statistics.f90 comm/comm.lo common/utils.lo math/matrix.lo io/file.lo common/json_utils.lo config/num_types.lo adt/tuple.lo adt/stack.lo common/log.lo 

--- a/src/common/json_utils.f90
+++ b/src/common/json_utils.f90
@@ -35,6 +35,7 @@ module json_utils
   use num_types, only : rp, dp, sp
   use json_module, only : json_file, json_value, json_core
   use utils, only : neko_error
+  use math, only : abscmp
   implicit none
   private
 
@@ -106,11 +107,20 @@ contains
     character(len=*), intent(in) :: name
     integer, intent(out) :: value
 
+    real(kind=rp) :: test_real
+
     if (.not. json%valid_path(name)) then
        call neko_error("Parameter " // name // " missing from the case file")
     end if
 
     call json%get(name, value)
+    call json%get(name, test_real)
+
+    if (.not. abscmp(real(value, kind=rp), test_real)) then
+       call neko_error("Parameter " // name // " is not an integer value")
+    end if
+
+
   end subroutine json_get_integer
 
   !> Retrieves a logical parameter by name or throws an error
@@ -186,11 +196,21 @@ contains
     character(len=*), intent(in) :: name
     integer, allocatable, intent(out) :: value(:)
 
+    real(kind=rp), allocatable :: test_real(:)
+    integer :: i
+
     if (.not. json%valid_path(name)) then
        call neko_error("Parameter " // name // " missing from the case file")
     end if
 
     call json%get(name, value)
+    call json%get(name, test_real)
+
+    do i = 1, size(value)
+       if (.not. abscmp(real(value(i), kind=rp), test_real(i))) then
+          call neko_error("Parameter " // name // " is not an integer array")
+       end if
+    end do
   end subroutine json_get_integer_array
 
   !> Retrieves a logical array parameter by name or throws an error

--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -60,4 +60,5 @@ fast3d/fast3d_test
 time_scheme/time_scheme_test
 time_scheme_controller/time_scheme_controller_test
 time_based_controller/time_based_controller_test
+json_utils/json_utils_test
 point_interpolation/point_interpolation_suite

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -33,6 +33,7 @@ SUBDIRS = tuple\
 	  time_scheme_controller\
 	  runge_kutta_scheme\
 	  time_based_controller\
+	  json_utils\
 	  point_interpolation
 
 TESTS = device/device_test\
@@ -70,6 +71,7 @@ TESTS = device/device_test\
 	time_scheme_controller/time_scheme_controller_test\
 	runge_kutta_scheme/runge_kutta_scheme_test\
 	time_based_controller/time_based_controller_test\
+	json_utils/json_utils_test\
 	point_interpolation/point_interpolation_test
 
 # Note we need to list .pf and runner scripts manually
@@ -142,6 +144,7 @@ EXTRA_DIST = \
 	time_scheme/test_ab.pf\
 	time_scheme_controller/test_time_scheme_controller.pf\
 	runge_kutta_scheme/test_runge_kutta_scheme.pf\
+	json_utils/test_json_utils.pf\
 	time_based_controller/test_time_based_controller.pf\
 	point_interpolation/point_interpolation_parallel.pf\
 	point_interpolation/point_interpolation_test

--- a/tests/unit/json_utils/Makefile.in
+++ b/tests/unit/json_utils/Makefile.in
@@ -1,0 +1,27 @@
+ifneq ("$(wildcard @PFUNIT_DIR@/include/PFUNIT.mk)", "")
+include @PFUNIT_DIR@/include/PFUNIT.mk
+endif
+FFLAGS += $(PFUNIT_EXTRA_FFLAGS) @NEKO_PKG_FCFLAGS@ -I@top_builddir@/src
+FC = @FC@
+
+%.o : %.F90
+	$(FC) -c $(FFLAGS) $<
+
+
+check: json_utils_test
+
+
+json_utils_test_TESTS := test_json_utils.pf
+j-L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@son_utils_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
+$(eval $(call make_pfunit_test,json_utils_test))
+
+distclean:
+clean:
+	$(RM) *.o *.mod *.a  *.inc *.F90 json_utils_test
+
+
+
+all:
+html:
+install:
+distdir:

--- a/tests/unit/json_utils/Makefile.in
+++ b/tests/unit/json_utils/Makefile.in
@@ -12,7 +12,7 @@ check: json_utils_test
 
 
 json_utils_test_TESTS := test_json_utils.pf
-j-L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@son_utils_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
+json_utils_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,json_utils_test))
 
 distclean:

--- a/tests/unit/json_utils/test_json_utils.pf
+++ b/tests/unit/json_utils/test_json_utils.pf
@@ -1,0 +1,38 @@
+module test_json_utils
+  use pfunit
+  use num_types, only : rp, dp
+  use json_utils, only : json_get_or_default, json_get, json_no_defaults
+  use json_module, only : json_file
+  implicit none
+
+contains
+
+  @test
+  subroutine test_json_no_defaults_starts_false()
+    @assertFalse(json_no_defaults)
+  end subroutine test_json_no_defaults_starts_false
+
+  @test
+  subroutine test_json_get_integer_allows_real_literal()
+    type(json_file) :: jf
+    integer :: int_value
+
+    ! Should work because 3.0 is exactly representable as an integer
+    call jf%load_from_string('{"params":{"value": 3.0}}')
+    call json_get(jf, "params.value", int_value)
+
+    @assertEqual(int_value, 3)
+  end subroutine test_json_get_integer_allows_real_literal
+
+  @test
+  subroutine test_json_get_integer_array_allows_reals()
+    type(json_file) :: jf
+    integer, allocatable :: int_value(:)
+
+    ! Should work because 3.0 and 4.0 are exactly representable as an integer
+    call jf%load_from_string('{"params":{"value": [3.0, 4.0, 5]}}')
+    call json_get(jf, "params.value", int_value)
+
+  end subroutine test_json_get_integer_array_allows_reals
+
+end module test_json_utils


### PR DESCRIPTION
json_fortran implicitly converts reals to integers when reading an entry into an integer.

This adds another read to the same entry with a real variable and checks that no rounding has occurred when populating the integer.

Also adds a skeleton for unit testing json_utils. Currently, just check that integer reads do work when json contains reals that have a
0 decimal.