### PR TITLE
Tiny correction to avoid diverging AMR from current develop

### DIFF
--- a/src/bc/bc.f90
+++ b/src/bc/bc.f90
@@ -576,16 +576,18 @@ contains
     end if
 
     if (.not. allocated(this%name)) then
-       this%name = ""
+! gives plenty of empty info lines during AMR restart
+!       this%name = ""
     else
        write(log_buf, '(A,A)') 'BC assigned name :   ', trim(this%name)
        call neko_log%message(log_buf)
     end if
 
-    if (.not. allocated(this%zone_indices)) then
-       allocate(this%zone_indices(1))
-       this%zone_indices(1) = -1
-    end if
+! causes trouble for AMR restart
+!    if (.not. allocated(this%zone_indices)) then
+!       allocate(this%zone_indices(1))
+!       this%zone_indices(1) = -1
+!    end if
 
   end subroutine bc_finalize_base
 


### PR DESCRIPTION
Just commenting a few lines of "default" values for not mesh initialised bc.