### PR TITLE
Change htable data from AoS to SoA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Develop
 
+- Change hash table data structure from AoS to SoA.
 - Update the simcomp wrappers to better handle allocation and deallocation.
 - Added a factory subroutine for scalar schemes, allowing for more flexible
   creation of scalar scheme objects based on JSON input.

--- a/src/adt/htable.f90
+++ b/src/adt/htable.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2019-2023, The Neko Authors
+! Copyright (c) 2019-2026, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -232,8 +232,8 @@ contains
   !> Initialize a hash table of type @a data
   subroutine htable_init(this, size, key, data)
     class(htable_t), intent(inout) :: this
-    integer, value :: size              !< Initial size of the table
-    class(*), intent(in) :: key            !< Type of key
+    integer, value :: size !< Initial size of the table
+    class(*), intent(in) :: key !< Type of key
     class(*), intent(in), optional :: data !< Type of data
 
     call htable_free(this)
@@ -316,8 +316,8 @@ contains
   !> Insert tuple @a (key, value) into the hash table
   recursive subroutine htable_set(this, key, data)
     class(htable_t), intent(inout) :: this
-    class(*), intent(inout) :: key   !< Table key
-    class(*), intent(inout) ::  data !< Data associated with @a key
+    class(*), intent(inout) :: key !< Table key
+    class(*), intent(inout) :: data !< Data associated with @a key
     class(htable_t), allocatable :: tmp
     integer index, i, c
 
@@ -387,7 +387,7 @@ contains
   !> Retrieve data associated with @a key into the hash table
   function htable_get(this, key, data) result(rcode)
     class(htable_t), intent(inout) :: this
-    class(*), intent(inout) :: key  !< Key to retrieve
+    class(*), intent(inout) :: key !< Key to retrieve
     class(*), intent(inout) :: data !< Retrieved data
     integer :: rcode
     integer :: index, i, c
@@ -420,7 +420,7 @@ contains
   !> Remove a @a key from the hash table
   subroutine htable_remove(this, key)
     class(htable_t), intent(inout) :: this
-    class(*), intent(inout) :: key  !< Key to remove
+    class(*), intent(inout) :: key !< Key to remove
     integer :: index, i, c
 
     c = 0
@@ -692,7 +692,7 @@ contains
   !> Initialize an integer based hash table
   subroutine htable_i4_init(this, size, data)
     class(htable_i4_t), intent(inout) :: this
-    integer, value :: size                    !< Initial size of the table
+    integer, value :: size !< Initial size of the table
     class(*), intent(inout), optional :: data !< Data to associate with @a key
     integer :: key
 
@@ -707,7 +707,7 @@ contains
   !> Insert an integer into the hash table
   subroutine htable_i4_set(this, key, data)
     class(htable_i4_t), intent(inout) :: this
-    integer, intent(inout) :: key   !< Table key
+    integer, intent(inout) :: key !< Table key
     class(*), intent(inout) :: data !< Data associated with @a key
 
     call htable_set(this, key, data)
@@ -717,7 +717,7 @@ contains
   !> Retrive an integer with key @a key from the hash table
   function htable_i4_get(this, key, data) result(rcode)
     class(htable_i4_t), intent(inout) :: this
-    integer, intent(inout) :: key   !< Key to retrieve
+    integer, intent(inout) :: key !< Key to retrieve
     class(*), intent(inout) :: data !< Retrieved data
     integer :: rcode
 
@@ -758,7 +758,7 @@ contains
   !> Remove an integer with key @a key from the hash table
   subroutine htable_i4_remove(this, key)
     class(htable_i4_t), intent(inout) :: this
-    integer, intent(inout) :: key   !< Table key
+    integer, intent(inout) :: key !< Table key
 
     call htable_remove(this, key)
 
@@ -814,7 +814,7 @@ contains
   !> Initialize an integer*8 based hash table
   subroutine htable_i8_init(this, size, data)
     class(htable_i8_t), intent(inout) :: this
-    integer, value :: size                    !< Initial size of the table
+    integer, value :: size !< Initial size of the table
     class(*), intent(inout), optional :: data !< Data to associate with @a key
     integer(kind=i8) :: key
 
@@ -829,7 +829,7 @@ contains
   !> Insert an integer*8 into the hash table
   subroutine htable_i8_set(this, key, data)
     class(htable_i8_t), intent(inout) :: this
-    integer(kind=i8), intent(inout) :: key   !< Table key
+    integer(kind=i8), intent(inout) :: key !< Table key
     class(*), intent(inout) :: data !< Data associated with @a key
 
     call htable_set(this, key, data)
@@ -839,7 +839,7 @@ contains
   !> Retrive an integer*8 with key @a key from the hash table
   function htable_i8_get(this, key, data) result(rcode)
     class(htable_i8_t), intent(inout) :: this
-    integer(kind=i8), intent(inout) :: key   !< Key to retrieve
+    integer(kind=i8), intent(inout) :: key !< Key to retrieve
     class(*), intent(inout) :: data !< Retrieved data
     integer :: rcode
 
@@ -881,7 +881,7 @@ contains
   !> Remove an integer*8 with key @a key from the hash table
   subroutine htable_i8_remove(this, key)
     class(htable_i8_t), intent(inout) :: this
-    integer(kind=i8), intent(inout) :: key   !< Table key
+    integer(kind=i8), intent(inout) :: key !< Table key
 
     call htable_remove(this, key)
 
@@ -947,7 +947,7 @@ contains
   !> Initialize a double precision based hash table
   subroutine htable_r8_init(this, size, data)
     class(htable_r8_t), intent(inout) :: this
-    integer, value :: size                    !< Initial size of the table
+    integer, value :: size !< Initial size of the table
     class(*), intent(inout), optional :: data !< Data to associate with @a key
     real(kind=dp) :: key
 
@@ -963,7 +963,7 @@ contains
   subroutine htable_r8_set(this, key, data)
     class(htable_r8_t), intent(inout) :: this
     real(kind=dp), intent(inout) :: key !< Table key
-    class(*), intent(inout) :: data     !< Data associated with @a key
+    class(*), intent(inout) :: data !< Data associated with @a key
 
     call htable_set(this, key, data)
 
@@ -973,7 +973,7 @@ contains
   function htable_r8_get(this, key, data) result(rcode)
     class(htable_r8_t), intent(inout) :: this
     real(kind=dp), intent(inout) :: key !< Key to retrieve
-    class(*), intent(inout) :: data     !< Retrieved data
+    class(*), intent(inout) :: data !< Retrieved data
     integer :: rcode
 
     rcode = htable_get(this, key, data)
@@ -997,7 +997,7 @@ contains
   !> Remove a double precision key @a key from the hash table
   subroutine htable_r8_remove(this, key)
     class(htable_r8_t), intent(inout) :: this
-    real(kind=dp), intent(inout) :: key   !< Table key
+    real(kind=dp), intent(inout) :: key !< Table key
 
     call htable_remove(this, key)
 
@@ -1054,7 +1054,7 @@ contains
   !> Initialize a point based hash table
   subroutine htable_pt_init(this, size, data)
     class(htable_pt_t), intent(inout) :: this
-    integer, value :: size                    !< Initial size of the table
+    integer, value :: size !< Initial size of the table
     class(*), intent(inout), optional :: data !< Data to associate with @a key
     type(point_t) :: key
 
@@ -1070,7 +1070,7 @@ contains
   subroutine htable_pt_set(this, key, data)
     class(htable_pt_t), intent(inout) :: this
     type(point_t), intent(inout) :: key !< Table key
-    class(*), intent(inout) :: data     !< Data associated with @a key
+    class(*), intent(inout) :: data !< Data associated with @a key
 
     call htable_set(this, key, data)
 
@@ -1080,7 +1080,7 @@ contains
   function htable_pt_get(this, key, data) result(rcode)
     class(htable_pt_t), intent(inout) :: this
     type(point_t), intent(inout) :: key !< Key to retrieve
-    class(*), intent(inout) :: data     !< Retrieved data
+    class(*), intent(inout) :: data !< Retrieved data
     integer :: rcode
 
     rcode = htable_get(this, key, data)
@@ -1128,7 +1128,7 @@ contains
   !> Remove a point with key @a key from the hash table
   subroutine htable_pt_remove(this, key)
     class(htable_pt_t), intent(inout) :: this
-    type(point_t), intent(inout) :: key   !< Table key
+    type(point_t), intent(inout) :: key !< Table key
 
     call htable_remove(this, key)
 
@@ -1185,7 +1185,7 @@ contains
   !> Initialize an integer 2-tuple hash table
   subroutine htable_i4t2_init(this, size, data)
     class(htable_i4t2_t), intent(inout) :: this
-    integer, value :: size                    !< Initial size of the table
+    integer, value :: size !< Initial size of the table
     class(*), intent(inout), optional :: data !< Data to associate with @a key
     type(tuple_i4_t) :: key
 
@@ -1200,7 +1200,7 @@ contains
   !> Insert an integer 2-tuple into the hash table
   subroutine htable_i4t2_set(this, key, data)
     class(htable_i4t2_t), intent(inout) :: this
-    type(tuple_i4_t), intent(inout) :: key   !< Table key
+    type(tuple_i4_t), intent(inout) :: key !< Table key
     class(*), intent(inout) :: data !< Data associated with @a key
 
     call htable_set(this, key, data)
@@ -1210,7 +1210,7 @@ contains
   !> Retrive an integer 2-tuple with key @a key from the hash table
   function htable_i4t2_get(this, key, data) result(rcode)
     class(htable_i4t2_t), intent(inout) :: this
-    type(tuple_i4_t), intent(inout) :: key   !< Key to retrieve
+    type(tuple_i4_t), intent(inout) :: key !< Key to retrieve
     class(*), intent(inout) :: data !< Retrieved data
     integer :: rcode
 
@@ -1258,7 +1258,7 @@ contains
   !> Remove an integer 2-tuple with key @a key from the hash table
   subroutine htable_i4t2_remove(this, key)
     class(htable_i4t2_t), intent(inout) :: this
-    type(tuple_i4_t), intent(inout) :: key   !< Table key
+    type(tuple_i4_t), intent(inout) :: key !< Table key
 
     call htable_remove(this, key)
 
@@ -1314,7 +1314,7 @@ contains
   !> Initialize an integer 4-tuple  hash table
   subroutine htable_i4t4_init(this, size, data)
     class(htable_i4t4_t), intent(inout) :: this
-    integer, value :: size                    !< Initial size of the table
+    integer, value :: size !< Initial size of the table
     class(*), intent(inout), optional :: data !< Data to associate with @a key
     type(tuple4_i4_t) :: key
 
@@ -1329,7 +1329,7 @@ contains
   !> Insert an integer 4-tuple into the hash table
   subroutine htable_i4t4_set(this, key, data)
     class(htable_i4t4_t), intent(inout) :: this
-    type(tuple4_i4_t), intent(inout) :: key   !< Table key
+    type(tuple4_i4_t), intent(inout) :: key !< Table key
     class(*), intent(inout) :: data !< Data associated with @a key
 
     call htable_set(this, key, data)
@@ -1339,7 +1339,7 @@ contains
   !> Retrive an integer 4-tuple with key @a key from the hash table
   function htable_i4t4_get(this, key, data) result(rcode)
     class(htable_i4t4_t), intent(inout) :: this
-    type(tuple4_i4_t), intent(inout) :: key   !< Key to retrieve
+    type(tuple4_i4_t), intent(inout) :: key !< Key to retrieve
     class(*), intent(inout) :: data !< Retrieved data
     integer :: rcode
 
@@ -1387,7 +1387,7 @@ contains
   !> Remove an integer 4-tuple with key @a key from the hash table
   subroutine htable_i4t4_remove(this, key)
     class(htable_i4t4_t), intent(inout) :: this
-    type(tuple4_i4_t), intent(inout) :: key   !< Table key
+    type(tuple4_i4_t), intent(inout) :: key !< Table key
 
     call htable_remove(this, key)
 
@@ -1451,7 +1451,7 @@ contains
   !> Initialize a C pointer based  hash table
   subroutine htable_cptr_init(this, size, data)
     class(htable_cptr_t), intent(inout) :: this
-    integer, value :: size                    !< Initial size of the table
+    integer, value :: size !< Initial size of the table
     class(*), intent(inout), optional :: data !< Data to associate with @a key
     type(h_cptr_t) :: key
 
@@ -1466,7 +1466,7 @@ contains
   !> Insert a C pointer into the hash table
   subroutine htable_cptr_set(this, key, data)
     class(htable_cptr_t), target, intent(inout) :: this
-    type(h_cptr_t), intent(inout) :: key   !< Table key
+    type(h_cptr_t), intent(inout) :: key !< Table key
     class(*), intent(inout) :: data !< Data associated with @a key
 
     call htable_set(this, key, data)
@@ -1476,7 +1476,7 @@ contains
   !> Retrive a C pointer with key @a key from the hash table
   function htable_cptr_get(this, key, data) result(rcode)
     class(htable_cptr_t), target, intent(inout) :: this
-    type(h_cptr_t), intent(inout) :: key   !< Key to retrieve
+    type(h_cptr_t), intent(inout) :: key !< Key to retrieve
     class(*), intent(inout) :: data !< Retrieved data
     integer :: rcode
 
@@ -1505,7 +1505,7 @@ contains
   !> Remove a C pointer with key @a key from the hash table
   subroutine htable_cptr_remove(this, key)
     class(htable_cptr_t), target, intent(inout) :: this
-    type(h_cptr_t), intent(inout) :: key   !< Table key
+    type(h_cptr_t), intent(inout) :: key !< Table key
 
     call htable_remove(this, key)
 

--- a/src/adt/htable.f90
+++ b/src/adt/htable.f90
@@ -244,7 +244,7 @@ contains
 
     size = ishft(1, ceiling(log(dble(size)) / NEKO_M_LN2))
 
-   allocate(this%key(0:size), source = key)
+    allocate(this%key(0:size), source = key)
     if (present(data)) then
        allocate(this%data(0:size), source = data)
     else

--- a/src/adt/htable.f90
+++ b/src/adt/htable.f90
@@ -43,19 +43,14 @@ module htable
   implicit none
   private
 
-  !> Hash table entry, tuple (key, data)
-  type :: h_tuple_t
-     logical :: valid = .false.
-     logical :: skip = .false.
-     class(*), allocatable :: key
-     class(*), allocatable :: data
-  end type h_tuple_t
-
   !> Base type for a hash table
   type, public, abstract :: htable_t
-     integer, private :: size = 0 
+     integer, private :: size = 0
      integer, private :: entries = 0
-     type(h_tuple_t), private, allocatable :: t(:)
+     class(*), private, allocatable :: key(:)
+     class(*), private, allocatable :: data(:)
+     logical, private, allocatable :: valid(:)
+     logical, private, allocatable :: skip(:)
    contains
      procedure(htable_hash), pass(this), deferred :: hash
      procedure, public, pass(this) :: clear => htable_clear
@@ -238,11 +233,8 @@ contains
   subroutine htable_init(this, size, key, data)
     class(htable_t), intent(inout) :: this
     integer, value :: size              !< Initial size of the table
-    class(*), target, intent(in) :: key            !< Type of key
-    class(*), target, intent(in), optional :: data !< Type of data
-    class(*), pointer :: dp
-    integer :: i
-
+    class(*), intent(in) :: key            !< Type of key
+    class(*), intent(in), optional :: data !< Type of data
 
     call htable_free(this)
 
@@ -252,33 +244,40 @@ contains
 
     size = ishft(1, ceiling(log(dble(size)) / NEKO_M_LN2))
 
-    allocate(this%t(0:size))
-    this%t(:)%valid = .false.
+   allocate(this%key(0:size), source = key)
+    if (present(data)) then
+       allocate(this%data(0:size), source = data)
+    else
+       allocate(this%data(0:size), source = key)
+    end if
+
+    allocate(this%skip(0:size))
+    allocate(this%valid(0:size))
+    this%valid = .false.
+    this%skip = .false.
     this%size = size
     this%entries = 0
 
-    dp => key
-    if (present(data)) then
-       dp => data
-    end if
-
-    do i = 0, size
-       allocate(this%t(i)%key, source=key)
-       allocate(this%t(i)%data, source=dp)
-    end do
   end subroutine htable_init
 
   !> Destroy a hash table
   subroutine htable_free(this)
     class(htable_t), intent(inout) :: this
-    integer i
 
-    if (allocated(this%t)) then
-       do i = 0, this%size !< @todo check range
-          deallocate(this%t(i)%key)
-          deallocate(this%t(i)%data)
-       end do
-       deallocate(this%t)
+    if (allocated(this%key)) then
+       deallocate(this%key)
+    end if
+
+    if (allocated(this%data)) then
+       deallocate(this%data)
+    end if
+
+    if (allocated(this%valid)) then
+       deallocate(this%valid)
+    end if
+
+    if (allocated(this%skip)) then
+       deallocate(this%skip)
     end if
 
     this%size = 0
@@ -290,8 +289,8 @@ contains
   subroutine htable_clear(this)
     class(htable_t), intent(inout) :: this
 
-    if (allocated(this%t)) then
-       this%t(:)%valid = .false.
+    if (allocated(this%valid)) then
+       this%valid = .false.
        this%entries = 0
     else
        call neko_error("Hash table not allocated")
@@ -332,15 +331,15 @@ contains
           call neko_error("Invalid hash generated")
        end if
        !> Check if entry at this index is empty or if key matches
-       if ((.not. this%t(index)%valid) .or. &
-            htable_eq_key(this, index, key)) then
-          call htable_set_key(this, index, key)
-          call htable_set_data(this, index, data)
-          if (.not. this%t(index)%valid) then
+       if ((.not. this%valid(index)) .or. &
+            htable_eq_key(this%key(index), key)) then
+          call htable_set_key(this%key(index), key)
+          call htable_set_data(this%data(index), data)
+          if (.not. this%valid(index)) then
              this%entries = this%entries + 1
           end if
-          this%t(index)%valid = .true.
-          this%t(index)%skip = .false.
+          this%valid(index) = .true.
+          this%skip(index) = .false.
           return
        end if
        i = i - 1
@@ -368,48 +367,18 @@ contains
 
     call htable_init(tmp, ishft(this%size, 1), key, data)
 
-    !
-    ! When rebuilding the table we used the following loop:
-    !
-    ! do i = 0, this%size - 1
-    !   if (this%t(i)%valid) then
-    !      call htable_set(tmp, this%t(i)%key, this%t(i)%data)
-    !   end if
-    ! end do
-    !
-    ! However, CCE 18.x (and probably other llvm based compilers)
-    ! segfault faults unless the data variable is enclosed in a
-    ! select type block
-    !
-
     do i = 0, this%size - 1
-       if (this%t(i)%valid) then
-          select type (datap => this%t(i)%data)
-          type is (integer)
-             call htable_set(tmp, this%t(i)%key, datap)
-          type is (integer(i8))
-             call htable_set(tmp, this%t(i)%key, datap)
-          type is (double precision)
-             call htable_set(tmp, this%t(i)%key, datap)
-          type is (point_t)
-             call htable_set(tmp, this%t(i)%key, datap)
-          class is (tuple_t)
-             select type(tuplep => datap)
-             type is (tuple_i4_t)
-                call htable_set(tmp, this%t(i)%key, tuplep)
-             type is (tuple4_i4_t)
-                call htable_set(tmp, this%t(i)%key, tuplep)
-             end select
-          type is (h_cptr_t)
-             call htable_set(tmp, this%t(i)%key, datap)
-          class default
-             call neko_error('Invalid htable data')
-          end select
+       if (this%valid(i)) then
+          call htable_set(tmp, this%key(i), this%data(i))
        end if
     end do
-
     this%size = tmp%size
-    call move_alloc(tmp%t, this%t)
+    this%entries = tmp%entries
+
+    call move_alloc(tmp%key, this%key)
+    call move_alloc(tmp%data, this%data)
+    call move_alloc(tmp%valid, this%valid)
+    call move_alloc(tmp%skip, this%skip)
 
     call htable_set(this, key, data)
 
@@ -432,13 +401,13 @@ contains
           call neko_error("Invalid hash generated")
        end if
 
-       if (.not. this%t(index)%valid .and. &
-            .not. this%t(index)%skip) then
+       if (.not. this%valid(index) .and. &
+            .not. this%skip(index)) then
           rcode = 1
           return
-       else if ((this%t(index)%valid) .and. &
-            htable_eq_key(this, index, key)) then
-          call htable_get_data(this, index, data)
+       else if ((this%valid(index)) .and. &
+            htable_eq_key(this%key(index), key)) then
+          call htable_get_data(this%data(index), data)
           rcode = 0
           return
        end if
@@ -463,10 +432,10 @@ contains
           call neko_error("Invalid hash generated")
        end if
 
-       if ((this%t(index)%valid) .and. &
-            htable_eq_key(this, index, key)) then
-          this%t(index)%valid = .false.
-          this%t(index)%skip = .true.
+       if ((this%valid(index)) .and. &
+            htable_eq_key(this%key(index), key)) then
+          this%valid(index) = .false.
+          this%skip(index) = .true.
           this%entries = this%entries - 1
           return
        end if
@@ -476,45 +445,42 @@ contains
   end subroutine htable_remove
 
   !> Set data at @a idx to @a value
-  subroutine htable_set_data(this, idx, data)
-    class(htable_t), target, intent(inout) :: this
-    integer, intent(in) :: idx   !< Table index
-    class(*), intent(in) :: data !< Data to set at @a idx
-    class(*), pointer :: hdp
+  subroutine htable_set_data(ht_data, data)
+    class(*), intent(inout) :: ht_data !< Data entry in table
+    class(*), intent(in) :: data !< Data to set
 
-    hdp => this%t(idx)%data
     select type (data)
     type is (integer)
-       select type(hdp)
+       select type(ht_data)
        type is (integer)
-          hdp = data
+          ht_data = data
        end select
     type is (integer(i8))
-       select type(hdp)
+       select type(ht_data)
        type is (integer(i8))
-          hdp = data
+          ht_data = data
        end select
     type is (double precision)
-       select type(hdp)
+       select type(ht_data)
        type is (double precision)
-          hdp = data
+          ht_data = data
        end select
     type is (point_t)
-       select type(hdp)
+       select type(ht_data)
        type is (point_t)
-          hdp = data
+          ht_data = data
        end select
     class is (tuple_t)
-       select type(hdp)
+       select type(ht_data)
        type is (tuple_i4_t)
-          hdp = data
+          ht_data = data
        type is (tuple4_i4_t)
-          hdp = data
+          ht_data = data
        end select
     type is (h_cptr_t)
-       select type(hdp)
+       select type(ht_data)
        type is (h_cptr_t)
-          hdp = data
+          ht_data = data
        end select
     class default
        call neko_error('Invalid htable data (set)')
@@ -522,43 +488,42 @@ contains
   end subroutine htable_set_data
 
   !> Return data at @a idx in @a value
-  subroutine htable_get_data(this, idx, data)
-    class(htable_t), intent(in) :: this
-    integer, intent(in) :: idx      !< Table index
-    class(*), intent(inout) :: data !< Data to retrieve
+  subroutine htable_get_data(ht_data, data)
+    class(*), intent(in) :: ht_data !< Data entry in table
+    class(*), intent(inout) :: data !< Retrieved data
 
-    select type (hdp=>this%t(idx)%data)
+    select type (ht_data)
     type is (integer)
        select type(data)
        type is (integer)
-          data = hdp
+          data = ht_data
        end select
     type is (integer(i8))
        select type(data)
        type is (integer(i8))
-          data = hdp
+          data = ht_data
        end select
     type is (double precision)
        select type(data)
        type is (double precision)
-          data = hdp
+          data = ht_data
        end select
     type is (point_t)
        select type(data)
        type is (point_t)
-          data = hdp
+          data = ht_data
        end select
     class is (tuple_t)
        select type(data)
        type is (tuple_i4_t)
-          data = hdp
+          data = ht_data
        type is (tuple4_i4_t)
-          data = hdp
+          data = ht_data
        end select
     type is (h_cptr_t)
        select type (data)
        type is (h_cptr_t)
-          data = hdp
+          data = ht_data
        end select
     class default
        call neko_error('Invalid htable data (get)')
@@ -566,89 +531,85 @@ contains
   end subroutine htable_get_data
 
   !> Compare key at @a idx to @a key
-  pure function htable_eq_key(this, idx, key) result(res)
-    class(htable_t), intent(in) :: this
-    integer, intent(in) :: idx  !< Table index
-    class(*), intent(in) :: key !< Key to compare against the key at @a idx
+  pure function htable_eq_key(ht_key, key) result(res)
+    class(*), intent(in) :: ht_key !< Key entry in table
+    class(*), intent(in) :: key !< Key to compare against
     logical :: res
 
     res = .true.
-    select type (kp=>this%t(idx)%key)
+    select type (ht_key)
     type is (integer)
        select type(key)
        type is (integer)
-          res = (kp .eq. key)
+          res = (ht_key .eq. key)
        end select
     type is (integer(i8))
        select type(key)
        type is (integer(i8))
-          res = (kp .eq. key)
+          res = (ht_key .eq. key)
        end select
     type is (double precision)
        select type(key)
        type is (double precision)
-          res = abs(kp - key) .lt. epsilon(1.0_dp)
+          res = abs(ht_key - key) .lt. epsilon(1.0_dp)
        end select
     type is (point_t)
        select type (key)
        type is (point_t)
-          res = (kp .eq. key)
+          res = (ht_key .eq. key)
        end select
     class is (tuple_t)
        select type (key)
        type is (tuple_i4_t)
-          res = (key .eq. kp)
+          res = (key .eq. ht_key)
        type is (tuple4_i4_t)
-          res = (key .eq. kp)
+          res = (key .eq. ht_key)
        end select
     type is (h_cptr_t)
        select type (key)
        type is (h_cptr_t)
-          res = c_associated(kp%ptr, key%ptr)
+          res = c_associated(ht_key%ptr, key%ptr)
        end select
     end select
   end function htable_eq_key
 
   !> Set key at @a idx to @a key
-  subroutine htable_set_key(this, idx, key)
-    class(htable_t), target, intent(inout) :: this
-    integer, intent(in) :: idx  !< Table index
-    class(*), intent(in) :: key !< Key to set at @a idx
-    class(*), pointer :: kp
+  subroutine htable_set_key(ht_key, key)
+    class(*), intent(inout) :: ht_key !< Key entry in table
+    class(*), intent(in) :: key !< Key to set
 
-    kp => this%t(idx)%key
     select type(key)
     type is (integer)
-       select type(kp)
+       select type(ht_key)
        type is (integer)
-          kp = key
+          ht_key = key
        end select
     type is (integer(i8))
-       select type(kp)
+       select type(ht_key)
        type is (integer(i8))
-          kp = key
+          ht_key = key
        end select
     type is (double precision)
-       select type(kp)
+       select type(ht_key)
        type is (double precision)
-          kp = key
+          ht_key = key
        end select
     type is (point_t)
-       select type (kp)
+       select type (ht_key)
        type is (point_t)
-          kp = key
+          ht_key = key
        end select
     class is (tuple_t)
-       select type(kp)
+       select type(ht_key)
        type is (tuple_i4_t)
-          kp = key
+          ht_key = key
        type is (tuple4_i4_t)
-          kp = key
+          ht_key = key
        end select
     type is (h_cptr_t)
-       select type(kp)
+       select type(ht_key)
        type is (h_cptr_t)
-          kp = key
+          ht_key = key
        end select
     class default
        call neko_error('Invalid htable key (set)')
@@ -661,7 +622,7 @@ contains
     logical :: valid
 
     this%n = this%n + 1
-    do while ((.not. this%t%t(this%n)%valid) .and. (this%n .lt. this%t%size))
+    do while ((.not. this%t%valid(this%n)) .and. (this%n .lt. this%t%size))
        this%n = this%n + 1
     end do
 
@@ -685,7 +646,7 @@ contains
     class(*), intent(inout) :: data !< Data to retrieve
     class(*), pointer :: hdp
 
-    hdp => this%t%t(this%n)%data
+    hdp => this%t%data(this%n)
     select type(hdp)
     type is (integer)
        select type (data)
@@ -824,7 +785,7 @@ contains
     class(htable_iter_i4_t), target, intent(inout) :: this
     integer, pointer :: value
 
-    select type (hdp => this%t%t(this%n)%data)
+    select type (hdp => this%t%data(this%n))
     type is (integer)
        value => hdp
     class default
@@ -838,7 +799,7 @@ contains
     class(htable_iter_i4_t), target, intent(inout) :: this
     integer, pointer :: key
 
-    select type (kp => this%t%t(this%n)%key)
+    select type (kp => this%t%key(this%n))
     type is (integer)
        key => kp
     class default
@@ -948,7 +909,7 @@ contains
     integer(kind=i8), pointer :: value
 
 
-    select type (hdp => this%t%t(this%n)%data)
+    select type (hdp => this%t%data(this%n))
     type is (integer(i8))
        value => hdp
     class default
@@ -967,7 +928,7 @@ contains
     ! (>11.0.x) when using high opt. levels.
     select type(hti => this)
     type is(htable_iter_i8_t)
-       select type (kp => hti%t%t(this%n)%key)
+       select type (kp => hti%t%key(this%n))
        type is (integer(i8))
           key => kp
        class default
@@ -1064,7 +1025,7 @@ contains
     class(htable_iter_r8_t), target, intent(inout) :: this
     real(kind=dp), pointer :: value
 
-    select type (hdp => this%t%t(this%n)%data)
+    select type (hdp => this%t%data(this%n))
     type is (double precision)
        value => hdp
     class default
@@ -1078,7 +1039,7 @@ contains
     class(htable_iter_r8_t), target, intent(inout) :: this
     real(kind=dp), pointer :: key
 
-    select type (kp => this%t%t(this%n)%key)
+    select type (kp => this%t%key(this%n))
     type is (double precision)
        key => kp
     class default
@@ -1195,7 +1156,7 @@ contains
     class(htable_iter_pt_t), target, intent(inout) :: this
     type(point_t), pointer :: value
 
-    select type (hdp => this%t%t(this%n)%data)
+    select type (hdp => this%t%data(this%n))
     type is (point_t)
        value => hdp
     class default
@@ -1209,7 +1170,7 @@ contains
     class(htable_iter_pt_t), target, intent(inout) :: this
     type(point_t), pointer :: key
 
-    select type (kp => this%t%t(this%n)%key)
+    select type (kp => this%t%key(this%n))
     type is (point_t)
        key => kp
     class default
@@ -1324,7 +1285,7 @@ contains
     class(htable_iter_i4t2_t), intent(inout) :: this
     type(tuple_i4_t), pointer :: value
 
-    select type (hdp => this%t%t(this%n)%data)
+    select type (hdp => this%t%data(this%n))
     type is (tuple_i4_t)
        value => hdp
     class default
@@ -1338,7 +1299,7 @@ contains
     class(htable_iter_i4t2_t), intent(inout) :: this
     type(tuple_i4_t), pointer :: key
 
-    select type (kp => this%t%t(this%n)%key)
+    select type (kp => this%t%key(this%n))
     type is (tuple_i4_t)
        key => kp
     class default
@@ -1453,7 +1414,7 @@ contains
     class(htable_iter_i4t4_t), target, intent(inout) :: this
     type(tuple4_i4_t), pointer :: value
 
-    select type (hdp => this%t%t(this%n)%data)
+    select type (hdp => this%t%data(this%n))
     type is (tuple4_i4_t)
        value => hdp
     class default
@@ -1472,7 +1433,7 @@ contains
     ! (>11.0.x) when using high opt. levels.
     select type(hti => this)
     type is(htable_iter_i4t4_t)
-       select type (kp => hti%t%t(this%n)%key)
+       select type (kp => hti%t%key(this%n))
        type is (tuple4_i4_t)
           key => kp
        class default
@@ -1572,7 +1533,7 @@ contains
     class(*), pointer :: hdp
     type(h_cptr_t), pointer :: value
 
-    hdp => this%t%t(this%n)%data
+    hdp => this%t%data(this%n)
     select type (hdp)
     type is (h_cptr_t)
        value => hdp
@@ -1588,7 +1549,7 @@ contains
     class(*), pointer :: kp
     type(h_cptr_t), pointer :: key
 
-    kp => this%t%t(this%n)%key
+    kp => this%t%key(this%n)
     select type (kp)
     type is (h_cptr_t)
        key => kp


### PR DESCRIPTION
This pr changes the hash table data structure to use SoA instead of AoS. This refactoring significantly improves the hash table performance on A64FX, and also reduces potentially select type constructs during rebuild (and free) for certain, less competent compilers.

**Tested compilers**
- [ ] Cray (CCE 18)
- [ ] Cray (CCE 19)
- [ ] Cray (CCE 20)
- [x] NAG
- [ ] Intel (ifx)
- [x] GNU
- [ ] Fujitsu
- [ ] Flang
