### PR TITLE
Fix index range in concurrent loop for gs_scatter_kernel

### DIFF
--- a/src/gs/bcknd/cpu/gs_cpu.f90
+++ b/src/gs/bcknd/cpu/gs_cpu.f90
@@ -287,7 +287,7 @@ contains
        end do
     end do
 
-    do concurrent (i = (k + b(nb) + 1):m)
+    do concurrent (i = (bo(nb) + b(nb) + 1):m)
        u(gd(i)) = v(dg(i))
     end do
 


### PR DESCRIPTION
This should fix the recent regression test fails 