### PR TITLE
Add field wrapper and pointer types with usage guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Develop
+- Updated field types with a wrapper and ensure lifetime management of field
+  data in field lists and arrays.
+- Updated Developer Patterns documentation with new information on how to manage
+  pointers and lists of complex objects.
 - Added cache cleanup job for CI workflows upon PR closure.
 - Updated compiler check workflows to run on release branches and master.
 - Removed commented-out workflow sections.

--- a/doc/pages/developer-guide/dev_patterns.md
+++ b/doc/pages/developer-guide/dev_patterns.md
@@ -209,11 +209,59 @@ so, code repetition is fine, it will eventually cease to exist naturally.
    True code duplication is when a change in one place will also necessary a
    change in the other.
 
+## F. Complex and Polymorphic arrays.
 
+We often need to use arrays of complex or polymorphic types. Objects which
+support this, must implement a wrapper type following one of the two patterns
+below. 
+- A wrapper type, maintain the lifetime of the object it wraps, allocating and
+  deallocating it as needed.
+- A pointer type, which just holds a pointer to an object managed elsewhere.
+  These can be good to group a bunch of objects for easier access elsewhere.
 
+### F.1. Object wrapper pattern
+```fortran
+type :: object_wrapper_t
+   type(object_t), pointer :: obj => null()
+contains
+   procedure, pass(this) :: init => object_wrapper_init
+   procedure, pass(this) :: free => object_wrapper_free
+end type
 
+subroutine object_wrapper_init(this, args, ...)
+     type(object_wrapper_t) :: this
+     call this%free()
+     allocate(this%obj)                    ! For polymorphic types
+     call this%obj%init(args, ...)         ! use a factory method instead
+end subroutine
 
+subroutine object_wrapper_free(this)
+     type(object_wrapper_t) :: this
+     if (associated(this%obj)) then
+          call this%obj%free()
+          deallocate(this%obj)
+     end if
+end subroutine
+```
 
+### F.2. Object pointer pattern
+```fortran
+type :: object_ptr_t
+   type(object_t), pointer :: ptr => null()
+contains
+   procedure, pass(this) :: init => object_ptr_init
+   procedure, pass(this) :: free => object_ptr_free
+end type
 
+subroutine object_ptr_init(this, object)
+     type(object_ptr_t) :: this
+     type(object_t), target :: object
+     call this%free()
+     this%ptr_ => object
+end subroutine
 
-
+subroutine object_ptr_free(this)
+     type(object_ptr_t) :: this
+     if (associated(this%ptr)) nullify(this%ptr)
+end subroutine
+```

--- a/src/field/field.f90
+++ b/src/field/field.f90
@@ -93,7 +93,9 @@ module field
      type(field_t), pointer :: field => null()
    contains
      !> Constructor. Allocates a field and assigns the pointer.
-     generic :: init => init_internal_dof, init_external_dof
+     generic :: init => init_field, init_internal_dof, init_external_dof
+     !> Initialize a field wrapper with an allocated field
+     procedure, pass(this) :: init_field => field_wrapper_init_field
      !> Initialize a field wrapper with an internal dofmap
      procedure, pass(this) :: init_internal_dof => &
           field_wrapper_init_internal_dof
@@ -351,6 +353,16 @@ contains
 
   ! ========================================================================== !
   ! Field wrapper type subroutines
+
+  subroutine field_wrapper_init_field(this, f)
+    class(field_wrapper_t), intent(inout) :: this
+    type(field_t), intent(in) :: f
+
+    call this%free()
+    allocate(this%field)
+    this%field = f
+
+  end subroutine field_wrapper_init_field
 
   subroutine field_wrapper_init_internal_dof(this, msh, space, fld_name)
     class(field_wrapper_t), intent(inout) :: this

--- a/src/field/field.f90
+++ b/src/field/field.f90
@@ -81,7 +81,28 @@ module field
   !> field_ptr_t, To easily obtain a pointer to a field
   type, public :: field_ptr_t
      type(field_t), pointer :: ptr => null()
+   contains
+     !> Constructor. Just assigns the pointer.
+     procedure, pass(this) :: init => field_ptr_init
+     !> Destructor. Just nullifies the pointer.
+     procedure, pass(this) :: free => field_ptr_free
   end type field_ptr_t
+
+  !> field_wrapper_t, used to wrap an allocated field for use in a field list
+  type, public :: field_wrapper_t
+     type(field_t), pointer :: field => null()
+   contains
+     !> Constructor. Allocates a field and assigns the pointer.
+     generic :: init => init_internal_dof, init_external_dof
+     !> Initialize a field wrapper with an internal dofmap
+     procedure, pass(this) :: init_internal_dof => &
+          field_wrapper_init_internal_dof
+     !> Initialize a field wrapper with an external dofmap
+     procedure, pass(this) :: init_external_dof => &
+          field_wrapper_init_external_dof
+     !> Destructor. Frees the field and nullifies the pointer.
+     procedure, pass(this) :: free => field_wrapper_free
+  end type field_wrapper_t
 
 contains
 
@@ -305,5 +326,63 @@ contains
 
     size = this%dof%size()
   end function field_size
+
+  ! ========================================================================== !
+  ! Field pointer type subroutines
+
+  subroutine field_ptr_init(this, ptr)
+    class(field_ptr_t), intent(inout) :: this
+    type(field_t), pointer, intent(in) :: ptr
+
+    call this%free()
+
+    this%ptr => ptr
+
+  end subroutine field_ptr_init
+
+  subroutine field_ptr_free(this)
+    class(field_ptr_t), intent(inout) :: this
+
+    if (associated(this%ptr)) then
+       nullify(this%ptr)
+    end if
+
+  end subroutine field_ptr_free
+
+  ! ========================================================================== !
+  ! Field wrapper type subroutines
+
+  subroutine field_wrapper_init_internal_dof(this, msh, space, fld_name)
+    class(field_wrapper_t), intent(inout) :: this
+    type(mesh_t), target, intent(in) :: msh
+    type(space_t), target, intent(in) :: space
+    character(len=*), optional :: fld_name
+
+    call this%free()
+    allocate(this%field)
+    call this%field%init(msh, space, fld_name)
+
+  end subroutine field_wrapper_init_internal_dof
+
+  subroutine field_wrapper_init_external_dof(this, dof, fld_name)
+    class(field_wrapper_t), intent(inout) :: this
+    type(dofmap_t), target, intent(in) :: dof
+    character(len=*), optional :: fld_name
+
+    call this%free()
+    allocate(this%field)
+    call this%field%init(dof, fld_name)
+
+  end subroutine field_wrapper_init_external_dof
+
+  subroutine field_wrapper_free(this)
+    class(field_wrapper_t), intent(inout) :: this
+
+    if (associated(this%field)) then
+       call this%field%free()
+       deallocate(this%field)
+    end if
+
+  end subroutine field_wrapper_free
 
 end module field

--- a/src/field/field_array.f90
+++ b/src/field/field_array.f90
@@ -1,0 +1,244 @@
+module field_array
+  use, intrinsic :: iso_fortran_env, only : error_unit
+  use field, only : field_wrapper_t, field_t
+  use iso_c_binding, only : c_ptr
+  use num_types, only : rp
+  use space, only : space_t
+  use dofmap, only : dofmap_t
+  use mesh, only : mesh_t
+  use utils, only : neko_error
+  use comm, only : pe_rank
+  implicit none
+  private
+
+  !> field_array_t, To be able to group fields together
+  type, public :: field_array_t
+     type(field_wrapper_t), allocatable :: items(:)
+   contains
+     !> Constructor. Allocates array and pointers.
+     procedure, pass(this) :: init => field_array_init
+     !> Destructor.
+     procedure, pass(this) :: free => field_array_free
+     !> Append a field to the list.
+     procedure, pass(this) :: append => field_array_append
+     generic :: get => get_by_index, get_by_name
+     !> Get an item pointer by array index
+     procedure, pass(this) :: get_by_index => field_array_get_by_index
+     !> Get an item pointer by field name
+     procedure, pass(this) :: get_by_name => field_array_get_by_name
+     !> Point item at given index.
+     generic :: assign => assign_to_field, assign_to_field_wrapper
+     procedure, pass(this) :: assign_to_field => field_array_assign_to_field
+     procedure, pass(this) :: assign_to_field_wrapper => &
+          field_array_assign_to_field_wrapper
+
+     !> Get device pointer for a given index.
+     procedure, pass(this) :: x_d => field_array_x_d
+     !> Get pointer to the raw data array for a given index.
+     procedure, pass(this) :: x => field_array_x
+     !> Get number of items in the list.
+     procedure, pass(this) :: size => field_array_size
+     !> Get the size of dofmap for an item in the list.
+     procedure, pass(this) :: item_size => field_array_item_size
+     !> Get the dofmap for an item in the list.
+     procedure, pass(this) :: dof => field_array_dof
+     !> Get the space for an item in the list.
+     procedure, pass(this) :: Xh => field_array_space
+     !> Get the mesh for an item in the list.
+     procedure, pass(this) :: msh => field_array_msh
+     !> Check wether the dofmap is internal for an item in the list.
+     procedure, pass(this) :: internal_dofmap => field_array_internal_dofmap
+     !> Get the name for an item in the list.
+     procedure, pass(this) :: name => field_array_name
+  end type field_array_t
+
+contains
+  !> Constructor. Just allocates the array.
+  !! @param size The size of the list to preallocate
+  subroutine field_array_init(this, size)
+    class(field_array_t), intent(inout) :: this
+    integer, intent(in) :: size
+
+    call this%free()
+
+    allocate(this%items(size))
+  end subroutine field_array_init
+
+  !> Get number of items in the list.
+  pure function field_array_size(this) result(n)
+    class(field_array_t), intent(in) :: this
+    integer :: n
+    n = size(this%items)
+  end function field_array_size
+
+  !> Get an item pointer by array index
+  !! @param i The index of the item.
+  function field_array_get_by_index(this, i) result(f)
+    class(field_array_t), intent(inout) :: this
+    type(field_t), pointer :: f
+    integer, intent(in) :: i
+    f => this%items(i)%field
+  end function field_array_get_by_index
+
+  !> Get an item pointer by array index
+  !! @param i The index of the item.
+  function field_array_get_by_name(this, name) result(f)
+    class(field_array_t), intent(inout) :: this
+    type(field_t), pointer :: f
+    character(len=*), intent(in) :: name
+    integer :: i
+
+    nullify(f)
+
+    do i = 1, this%size()
+       if (this%name(i) .eq. trim(name)) then
+          f => this%items(i)%field
+          return
+       end if
+    end do
+
+    if (pe_rank .eq. 0) then
+       write(error_unit,*) "Current field list contents:"
+
+       do i = 1, this%size()
+          write(error_unit,*) "- ", this%name(i)
+       end do
+    end if
+
+    call neko_error("No field with name " // trim(name) // " found in list")
+  end function field_array_get_by_name
+
+  !> Append a field to the list, by copy assignment.
+  !! @param f The field to append.
+  subroutine field_array_append(this, f)
+    class(field_array_t), intent(inout) :: this
+    class(field_t), intent(in) :: f
+    type(field_wrapper_t), allocatable :: tmp(:)
+    integer :: len
+
+    len = size(this%items)
+
+    allocate(tmp(len+1))
+    tmp(1:len) = this%items
+    call move_alloc(tmp, this%items)
+    call this%items(len+1)%init(f)
+
+  end subroutine field_array_append
+
+  !> Destructor.
+  subroutine field_array_free(this)
+    class(field_array_t), intent(inout) :: this
+    integer :: i, n_fields
+
+    if (allocated(this%items)) then
+       n_fields = this%size()
+       do i = 1, n_fields
+          call this%items(i)%free()
+       end do
+       deallocate(this%items)
+    end if
+
+  end subroutine field_array_free
+
+  !> Get device pointer for a given index
+  !! @param i The index of the item.
+  function field_array_x_d(this, i) result(x_d)
+    class(field_array_t), intent(in) :: this
+    integer, intent(in) :: i
+    type(c_ptr) :: x_d
+
+    x_d = this%items(i)%field%x_d
+  end function field_array_x_d
+
+  function field_array_x(this, i) result(x)
+    class(field_array_t), target, intent(in) :: this
+    real(kind=rp), pointer, contiguous :: x(:,:,:,:)
+    integer, intent(in) :: i
+    x => this%items(i)%field%x
+  end function field_array_x
+
+  !> Get the size of the dofmap for item `i`.
+  !! @param i The index of the item.
+  function field_array_item_size(this, i) result(size)
+    class(field_array_t), target, intent(in) :: this
+    integer, intent(in) :: i
+    integer :: size
+
+    size = this%items(i)%field%size()
+
+  end function field_array_item_size
+
+  !> Assign item at a given index to field, by copy assignment.
+  !! @param i The index of the item.
+  !! @param ptr A field pointer to point the item to.
+  subroutine field_array_assign_to_field(this, i, f)
+    class(field_array_t), intent(inout) :: this
+    integer, intent(in) :: i
+    type(field_t), intent(in) :: f
+
+    call this%items(i)%init(f)
+
+  end subroutine field_array_assign_to_field
+
+  !> Point item at a given index.
+  !! @param i The index of the item.
+  !! @param ptr An encapsulated field pointer to point the item to.
+  subroutine field_array_assign_to_field_wrapper(this, i, wrapper)
+    class(field_array_t), intent(inout) :: this
+    integer, intent(in) :: i
+    type(field_wrapper_t), target, intent(in) :: wrapper
+
+    call this%items(i)%init(wrapper%field)
+  end subroutine field_array_assign_to_field_wrapper
+
+  !> Get the the dofmap for item `i`.
+  !! @param i The index of the item.
+  function field_array_dof(this, i) result(result)
+    class(field_array_t), target, intent(in) :: this
+    integer, intent(in) :: i
+    type(dofmap_t), pointer :: result
+
+    result => this%items(i)%field%dof
+  end function field_array_dof
+
+  !> Get the the space for item `i`.
+  !! @param i The index of the item.
+  function field_array_space(this, i) result(result)
+    class(field_array_t), target, intent(in) :: this
+    integer, intent(in) :: i
+    type(space_t), pointer :: result
+
+    result => this%items(i)%field%Xh
+  end function field_array_space
+
+  !> Get the the mesh for item `i`.
+  !! @param i The index of the item.
+  function field_array_msh(this, i) result(result)
+    class(field_array_t), target, intent(in) :: this
+    integer, intent(in) :: i
+    type(mesh_t), pointer :: result
+
+    result => this%items(i)%field%msh
+  end function field_array_msh
+
+  !> Whether the dofmap is internal for item `i`.
+  !! @param i The index of the item.
+  function field_array_internal_dofmap(this, i) result(result)
+    class(field_array_t), target, intent(in) :: this
+    integer, intent(in) :: i
+    logical :: result
+
+    result = this%items(i)%field%internal_dofmap
+  end function field_array_internal_dofmap
+
+  !> Get the name for an item in the list.
+  !! @param i The index of the item.
+  function field_array_name(this, i) result(result)
+    class(field_array_t), target, intent(in) :: this
+    integer, intent(in) :: i
+    character(len=80) :: result
+
+    result = this%items(i)%field%name
+  end function field_array_name
+
+end module field_array

--- a/src/field/field_list.f90
+++ b/src/field/field_list.f90
@@ -122,7 +122,7 @@ contains
     allocate(tmp(len+1))
     tmp(1:len) = this%items
     call move_alloc(tmp, this%items)
-    this%items(len+1)%ptr => f
+    call this%items(len+1)%init(f)
 
   end subroutine field_list_append
 
@@ -134,10 +134,7 @@ contains
     if (allocated(this%items)) then
        n_fields = this%size()
        do i = 1, n_fields
-          if (associated(this%items(i)%ptr)) then
-             call this%items(i)%ptr%free()
-          end if
-          nullify(this%items(i)%ptr)
+          call this%items(i)%free()
        end do
        deallocate(this%items)
     end if
@@ -180,7 +177,8 @@ contains
     integer, intent(in) :: i
     type(field_t), pointer, intent(in) :: ptr
 
-    this%items(i)%ptr => ptr
+    call this%items(i)%init(ptr)
+
   end subroutine field_list_assign_to_ptr
 
   !> Point item at a given index.
@@ -191,7 +189,7 @@ contains
     integer, intent(in) :: i
     type(field_ptr_t), target, intent(in) :: ptr
 
-    this%items(i)%ptr => ptr%ptr
+    call this%items(i)%init(ptr%ptr)
   end subroutine field_list_assign_to_field_ptr
 
   !> Point item at a given index.
@@ -202,7 +200,7 @@ contains
     integer, intent(in) :: i
     type(field_t), target, intent(in) :: fld
 
-    this%items(i)%ptr => fld
+    call this%items(i)%init(fld)
   end subroutine field_list_assign_to_field
 
   !> Get the the dofmap for item `i`.


### PR DESCRIPTION
Introduce guidelines for implementing wrapper and pointer types. Add a Field wrapper and update the pointer management in field_list. Introduce field_array to manage the lifetime of its components effectively.

This is the first step in trying to manage how we deal with complex object lifetime in a streamlined fashion.