### PR TITLE
Change default amg and phmg params to be less expensive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   pre-existing names.
 - Fix cyclic boundary rotation device bug, which tried to launch kernels
   with zero threads for ranks not containing cyclic boundaries.
+- Change default parameters for tamg and phmg to be less expensive.
 
 ### Deprecated features
 - `operator::ortho` calls with implicit device arrays are deprecated. Please use

--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -1118,18 +1118,18 @@ For `hsmg`, the following keywords are used:
 | `coarse_grid.monitor`        | Monitor residuals in the coarse grid (only valid for a Krylov based `solver`)           | `true` or `false`       | `false`       |
 | `coarse_grid.levels`         | Number of AMG levels to construct (only valid for `solver` type `tamg`)                 | An integer              | 3             |
 | `coarse_grid.iterations`     | Number of AMG iterations (only valid for `solver` type `tamg`)                          | An integer              | 1             |
-| `coarse_grid.cheby_degree`   | Degree of the Chebyshev based AMG smoother                                              | An integer              | 5             |
+| `coarse_grid.cheby_degree`   | Degree of the Chebyshev based AMG smoother                                              | An integer              | 4             |
 
 For `phmg`, the following keywords are used:
 
 | Name                       | Description                                                                                 | Admissible values     | Default value |
 | -------------------------- | ------------------------------------------------------------------------------------------- | --------------------- | ------------- |
 | `pcoarsening_schedule`     | P-multigrid coarsening schedule (polynomial order, high to low)                             | Array of integers     | `[3, 1]`      |
-| `smoother_iterations`      | Number of smoother iterations in the p-multigrid parts                                      | An integer            | 10            |
-| `smoother_cheby_acc`       | Type of Chebyshev acceleration (non-accelerated semi-iterative Chebyshev method if not set) | `jacobi` or `schwarz` | -             |
+| `smoother_iterations`      | Number of smoother iterations in the p-multigrid parts                                      | An integer            | 3             |
+| `smoother_cheby_acc`       | Type of Chebyshev acceleration (non-accelerated semi-iterative Chebyshev method if not set) | `jacobi` or `schwarz` | `jacobi`      |
 | `coarse_grid.levels`       | Number of AMG levels to construct (only valid for `solver` type `tamg`)                     | An integer            | 3             |
 | `coarse_grid.iterations`   | Number of linear solver iterations for coarse grid solver                                   | An integer            | 1             |
-| `coarse_grid.cheby_degree` | Degree of the Chebyshev based AMG smoother                                                  | An integer            | 5             |
+| `coarse_grid.cheby_degree` | Degree of the Chebyshev based AMG smoother                                                  | An integer            | 4             |
 
 
 ### Flow rate forcing

--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -1122,14 +1122,14 @@ For `hsmg`, the following keywords are used:
 
 For `phmg`, the following keywords are used:
 
-| Name                       | Description                                                                                 | Admissible values     | Default value |
-| -------------------------- | ------------------------------------------------------------------------------------------- | --------------------- | ------------- |
-| `pcoarsening_schedule`     | P-multigrid coarsening schedule (polynomial order, high to low)                             | Array of integers     | `[3, 1]`      |
-| `smoother_iterations`      | Number of smoother iterations in the p-multigrid parts                                      | An integer            | 3             |
-| `smoother_cheby_acc`       | Type of Chebyshev acceleration (non-accelerated semi-iterative Chebyshev method if not set) | `jacobi` or `schwarz` | `jacobi`      |
-| `coarse_grid.levels`       | Number of AMG levels to construct (only valid for `solver` type `tamg`)                     | An integer            | 3             |
-| `coarse_grid.iterations`   | Number of linear solver iterations for coarse grid solver                                   | An integer            | 1             |
-| `coarse_grid.cheby_degree` | Degree of the Chebyshev based AMG smoother                                                  | An integer            | 4             |
+| Name                       | Description                                                                                 | Admissible values             | Default value |
+| -------------------------- | ------------------------------------------------------------------------------------------- | ----------------------------- | ------------- |
+| `pcoarsening_schedule`     | P-multigrid coarsening schedule (polynomial order, high to low)                             | Array of integers             | `[3, 1]`      |
+| `smoother_iterations`      | Number of smoother iterations in the p-multigrid parts                                      | An integer                    | 3             |
+| `smoother_cheby_acc`       | Type of Chebyshev acceleration                                                              | `none`, `jacobi` or `schwarz` | `jacobi`      |
+| `coarse_grid.levels`       | Number of AMG levels to construct (only valid for `solver` type `tamg`)                     | An integer                    | 3             |
+| `coarse_grid.iterations`   | Number of linear solver iterations for coarse grid solver                                   | An integer                    | 1             |
+| `coarse_grid.cheby_degree` | Degree of the Chebyshev based AMG smoother                                                  | An integer                    | 4             |
 
 
 ### Flow rate forcing

--- a/src/krylov/pc_hsmg.f90
+++ b/src/krylov/pc_hsmg.f90
@@ -179,7 +179,7 @@ contains
          crs_tamg_itrs, 1)
 
     call json_get_or_default(hsmg_params, 'coarse_grid.cheby_degree', &
-         crs_tamg_cheby_degree, 5)
+         crs_tamg_cheby_degree, 4)
 
     call this%init_from_components(coef, bclst, crs_solver, crs_pc, &
          crs_monitor, crs_tamg_lvls, crs_tamg_itrs, crs_tamg_cheby_degree)

--- a/src/multigrid/phmg.f90
+++ b/src/multigrid/phmg.f90
@@ -120,7 +120,7 @@ contains
     integer, allocatable :: pcrs_sched(:)
 
     call json_get_or_default(phmg_params, 'smoother_iterations', &
-         smoother_itrs, 10)
+         smoother_itrs, 3)
 
     call json_get_or_default(phmg_params, 'smoother_cheby_acc', &
          cheby_acc, "jacobi")
@@ -132,7 +132,7 @@ contains
          crs_tamg_itrs, 1)
 
     call json_get_or_default(phmg_params, 'coarse_grid.cheby_degree', &
-         crs_tamg_cheby_degree, 5)
+         crs_tamg_cheby_degree, 4)
 
     if (phmg_params%valid_path('pcoarsening_schedule')) then
        call json_get(phmg_params, 'pcoarsening_schedule', pcrs_sched)


### PR DESCRIPTION
Change the default amg and phmg parameters to be less expensive.

AMG cheby degree 5 -> 4
p-multigrid smoother iterations 10 -> 3

Also fix documentation to correctly reflect that the p-multigrid smoother default is Chebyshev with a Jacobi preconditioner.