### PR TITLE
Allow neko to initialize with explicit filename

### DIFF
--- a/src/neko.f90
+++ b/src/neko.f90
@@ -151,8 +151,9 @@ module neko
 contains
 
   !> Initialise Neko
-  subroutine neko_init(C)
+  subroutine neko_init(C, filename)
     type(case_t), target, intent(inout), optional :: C
+    character(len=*), intent(in), optional :: filename
     character(len=NEKO_FNAME_LEN) :: case_file, args
     character(len=LOG_SIZE) :: log_buf
     character(len=10) :: suffix
@@ -175,17 +176,21 @@ contains
 
     if (present(C)) then
 
-       !
-       ! Command line arguments
-       !
-       argc = command_argument_count()
+       if (present(filename)) then
+          case_file = filename
+       else
+          !
+          ! Command line arguments
+          !
+          argc = command_argument_count()
 
-       if (argc .lt. 1) then
-          if (pe_rank .eq. 0) write(*,*) 'Usage: ./neko <case file>'
-          stop
+          if (argc .lt. 1) then
+             if (pe_rank .eq. 0) write(*,*) 'Usage: ./neko <case file>'
+             stop
+          end if
+
+          call get_command_argument(1, case_file)
        end if
-
-       call get_command_argument(1, case_file)
 
        call filename_suffix(case_file, suffix)
 


### PR DESCRIPTION
Neko can now be initialized with an explicit filename, providing more flexibility in case file handling. If no filename is provided, it defaults to using command line arguments.