### PR TITLE
Fix unsafe nullify of pointers

### DIFF
--- a/src/adt/htable.f90
+++ b/src/adt/htable.f90
@@ -277,6 +277,9 @@ contains
     class(htable_t), intent(inout) :: this
     integer i
 
+    nullify(this%head)
+    nullify(this%tail)
+
     if (allocated(this%t)) then
        do i = 0, this%size !< @todo check range
           deallocate(this%t(i)%key)
@@ -284,9 +287,6 @@ contains
        end do
        deallocate(this%t)
     end if
-
-    nullify(this%head)
-    nullify(this%tail)
 
     this%size = 0
     this%entries = 0

--- a/src/adt/htable.f90
+++ b/src/adt/htable.f90
@@ -275,7 +275,7 @@ contains
   !> Destroy a hash table
   subroutine htable_free(this)
     class(htable_t), intent(inout) :: this
-    integer i
+    integer :: i
 
     nullify(this%head)
     nullify(this%tail)


### PR DESCRIPTION
This fixes observed issues (SEGV) when deallocating a hash table.


