### PR TITLE
Add missing end_section

### DIFF
--- a/src/fluid/fluid_scheme_compressible.f90
+++ b/src/fluid/fluid_scheme_compressible.f90
@@ -430,6 +430,7 @@ contains
     call json_get_or_default(params, 'case.numerics.time_order', integer_val, 4)
     write(log_buf, '(A, I0)') 'RK order   : ', integer_val
     call neko_log%message(log_buf)
+    call neko_log%end_section()
 
   end subroutine fluid_scheme_compressible_log_solver_info
 

--- a/src/neko.f90
+++ b/src/neko.f90
@@ -267,6 +267,8 @@ contains
 
     call neko_registry%free()
     call neko_user_access%free()
+    call neko_log%free()
+
     call device_finalize
     call neko_mpi_types_free
     call comm_free


### PR DESCRIPTION
This fixes the logging for the compressible solver, which was of compared to the incompressible one