### PR TITLE
Hook errors to pFUnit exception system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+
+## Develop
+- Hooked up error and warning routines to pFUnit's exceptions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 
 ## Develop
-- Hooked up error and warning routines to pFUnit's exceptions.
+- Error and warning routines are now hooked to pFUnit's exceptions, making it
+  possible to test for errror emission.

--- a/configure.ac
+++ b/configure.ac
@@ -416,6 +416,7 @@ AC_CONFIG_FILES([tests/unit/stack/Makefile\
         tests/unit/octree/Makefile\
         tests/unit/vector/Makefile\
         tests/unit/matrix/Makefile\
+        tests/unit/errors/Makefile\
         tests/unit/scratch_registry/Makefile\
         tests/unit/registry/Makefile\
         tests/unit/fast3d/Makefile\
@@ -443,4 +444,3 @@ fi
 AC_CONFIG_FILES([doc/Doxyfile doc/Makefile])
 
 AC_OUTPUT
-

--- a/src/.depends
+++ b/src/.depends
@@ -17,7 +17,7 @@ comm/mpi_types.lo : comm/mpi_types.f90 io/format/stl.lo io/format/nmsh.lo io/for
 common/datadist.lo : common/datadist.f90 
 common/distdata.lo : common/distdata.f90 adt/uset.lo adt/tuple.lo adt/stack.lo 
 common/utils.lo : common/utils.f90 
-common/errors.lo : common/errors.f90 
+common/errors.lo : common/errors.f90 common/utils.lo 
 common/time_state.lo : common/time_state.f90 common/json_utils.lo common/checkpoint.lo common/log.lo config/num_types.lo 
 common/json_utils.lo : common/json_utils.f90 math/math.lo common/utils.lo config/num_types.lo 
 common/mask.lo : common/mask.f90 common/utils.lo math/bcknd/device/device_math.lo device/device.lo config/neko_config.lo 

--- a/src/.depends
+++ b/src/.depends
@@ -17,6 +17,7 @@ comm/mpi_types.lo : comm/mpi_types.f90 io/format/stl.lo io/format/nmsh.lo io/for
 common/datadist.lo : common/datadist.f90 
 common/distdata.lo : common/distdata.f90 adt/uset.lo adt/tuple.lo adt/stack.lo 
 common/utils.lo : common/utils.f90 
+common/errors.lo : common/errors.f90 
 common/time_state.lo : common/time_state.f90 common/json_utils.lo common/checkpoint.lo common/log.lo config/num_types.lo 
 common/json_utils.lo : common/json_utils.f90 common/utils.lo config/num_types.lo 
 common/mask.lo : common/mask.f90 common/utils.lo math/bcknd/device/device_math.lo device/device.lo config/neko_config.lo 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,6 +20,7 @@ neko_fortran_SOURCES = \
 	common/datadist.f90\
 	common/distdata.f90\
 	common/utils.f90\
+	common/errors.f90\
 	common/time_state.f90\
 	common/json_utils.f90\
 	common/mask.f90\

--- a/src/common/errors.f90
+++ b/src/common/errors.f90
@@ -1,0 +1,153 @@
+! Copyright (c) 2025, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Errors that can be thrown by Neko.
+!! @details Various error handling routines that can be used in the code.
+!! Also contans additional hooks for pFUnit to catch errors during testing.
+module errors
+  use, intrinsic :: iso_fortran_env, only: error_unit, output_unit
+  implicit none
+  private
+
+  abstract interface
+     !> Interface for the throw procedure. Follows pFunit conventions.
+     subroutine throw_intf(filename, line_number, message)
+        character(len=*), intent(in) :: filename
+        integer, intent(in) :: line_number
+        character(len=*), optional, intent(in) :: message
+     end subroutine throw_intf
+  end interface
+
+  !> Pointer to the throw procedure.
+  !! @details Ordinarily only raises an error stop. During testing,
+  !! pFUnit will hijack this procedure to raise an excpeption that
+  !! can be caught by the testing framework.
+  procedure(throw_intf), public, pointer :: throw_error => &
+       default_throw_error
+  !> Same as above, but for warnings. Does nothing by default
+  procedure(throw_intf), public, pointer :: throw_warning => &
+       default_throw_warning
+
+  public :: throw_intf, neko_error, neko_type_error, &
+       neko_type_registration_error, neko_warning
+
+contains
+  !> Default throw method that stops execution.
+  !! @details pFUnit will highjack this method during testing to catch
+  !! exceptions.
+  subroutine default_throw_error(filename, line_number, message)
+     character(len=*), intent(in) :: filename
+     integer, intent(in) :: line_number
+     character(len=*), optional, intent(in) :: message
+
+     error stop
+  end subroutine default_throw_error
+
+  !> Default throw method for warnings. Does nothing.
+  subroutine default_throw_warning(filename, line_number, message)
+     character(len=*), intent(in) :: filename
+     integer, intent(in) :: line_number
+     character(len=*), optional, intent(in) :: message
+  end subroutine default_throw_warning
+
+  !> Reports a type selection error and stops execution.
+  !! @param base_type The base type for which the selection was attempted.
+  !! @param wrong_type The type that was attempted to be selected.
+  !! @param known_types An array of known valid types.
+  subroutine neko_type_error(base_type, wrong_type, known_types)
+    character(len=*), intent(in) :: base_type
+    character(len=*), intent(in) :: wrong_type
+    character(len=*), intent(in) :: known_types(:)
+    integer :: i
+
+    write(error_unit, *) '*** ERROR WHEN SELECTING TYPE ***'
+    write(error_unit, *) 'Type ', wrong_type, ' does not exist for ', base_type
+    write(error_unit, *) 'Valid types are:'
+    do i = 1, size(known_types)
+       write(error_unit, *) "    ", known_types(i)
+    end do
+
+    call throw_error('errors.f90', -1, message='')
+  end subroutine neko_type_error
+
+  !> Reports an error and stops execution.
+  !! @param error_msg Optional error message to report.
+  !! @param error_code Optional error code to report.
+  subroutine neko_error(error_msg, error_code)
+    character(len=*), optional :: error_msg
+    integer, optional :: error_code
+    character(len=:), allocatable :: msg
+
+    if (present(error_code)) then
+       write(error_unit, *) '*** ERROR ***', error_code
+       error stop
+    else if (present(error_msg)) then
+       write(error_unit, *) '*** ERROR: ', error_msg, ' ***'
+    else
+       write(error_unit, *) '*** ERROR ***'
+       error stop
+    end if
+
+    call throw_error('errors.f90', -1, message='')
+  end subroutine neko_error
+
+  !> Reports a type registration error and stops execution.
+  !! @param base_type The base type for which the registration was attempted.
+  !! @param wrong_type The type that was attempted to be registered.
+  !! @param known Whether the conflicting type is known (standard) or custom.
+  subroutine neko_type_registration_error(base_type, wrong_type, known)
+    character(len=*), intent(in) :: base_type
+    character(len=*),intent(in) :: wrong_type
+    logical, intent(in) :: known
+
+    write(error_unit, *) '*** ERROR WHEN REGISTERING TYPE ***'
+    write(error_unit, *) 'Type name ', wrong_type, &
+         ' conflicts with and already existing ', base_type, " type"
+    if (known) then
+       write(error_unit, *) 'Please rename your custom type.'
+    else
+       write(error_unit, *) 'The already existing type is also custom.' // &
+            ' Make all custom type names unique!'
+    end if
+
+    call throw_error('errors.f90', -1, message='')
+  end subroutine neko_type_registration_error
+
+  !> Reports a warning to standard output
+  subroutine neko_warning(warning_msg)
+    character(len=*) :: warning_msg
+    write(output_unit, *) '*** WARNING: ', warning_msg, ' ***'
+
+    call throw_warning('errors.f90', -1, message='')
+  end subroutine neko_warning
+
+end module errors

--- a/src/common/errors.f90
+++ b/src/common/errors.f90
@@ -39,24 +39,6 @@ submodule (utils) errors
 
 contains
 
-  !> Default throw method for warnings. Does nothing.
-  module subroutine default_throw_warning(filename, line_number, message)
-    character(len=*), intent(in) :: filename
-    integer, intent(in) :: line_number
-    character(len=*), optional, intent(in) :: message
-  end subroutine default_throw_warning
-
-  !> Default throw method that stops execution.
-  !! @details pFUnit will highjack this method during testing to catch
-  !! exceptions.
-  module subroutine default_throw_error(filename, line_number, message)
-    character(len=*), intent(in) :: filename
-    integer, intent(in) :: line_number
-    character(len=*), optional, intent(in) :: message
-
-    error stop
-  end subroutine default_throw_error
-
   !> Reports a type selection error and stops execution.
   !! @param base_type The base type for which the selection was attempted.
   !! @param wrong_type The type that was attempted to be selected.

--- a/src/common/errors.f90
+++ b/src/common/errors.f90
@@ -56,6 +56,7 @@ contains
        write(error_unit, *) "    ", known_types(i)
     end do
 
+    if (.not. associated(throw_error)) throw_error => default_throw_error
     call throw_error('errors.f90', -1, message='')
   end subroutine neko_type_error
 
@@ -78,6 +79,7 @@ contains
             ' Make all custom type names unique!'
     end if
 
+    if (.not. associated(throw_error)) throw_error => default_throw_error
     call throw_error('errors.f90', -1, message='')
   end subroutine neko_type_registration_error
 
@@ -87,6 +89,7 @@ contains
     character(len=*) :: warning_msg
     write(output_unit, *) '*** WARNING: ', warning_msg, ' ***'
 
+    if (.not. associated(throw_warning)) throw_warning => default_throw_warning
     call throw_warning('errors.f90', -1, message='')
   end subroutine neko_warning
 
@@ -101,6 +104,7 @@ contains
        write(error_unit, *) '*** ERROR ***'
     end if
 
+    if (.not. associated(throw_error)) throw_error => default_throw_error
     call throw_error('errors.f90', -1, message='')
   end subroutine neko_error_plain
 
@@ -110,6 +114,7 @@ contains
     character(len=*), intent(in) :: error_msg
     write(error_unit, *) '*** ERROR: ', error_msg, ' ***'
 
+    if (.not. associated(throw_error)) throw_error => default_throw_error
     call throw_error('errors.f90', -1, message='')
   end subroutine neko_error_msg
 

--- a/src/common/errors.f90
+++ b/src/common/errors.f90
@@ -32,39 +32,24 @@
 !
 !> Errors that can be thrown by Neko.
 !! @details Various error handling routines that can be used in the code.
-!! Also contans additional hooks for pFUnit to catch errors during testing.
-module errors
-  use, intrinsic :: iso_fortran_env, only: error_unit, output_unit
+!! They use the throw_error and throw_warning mechanisms defined in utils.f90
+!! in order to allow pFUnit to catch them during testing.
+submodule (utils) errors
   implicit none
-  private
-
-  abstract interface
-     !> Interface for the throw procedure. Follows pFunit conventions.
-     subroutine throw_intf(filename, line_number, message)
-       character(len=*), intent(in) :: filename
-       integer, intent(in) :: line_number
-       character(len=*), optional, intent(in) :: message
-     end subroutine throw_intf
-  end interface
-
-  !> Pointer to the throw procedure.
-  !! @details Ordinarily only raises an error stop. During testing,
-  !! pFUnit will hijack this procedure to raise an excpeption that
-  !! can be caught by the testing framework.
-  procedure(throw_intf), public, pointer :: throw_error => &
-       default_throw_error
-  !> Same as above, but for warnings. Does nothing by default
-  procedure(throw_intf), public, pointer :: throw_warning => &
-       default_throw_warning
-
-  public :: throw_intf, neko_error, neko_type_error, &
-       neko_type_registration_error, neko_warning
 
 contains
+
+  !> Default throw method for warnings. Does nothing.
+  module subroutine default_throw_warning(filename, line_number, message)
+    character(len=*), intent(in) :: filename
+    integer, intent(in) :: line_number
+    character(len=*), optional, intent(in) :: message
+  end subroutine default_throw_warning
+
   !> Default throw method that stops execution.
   !! @details pFUnit will highjack this method during testing to catch
   !! exceptions.
-  subroutine default_throw_error(filename, line_number, message)
+  module subroutine default_throw_error(filename, line_number, message)
     character(len=*), intent(in) :: filename
     integer, intent(in) :: line_number
     character(len=*), optional, intent(in) :: message
@@ -72,18 +57,11 @@ contains
     error stop
   end subroutine default_throw_error
 
-  !> Default throw method for warnings. Does nothing.
-  subroutine default_throw_warning(filename, line_number, message)
-    character(len=*), intent(in) :: filename
-    integer, intent(in) :: line_number
-    character(len=*), optional, intent(in) :: message
-  end subroutine default_throw_warning
-
   !> Reports a type selection error and stops execution.
   !! @param base_type The base type for which the selection was attempted.
   !! @param wrong_type The type that was attempted to be selected.
   !! @param known_types An array of known valid types.
-  subroutine neko_type_error(base_type, wrong_type, known_types)
+  module subroutine neko_type_error(base_type, wrong_type, known_types)
     character(len=*), intent(in) :: base_type
     character(len=*), intent(in) :: wrong_type
     character(len=*), intent(in) :: known_types(:)
@@ -99,32 +77,11 @@ contains
     call throw_error('errors.f90', -1, message='')
   end subroutine neko_type_error
 
-  !> Reports an error and stops execution.
-  !! @param error_msg Optional error message to report.
-  !! @param error_code Optional error code to report.
-  subroutine neko_error(error_msg, error_code)
-    character(len=*), optional :: error_msg
-    integer, optional :: error_code
-    character(len=:), allocatable :: msg
-
-    if (present(error_code)) then
-       write(error_unit, *) '*** ERROR ***', error_code
-       error stop
-    else if (present(error_msg)) then
-       write(error_unit, *) '*** ERROR: ', error_msg, ' ***'
-    else
-       write(error_unit, *) '*** ERROR ***'
-       error stop
-    end if
-
-    call throw_error('errors.f90', -1, message='')
-  end subroutine neko_error
-
   !> Reports a type registration error and stops execution.
   !! @param base_type The base type for which the registration was attempted.
   !! @param wrong_type The type that was attempted to be registered.
   !! @param known Whether the conflicting type is known (standard) or custom.
-  subroutine neko_type_registration_error(base_type, wrong_type, known)
+  module subroutine neko_type_registration_error(base_type, wrong_type, known)
     character(len=*), intent(in) :: base_type
     character(len=*),intent(in) :: wrong_type
     logical, intent(in) :: known
@@ -143,11 +100,36 @@ contains
   end subroutine neko_type_registration_error
 
   !> Reports a warning to standard output
-  subroutine neko_warning(warning_msg)
+  !! @param warning_msg The warning message to report.
+  module subroutine neko_warning(warning_msg)
     character(len=*) :: warning_msg
     write(output_unit, *) '*** WARNING: ', warning_msg, ' ***'
 
     call throw_warning('errors.f90', -1, message='')
   end subroutine neko_warning
 
-end module errors
+  !> Reports an error and stops execution.
+  !! @param[optional] error_code The error code to report.
+  module subroutine neko_error_plain(error_code)
+    integer, optional, intent(in) :: error_code
+
+    if (present(error_code)) then
+       write(error_unit, *) '*** ERROR ***', error_code
+    else
+       write(error_unit, *) '*** ERROR ***'
+    end if
+
+    call throw_error('errors.f90', -1, message='')
+  end subroutine neko_error_plain
+
+  !> Reports an error and stops execution.
+  !! @param error_msg The error message to report.
+  module subroutine neko_error_msg(error_msg)
+    character(len=*), intent(in) :: error_msg
+    write(error_unit, *) '*** ERROR: ', error_msg, ' ***'
+
+    call throw_error('errors.f90', -1, message='')
+  end subroutine neko_error_msg
+
+
+end submodule errors

--- a/src/common/errors.f90
+++ b/src/common/errors.f90
@@ -41,9 +41,9 @@ module errors
   abstract interface
      !> Interface for the throw procedure. Follows pFunit conventions.
      subroutine throw_intf(filename, line_number, message)
-        character(len=*), intent(in) :: filename
-        integer, intent(in) :: line_number
-        character(len=*), optional, intent(in) :: message
+       character(len=*), intent(in) :: filename
+       integer, intent(in) :: line_number
+       character(len=*), optional, intent(in) :: message
      end subroutine throw_intf
   end interface
 
@@ -65,18 +65,18 @@ contains
   !! @details pFUnit will highjack this method during testing to catch
   !! exceptions.
   subroutine default_throw_error(filename, line_number, message)
-     character(len=*), intent(in) :: filename
-     integer, intent(in) :: line_number
-     character(len=*), optional, intent(in) :: message
+    character(len=*), intent(in) :: filename
+    integer, intent(in) :: line_number
+    character(len=*), optional, intent(in) :: message
 
-     error stop
+    error stop
   end subroutine default_throw_error
 
   !> Default throw method for warnings. Does nothing.
   subroutine default_throw_warning(filename, line_number, message)
-     character(len=*), intent(in) :: filename
-     integer, intent(in) :: line_number
-     character(len=*), optional, intent(in) :: message
+    character(len=*), intent(in) :: filename
+    integer, intent(in) :: line_number
+    character(len=*), optional, intent(in) :: message
   end subroutine default_throw_warning
 
   !> Reports a type selection error and stops execution.

--- a/src/common/utils.f90
+++ b/src/common/utils.f90
@@ -83,22 +83,6 @@ module utils
      module subroutine neko_warning(warning_msg)
        character(len=*) :: warning_msg
      end subroutine neko_warning
-
-     !> Default throw method for warnings. Does nothing.
-     module subroutine default_throw_warning(filename, line_number, message)
-       character(len=*), intent(in) :: filename
-       integer, intent(in) :: line_number
-       character(len=*), optional, intent(in) :: message
-     end subroutine default_throw_warning
-
-     !> Default throw method that stops execution.
-     !! @details pFUnit will highjack this method during testing to catch
-     !! exceptions.
-     module subroutine default_throw_error(filename, line_number, message)
-       character(len=*), intent(in) :: filename
-       integer, intent(in) :: line_number
-       character(len=*), optional, intent(in) :: message
-     end subroutine default_throw_error
   end interface
 
   abstract interface
@@ -129,6 +113,25 @@ module utils
 
 
 contains
+
+  !> Default throw method for warnings. Does nothing.
+  subroutine default_throw_warning(filename, line_number, message)
+    character(len=*), intent(in) :: filename
+    integer, intent(in) :: line_number
+    character(len=*), optional, intent(in) :: message
+  end subroutine default_throw_warning
+
+  !> Default throw method that stops execution.
+  !! @details pFUnit will highjack this method during testing to catch
+  !! exceptions.
+  subroutine default_throw_error(filename, line_number, message)
+    character(len=*), intent(in) :: filename
+    integer, intent(in) :: line_number
+    character(len=*), optional, intent(in) :: message
+
+    error stop
+  end subroutine default_throw_error
+
 
   !> Find position (in the string) of a filename's suffix
   pure function filename_suffix_pos(fname) result(suffix_pos)

--- a/src/common/utils.f90
+++ b/src/common/utils.f90
@@ -130,24 +130,6 @@ module utils
 
 contains
 
-  !> Default throw method that stops execution.
-  !! @details pFUnit will highjack this method during testing to catch
-  !! exceptions.
-  subroutine default_throw_error(filename, line_number, message)
-    character(len=*), intent(in) :: filename
-    integer, intent(in) :: line_number
-    character(len=*), optional, intent(in) :: message
-
-    error stop
-  end subroutine default_throw_error
-
-  !> Default throw method for warnings. Does nothing.
-  subroutine default_throw_warning(filename, line_number, message)
-    character(len=*), intent(in) :: filename
-    integer, intent(in) :: line_number
-    character(len=*), optional, intent(in) :: message
-  end subroutine default_throw_warning
-
   !> Find position (in the string) of a filename's suffix
   pure function filename_suffix_pos(fname) result(suffix_pos)
     character(len=*), intent(in) :: fname

--- a/src/common/utils.f90
+++ b/src/common/utils.f90
@@ -98,18 +98,17 @@ module utils
   !! @details Ordinarily only raises an error stop. During testing,
   !! pFUnit will hijack this procedure to raise an excpeption that
   !! can be caught by the testing framework.
-  procedure(throw_intf), pointer :: throw_error => &
-       default_throw_error
+  procedure(throw_intf), pointer :: throw_error => null()
   !> Same as above, but for warnings. Does nothing by default
-  procedure(throw_intf), pointer :: throw_warning => &
-       default_throw_warning
+  procedure(throw_intf), pointer :: throw_warning => null()
 
   public :: neko_error, neko_warning, nonlinear_index, filename_chsuffix, &
        filename_path, filename_name, filename_suffix, &
        filename_suffix_pos, filename_tslash_pos, &
        linear_index, split_string, NEKO_FNAME_LEN, index_is_on_facet, &
        concat_string_array, extract_fld_file_index, neko_type_error, &
-       neko_type_registration_error, throw_error, throw_warning, throw_intf
+       neko_type_registration_error, throw_error, throw_warning, throw_intf, &
+       default_throw_error, default_throw_warning
 
 
 contains

--- a/src/common/utils.f90
+++ b/src/common/utils.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2019-2021, The Neko Authors
+! Copyright (c) 2019-2025, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -43,12 +43,89 @@ module utils
      module procedure neko_error_plain, neko_error_msg
   end interface neko_error
 
+  !! Interfaces for error and warning routines found in the
+  !! errors submodule.
+  interface
+     !> Reports an error and stops execution.
+     !! @param[optional] error_code The error code to report.
+     module subroutine neko_error_plain(error_code)
+       integer, optional, intent(in) :: error_code
+     end subroutine neko_error_plain
+
+     !> Reports an error and stops execution.
+     !! @param error_msg The error message to report.
+     module subroutine neko_error_msg(error_msg)
+       character(len=*), intent(in) :: error_msg
+     end subroutine neko_error_msg
+     !> Reports a type selection error and stops execution.
+     !! @param base_type The base type for which the selection was attempted.
+     !! @param wrong_type The type that was attempted to be selected.
+     !! @param known_types An array of known valid types.
+     module subroutine neko_type_error(base_type, wrong_type, known_types)
+       character(len=*), intent(in) :: base_type
+       character(len=*), intent(in) :: wrong_type
+       character(len=*), intent(in) :: known_types(:)
+     end subroutine neko_type_error
+
+     !> Reports a type registration error and stops execution.
+     !! @param base_type The base type for which the registration was attempted.
+     !! @param wrong_type The type that was attempted to be registered.
+     !! @param known Whether the conflicting type is known (standard) or custom.
+     module subroutine neko_type_registration_error(base_type, wrong_type, &
+          known)
+       character(len=*), intent(in) :: base_type
+       character(len=*),intent(in) :: wrong_type
+       logical, intent(in) :: known
+     end subroutine neko_type_registration_error
+
+     !> Reports a warning to standard output
+     !! @param warning_msg The warning message to report.
+     module subroutine neko_warning(warning_msg)
+       character(len=*) :: warning_msg
+     end subroutine neko_warning
+
+     !> Default throw method for warnings. Does nothing.
+     module subroutine default_throw_warning(filename, line_number, message)
+       character(len=*), intent(in) :: filename
+       integer, intent(in) :: line_number
+       character(len=*), optional, intent(in) :: message
+     end subroutine default_throw_warning
+
+     !> Default throw method that stops execution.
+     !! @details pFUnit will highjack this method during testing to catch
+     !! exceptions.
+     module subroutine default_throw_error(filename, line_number, message)
+       character(len=*), intent(in) :: filename
+       integer, intent(in) :: line_number
+       character(len=*), optional, intent(in) :: message
+     end subroutine default_throw_error
+  end interface
+
+  abstract interface
+     !> Interface for the throw procedure. Follows pFunit conventions.
+     subroutine throw_intf(filename, line_number, message)
+       character(len=*), intent(in) :: filename
+       integer, intent(in) :: line_number
+       character(len=*), optional, intent(in) :: message
+     end subroutine throw_intf
+  end interface
+
+  !> Pointer to the throw procedure.
+  !! @details Ordinarily only raises an error stop. During testing,
+  !! pFUnit will hijack this procedure to raise an excpeption that
+  !! can be caught by the testing framework.
+  procedure(throw_intf), pointer :: throw_error => &
+       default_throw_error
+  !> Same as above, but for warnings. Does nothing by default
+  procedure(throw_intf), pointer :: throw_warning => &
+       default_throw_warning
+
   public :: neko_error, neko_warning, nonlinear_index, filename_chsuffix, &
        filename_path, filename_name, filename_suffix, &
        filename_suffix_pos, filename_tslash_pos, &
        linear_index, split_string, NEKO_FNAME_LEN, index_is_on_facet, &
        concat_string_array, extract_fld_file_index, neko_type_error, &
-       neko_type_registration_error
+       neko_type_registration_error, throw_error, throw_warning, throw_intf
 
 
 contains
@@ -279,73 +356,6 @@ contains
     end select
 
   end function index_is_on_facet
-
-  !> Reports an error and stops execution
-  !! @param[optional] error_code The error code to report.
-  subroutine neko_error_plain(error_code)
-    integer, optional :: error_code
-
-    if (present(error_code)) then
-       write(error_unit, *) '*** ERROR ***', error_code
-       error stop
-    else
-       write(error_unit, *) '*** ERROR ***'
-       error stop
-    end if
-
-  end subroutine neko_error_plain
-
-  !> Reports an error and stops execution
-  !! @param error_msg The error message to report.
-  subroutine neko_error_msg(error_msg)
-    character(len=*) :: error_msg
-    write(error_unit, *) '*** ERROR: ', error_msg, ' ***'
-    error stop
-  end subroutine neko_error_msg
-
-  !> Reports an error allocating a type for a particular base pointer class.
-  !! @details Should be used in factories.
-  !! @param base_type The base type of the object, which the factory tried to
-  !! construct.
-  !! @param wrong_type The type that was attempted to construct.
-  !! @param known_types A list of the types that are known.
-  subroutine neko_type_error(base_type, wrong_type, known_types)
-    character(len=*), intent(in) :: base_type
-    character(len=*), intent(in) :: wrong_type
-    character(len=*), intent(in) :: known_types(:)
-    integer :: i
-
-    write(error_unit, *) '*** ERROR WHEN SELECTING TYPE ***'
-    write(error_unit, *) 'Type ', wrong_type, ' does not exist for ', base_type
-    write(error_unit, *) 'Valid types are:'
-    do i = 1, size(known_types)
-       write(error_unit, *) "    ", known_types(i)
-    end do
-    error stop
-  end subroutine neko_type_error
-
-  subroutine neko_type_registration_error(base_type, wrong_type, known)
-    character(len=*), intent(in) :: base_type
-    character(len=*),intent(in) :: wrong_type
-    logical, intent(in) :: known
-
-    write(error_unit, *) '*** ERROR WHEN REGISTERING TYPE ***'
-    write(error_unit, *) 'Type name ', wrong_type, &
-         ' conflicts with and already existing ', base_type, " type"
-    if (known) then
-       write(error_unit, *) 'Please rename your custom type.'
-    else
-       write(error_unit, *) 'The already existing type is also custom.' // &
-            ' Make all custom type names unique!'
-    end if
-    error stop
-  end subroutine neko_type_registration_error
-
-  !> Reports a warning to standard output
-  subroutine neko_warning(warning_msg)
-    character(len=*) :: warning_msg
-    write(output_unit, *) '*** WARNING: ', warning_msg, ' ***'
-  end subroutine neko_warning
 
   !> Concatenate an array of strings into one string with array items
   !! separated by spaces.

--- a/src/common/utils.f90
+++ b/src/common/utils.f90
@@ -43,15 +43,94 @@ module utils
      module procedure neko_error_plain, neko_error_msg
   end interface neko_error
 
+  !! Interfaces for error and warning routines found in the
+  !! errors submodule.
+  interface
+     !> Reports an error and stops execution.
+     !! @param[optional] error_code The error code to report.
+     module subroutine neko_error_plain(error_code)
+       integer, optional, intent(in) :: error_code
+     end subroutine neko_error_plain
+
+     !> Reports an error and stops execution.
+     !! @param error_msg The error message to report.
+     module subroutine neko_error_msg(error_msg)
+       character(len=*), intent(in) :: error_msg
+     end subroutine neko_error_msg
+     !> Reports a type selection error and stops execution.
+     !! @param base_type The base type for which the selection was attempted.
+     !! @param wrong_type The type that was attempted to be selected.
+     !! @param known_types An array of known valid types.
+     module subroutine neko_type_error(base_type, wrong_type, known_types)
+       character(len=*), intent(in) :: base_type
+       character(len=*), intent(in) :: wrong_type
+       character(len=*), intent(in) :: known_types(:)
+     end subroutine neko_type_error
+
+     !> Reports a type registration error and stops execution.
+     !! @param base_type The base type for which the registration was attempted.
+     !! @param wrong_type The type that was attempted to be registered.
+     !! @param known Whether the conflicting type is known (standard) or custom.
+     module subroutine neko_type_registration_error(base_type, wrong_type, &
+          known)
+       character(len=*), intent(in) :: base_type
+       character(len=*),intent(in) :: wrong_type
+       logical, intent(in) :: known
+     end subroutine neko_type_registration_error
+
+     !> Reports a warning to standard output
+     !! @param warning_msg The warning message to report.
+     module subroutine neko_warning(warning_msg)
+       character(len=*) :: warning_msg
+     end subroutine neko_warning
+  end interface
+
+  abstract interface
+     !> Interface for the throw procedure. Follows pFunit conventions.
+     subroutine throw_intf(filename, line_number, message)
+       character(len=*), intent(in) :: filename
+       integer, intent(in) :: line_number
+       character(len=*), optional, intent(in) :: message
+     end subroutine throw_intf
+  end interface
+
+  !> Pointer to the throw procedure.
+  !! @details Ordinarily only raises an error stop. During testing,
+  !! pFUnit will hijack this procedure to raise an excpeption that
+  !! can be caught by the testing framework.
+  procedure(throw_intf), pointer :: throw_error => &
+       default_throw_error
+  !> Same as above, but for warnings. Does nothing by default
+  procedure(throw_intf), pointer :: throw_warning => &
+       default_throw_warning
+
   public :: neko_error, neko_warning, nonlinear_index, filename_chsuffix, &
        filename_path, filename_name, filename_suffix, &
        filename_suffix_pos, filename_tslash_pos, &
        linear_index, split_string, NEKO_FNAME_LEN, index_is_on_facet, &
        concat_string_array, extract_fld_file_index, neko_type_error, &
-       neko_type_registration_error
+       neko_type_registration_error, throw_error, throw_warning, throw_intf
 
 
 contains
+
+  !> Default throw method that stops execution.
+  !! @details pFUnit will highjack this method during testing to catch
+  !! exceptions.
+  subroutine default_throw_error(filename, line_number, message)
+    character(len=*), intent(in) :: filename
+    integer, intent(in) :: line_number
+    character(len=*), optional, intent(in) :: message
+
+    error stop
+  end subroutine default_throw_error
+
+  !> Default throw method for warnings. Does nothing.
+  subroutine default_throw_warning(filename, line_number, message)
+    character(len=*), intent(in) :: filename
+    integer, intent(in) :: line_number
+    character(len=*), optional, intent(in) :: message
+  end subroutine default_throw_warning
 
   !> Find position (in the string) of a filename's suffix
   pure function filename_suffix_pos(fname) result(suffix_pos)
@@ -279,73 +358,6 @@ contains
     end select
 
   end function index_is_on_facet
-
-  !> Reports an error and stops execution
-  !! @param[optional] error_code The error code to report.
-  subroutine neko_error_plain(error_code)
-    integer, optional :: error_code
-
-    if (present(error_code)) then
-       write(error_unit, *) '*** ERROR ***', error_code
-       error stop
-    else
-       write(error_unit, *) '*** ERROR ***'
-       error stop
-    end if
-
-  end subroutine neko_error_plain
-
-  !> Reports an error and stops execution
-  !! @param error_msg The error message to report.
-  subroutine neko_error_msg(error_msg)
-    character(len=*) :: error_msg
-    write(error_unit, *) '*** ERROR: ', error_msg, ' ***'
-    error stop
-  end subroutine neko_error_msg
-
-  !> Reports an error allocating a type for a particular base pointer class.
-  !! @details Should be used in factories.
-  !! @param base_type The base type of the object, which the factory tried to
-  !! construct.
-  !! @param wrong_type The type that was attempted to construct.
-  !! @param known_types A list of the types that are known.
-  subroutine neko_type_error(base_type, wrong_type, known_types)
-    character(len=*), intent(in) :: base_type
-    character(len=*), intent(in) :: wrong_type
-    character(len=*), intent(in) :: known_types(:)
-    integer :: i
-
-    write(error_unit, *) '*** ERROR WHEN SELECTING TYPE ***'
-    write(error_unit, *) 'Type ', wrong_type, ' does not exist for ', base_type
-    write(error_unit, *) 'Valid types are:'
-    do i = 1, size(known_types)
-       write(error_unit, *) "    ", known_types(i)
-    end do
-    error stop
-  end subroutine neko_type_error
-
-  subroutine neko_type_registration_error(base_type, wrong_type, known)
-    character(len=*), intent(in) :: base_type
-    character(len=*),intent(in) :: wrong_type
-    logical, intent(in) :: known
-
-    write(error_unit, *) '*** ERROR WHEN REGISTERING TYPE ***'
-    write(error_unit, *) 'Type name ', wrong_type, &
-         ' conflicts with and already existing ', base_type, " type"
-    if (known) then
-       write(error_unit, *) 'Please rename your custom type.'
-    else
-       write(error_unit, *) 'The already existing type is also custom.' // &
-            ' Make all custom type names unique!'
-    end if
-    error stop
-  end subroutine neko_type_registration_error
-
-  !> Reports a warning to standard output
-  subroutine neko_warning(warning_msg)
-    character(len=*) :: warning_msg
-    write(output_unit, *) '*** WARNING: ', warning_msg, ' ***'
-  end subroutine neko_warning
 
   !> Concatenate an array of strings into one string with array items
   !! separated by spaces.

--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -60,4 +60,5 @@ fast3d/fast3d_test
 time_scheme/time_scheme_test
 time_scheme_controller/time_scheme_controller_test
 time_based_controller/time_based_controller_test
+errors/errors_test
 point_interpolation/point_interpolation_suite

--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -25,6 +25,8 @@ test-suite.log
 */*.log
 */*.trs
 
+!error_redirection/error_redirection.F90
+
 bc/bc_test
 device/device_test
 device_math/device_math_suite

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -27,6 +27,7 @@ SUBDIRS = tuple\
 	  vector\
 	  matrix\
 	  registry\
+	  errors\
 	  scratch_registry\
 	  fast3d\
 	  time_scheme\
@@ -64,6 +65,7 @@ TESTS = device/device_test\
 	vector/vector_test\
 	matrix/matrix_test\
 	registry/registry_test\
+	errors/errors_test\
 	scratch_registry/scratch_registry_test\
 	fast3d/fast3d_test\
 	time_scheme/time_scheme_test\
@@ -131,6 +133,7 @@ EXTRA_DIST = \
 	registry/test_field_registry.pf\
 	registry/test_vector_registry.pf\
 	registry/test_matrix_registry.pf\
+	errors/test_errors.pf\
 	scratch_registry/test_scratch_registry.pf\
 	scratch_registry/test_field_scratch_registry.pf\
 	scratch_registry/test_vector_scratch_registry.pf\

--- a/tests/unit/error_redirection/error_redirection.F90
+++ b/tests/unit/error_redirection/error_redirection.F90
@@ -1,6 +1,6 @@
 module error_redirection
   use utils, only: throw_error, throw_warning, throw_intf
-  use funit, only: SourceLocation, pFUnit_throw => throw
+  use funit, only: SourceLocation, throw
 
   implicit none
   private
@@ -27,7 +27,7 @@ contains
        msg = '<no message>'
     end if
 
-    call pFUnit_throw(msg, SourceLocation(filename, line))
+    call throw(msg, SourceLocation(filename, line))
   end subroutine fail_with_pfunit
 
 end module error_redirection

--- a/tests/unit/error_redirection/error_redirection.F90
+++ b/tests/unit/error_redirection/error_redirection.F90
@@ -1,0 +1,33 @@
+module error_redirection
+  use errors, only: throw_error, throw_warning, throw_intf
+  use funit, only: SourceLocation, pFUnit_throw => throw
+
+  implicit none
+  private
+
+  public :: redirect_errors
+
+contains
+
+  subroutine redirect_errors()
+    throw_error => fail_with_pfunit
+    throw_warning => fail_with_pfunit
+  end subroutine redirect_errors
+
+  subroutine fail_with_pfunit(filename, line, message)
+    character(*), intent(in) :: filename
+    integer, intent(in) :: line
+    character(*), optional, intent(in) :: message
+
+    character(len=:), allocatable :: msg
+
+    if (present(message)) then
+       msg = message
+    else
+       msg = '<no message>'
+    end if
+
+    call pFUnit_throw(msg, SourceLocation(filename, line))
+  end subroutine fail_with_pfunit
+
+end module error_redirection

--- a/tests/unit/error_redirection/error_redirection.F90
+++ b/tests/unit/error_redirection/error_redirection.F90
@@ -1,5 +1,5 @@
 module error_redirection
-  use errors, only: throw_error, throw_warning, throw_intf
+  use utils, only: throw_error, throw_warning, throw_intf
   use funit, only: SourceLocation, pFUnit_throw => throw
 
   implicit none

--- a/tests/unit/errors/Makefile.in
+++ b/tests/unit/errors/Makefile.in
@@ -18,6 +18,9 @@ errors_test_EXTRA_INITIALIZE := redirect_errors
 
 errors_test_driver.o: error_redirection.o
 
+error_redirection.F90: ../error_redirection/error_redirection.F90
+	cp $< $@
+
 $(eval $(call make_pfunit_test,errors_test))
 
 distclean:

--- a/tests/unit/errors/Makefile.in
+++ b/tests/unit/errors/Makefile.in
@@ -1,0 +1,32 @@
+ifneq ("$(wildcard @PFUNIT_DIR@/include/PFUNIT.mk)", "")
+include @PFUNIT_DIR@/include/PFUNIT.mk
+endif
+FFLAGS += $(PFUNIT_EXTRA_FFLAGS) -I@top_builddir@/src
+FC = @FC@
+
+%.o : %.F90
+	$(FC) -c $(FFLAGS) $<
+
+
+check: errors_test
+
+errors_test_TESTS := test_errors.pf
+errors_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs/ -lneko @LDFLAGS@ @LIBS@
+errors_test_OTHER_SRCS := error_redirection.F90
+errors_test_EXTRA_USE := error_redirection
+errors_test_EXTRA_INITIALIZE := redirect_errors
+
+errors_test_driver.o: error_redirection.o
+
+$(eval $(call make_pfunit_test,errors_test))
+
+distclean:
+clean:
+	$(RM) *.o *.mod *.a  *.inc *.F90 errors_test
+
+
+
+all:
+html:
+install:
+distdir:

--- a/tests/unit/errors/test_errors.pf
+++ b/tests/unit/errors/test_errors.pf
@@ -2,9 +2,16 @@ module test_errors
   use pfunit
   use utils, only : neko_error, neko_type_error, neko_type_registration_error,&
       neko_warning
+  use error_redirection, only : redirect_errors
   implicit none
 
 contains
+
+
+  @before
+  subroutine setup()
+    call redirect_errors()
+  end subroutine setup
 
   @test
   subroutine test_neko_error_raises()

--- a/tests/unit/errors/test_errors.pf
+++ b/tests/unit/errors/test_errors.pf
@@ -1,6 +1,6 @@
 module test_errors
   use pfunit
-  use errors, only : neko_error, neko_type_error, neko_type_registration_error,&
+  use utils, only : neko_error, neko_type_error, neko_type_registration_error,&
       neko_warning
   implicit none
 

--- a/tests/unit/errors/test_errors.pf
+++ b/tests/unit/errors/test_errors.pf
@@ -1,0 +1,33 @@
+module test_errors
+  use pfunit
+  use errors, only : neko_error, neko_type_error, neko_type_registration_error,&
+      neko_warning
+  implicit none
+
+contains
+
+  @test
+  subroutine test_neko_error_raises()
+    call neko_error("boom")
+    @assertExceptionRaised()
+  end subroutine test_neko_error_raises
+
+  @test
+  subroutine test_neko_type_error_raises()
+    call neko_type_error("base", "wrong", ["known1", "known2"])
+    @assertExceptionRaised()
+  end subroutine test_neko_type_error_raises
+
+  @test
+  subroutine test_neko_type_registration_error_raises()
+    call neko_type_registration_error("base", "wrong", .true. )
+    @assertExceptionRaised()
+  end subroutine test_neko_type_registration_error_raises
+
+  @test
+  subroutine test_neko_warning_raises()
+    call neko_warning("this is a warning")
+    @assertExceptionRaised()
+  end subroutine test_neko_warning_raises
+
+end module test_errors


### PR DESCRIPTION
Adds errors.f90, which for now just contains a copy of our errors from utils.f90, but they are hooked up to the system pfunit uses
for exceptions.

Basically, there is subroutine pointer, that by default points:
- For errors to a routine that calls `error stop`
- For warnings to a routine that does nothing.

For unit tests, there is a module error_redirection.f90 added, which switches the pointers to a routine that registers a pfunit exception. This way one can do tests like

```
  subroutine test_neko_error_raises()
    call neko_error("boom")
    @assertExceptionRaised()
  end subroutine test_neko_error_raises
```
to make sure we are raising an error. In reality, it is some object that is tested that calls neko_error of course.

A separate question is whether to actually move errors and warnings out to their own module, or to add stuff to utils.f90. I feel like if we add more error later, it would be nice with a separate module.

The
```
error_redirection.F90: ../error_redirection/error_redirection.F90
	cp $< $@
```
seems to be the only way to get thigns to comple.


Bonus: added a CHANGELOG.md