### PR TITLE
Fixing tgv after adding %name to simcomps

### DIFF
--- a/examples/tgv/tgv.case
+++ b/examples/tgv/tgv.case
@@ -49,7 +49,7 @@
             {
                 "type": "curl",
                 "fields": [ "u", "v", "w" ],
-                "computed_field": "omega",
+                "name": "omega",
                 "compute_control": "tsteps",
                 "compute_value": 50
             }


### PR DESCRIPTION
There seems to be some inconsistency in simcomps right now, as "computed_field" seems to be still present in a number of them.