### PR TITLE
Removing 'optional' attribute for L and activ_step in projection_vel

### DIFF
--- a/src/common/projection_vel.f90
+++ b/src/common/projection_vel.f90
@@ -67,7 +67,7 @@ contains
   subroutine projection_init_vel(this, n, L, activ_step)
     class(projection_vel_t), target, intent(inout) :: this
     integer, intent(in) :: n
-    integer, optional, intent(in) :: L, activ_step
+    integer, intent(in) :: L, activ_step
     integer :: i
     integer(c_size_t) :: ptr_size
     type(c_ptr) :: ptr


### PR DESCRIPTION
There is inconsistency in default value of activ_step between projection and projection_vel. As activ_step is used in velocity projection it could cause a problem, so it should be consistent. Moreover, there is no need for having L with optional attribute.