### PR TITLE
Fix dimensions of inputs for tensor operators

### DIFF
--- a/src/global_interpolation/legendre_rst_finder.f90
+++ b/src/global_interpolation/legendre_rst_finder.f90
@@ -236,12 +236,12 @@ contains
     real(kind=rp), intent(inout) :: resy(n_pts)
     real(kind=rp), intent(inout) :: resz(n_pts)
     integer, intent(in) :: el_list(n_pts)
-    real(kind=rp) :: r_legendre(this%Xh%lx)
-    real(kind=rp) :: s_legendre(this%Xh%lx)
-    real(kind=rp) :: t_legendre(this%Xh%lx)
-    real(kind=rp) :: dr_legendre(this%Xh%lx)
-    real(kind=rp) :: ds_legendre(this%Xh%lx)
-    real(kind=rp) :: dt_legendre(this%Xh%lx)
+    real(kind=rp) :: r_legendre(1, this%Xh%lx)
+    real(kind=rp) :: s_legendre(this%Xh%lx, 1)
+    real(kind=rp) :: t_legendre(this%Xh%lx, 1)
+    real(kind=rp) :: dr_legendre(1, this%Xh%lx)
+    real(kind=rp) :: ds_legendre(this%Xh%lx, 1)
+    real(kind=rp) :: dt_legendre(this%Xh%lx, 1)
     real(kind=rp) :: jac(3,3)
     real(kind=xp) :: rst_d(3), jacinv(3,3)
     integer :: conv_pts
@@ -262,34 +262,34 @@ contains
        do while (.not. converged)
           iter = iter + 1
           ! Compute legendre polynomials in this rst coordinate
-          r_legendre(1) = 1.0
-          r_legendre(2) = rst(1,i)
-          s_legendre(1) = 1.0
-          s_legendre(2) = rst(2,i)
-          t_legendre(1) = 1.0
-          t_legendre(2) = rst(3,i)
-          dr_legendre(1) = 0.0
-          dr_legendre(2) = 1.0
-          ds_legendre(1) = 0.0
-          ds_legendre(2) = 1.0
-          dt_legendre(1) = 0.0
-          dt_legendre(2) = 1.0
+          r_legendre(1, 1) = 1.0
+          r_legendre(1, 2) = rst(1,i)
+          s_legendre(1, 1) = 1.0
+          s_legendre(2, 1) = rst(2,i)
+          t_legendre(1, 1) = 1.0
+          t_legendre(2, 1) = rst(3,i)
+          dr_legendre(1, 1) = 0.0
+          dr_legendre(1, 2) = 1.0
+          ds_legendre(1, 1) = 0.0
+          ds_legendre(2, 1) = 1.0
+          dt_legendre(1, 1) = 0.0
+          dt_legendre(2, 1) = 1.0
           do j = 2, lx-1
-             r_legendre(j+1) = ((2.0_xp*(j-1.0_xp)+1.0_xp) * rst(1,i) &
-                  * r_legendre(j) - (j-1.0_xp) &
-                  * r_legendre(j-1)) / (real(j,xp))
-             s_legendre(j+1) = ((2.0_xp*(j-1.0_xp)+1.0_xp) * rst(2,i) &
-                  * s_legendre(j) - (j-1.0_xp) &
-                  * s_legendre(j-1))/(real(j,xp))
-             t_legendre(j+1) = ((2.0_xp*(j-1.0_xp)+1.0_xp) * rst(3,i) &
-                  * t_legendre(j) - (j-1.0_xp) &
-                  * t_legendre(j-1))/(real(j,xp))
-             dr_legendre(j+1) = ((j-1.0_xp)+1.0_xp) * r_legendre(j) &
-                  + rst(1,i)*dr_legendre(j)
-             ds_legendre(j+1) = ((j-1.0_xp)+1.0_xp) * s_legendre(j) &
-                  + rst(2,i)*ds_legendre(j)
-             dt_legendre(j+1) = ((j-1.0_xp)+1.0_xp) * t_legendre(j) &
-                  + rst(3,i)*dt_legendre(j)
+             r_legendre(1, j+1) = ((2.0_xp*(j-1.0_xp)+1.0_xp) * rst(1,i) &
+                  * r_legendre(1, j) - (j-1.0_xp) &
+                  * r_legendre(1, j-1)) / (real(j,xp))
+             s_legendre(j+1, 1) = ((2.0_xp*(j-1.0_xp)+1.0_xp) * rst(2,i) &
+                  * s_legendre(j, 1) - (j-1.0_xp) &
+                  * s_legendre(j-1, 1))/(real(j,xp))
+             t_legendre(j+1, 1) = ((2.0_xp*(j-1.0_xp)+1.0_xp) * rst(3,i) &
+                  * t_legendre(j, 1) - (j-1.0_xp) &
+                  * t_legendre(j-1, 1))/(real(j,xp))
+             dr_legendre(1, j+1) = ((j-1.0_xp)+1.0_xp) * r_legendre(1, j) &
+                  + rst(1,i)*dr_legendre(1, j)
+             ds_legendre(j+1, 1) = ((j-1.0_xp)+1.0_xp) * s_legendre(j, 1) &
+                  + rst(2,i)*ds_legendre(j, 1)
+             dt_legendre(j+1, 1) = ((j-1.0_xp)+1.0_xp) * t_legendre(j, 1) &
+                  + rst(3,i)*dt_legendre(j, 1)
           end do
           e = (el_list(i))*this%Xh%lxyz + 1
           ! Compute the current xyz value

--- a/src/global_interpolation/legendre_rst_finder.f90
+++ b/src/global_interpolation/legendre_rst_finder.f90
@@ -302,9 +302,9 @@ contains
           ! This should in principle be merged into some larger kernel
           ! Compute the jacobian
           call tnsr3d_el_cpu(jac(1,1), 1, this%x_hat%x(e), lx, &
-               dr_legendre, s_legendre(1), t_legendre)
+               dr_legendre, s_legendre, t_legendre)
           call tnsr3d_el_cpu(jac(1,2), 1, this%y_hat%x(e), lx, &
-               dr_legendre, s_legendre(1), t_legendre)
+               dr_legendre, s_legendre, t_legendre)
           call tnsr3d_el_cpu(jac(1,3), 1, this%z_hat%x(e), lx, &
                dr_legendre, s_legendre, t_legendre)
           call tnsr3d_el_cpu(jac(2,1), 1, this%x_hat%x(e), lx, &


### PR DESCRIPTION
Adjust the dimensions of input arrays in the tensor operator functions to ensure proper variable extent.