### PR TITLE
Fix pkg_resources error by updating setuptools version

### DIFF
--- a/.github/actions/flint/requirements-flint.txt
+++ b/.github/actions/flint/requirements-flint.txt
@@ -1,2 +1,3 @@
+setuptools<81
 nobvisual==0.2.0
 flinter==0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Develop
+- Restrict the `setuptools` version to be less than 81, due to a breaking change
+  in that version for flinter.
 - Added the `full_elements` option to point_zones. Allows including all points
   in an element in the mask.
 - *BREAKING* The sign of the Boussinesq source term is fixed such that the input


### PR DESCRIPTION
Adjust the setuptools version constraint to resolve the pkg_resources error.

> [!NOTE]
> Must be forced due to issues with python dependencies for `flint`.