### PR TITLE
Fix HDF5 bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,6 @@
 ## Develop
 - Fix `mean_field_output_t` initialization, causing `start_time` to not be
   respected by the `user_stats` simulation component.
+- Fix field assignment operator to correctly handle name assignment only when
+  the current field's name is empty. Caused HDF5 bugs when writing fields with
+  pre-existing names.

--- a/examples/turb_channel/turb_channel.case
+++ b/examples/turb_channel/turb_channel.case
@@ -7,7 +7,6 @@
         "output_checkpoints": true,
         "checkpoint_control": "simulationtime",
         "checkpoint_value": 50,
-        "checkpoint_format": "hdf5",
         "time": {
             "end_time": 200.0,
             "variable_timestep": true,

--- a/examples/turb_channel/turb_channel.case
+++ b/examples/turb_channel/turb_channel.case
@@ -7,6 +7,7 @@
         "output_checkpoints": true,
         "checkpoint_control": "simulationtime",
         "checkpoint_value": 50,
+        "checkpoint_format": "hdf5",
         "time": {
             "end_time": 200.0,
             "variable_timestep": true,

--- a/src/field/field.f90
+++ b/src/field/field.f90
@@ -168,6 +168,7 @@ contains
   subroutine field_free(this)
     class(field_t), intent(inout) :: this
 
+    this%name = ""
     if (allocated(this%x)) then
        deallocate(this%x)
     end if

--- a/src/field/field.f90
+++ b/src/field/field.f90
@@ -52,7 +52,7 @@ module field
      type(dofmap_t), pointer :: dof !< Dofmap
 
      logical :: internal_dofmap = .false. !< Does the field have an own dofmap
-     character(len=80) :: name !< Name of the field
+     character(len=80) :: name = "" !< Name of the field
      type(c_ptr) :: x_d = C_NULL_PTR
    contains
      procedure, private, pass(this) :: init_common => field_init_common

--- a/src/field/field.f90
+++ b/src/field/field.f90
@@ -218,7 +218,9 @@ contains
 
     this%Xh => g%Xh
     this%msh => g%msh
-    this%name = g%name
+    if (len_trim(this%name) == 0) then
+       this%name = g%name
+    end if
 
     if (.not. g%internal_dofmap) then
        this%dof => g%dof

--- a/tests/unit/field/field_parallel.pf
+++ b/tests/unit/field/field_parallel.pf
@@ -166,7 +166,7 @@ contains
     type(space_t) :: Xh
     type(mesh_t) :: msh
     integer, parameter :: LX = 4
-    type(field_t) :: f, g
+    type(field_t) :: f, g, h
     integer :: ierr
 
     call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
@@ -186,7 +186,14 @@ contains
        call device_memcpy(g%x, g%x_d, size(f%x), DEVICE_TO_HOST, sync=.true.)
     end if
     @assertEqual(maxval(g%x), maxval(f%x))
-    @assertEqual(g%name, f%name)
+    @assertEqual('test2', g%name)
+
+    h = f
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_memcpy(h%x, h%x_d, size(f%x), DEVICE_TO_HOST, sync=.true.)
+    end if
+    @assertEqual(maxval(f%x), maxval(h%x))
+    @assertEqual(f%name, h%name)
 
   end subroutine test_field_assign_field
 


### PR DESCRIPTION
Address a bug in the HDF5 handling related to field assignment by ensuring the name is only assigned when it is empty.