### PR TITLE
Add code review instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,3 +137,35 @@ you are done, you should run `make check` in the test folder and make sure it
 compiles. If you cannot run this command yourself, you should ask the user to do
 it. Only when this succeds should you start populating the .pf with actual
 tests.
+
+## Code review
+You may be asked to review new code, in the context of a PR or a local git
+branch with changes with respect to develop. Your review will be kept to
+assessing the criteria outlined below, and not be a general review based on your
+opinion about good code. Essentially, you will be an intelligent static code
+analyzer, to compensate for the lack of those for Fortran. For the moment, you
+will only check Fortran code, and documentation, not CUDA and other accelerator
+code. Here is the list of things you need to check.
+
+- For all new files in the PR / branch.
+  - Any subroutine that creates a local `allocatable`, must also manually
+    `deallocate` it.
+  - Any type that that has `pointer` or `allocatable` components must have a
+    routine, in which the pointers are nullified and the allocatable are
+    deallocated. In concrete types, this routine must be called `free`, in types
+    with `deferred` procedures, it may be called `free_base` or similar, always
+    with a `free_` prefix.
+  - If a type has a destructor (`free` or similar) and a constructor (`init` or
+    similar), the constructor must begin with calling the destructor.
+  - All procedures, including type-bound, must have Doxygen documentation,
+    including @param for each dummy argument.
+- For *all* files changed in the PR / branch.
+  - Check for typos in the English in the documentation and the docstrings.
+  - Check the copyright statement in the header at the top of the Fortran files,
+    make sure it is the correct year(s).
+  - If the new code adds or modifies JSON paramters in the case file, this must
+    be documented in the User Guide. You can detect that by seeing lines that
+    use subroutines from the `json_utils` module, or directly using the
+    `json_file` type-bound procedures.
+- If CHANGELOG.md is not changed, and the PR at least seems to introduces
+  meaningful changes,  issue a reminder.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,29 +6,29 @@ Element Method. It primarily targets high-fidelity scale-resolving simulations
 of turbulent flows.
 
 ## Helping users setup new Neko simulation cases
-Neko is a simulation software, and a common scenario is that the user will ask
-you to help setup a simulation. Alternatively, they may want tips about specific
-settings or and explanation about a setup they find in an existing case. The
+Neko is simulation software, and a common scenario is that the user will ask
+you to help set up a simulation. Alternatively, they may want tips about specific
+settings or an explanation about a setup they find in an existing case. The
 instructions under this header are specifically for these scenarios. We will
-refer to a concrete simulation to as "the case".
+refer to a concrete simulation as "the case".
 
 ### General guidelines
 Below are the main guidelines you should follow for retrieving information and
 making decisions about how to setup a case.
 
-- A simulation case typically lives in its own separate folder, which will call
+- A simulation case typically lives in its own separate folder, which we will call
   the case folder.
-- In input to the simulation consists of at least two files
+- Input to the simulation consists of at least two files
   - A file with the computational mesh. More instructions on meshing follow.
   - A JSON file, which is either a .json or a .case (most often the latter),
     containing the configuration of the various components of the simulation.
     This file is referred to as the **case file**.
 - In many cases, an additional Fortran source file, referred to as the **user
   file** is part of the case setup. This allows advanced customization.
-- The folder `examples` contains already setup cases to demonstrate Neko's
+- The folder `examples` contains already set up cases to demonstrate Neko's
   functionality. The `examples/README.md` contains an overview of the cases in
   the different sub-folders, and each of them has a `README.md` of its own. If
-  you are tasked wih creating a new case, it is a very good idea to base it on
+  you are tasked with creating a new case, it is a very good idea to base it on
   one of the examples instead of starting from scratch. Think of the examples as
   templates for your work. It is a very good idea to ask the user, whether there
   is a particular example, which would serve as a good starting point for the
@@ -42,7 +42,8 @@ making decisions about how to setup a case.
 - Your definitive reference for the contents of the case file is the file
   `doc/pages/user-guide/case-file.md`. You should acknowledge that you got
   access to this file.
-- Save the case files as the name of the case folder plus .json, and try to pretty-format as good as you can.
+- Save the case files as the name of the case folder plus .json, and try to
+  pretty-format as good as you can.
 
 ### The mesh file
 - The general guide for meshing is `doc/pages/user-guide/meshing.md`.
@@ -66,24 +67,24 @@ making decisions about how to setup a case.
   and make sure it reports no errors.
 
 ### The user file
-- The general guide for the user file is is `doc/pages/user-guide/user-file.md`.
+- The general guide for the user file is `doc/pages/user-guide/user-file.md`.
 - The file is just a Fortran module.
 - Name the user file as the name of the case folder plus .f90.
-- If it is possible to setup the case without a user file, you should always do
+- If it is possible to set up the case without a user file, you should always do
   that. Only create a user file if it is really necessary for the case setup.
 - A **very good** idea is to look into the `examples/programming` directory,
   which contains examples for some basic things you can do in the user file.
-  Look at the `README.md` in that subfolder for a discription of what is in the
+  Look at the `README.md` in that subfolder for a description of what is in the
   files, but all the .f90 there are heavily documented.
   Other examples may also contain user files.
 - General development guidelines apply:
   - `doc/pages/developer-guide/code-style.md` for the Fortran code style.
   - `doc/pages/developer-guide/important_types.md` provides an overview of
     the most important types for Neko. It is a very good idea to look at their
-    implementation in the respective .f90 files under th `src` structure.
+    implementation in the respective .f90 files under the `src` structure.
 - Be generous with comments in the user file you generate, so that one can
   easily follow what your code does.
-- At the end always run `makeneko` on the generated user file and makes sure it
+- At the end always run `makeneko` on the generated user file and make sure it
   compiles.
 
 ## Writing tests for Neko
@@ -100,8 +101,8 @@ making decisions about how to setup a case.
     python and pytest are used to setup neko cases, run neko and makeneko as
     subprocesses and then post-process the results. These are run by CI for
     every PR.
-  - The folder `tests/reframe` contains nigthly tests that are run on a
-    supercomputer via a gitlab pipeline. The tests are written using
+- The folder `tests/reframe` contains nightly tests that are run on a
+  supercomputer via a gitlab pipeline. The tests are written using
     [reframe](https://reframe-hpc.readthedocs.io/en/stable/). These are
     validation tests checking that important cases produce the expected output.
 
@@ -109,8 +110,8 @@ making decisions about how to setup a case.
 - A guideline for writing these tests is given in
   `doc/pages/developer-guide/testing.md`. Make sure to read it.
 - There are fundamentally two types of tests here: those using MPI to run in
-  parallel and those that do not. The differ a bit in file naming and other
-  aspects metioned in the `testing.md` referred to above.
+  parallel and those that do not. They differ a bit in file naming and other
+  aspects mentioned in the `testing.md` referred to above.
   - A prototype for a test that needs MPI is `tests/unit/field`
   - A prototype for a test that doesn't need MPI is
     `tests/unit/time_based_controller`.
@@ -124,18 +125,18 @@ making decisions about how to setup a case.
      (e.g., test_case_file_utils.pf must declare module test_case_file_utils).
   - If you use multiple .pf files in one suite, each file’s module name should
     match its basename and be unique.
-- Some tests require a simple `mesh_t` to be contructed programmatically. See
+- Some tests require a simple `mesh_t` to be constructed programmatically. See
   `subroutine test_field_gen_msh` in `tests/unit/field/field_parallel.pf`.
 - If your test uses `json_module` you have to add `@NEKO_PKG_FCFLAGS@` to the
   `FFLAGS` in the `Makefile.in`
-- Note that in JSON routnes, the path in the file is spearated by periods,
+- Note that in JSON routines, the path in the file is separated by periods,
   for example `params.value`. NOT `params/value`.
 - If the user asks you to create a new unit test, you should first prepare all
 the necessary files and add them the build system. The .pf can just be a dummy
 at this point, but make sure to make all the file and module names correct. When
 you are done, you should run `make check` in the test folder and make sure it
 compiles. If you cannot run this command yourself, you should ask the user to do
-it. Only when this succeds should you start populating the .pf with actual
+it. Only when this succeeds should you start populating the .pf with actual
 tests.
 
 ## Code review
@@ -150,7 +151,7 @@ code. Here is the list of things you need to check.
 - For all new files in the PR / branch.
   - Any subroutine that creates a local `allocatable`, must also manually
     `deallocate` it.
-  - Any type that that has `pointer` or `allocatable` components must have a
+  - Any type that has `pointer` or `allocatable` components must have a
     routine, in which the pointers are nullified and the allocatable are
     deallocated. In concrete types, this routine must be called `free`, in types
     with `deferred` procedures, it may be called `free_base` or similar, always
@@ -163,9 +164,9 @@ code. Here is the list of things you need to check.
   - Check for typos in the English in the documentation and the docstrings.
   - Check the copyright statement in the header at the top of the Fortran files,
     make sure it is the correct year(s).
-  - If the new code adds or modifies JSON paramters in the case file, this must
+  - If the new code adds or modifies JSON parameters in the case file, this must
     be documented in the User Guide. You can detect that by seeing lines that
     use subroutines from the `json_utils` module, or directly using the
     `json_file` type-bound procedures.
-- If CHANGELOG.md is not changed, and the PR at least seems to introduces
-  meaningful changes,  issue a reminder.
+- If CHANGELOG.md is not changed, and the PR at least seems to introduce
+  meaningful changes, issue a reminder.


### PR DESCRIPTION
Quite minimalistic, mimicking static code analysis. Mainly targeting local use, but it could be fun to try unleashing this here on GH and see how it fares.