### PR TITLE
Appendix describing the "fld" format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Develop
+- Add description of the `fld` file format to the documentation.
 - Added cache cleanup job for CI workflows upon PR closure.
 - Updated compiler check workflows to run on release branches and master.
 - Removed commented-out workflow sections.

--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -8,6 +8,7 @@ of the code. But can be useful for users and developers alike.
 - [Environmental variable reference](@ref appendices_env-var)
 - \subpage governing-equations
 - \subpage nmsh-format
+- \subpage fld-format
 - \subpage publications
 
 ## Environmental variable reference {#appendices_env-var}

--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -7,6 +7,7 @@ of the code. But can be useful for users and developers alike.
 
 - [Environmental variable reference](@ref appendices_env-var)
 - \subpage governing-equations
+- \subpage nmsh-format
 - \subpage publications
 
 ## Environmental variable reference {#appendices_env-var}

--- a/doc/pages/appendices/fld-format.md
+++ b/doc/pages/appendices/fld-format.md
@@ -1,0 +1,142 @@
+# Neko .fld field format {#fld-format}
+
+\tableofcontents
+
+This appendix documents the Nek5000 file format as written and read by Neko in
+``src/io/fld_file.f90``. We refer to this format as `.fld` for brevity. Neko
+writes ``.fld`` files using MPI-IO, and the layout on disk follows the code
+paths in that module.
+
+## File naming and series
+
+Neko writes a file series in Nek5000 style:
+
+- Data files: ``<base>0.f#####`` (zero-padded index)
+- Metadata file: ``<base><start_counter>.nek5000``
+
+The ``.nek5000`` file contains the filetemplate and time range for the series
+and is used by Neko when reading a series.
+
+## File overview
+
+Each ``.fld`` data file consists of:
+
+1. **Header** (132 characters)
+2. **Test pattern** (single precision, value ``6.54321``)
+3. **Element index list** (``glb_nelv`` integers)
+4. **Field blocks** (mesh, velocity, pressure, temperature, scalars)
+5. **Metadata blocks** (per-element min/max, only for 3D)
+
+The presence and ordering of the field blocks is described by ``rdcode`` in the
+header.
+
+## Header
+
+The header is a 132-character record written with the format:
+
+```
+#std <fld_data_size> <lx> <ly> <lz> <glb_nelv> <glb_nelv> <time> <step>
+     <1> <1> <rdcode[10]>
+```
+
+In code, this is:
+
+```
+'#std', i1, i2, i2, i2, i10, i10, e20.13, i9, i6, i6, 10a
+```
+
+Fields:
+
+- ``fld_data_size``: byte size of field data (``MPI_REAL_SIZE`` or
+  ``MPI_DOUBLE_PRECISION_SIZE``)
+- ``lx, ly, lz``: polynomial orders (GLL grid size per element direction)
+- ``glb_nelv``: global number of elements (written twice)
+- ``time``: simulation time
+- ``step``: output counter
+- The two ``i6`` values are currently written as ``1``
+- ``rdcode``: 10-character field descriptor
+
+### rdcode
+
+``rdcode`` is a compact descriptor of which fields are present and in which
+order:
+
+- ``X``: mesh coordinates
+- ``U``: velocity (vector)
+- ``P``: pressure (scalar)
+- ``T``: temperature (scalar)
+- ``Snn``: scalars, with a two-digit count (``S00`` .. ``S99``)
+
+The writer appends ``S`` followed by two digits for the scalar count. The reader
+parses these digits to determine the number of scalar fields.
+
+## Test pattern
+
+Immediately after the header, the writer stores a single-precision real with
+value ``6.54321``. The reader validates this value to guard against format or
+endianness mismatches.
+
+## Element index list
+
+After the test pattern, the file contains ``glb_nelv`` integers storing the
+global element ids. Each MPI rank reads/writes its own slice based on
+``offset_el``.
+
+## Field blocks
+
+Field data is written in the order indicated by ``rdcode``. Within each block,
+Neko writes data in **element-major** order:
+
+- Loop elements ``e = 1..nelv``
+- For each element, loop GLL points ``j = 1..lxyz``
+
+### Vector fields (X and U)
+
+For vector fields, the layout per element is:
+
+1. All ``x`` values (``j = 1..lxyz``)
+2. All ``y`` values (``j = 1..lxyz``)
+3. All ``z`` values (``j = 1..lxyz``) if ``gdim == 3``
+
+The block size is ``gdim * lxyz * glb_nelv`` values.
+
+### Scalar fields (P, T, S)
+
+Scalar fields are stored as ``lxyz * glb_nelv`` values in element-major order.
+Scalars are written in sequence ``S1, S2, ...``.
+
+### Precision
+
+Field blocks are written in either single or double precision, depending on the
+``fld_data_size`` header value. Neko writes single precision by default unless
+configured otherwise.
+
+## Metadata blocks (3D only)
+
+For 3D output (``gdim == 3``), Neko appends per-element min/max metadata for
+all written fields. These metadata blocks are always **single precision** and
+follow the same field ordering as the data blocks.
+
+- Vector fields: ``2 * gdim * glb_nelv`` values
+  - ``xmin, xmax, ymin, ymax, zmin, zmax`` per element
+- Scalar fields: ``2 * glb_nelv`` values
+  - ``min, max`` per element
+
+For 2D output, these metadata blocks are not written.
+
+## 2D fields and Z-velocity
+
+When writing 2D fields, Neko sets ``gdim = 2`` (``lz = 1``). If a Z-velocity
+component exists, it is stored as an additional scalar field in the output.
+This is a semantic convention rather than a special file layout.
+
+## Portability notes
+
+The ``.fld`` format is not self-describing beyond the header. It depends on:
+
+- Endianness
+- ``MPI_INTEGER`` size
+- ``MPI_REAL`` and ``MPI_DOUBLE_PRECISION`` sizes
+
+For robust I/O, use Neko's ``fld_file`` reader/writer or convert using tools
+that understand the Nek5000 format.

--- a/doc/pages/appendices/fld-format.md
+++ b/doc/pages/appendices/fld-format.md
@@ -14,12 +14,12 @@ Neko writes a file series in Nek5000 style:
 - Data files: ``<base>0.f#####`` (zero-padded index)
 - Metadata file: ``<base><start_counter>.nek5000``
 
-The ``.nek5000`` file contains the filetemplate and time range for the series
+The ``.nek5000`` file contains the file template and time range for the series
 and is used by Neko when reading a series.
 
 ## File overview
 
-Each ``.fld`` data file consists of:
+Each ``.fld`` data file is binary and consists of:
 
 1. **Header** (132 characters)
 2. **Test pattern** (single precision, value ``6.54321``)
@@ -48,7 +48,7 @@ In code, this is:
 Fields:
 
 - ``fld_data_size``: byte size of field data (``MPI_REAL_SIZE`` or
-  ``MPI_DOUBLE_PRECISION_SIZE``)
+  ``MPI_DOUBLE_PRECISION_SIZE``). In practice, this is either 4 or 8.
 - ``lx, ly, lz``: polynomial orders (GLL grid size per element direction)
 - ``glb_nelv``: global number of elements (written twice)
 - ``time``: simulation time
@@ -98,8 +98,11 @@ For vector fields, the layout per element is:
 2. All ``y`` values (``j = 1..lxyz``)
 3. All ``z`` values (``j = 1..lxyz``) if ``gdim == 3``
 
-The block size is ``gdim * lxyz * glb_nelv`` values.
+The block size is ``gdim * lxyz * glb_nelv`` values. Note that if `U` is
+written, all three components have to be present. One cannot, for example, write
+only one component of velocity.
 
+If `X` is not written, then the files does not contain the mesh!
 ### Scalar fields (P, T, S)
 
 Scalar fields are stored as ``lxyz * glb_nelv`` values in element-major order.
@@ -134,7 +137,7 @@ This is a semantic convention rather than a special file layout.
 
 The ``.fld`` format is not self-describing beyond the header. It depends on:
 
-- Endianness
+- Endianness (typically little).
 - ``MPI_INTEGER`` size
 - ``MPI_REAL`` and ``MPI_DOUBLE_PRECISION`` sizes
 

--- a/doc/pages/appendices/nmsh-format.md
+++ b/doc/pages/appendices/nmsh-format.md
@@ -1,0 +1,135 @@
+# Neko .nmsh mesh format {#nmsh-format}
+
+\tableofcontents
+
+This appendix documents the Neko binary mesh format (``.nmsh``) as implemented
+in ``src/io/format/nmsh.f90`` and ``src/io/nmsh_file.f90``. The format is
+written and read with MPI-IO using MPI derived types, so the on-disk layout
+mirrors the in-memory layout of the Fortran derived types.
+
+## File overview
+
+An ``.nmsh`` file is a binary stream with the following blocks, in order:
+
+1. **Header** (two ``MPI_INTEGER`` values)
+   - ``nelv``: number of elements (global)
+   - ``gdim``: geometric dimension (2 or 3)
+
+2. **Element block**
+   - ``nelv`` records of ``nmsh_quad_t`` if ``gdim == 2``
+   - ``nelv`` records of ``nmsh_hex_t`` if ``gdim == 3``
+
+3. **Zone block**
+   - ``nzones``: number of zone records (``MPI_INTEGER``)
+   - ``nzones`` records of ``nmsh_zone_t``
+
+4. **Curve block**
+   - ``ncurves``: number of curve records (``MPI_INTEGER``)
+   - ``ncurves`` records of ``nmsh_curve_el_t``
+
+If ``nzones`` or ``ncurves`` is zero, the corresponding record array is omitted.
+
+## Data types and portability
+
+The file uses:
+
+- ``MPI_INTEGER`` for integer fields
+- ``MPI_DOUBLE_PRECISION`` for real fields (``real(kind=dp)``)
+
+The layout is **not self-describing**. It depends on the platform endianness,
+``MPI_INTEGER`` size, and Fortran derived-type padding/alignment. In practice,
+all ``.nmsh`` files in this repository are little-endian with 32-bit integers,
+but external readers should **not** assume this. For robust I/O, use Neko's
+``nmsh_file`` reader/writer or convert via ``rea2nbin``.
+
+All element and vertex indices stored in the file are **global, 1-based** ids
+as used by Neko internally.
+
+## Element records
+
+### Vertex record (``nmsh_vertex_t``)
+
+| Field | Type | Description |
+| --- | --- | --- |
+| ``v_idx`` | ``MPI_INTEGER`` | Global vertex id |
+| ``v_xyz`` | ``MPI_DOUBLE_PRECISION[3]`` | Vertex coordinates (x, y, z) |
+
+### Quad record (``nmsh_quad_t``)
+
+| Field | Type | Description |
+| --- | --- | --- |
+| ``el_idx`` | ``MPI_INTEGER`` | Global element id |
+| ``v(1:4)`` | 4×``nmsh_vertex_t`` | Quad vertices |
+
+### Hex record (``nmsh_hex_t``)
+
+| Field | Type | Description |
+| --- | --- | --- |
+| ``el_idx`` | ``MPI_INTEGER`` | Global element id |
+| ``v(1:8)`` | 8×``nmsh_vertex_t`` | Hex vertices |
+
+### Vertex ordering
+
+The writer stores vertices using the ``vcyc_to_sym`` mapping in
+``src/io/nmsh_file.f90``:
+
+```
+[1, 2, 4, 3, 5, 6, 8, 7]
+```
+
+This is the ordering used for the ``nmsh_hex_t`` / ``nmsh_quad_t`` records. The
+reader swaps vertices when constructing elements to restore Neko's internal
+ordering. External tools should preserve the file ordering as-is.
+
+## Zone records (boundary and periodic data)
+
+The zone record is defined by ``nmsh_zone_t``:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| ``e`` | ``MPI_INTEGER`` | Global element id |
+| ``f`` | ``MPI_INTEGER`` | Facet number (1-based) |
+| ``p_e`` | ``MPI_INTEGER`` | Periodic partner element id |
+| ``p_f`` | ``MPI_INTEGER`` | Periodic partner facet id (or label id) |
+| ``glb_pt_ids(1:4)`` | ``MPI_INTEGER[4]`` | Global point ids for the facet |
+| ``type`` | ``MPI_INTEGER`` | Zone type |
+
+Currently, Neko writes:
+
+- ``type = 5``: periodic facet. ``p_e`` and ``p_f`` identify the partner facet;
+  ``glb_pt_ids`` stores the ordered global point ids of the facet.
+- ``type = 7``: labeled facet. ``p_f`` stores the zone label index.
+
+Other zone types are not emitted by the current writer.
+
+## Curve records (curved edges/faces)
+
+The curve record is defined by ``nmsh_curve_el_t``:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| ``e`` | ``MPI_INTEGER`` | Global element id |
+| ``curve_data`` | ``MPI_DOUBLE_PRECISION[5,12]`` | Curve parameters |
+| ``type`` | ``MPI_INTEGER[12]`` | Curve type per edge |
+
+The meaning of ``curve_data`` and the ``type`` codes follows the same
+conventions as the ``re2`` importer in ``src/io/re2_file.f90``. The current
+implementation recognizes:
+
+- ``0``: no curve
+- ``3``: arc (``'C'`` in ``.re2``)
+- ``4``: mapped curve (``'m'`` in ``.re2``)
+
+Other curve types (e.g. ``1`` / ``2`` from ``'s'`` / ``'e'``) are read but
+treated as unsupported by the importer.
+
+## 2D meshes
+
+If the header ``gdim`` is ``2``, the file stores ``nmsh_quad_t`` records. The
+reader in ``nmsh_file_read_2d`` extrudes these into a thin 3D slab:
+
+- Bottom vertices are placed at ``z = 0``
+- Top vertices are placed at ``z = 1``
+- Periodic facets are added between the two planes
+
+This behavior is specific to the reader and is **not** encoded in the file.


### PR DESCRIPTION
Dep on #2285 by accident, but here only fld-format.md is to be reviewed. The text is generated by AI, based on our IO code, with some minor editing from my side. I am not very well-versed in the format, so those well-familiar with it, please critically review this.

I know there are different versions of the format around, it would be good if this appendix tracks exactly the specification we use in Neko.