### PR TITLE
Restore computed_field to curl

### DIFF
--- a/examples/tgv/tgv.case
+++ b/examples/tgv/tgv.case
@@ -50,6 +50,7 @@
                 "type": "curl",
                 "fields": [ "u", "v", "w" ],
                 "name": "omega",
+                "computed_field": "omega",
                 "compute_control": "tsteps",
                 "compute_value": 50
             }

--- a/src/simulation_components/curl_simcomp.f90
+++ b/src/simulation_components/curl_simcomp.f90
@@ -103,9 +103,12 @@ contains
     class(case_t), intent(inout), target :: case
     character(len=20) :: fields(3)
     character(len=20), allocatable :: field_names(:)
+    character(len=:), allocatable :: computed_field
 
 
     call json_get_or_default(json, "name", this%name, "curl")
+    call json_get_or_default(json, "computed_field", computed_field, &
+         "omega")
     call json_get(json, "fields", field_names)
 
     if (size(field_names) .ne. 3) then
@@ -113,9 +116,9 @@ contains
             "fields.")
     end if
 
-    fields(1) = trim(this%name) // "_x"
-    fields(2) = trim(this%name) // "_y"
-    fields(3) = trim(this%name) // "_z"
+    fields(1) = trim(computed_field) // "_x"
+    fields(2) = trim(computed_field) // "_y"
+    fields(3) = trim(computed_field) // "_z"
 
     ! This is needed for the field writer to pick up the fields.
     call json%add("fields", fields)
@@ -123,25 +126,26 @@ contains
     call this%init_base(json, case)
     call this%writer%init(json, case)
 
-    call curl_init_common(this, this%name, field_names)
+    call curl_init_common(this, this%name, field_names, computed_field)
   end subroutine curl_init_from_json
 
   !> Common part of the constructors.
   !! @param name The unique name of the simcomp.
-  !! @param field_names The names of the fields to compute the curl of.
-  subroutine curl_init_common(this, name, field_names)
+  !! @param field_names The component names of the field to compute the curl of.
+  !! @param computed_field The name prefix of the computed curl field.
+  subroutine curl_init_common(this, name, field_names, computed_field)
     class(curl_t), intent(inout) :: this
-    character(len=*) :: name
-    character(len=*) :: field_names(3)
-
+    character(len=*), intent(in) :: name
+    character(len=*), intent(in) :: field_names(3)
+    character(len=*), intent(in) :: computed_field
     this%name = name
     this%u => neko_registry%get_field_by_name(field_names(1))
     this%v => neko_registry%get_field_by_name(field_names(2))
     this%w => neko_registry%get_field_by_name(field_names(3))
 
-    this%curl_x => neko_registry%get_field_by_name(name // "_x")
-    this%curl_y => neko_registry%get_field_by_name(name // "_y")
-    this%curl_z => neko_registry%get_field_by_name(name // "_z")
+    this%curl_x => neko_registry%get_field_by_name(computed_field // "_x")
+    this%curl_y => neko_registry%get_field_by_name(computed_field // "_y")
+    this%curl_z => neko_registry%get_field_by_name(computed_field // "_z")
 
   end subroutine curl_init_common
 
@@ -153,13 +157,14 @@ contains
   !! @param preprocess_controller The controller for running preprocessing.
   !! @param compute_controller The controller for running compute.
   !! @param output_controller The controller for producing output.
-  !! @param field_names The name of the fields to compute the curl of.
+  !! @param field_names The component names of the field to compute the curl of.
+  !! @param computed_field The base name of the curl field components.
   !! @param filename The name of the file save the fields to. Optional, if not
   !! @param precision The real precision of the output data. Optional, defaults
   !! to single precision.
   subroutine curl_init_from_controllers(this, name, case, order, &
        preprocess_controller, compute_controller, output_controller, &
-       field_names, filename, precision)
+       field_names, computed_field, filename, precision)
     class(curl_t), intent(inout) :: this
     character(len=*), intent(in) :: name
     class(case_t), intent(inout), target :: case
@@ -167,7 +172,8 @@ contains
     type(time_based_controller_t), intent(in) :: preprocess_controller
     type(time_based_controller_t), intent(in) :: compute_controller
     type(time_based_controller_t), intent(in) :: output_controller
-    character(len=*) :: field_names(3)
+    character(len=*), intent(in) :: field_names(3)
+    character(len=*), intent(in) :: computed_field
     character(len=*), intent(in), optional :: filename
     integer, intent(in), optional :: precision
 
@@ -184,7 +190,7 @@ contains
     call this%writer%init_from_components("field_writer", case, order, &
          preprocess_controller, compute_controller, output_controller, fields, &
          filename, precision)
-    call this%init_common(this%name, field_names)
+    call this%init_common(this%name, field_names, computed_field)
 
   end subroutine curl_init_from_controllers
 
@@ -200,16 +206,18 @@ contains
   !! @param compute_value Value parameter for computing.
   !! @param output_controller Control mode for output.
   !! @param output_value Value parameter for output.
-  !! @param field_names The name of the field to compute the curl of.
+  !! @param field_names The component names of the field to compute the curl of.
+  !! @param computed_field The base name of the curl field components.
   !! @param filename The name of the file save the fields to. Optional, if not
   !! provided, fields are added to the main output file.
   !! @param precision The real precision of the output data. Optional, defaults
   !! to single precision.
   subroutine curl_init_from_controllers_properties(this, name, case, order, &
        preprocess_control, preprocess_value, compute_control, compute_value, &
-       output_control, output_value, field_names, filename, precision)
+       output_control, output_value, field_names, computed_field, filename, &
+       precision)
     class(curl_t), intent(inout) :: this
-    character(len=*) :: name
+    character(len=*), intent(in) :: name
     class(case_t), intent(inout), target :: case
     integer :: order
     character(len=*), intent(in) :: preprocess_control
@@ -218,7 +226,8 @@ contains
     real(kind=rp), intent(in) :: compute_value
     character(len=*), intent(in) :: output_control
     real(kind=rp), intent(in) :: output_value
-    character(len=*) :: field_names(3)
+    character(len=*), intent(in) :: field_names(3)
+    character(len=*), intent(in) :: computed_field
     character(len=*), intent(in), optional :: filename
     integer, intent(in), optional :: precision
 
@@ -226,9 +235,9 @@ contains
 
     this%name = name
 
-    fields(1) = trim(name) // "_x"
-    fields(2) = trim(name) // "_y"
-    fields(3) = trim(name) // "_z"
+    fields(1) = trim(computed_field) // "_x"
+    fields(2) = trim(computed_field) // "_y"
+    fields(3) = trim(computed_field) // "_z"
 
     call this%init_base_from_components(case, order, preprocess_control, &
          preprocess_value, compute_control, compute_value, output_control, &
@@ -236,7 +245,7 @@ contains
     call this%writer%init_from_components("field_writer", case, order, &
          preprocess_control, preprocess_value, compute_control, compute_value, &
          output_control, output_value, fields, filename, precision)
-    call this%init_common(this%name, field_names)
+    call this%init_common(this%name, field_names, computed_field)
 
   end subroutine curl_init_from_controllers_properties
 

--- a/src/simulation_components/divergence_simcomp.f90
+++ b/src/simulation_components/divergence_simcomp.f90
@@ -126,9 +126,9 @@ contains
   !! @param computed_field The base name of the divergence field components.
   subroutine divergence_init_common(this, name, field_names, computed_field)
     class(divergence_t), intent(inout) :: this
-    character(len=*) :: name
-    character(len=*) :: field_names(3)
-    character(len=*) :: computed_field
+    character(len=*), intent(in) :: name
+    character(len=*), intent(in) :: field_names(3)
+    character(len=*), intent(in) :: computed_field
 
     this%name = name
     this%u => neko_registry%get_field_by_name(field_names(1))
@@ -161,8 +161,8 @@ contains
     type(time_based_controller_t), intent(in) :: preprocess_controller
     type(time_based_controller_t), intent(in) :: compute_controller
     type(time_based_controller_t), intent(in) :: output_controller
-    character(len=*) :: field_names(3)
-    character(len=*) :: computed_field
+    character(len=*), intent(in) :: field_names(3)
+    character(len=*), intent(in) :: computed_field
     character(len=*), intent(in), optional :: filename
     integer, intent(in), optional :: precision
 

--- a/tests/bench/tgv32/tgv.case
+++ b/tests/bench/tgv32/tgv.case
@@ -42,6 +42,7 @@
         [
             {
                 "type": "vorticity",
+                "computed_field": "omega",
                 "compute_control": "tsteps",
                 "compute_value": 50
             }

--- a/tests/reframe/src/tgv.case.template
+++ b/tests/reframe/src/tgv.case.template
@@ -47,6 +47,7 @@
   [
     {
       "type": "vorticity",
+      "computed_field": "omega",
       "compute_control": "tsteps",
       "compute_value": 50
     }


### PR DESCRIPTION
Restores the "computed_field" keyword in the curl simcomp, defaults to "omega" like before. The "name" keyword is now dormant, while we think about how to handle name mangling in a good way. This is consistent with the other simcomps.