### PR TITLE
Fix kernel launch failures for ranks without cyclic boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## Develop
 - Fix `mean_field_output_t` initialization, causing `start_time` to not be
   respected by the `user_stats` simulation component.
+- Fix cyclic boundary rotation device bug, which tried to launch kernels
+  with zero threads for ranks not containing cyclic boundaries.

--- a/src/math/bcknd/device/opr_device.F90
+++ b/src/math/bcknd/device/opr_device.F90
@@ -882,6 +882,8 @@ contains
     vz_d = device_get_ptr(vz)
     ncyc = coef%cyc_msk(0) - 1
 
+    if (ncyc .le. 0) return
+
 #ifdef HAVE_HIP
     call hip_rotate_cyc(vx_d, vy_d, vz_d, &
          coef%dof%x_d, coef%dof%y_d, coef%dof%z_d, &
@@ -911,6 +913,8 @@ contains
     vy_d = device_get_ptr(vy)
     vz_d = device_get_ptr(vz)
     ncyc = coef%cyc_msk(0) - 1
+
+    if (ncyc .le. 0) return
 
 #ifdef HAVE_HIP
     call hip_rotate_cyc(vx_d, vy_d, vz_d, &


### PR DESCRIPTION
I ran into issues with larger cases where the cyclic kernels would fail to launch because some ranks have no cyclic boundary faces, meaning `ncyc = 0`. This would cause the `rotate_cyc` kernel to try to launch with zero blocks.

I added an if condition to prevent this, but if there's a better way to do this, or a more ideal place to put it, please let me know.