### PR TITLE
Fix: Support appending to an empty field list

### DIFF
--- a/src/field/field_list.f90
+++ b/src/field/field_list.f90
@@ -117,6 +117,12 @@ contains
     type(field_ptr_t), allocatable :: tmp(:)
     integer :: len
 
+    if (.not. allocated(this%items)) then
+       allocate(this%items(1))
+       call this%items(1)%init(f)
+       return
+    end if
+
     len = size(this%items)
 
     allocate(tmp(len+1))


### PR DESCRIPTION
Allow appending to a field list even when it is initially empty by allocating the items array when necessary.