### PR TITLE
Feature/names for bcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Develop
-- Added possibility to assign names to boundary conditions in the case file. The `bc_list_t` now supports item retrieval by name or zone_index.
+- Added possibility to assign names to boundary conditions in the case file. The 
+  `bc_list_t` now supports item retrieval by name or zone_index.
 - Added the `full_elements` option to point_zones. Allows including all points
   in an element in the mask.
 - *BREAKING* The sign of the Boussinesq source term is fixed such that the input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Develop
+- Added posibility to retrieve BCs from names and zone_indices.
 - Added an option for writing the mesh in every output field file.
 - *BREAKING* All simcomps now have a `name` keyword in the case file. A default
   name is assigned, but all `name`s must be unique. If you have two or more

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Develop
-- Added posibility to retrieve BCs from names and zone_indices.
+- Added possibility to assign names to boundary conditions in the case file. The `bc_list_t` now supports item retrieval by name or zone_index.
 - Added an option for writing the mesh in every output field file.
 - *BREAKING* All simcomps now have a `name` keyword in the case file. A default
   name is assigned, but all `name`s must be unique. If you have two or more

--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -386,7 +386,7 @@ the streamwise direction. Only one condition, corresponding to zone index 3 (the
 wall) is the specified in the case file.
 
 It is possible to assign specific names to the boundary conditions through the
-`name` keyword. Boundary conditions can then be retireved in the code by using
+`name` keyword. Boundary conditions can then be retrieved in the code by using
 the name or the `zone_index` where it is applied.
 
 #### Available conditions

--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -385,7 +385,7 @@ periodic pipe simulation, two periodic zones comprise the boundary conditions in
 the streamwise direction. Only one condition, corresponding to zone index 3 (the
 wall) is the specified in the case file.
 
-It is possible to name specific names to the boundary conditions through the
+It is possible to assign specific names to the boundary conditions through the
 `name` keyword. Boundary conditions can then be retireved in the code by using
 the name or the `zone_index` where it is applied.
 

--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -386,8 +386,12 @@ the streamwise direction. Only one condition, corresponding to zone index 3 (the
 wall) is the specified in the case file.
 
 It is possible to assign specific names to the boundary conditions through the
-`name` keyword. Boundary conditions can then be retrieved in the code by using
+`name` keyword. Boundary conditions can then be retireved in the code by using
 the name or the `zone_index` where it is applied.
+
+The default name of the boundary conditions is given by the `<variable>_bc_<zone_index>`
+pattern. i.e., the pressure boundary condition that applies in zone index 5 can be
+retrieved by the `pressure_bc_5` name.
 
 #### Available conditions
 The conditions to apply is specified by `type` keyword inside each of the JSON

--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -385,6 +385,10 @@ periodic pipe simulation, two periodic zones comprise the boundary conditions in
 the streamwise direction. Only one condition, corresponding to zone index 3 (the
 wall) is the specified in the case file.
 
+It is possible to name specific names to the boundary conditions through the
+`name` keyword. Boundary conditions can then be retireved in the code by using
+the name or the `zone_index` where it is applied.
+
 #### Available conditions
 The conditions to apply is specified by `type` keyword inside each of the JSON
 objects. The full list of possible conditions for the fluid is specified in the

--- a/src/.depends
+++ b/src/.depends
@@ -165,7 +165,7 @@ global_interpolation/legendre_rst_finder.lo : global_interpolation/legendre_rst_
 io/mean_field_output.lo : io/mean_field_output.f90 math/matrix.lo io/output.lo field/mean_field.lo device/device.lo sem/coef.lo sem/map_1d.lo sem/map_2d.lo io/fld_file_data.lo config/neko_config.lo field/field_list.lo config/num_types.lo 
 common/profiler.lo : common/profiler.F90 common/runtime_statistics.lo common/craypat.lo device/hip/roctx.lo device/cuda/nvtx.lo device/device.lo config/neko_config.lo 
 common/craypat.lo : common/craypat.F90 
-bc/bc.lo : bc/bc.f90 io/file.lo common/time_state.lo common/utils.lo math/math.lo gs/gs_ops.lo field/field.lo adt/tuple.lo adt/stack.lo mesh/facet_zone.lo mesh/mesh.lo sem/space.lo sem/coef.lo sem/dofmap.lo device/device.lo config/num_types.lo config/neko_config.lo 
+bc/bc.lo : bc/bc.f90 io/file.lo common/time_state.lo common/log.lo common/utils.lo math/math.lo gs/gs_ops.lo field/field.lo adt/tuple.lo adt/stack.lo mesh/facet_zone.lo mesh/mesh.lo sem/space.lo sem/coef.lo sem/dofmap.lo device/device.lo config/num_types.lo config/neko_config.lo 
 bc/bc_list.lo : bc/bc_list.f90 common/time_state.lo bc/bc.lo common/utils.lo device/device.lo field/field.lo config/num_types.lo config/neko_config.lo 
 bc/dirichlet.lo : bc/dirichlet.f90 common/time_state.lo common/json_utils.lo sem/coef.lo bc/bc.lo config/num_types.lo bc/bcknd/device/device_dirichlet.lo 
 bc/neumann.lo : bc/neumann.f90 common/time_state.lo bc/bcknd/device/device_neumann.lo device/device.lo math/bcknd/device/device_math.lo config/neko_config.lo math/vector.lo math/math.lo common/json_utils.lo sem/coef.lo common/utils.lo bc/bc.lo config/num_types.lo 

--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -576,7 +576,6 @@ contains
     end if
 
     if (.not. allocated(this%name)) then
-       allocate(character(len=1) :: this%name)
        this%name = ""
     else
        write(log_buf, '(A,A)') 'BC assigned name :   ', trim(this%name)

--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -88,7 +88,7 @@ module bc
      !!> Name of the bc
      character(len=:), allocatable :: name
      !!> Zone indices where the bc is applied
-    integer, allocatable :: zone_indices(:)
+     integer, allocatable :: zone_indices(:)
    contains
      !> Constructor
      procedure, pass(this) :: init_base => bc_init_base

--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -85,7 +85,7 @@ module bc
      !> Indicates wether the bc has been updated, for those BCs that need
      !! additional computations
      logical :: updated = .false.
-     !!> Name of the bc
+     !> Name of the bc
      character(len=:), allocatable :: name
      !!> Zone indices where the bc is applied
      integer, allocatable :: zone_indices(:)

--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -85,6 +85,10 @@ module bc
      !> Indicates wether the bc has been updated, for those BCs that need
      !! additional computations
      logical :: updated = .false.
+     !!> Name of the bc
+     character(len=:), allocatable :: name
+     !!> Zone indices where the bc is applied
+    integer, allocatable :: zone_indices(:)
    contains
      !> Constructor
      procedure, pass(this) :: init_base => bc_init_base

--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -291,6 +291,14 @@ contains
        call device_free(this%facet_d)
        this%facet_d = C_NULL_PTR
     end if
+    
+    if (allocated(this%name)) then
+       deallocate(this%name)
+    end if
+    
+    if (allocated(this%zone_indices)) then
+       deallocate(this%zone_indices)
+    end if
 
   end subroutine bc_free_base
 

--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -48,6 +48,7 @@ module bc
   use gs_ops, only : GS_OP_ADD
   use math, only : relcmp
   use utils, only : neko_error, linear_index, split_string
+  use logger, only : neko_log, LOG_SIZE
   use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR
   use json_module, only : json_file
   use time_state, only : time_state_t
@@ -85,9 +86,9 @@ module bc
      !> Indicates wether the bc has been updated, for those BCs that need
      !! additional computations
      logical :: updated = .false.
-     !> Name of the bc
+     !!> Name of the bc
      character(len=:), allocatable :: name
-     !> Zone indices where the bc is applied
+     !!> Zone indices where the bc is applied
      integer, allocatable :: zone_indices(:)
    contains
      !> Constructor
@@ -439,6 +440,7 @@ contains
     logical :: only_facet = .false.
     integer :: i, j, k, l, msk_c
     integer :: lx, ly, lz, n
+    character(len=LOG_SIZE) :: log_buf
     lx = this%Xh%lx
     ly = this%Xh%ly
     lz = this%Xh%lz
@@ -576,6 +578,9 @@ contains
     if (.not. allocated(this%name)) then
        allocate(character(len=1) :: this%name)
        this%name = ""
+    else
+       write(log_buf, '(A,A)') 'BC assigned name :   ', trim(this%name)
+       call neko_log%message(log_buf)
     end if
 
     if (.not. allocated(this%zone_indices)) then

--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -291,11 +291,11 @@ contains
        call device_free(this%facet_d)
        this%facet_d = C_NULL_PTR
     end if
-    
+
     if (allocated(this%name)) then
        deallocate(this%name)
     end if
-    
+
     if (allocated(this%zone_indices)) then
        deallocate(this%zone_indices)
     end if

--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -573,6 +573,16 @@ contains
             HOST_TO_DEVICE, sync = .true.)
     end if
 
+    if (.not. allocated(this%name)) then
+       allocate(character(len=1) :: this%name)
+       this%name = ""
+    end if
+
+    if (.not. allocated(this%zone_indices)) then
+       allocate(this%zone_indices(1))
+       this%zone_indices(1) = -1
+    end if
+
   end subroutine bc_finalize_base
 
   !> Write a field showing the mask of the bc

--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -87,7 +87,7 @@ module bc
      logical :: updated = .false.
      !> Name of the bc
      character(len=:), allocatable :: name
-     !!> Zone indices where the bc is applied
+     !> Zone indices where the bc is applied
      integer, allocatable :: zone_indices(:)
    contains
      !> Constructor

--- a/src/bc/bc_list.f90
+++ b/src/bc/bc_list.f90
@@ -63,6 +63,10 @@ module bc_list
      procedure, pass(this) :: append => bc_list_append
      !> Get the item at the given index.
      procedure, pass(this) :: get => bc_list_get
+     !> Get the item with the given name.
+     procedure, pass(this) :: get_from_name => bc_list_get_from_name
+     !> Get the item that applies to the given zone_index.
+     procedure, pass(this) :: get_from_zone_index => bc_list_get_from_zone_index
 
      !> Check whether the list is empty
      procedure, pass(this) :: is_empty => bc_list_is_empty
@@ -164,6 +168,50 @@ contains
     bc => this%items(i)%ptr
 
   end function bc_list_get
+  
+  !> Get the item from a given name.
+  !! @param name The name of the item to get.
+  !! @return The item with the given name.
+  function bc_list_get_from_name(this, name) result(bc)
+    class(bc_list_t), intent(in) :: this
+    class(bc_t), pointer :: bc
+    character(len=*), intent(in) :: name
+    integer :: i
+
+    do i = 1, this%size_
+       if (this%items(i)%ptr%name .eq. trim(name)) then
+          bc => this%items(i)%ptr
+          return
+       end if
+    end do
+
+    ! If the function reaches this point, no item was found
+    call neko_error("Name not found in bc_list")
+
+  end function bc_list_get_from_name
+  
+  !> Get the item from zone_index.
+  !! @param zone_index where the bc applies. 
+  !! @return The item at the given zone_index.
+  function bc_list_get_from_zone_index(this, zone_index) result(bc)
+    class(bc_list_t), intent(in) :: this
+    class(bc_t), pointer :: bc
+    integer, intent(in) :: zone_index
+    integer :: i, j
+
+    do i = 1, this%size_
+       do j = 1, size(this%items(i)%ptr%zone_indices)
+          if (this%items(i)%ptr%zone_indices(j) == zone_index) then
+             bc => this%items(i)%ptr
+             return
+          end if
+       end do
+    end do
+
+    ! If the function reaches this point, no item was found
+    call neko_error("Zone index not found in bc_list")
+
+  end function bc_list_get_from_zone_index
 
   !> Apply a list of boundary conditions to a scalar field
   !! @param x The field to apply the boundary conditions to.

--- a/src/bc/bc_list.f90
+++ b/src/bc/bc_list.f90
@@ -168,7 +168,7 @@ contains
     bc => this%items(i)%ptr
 
   end function bc_list_get
-  
+
   !> Get the item from a given name.
   !! @param name The name of the item to get.
   !! @return The item with the given name.
@@ -189,9 +189,9 @@ contains
     call neko_error("Name not found in bc_list")
 
   end function bc_list_get_from_name
-  
+
   !> Get the item from zone_index.
-  !! @param zone_index where the bc applies. 
+  !! @param zone_index where the bc applies.
   !! @return The item at the given zone_index.
   function bc_list_get_from_zone_index(this, zone_index) result(bc)
     class(bc_list_t), intent(in) :: this

--- a/src/bc/bc_list.f90
+++ b/src/bc/bc_list.f90
@@ -64,9 +64,9 @@ module bc_list
      !> Get the item at the given index.
      procedure, pass(this) :: get => bc_list_get
      !> Get the item with the given name.
-     procedure, pass(this) :: get_from_name => bc_list_get_from_name
+     procedure, pass(this) :: get_by_name => bc_list_get_by_name
      !> Get the item that applies to the given zone_index.
-     procedure, pass(this) :: get_from_zone_index => bc_list_get_from_zone_index
+     procedure, pass(this) :: get_by_zone_index => bc_list_get_by_zone_index
 
      !> Check whether the list is empty
      procedure, pass(this) :: is_empty => bc_list_is_empty
@@ -172,7 +172,7 @@ contains
   !> Get the item from a given name.
   !! @param name The name of the item to get.
   !! @return The item with the given name.
-  function bc_list_get_from_name(this, name) result(bc)
+  function bc_list_get_by_name(this, name) result(bc)
     class(bc_list_t), intent(in) :: this
     class(bc_t), pointer :: bc
     character(len=*), intent(in) :: name
@@ -188,12 +188,12 @@ contains
     ! If the function reaches this point, no item was found
     call neko_error("Name not found in bc_list")
 
-  end function bc_list_get_from_name
+  end function bc_list_get_by_name
 
   !> Get the item from zone_index.
   !! @param zone_index where the bc applies.
   !! @return The item at the given zone_index.
-  function bc_list_get_from_zone_index(this, zone_index) result(bc)
+  function bc_list_get_by_zone_index(this, zone_index) result(bc)
     class(bc_list_t), intent(in) :: this
     class(bc_t), pointer :: bc
     integer, intent(in) :: zone_index
@@ -211,7 +211,7 @@ contains
     ! If the function reaches this point, no item was found
     call neko_error("Zone index not found in bc_list")
 
-  end function bc_list_get_from_zone_index
+  end function bc_list_get_by_zone_index
 
   !> Apply a list of boundary conditions to a scalar field
   !! @param x The field to apply the boundary conditions to.

--- a/src/fluid/euler_bc_fctry.f90
+++ b/src/fluid/euler_bc_fctry.f90
@@ -65,6 +65,8 @@ contains
     character(len=:), allocatable :: type
     integer :: i, j, k
     integer, allocatable :: zone_indices(:)
+    character(len=:), allocatable :: default_name
+    character(len=64) :: buf
 
     call json_get(json, "type", type)
 
@@ -85,7 +87,10 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
-    call json_get_or_default(json, "name", object%name, "density_bc")
+    
+    write(buf,'("density_bc_",I0)') zone_indices(1)
+    default_name = trim(buf)
+    call json_get_or_default(json, "name", object%name, default_name)
     object%zone_indices = zone_indices
     call object%finalize()
   end subroutine density_bc_factory
@@ -105,6 +110,8 @@ contains
     character(len=:), allocatable :: type
     integer :: i, j, k
     integer, allocatable :: zone_indices(:)
+    character(len=:), allocatable :: default_name
+    character(len=64) :: buf
 
     call json_get(json, "type", type)
 
@@ -127,7 +134,10 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
-    call json_get_or_default(json, "name", object%name, "pressure_bc")
+    
+    write(buf,'("pressure_bc_",I0)') zone_indices(1)
+    default_name = trim(buf)
+    call json_get_or_default(json, "name", object%name, default_name)
     object%zone_indices = zone_indices
     call object%finalize()
 
@@ -159,6 +169,8 @@ contains
     character(len=:), allocatable :: type
     integer :: i, j, k
     integer, allocatable :: zone_indices(:)
+    character(len=:), allocatable :: default_name
+    character(len=64) :: buf
 
     call json_get(json, "type", type)
 
@@ -182,7 +194,10 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
-    call json_get_or_default(json, "name", object%name, "velocity_bc")
+    
+    write(buf,'("velocity_bc_",I0)') zone_indices(1)
+    default_name = trim(buf)
+    call json_get_or_default(json, "name", object%name, default_name)
     object%zone_indices = zone_indices
     call object%finalize()
 

--- a/src/fluid/euler_bc_fctry.f90
+++ b/src/fluid/euler_bc_fctry.f90
@@ -85,6 +85,8 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
+    call json_get_or_default(json, "name", object%name, "density_bc")
+    object%zone_indices = zone_indices
     call object%finalize()
   end subroutine density_bc_factory
 
@@ -125,6 +127,8 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
+    call json_get_or_default(json, "name", object%name, "pressure_bc")
+    object%zone_indices = zone_indices
     call object%finalize()
 
     ! All pressure bcs are currently strong, so for all of them we
@@ -178,6 +182,8 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
+    call json_get_or_default(json, "name", object%name, "velocity_bc")
+    object%zone_indices = zone_indices
     call object%finalize()
 
   end subroutine velocity_bc_factory

--- a/src/fluid/euler_bc_fctry.f90
+++ b/src/fluid/euler_bc_fctry.f90
@@ -87,7 +87,7 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
-    
+
     write(buf,'("density_bc_",I0)') zone_indices(1)
     default_name = trim(buf)
     call json_get_or_default(json, "name", object%name, default_name)
@@ -134,7 +134,7 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
-    
+
     write(buf,'("pressure_bc_",I0)') zone_indices(1)
     default_name = trim(buf)
     call json_get_or_default(json, "name", object%name, default_name)
@@ -194,7 +194,7 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
-    
+
     write(buf,'("velocity_bc_",I0)') zone_indices(1)
     default_name = trim(buf)
     call json_get_or_default(json, "name", object%name, default_name)

--- a/src/fluid/fluid_pnpn_bc_fctry.f90
+++ b/src/fluid/fluid_pnpn_bc_fctry.f90
@@ -80,6 +80,8 @@ contains
     character(len=:), allocatable :: type
     integer :: i, j, k
     integer, allocatable :: zone_indices(:)
+    character(len=:), allocatable :: default_name
+    character(len=64) :: buf
 
     if (associated(object)) then
        call object%free()
@@ -117,7 +119,10 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
-    call json_get_or_default(json, "name", object%name, "pressure_bc")
+    
+    write(buf,'("pressure_bc_",I0)') zone_indices(1)
+    default_name = trim(buf)
+    call json_get_or_default(json, "name", object%name, default_name)
     object%zone_indices = zone_indices
     call object%finalize()
 
@@ -157,6 +162,8 @@ contains
     character(len=:), allocatable :: type
     integer :: i, j, k
     integer, allocatable :: zone_indices(:)
+    character(len=:), allocatable :: default_name
+    character(len=64) :: buf
 
     call json_get(json, "type", type)
 
@@ -198,7 +205,10 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
-    call json_get_or_default(json, "name", object%name, "velocity_bc")
+    
+    write(buf,'("velocity_bc_",I0)') zone_indices(1)
+    default_name = trim(buf)
+    call json_get_or_default(json, "name", object%name, default_name)
     object%zone_indices = zone_indices
     call object%finalize()
 

--- a/src/fluid/fluid_pnpn_bc_fctry.f90
+++ b/src/fluid/fluid_pnpn_bc_fctry.f90
@@ -119,7 +119,7 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
-    
+
     write(buf,'("pressure_bc_",I0)') zone_indices(1)
     default_name = trim(buf)
     call json_get_or_default(json, "name", object%name, default_name)
@@ -205,7 +205,7 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
-    
+
     write(buf,'("velocity_bc_",I0)') zone_indices(1)
     default_name = trim(buf)
     call json_get_or_default(json, "name", object%name, default_name)

--- a/src/fluid/fluid_pnpn_bc_fctry.f90
+++ b/src/fluid/fluid_pnpn_bc_fctry.f90
@@ -117,6 +117,8 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
+    call json_get_or_default(json, "name", object%name, "pressure_bc")
+    object%zone_indices = zone_indices
     call object%finalize()
 
     ! All pressure bcs are currently strong, so for all of them we
@@ -196,6 +198,8 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
+    call json_get_or_default(json, "name", object%name, "velocity_bc")
+    object%zone_indices = zone_indices
     call object%finalize()
 
     ! Exclude these two because they are bcs for the residual, not velocity

--- a/src/scalar/scalar_pnpn_bc_fctry.f90
+++ b/src/scalar/scalar_pnpn_bc_fctry.f90
@@ -96,6 +96,8 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
+    call json_get_or_default(json, "name", object%name, "scalar_bc")
+    object%zone_indices = zone_indices
     call object%finalize()
 
   end subroutine bc_factory

--- a/src/scalar/scalar_pnpn_bc_fctry.f90
+++ b/src/scalar/scalar_pnpn_bc_fctry.f90
@@ -64,6 +64,8 @@ contains
     character(len=:), allocatable :: type
     integer :: i
     integer, allocatable :: zone_indices(:)
+    character(len=:), allocatable :: default_name
+    character(len=64) :: buf
 
     if (associated(object)) then
        call object%free()
@@ -96,7 +98,10 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
-    call json_get_or_default(json, "name", object%name, "scalar_bc")
+    
+    write(buf,'("scalar_bc_",I0)') zone_indices(1)
+    default_name = trim(buf)
+    call json_get_or_default(json, "name", object%name, default_name)
     object%zone_indices = zone_indices
     call object%finalize()
 

--- a/src/scalar/scalar_pnpn_bc_fctry.f90
+++ b/src/scalar/scalar_pnpn_bc_fctry.f90
@@ -98,7 +98,7 @@ contains
     do i = 1, size(zone_indices)
        call object%mark_zone(coef%msh%labeled_zones(zone_indices(i)))
     end do
-    
+
     write(buf,'("scalar_bc_",I0)') zone_indices(1)
     default_name = trim(buf)
     call json_get_or_default(json, "name", object%name, default_name)


### PR DESCRIPTION
As the title says. The idea is to be able to access the mask easier, at least from the user module. One can do:

``` fortran   
    bc_list => neko_user_access%case%fluid%bcs_vel
    bc => bc_list%get_from_zone_index(3)
```

Or 

``` fortran   
    bc_list => neko_user_access%case%fluid%bcs_vel
    bc => bc_list%get_from_name("wall")
```

For the latter to work on would need to add the name in the case file:

``` json
   {
    "type": "no_slip",
    "zone_indices": [ 3 ],
    "name" : "wall"
   }
```

What I don't like is that I need to know if it is in bcs_vel or bcs_prs but it is what it is for now.

This might be redundant if one knows that the bcs are added in the order you put them in the case file, bu I find this useful at least for a very particular thing I am doing haha. I do not think it hurts to have it but let me know.