### PR TITLE
Fix scalar boundary conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Develop
+- Add min/max operations when applying strong boundary conditions for the
+  scalar, mimicing the procedure for the fluid. Needed with meshes where an
+  element touches the boundary with only an edge.
+- Fix `user` scalar boundary conditions only being applied once in the beginning
+  of the simulation.
 - Fix `mean_field_output_t` initialization, causing `start_time` to not be
   respected by the `user_stats` simulation component.
 - Fix field assignment operator to correctly handle name assignment only when

--- a/src/scalar/scalar_pnpn.f90
+++ b/src/scalar/scalar_pnpn.f90
@@ -43,8 +43,9 @@ module scalar_pnpn
   use bc_list, only : bc_list_t
   use mesh, only : mesh_t
   use coefs, only : coef_t
-  use device, only : HOST_TO_DEVICE, device_memcpy
-  use gather_scatter, only : gs_t, GS_OP_ADD
+  use device, only : HOST_TO_DEVICE, device_memcpy, glb_cmd_event, &
+       device_event_sync
+  use gather_scatter, only : gs_t, GS_OP_ADD, GS_OP_MIN, GS_OP_MAX
   use scalar_residual, only : scalar_residual_t, scalar_residual_factory
   use ax_product, only : ax_t, ax_helm_factory
   use field_series, only: field_series_t
@@ -130,6 +131,8 @@ module scalar_pnpn
      procedure, pass(this) :: free => scalar_pnpn_free
      !> Solve for the current timestep.
      procedure, pass(this) :: step => scalar_pnpn_step
+     !> Apply boundary conditions
+     procedure, pass(this) :: apply_strong_bcs => scalar_scheme_apply_strong_bcs
      !> Setup the boundary conditions
      procedure, pass(this) :: setup_bcs_ => scalar_pnpn_setup_bcs_
      !> Sync lag field data to registry for checkpointing
@@ -406,7 +409,7 @@ contains
       call slag%update()
 
       !> Apply strong boundary conditions.
-      call this%bcs%apply_scalar(this%s%x, this%dm_Xh%size(), time, .true.)
+      call this%apply_strong_bcs(time)
 
       ! Update material properties if necessary
       call this%update_material_properties(time)
@@ -559,6 +562,46 @@ contains
 
     end if
   end subroutine scalar_pnpn_setup_bcs_
+
+  !> Apply strong boundary conditions.
+  !! @details Applies strong boundary conditions and takes care of resolution
+  !! of the boundary condition type on points shared accross weak and strong
+  !! conditions.
+  !! @param time The current time state.
+  subroutine scalar_scheme_apply_strong_bcs(this, time)
+    class(scalar_pnpn_t), intent(inout) :: this
+    type(time_state_t), intent(in) :: time
+
+    integer :: i
+    class(bc_t), pointer :: bc_i
+    bc_i => null()
+
+    ! First apply call, sets the dirichlet value, let's call it d.
+    call this%bcs%apply(this%s, time = time, strong = .true.)
+    ! If we now have two local nodes sharing the same global node, and with
+    ! conflicting dirichlet / neumann bcs the node with a strong bc
+    ! will have the value d, and the the other one just some random value u.
+    ! Take nodewise minimum between the local nodes .
+    ! Now, all local nodes store m = min(d, u)
+    call this%gs_Xh%op(this%s, GS_OP_MIN, glb_cmd_event)
+    call device_event_sync(glb_cmd_event)
+
+    ! Second apply call, so dirichlet nodes again store d, the rest still store
+    ! m, where m < d by construction.
+    call this%bcs%apply(this%s, time = time, strong = .true.)
+    ! Now apply a max, which guarantees that d wins and gets stored in all the
+    ! local conflicting nodes.
+    call this%gs_Xh%op(this%s, GS_OP_MAX, glb_cmd_event)
+    call device_event_sync(glb_cmd_event)
+
+    ! Reset updated flags
+    do i = 1, this%bcs%size()
+       bc_i => this%bcs%get(i)
+       bc_i%updated = .false.
+    end do
+    nullify(bc_i)
+
+  end subroutine scalar_scheme_apply_strong_bcs
 
 
 end module scalar_pnpn

--- a/src/scalar/scalar_pnpn.f90
+++ b/src/scalar/scalar_pnpn.f90
@@ -131,7 +131,7 @@ module scalar_pnpn
      procedure, pass(this) :: free => scalar_pnpn_free
      !> Solve for the current timestep.
      procedure, pass(this) :: step => scalar_pnpn_step
-     !> Apply boundary conditions
+     !> Apply strong boundary conditions
      procedure, pass(this) :: apply_strong_bcs => scalar_scheme_apply_strong_bcs
      !> Setup the boundary conditions
      procedure, pass(this) :: setup_bcs_ => scalar_pnpn_setup_bcs_

--- a/src/scalar/scalar_pnpn.f90
+++ b/src/scalar/scalar_pnpn.f90
@@ -564,9 +564,6 @@ contains
   end subroutine scalar_pnpn_setup_bcs_
 
   !> Apply strong boundary conditions.
-  !! @details Applies strong boundary conditions and takes care of resolution
-  !! of the boundary condition type on points shared accross weak and strong
-  !! conditions.
   !! @param time The current time state.
   subroutine scalar_scheme_apply_strong_bcs(this, time)
     class(scalar_pnpn_t), intent(inout) :: this
@@ -576,21 +573,21 @@ contains
     class(bc_t), pointer :: bc_i
     bc_i => null()
 
-    ! First apply call, sets the dirichlet value, let's call it d.
+    ! First apply call, sets the Dirichlet value, let's call it d.
     call this%bcs%apply(this%s, time = time, strong = .true.)
-    ! If we now have two local nodes sharing the same global node, and with
-    ! conflicting dirichlet / neumann bcs the node with a strong bc
-    ! will have the value d, and the the other one just some random value u.
-    ! Take nodewise minimum between the local nodes .
+    ! If we now have local nodes sharing the same global node, and with
+    ! some nodes not masked as Dirichlet, the node which *is* masked
+    ! will have the value d, and the the other ones just some value u.
+    ! Take a nodewise minimum between the local nodes.
     ! Now, all local nodes store m = min(d, u)
     call this%gs_Xh%op(this%s, GS_OP_MIN, glb_cmd_event)
     call device_event_sync(glb_cmd_event)
 
-    ! Second apply call, so dirichlet nodes again store d, the rest still store
+    ! Second apply call, so Dirichlet nodes again store d, the rest still store
     ! m, where m < d by construction.
     call this%bcs%apply(this%s, time = time, strong = .true.)
     ! Now apply a max, which guarantees that d wins and gets stored in all the
-    ! local conflicting nodes.
+    ! local nodes.
     call this%gs_Xh%op(this%s, GS_OP_MAX, glb_cmd_event)
     call device_event_sync(glb_cmd_event)
 


### PR DESCRIPTION
This fixes two issues

- The scalar scheme did not implement the boundary condition gs_op min /max fix for handling nodes touching the boundary with an edge. This PR adds this treatment.

- Since boundary conditions are applied twice as per above, the bc_t%updated flag was introduced before, and the fluid scheme takes care of reseting that properly, but the scalar scheme did not. So e.g. `user` boundary conditions did not work properly for the scalar, they were only applied once at the beginning of the simulation. The latter is actually a typical use case, so not caught before. The reseting is now properly handled.