### PR TITLE
Increase length of SOURCE_KNOWN_TYPES elements

### DIFF
--- a/src/source_terms/source_term_fctry.f90
+++ b/src/source_terms/source_term_fctry.f90
@@ -45,7 +45,7 @@ submodule (source_term) source_term_fctry
   implicit none
 
   ! List of all possible types created by the factory routine
-  character(len=20) :: SOURCE_KNOWN_TYPES(7) = [character(len=25) :: &
+  character(len=25) :: SOURCE_KNOWN_TYPES(7) = [character(len=25) :: &
        "constant", &
        "boussinesq", &
        "coriolis", &

--- a/src/source_terms/source_term_fctry.f90
+++ b/src/source_terms/source_term_fctry.f90
@@ -45,7 +45,7 @@ submodule (source_term) source_term_fctry
   implicit none
 
   ! List of all possible types created by the factory routine
-  character(len=20) :: SOURCE_KNOWN_TYPES(7) = [character(len=20) :: &
+  character(len=20) :: SOURCE_KNOWN_TYPES(7) = [character(len=25) :: &
        "constant", &
        "boussinesq", &
        "coriolis", &


### PR DESCRIPTION
make sure gjp is fully included in the error message