### PR TITLE
Documentation: add some brief comments to Poisson example

### DIFF
--- a/examples/poisson/ax_poisson.f90
+++ b/examples/poisson/ax_poisson.f90
@@ -69,7 +69,10 @@ contains
          G12 => coef%G12, G13 => coef%G13, G23 => coef%G23, &
          n => msh%nelv, lx => Xh%lx)
 
+      ! Loop over mesh elements
       do e = 1, n
+         ! Compute the action of the derivative operator (D u)
+         ! (D_xi u)
          do j = 1, lx * lx
             do i = 1, lx
                tmp = 0.0_rp
@@ -80,6 +83,7 @@ contains
             end do
          end do
 
+         ! (D_eta u)
          do k = 1, lx
             do j = 1, lx
                do i = 1, lx
@@ -92,6 +96,7 @@ contains
             end do
          end do
 
+         ! (D_gamma u)
          do k = 1, lx
             do i = 1, lx*lx
                tmp = 0.0_rp
@@ -102,6 +107,7 @@ contains
             end do
          end do
 
+         ! Compute the geometric mapping information and apply it (G (D u))
          do i = 1, lx*lx*lx
             ur(i,1,1) = ( G11(i,1,1,e) * wur(i,1,1) &
                         + G12(i,1,1,e) * wus(i,1,1) &
@@ -114,6 +120,8 @@ contains
                         + G33(i,1,1,e) * wut(i,1,1) )
          end do
 
+         ! Compute the action of the derivative transpose operator (D^T (G (D u)))
+         ! (D^T_xi u)
          do j = 1, lx*lx
             do i = 1, lx
                tmp = 0.0_rp
@@ -124,6 +132,7 @@ contains
             end do
          end do
 
+         ! (D^T_eta u)
          do k = 1, lx
             do j = 1, lx
                do i = 1, lx
@@ -136,6 +145,7 @@ contains
             end do
          end do
 
+         ! (D^T_gamma u)
          do k = 1, lx
             do i = 1, lx*lx
                tmp = 0.0_rp


### PR DESCRIPTION
This adds some comments to the documentation for the Poisson example describing things using similar operator notation as the paper.