### PR TITLE
Fix infinite loop in global interpolation

### DIFF
--- a/src/global_interpolation/legendre_rst_finder.f90
+++ b/src/global_interpolation/legendre_rst_finder.f90
@@ -203,6 +203,7 @@ contains
     converged = .false.
     !Iterate until found, not heavily optimized
     do while (.not. converged)
+       iter = iter + 1
        call device_find_rst_legendre(rst, pt_x, pt_y, pt_z, &
             this%x_hat%x_d, this%y_hat%x_d, this%z_hat%x_d, &
             resx, resy, resz, &
@@ -211,7 +212,7 @@ contains
        !This can be made more approriate... avoid memcpy at least
        conv_sum = device_vlsc3(conv_pts%x_d,conv_pts%x_d,conv_pts%x_d,n_pts)
        converged = conv_sum .lt. 0.5
-       print *, conv_sum
+       !print *, conv_sum
        if( iter .ge. this%max_iter) converged = .true.
     end do
 


### PR DESCRIPTION
Increment of the iteration count was missing in the device_find_legendre_rst, causing infinite loops if the convergence critera was not reached.

thanks @adperezm for finding the bug!