### PR TITLE
Fix mean_output_t initilization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Develop
+- Fix `mean_field_output_t` initialization, causing `start_time` to not be
+  respected by the `user_stats` simulation component.

--- a/src/io/mean_field_output.f90
+++ b/src/io/mean_field_output.f90
@@ -93,6 +93,8 @@ contains
     character(len=1024) :: fname
     integer :: i
 
+    this%start_time = start_time
+
     if (trim(avg_dir) .eq. 'none' .or. &
          trim(avg_dir) .eq. 'x' .or.&
          trim(avg_dir) .eq. 'y' .or.&

--- a/src/io/mean_field_output.f90
+++ b/src/io/mean_field_output.f90
@@ -53,15 +53,15 @@ module mean_field_output
      !> Pointers to the fields inside the mean_fields
      type(field_list_t) :: fields
      !> Time to start output
-     real(kind=rp) :: start_time
+     real(kind=rp) :: start_time = 0.0_rp
      !> Number of fields
-     integer :: n_fields
+     integer :: n_fields = 0
      !> Space averaging object for 2 homogeneous directions.
      type(map_1d_t) :: map_1d
      !> Space averaging object for 1 homogeneous direction.
      type(map_2d_t) :: map_2d
      !> The dimension of the output fields. Either 1, 2, or 3.
-     integer :: output_dim
+     integer :: output_dim = 0
    contains
      !> Constructor
      procedure, pass(this) :: init => mean_field_output_init


### PR DESCRIPTION
Asked AI why it thinks we get this weird error with user_stats.csv failing to appear randomly in the pytest CI, and it directly found this very sad bug. 

`this%start_time` was not initialized, so randomly the check of time > this%start_time would fail...

We should not have let that error slide like that.