### PR TITLE
inverse the direction of gravity vector for Boussinesq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Develop
+- *BREAKING* The sign of the Boussinesq source term is fixed such that the input
+  gravity vector could be prescribed correctly.
 - Added an option for writing the mesh in every output field file.
 - *BREAKING* All simcomps now have a `name` keyword in the case file. A default
   name is assigned, but all `name`s must be unique. If you have two or more

--- a/examples/rayleigh_benard_cylinder/rayleigh.case
+++ b/examples/rayleigh_benard_cylinder/rayleigh.case
@@ -25,7 +25,7 @@
                 {
                     "type": "boussinesq",
                     "scalar_field": "temperature",
-                    "g": [ 0.0, 0.0, 1.0 ],
+                    "g": [ 0.0, 0.0, -1.0 ],
                     "reference_value": 0.0,
                     "beta": 1.0
                 }

--- a/src/source_terms/bcknd/cpu/boussinesq_source_term_cpu.f90
+++ b/src/source_terms/bcknd/cpu/boussinesq_source_term_cpu.f90
@@ -61,8 +61,8 @@ contains
     n = fields%item_size(1)
 
     do i=1, n_fields
-       call add2s2(fields%items(i)%ptr%x, s%x, g(i)*beta, n)
-       call cadd(fields%items(i)%ptr%x, -g(i)*beta*ref_value, n)
+       call add2s2(fields%items(i)%ptr%x, s%x, -g(i)*beta, n)
+       call cadd(fields%items(i)%ptr%x, g(i)*beta*ref_value, n)
     end do
   end subroutine boussinesq_source_term_compute_cpu
 

--- a/src/source_terms/bcknd/device/boussinesq_source_term_device.f90
+++ b/src/source_terms/bcknd/device/boussinesq_source_term_device.f90
@@ -62,8 +62,8 @@ contains
     n = fields%item_size(1)
 
     do i=1, n_fields
-       call device_add2s2(fields%x_d(i), s%x_d, g(i)*beta, n)
-       call device_cadd(fields%x_d(i), -g(i)*beta*ref_value, n)
+       call device_add2s2(fields%x_d(i), s%x_d, -g(i)*beta, n)
+       call device_cadd(fields%x_d(i), g(i)*beta*ref_value, n)
     end do
   end subroutine boussinesq_source_term_compute_device
 


### PR DESCRIPTION
In that way, we can always prescribe our gravity vector to the ground in an ABL simulation