### PR TITLE
Add AGENTS.md for docs, and a doc review agent

### DIFF
--- a/.github/agents/shakespear.agent.md
+++ b/.github/agents/shakespear.agent.md
@@ -1,0 +1,29 @@
+---
+name: shakespear
+description: Reviews pull requests for documentation quality and consistency only.
+target: github-copilot
+---
+
+You are a documentation review specialist for the Neko repository.
+
+Your scope is strictly documentation:
+- Markdown files (`*.md`), including README files and `CHANGELOG.md`.
+- Documentation under `doc/`.
+- Doxygen docstrings in new Fortran source code.
+
+Do not review implementation correctness, performance, or architecture unless a
+change directly affects documentation completeness.
+
+Use `doc/AGENTS.md` as the source of truth for documentation
+review criteria, scope, and style requirements. In particular, go through the
+"Reviewing documentation" section of that file and apply the listed checks.
+
+Do not provide a summary, make a list of issues, with suggested fixed, when 
+available.
+In a github PR review, you would typically comment directly on the relevant 
+lines of the diff.
+
+If no documentation changes are present, respond with a brief note and no 
+further comments.
+
+

--- a/.github/agents/shakespeare.agent.md
+++ b/.github/agents/shakespeare.agent.md
@@ -1,5 +1,5 @@
 ---
-name: shakespear
+name: shakespeare
 description: Reviews pull requests for documentation quality and consistency only.
 target: github-copilot
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,20 @@
 # Neko guide for AI agents
 
-# What is Neko?
+## What is Neko?
 Neko is computational fluid dynamics (CFD) software based on the Spectral
 Element Method. It primarily targets high-fidelity scale-resolving simulations
 of turbulent flows.
 
-## Helping users setup new Neko simulation cases
+## High-level repository structure
+- `src`, the majority of the source code.
+- `doc`, the Doxygen documentation, with additional pages in markdown format.
+- `examples`, curated collection of simulation cases, and user files, showcasing
+  capabilities.
+- `tests`, unit, integration, and system tests, see "writing tests for Neko"
+  below.
+- `contrib`, misc scripts and utilities for working with Neko.
+
+## Helping users set up new Neko simulation cases
 Neko is simulation software, and a common scenario is that the user will ask
 you to help set up a simulation. Alternatively, they may want tips about specific
 settings or an explanation about a setup they find in an existing case. The
@@ -14,7 +23,7 @@ refer to a concrete simulation as "the case".
 
 ### General guidelines
 Below are the main guidelines you should follow for retrieving information and
-making decisions about how to setup a case.
+making decisions about how to set up a case.
 
 - A simulation case typically lives in its own separate folder, which we will call
   the case folder.
@@ -98,7 +107,7 @@ making decisions about how to setup a case.
     [pFUnit](https://github.com/Goddard-Fortran-Ecosystem/pFUnit). These are run
     by CI for every PR.
   - The folder `tests/integration` contains tests written with pytest. Here,
-    python and pytest are used to setup neko cases, run neko and makeneko as
+    python and pytest are used to set up Neko cases, run `neko` and `makeneko` as
     subprocesses and then post-process the results. These are run by CI for
     every PR.
 - The folder `tests/reframe` contains nightly tests that are run on a
@@ -118,7 +127,7 @@ making decisions about how to setup a case.
 - Make sure you understand how to add the test to the build system, that is
   somewhat tedious. Study `doc/pages/developer-guide/testing.md` carefully to
   that end.
- - File/module naming: pFUnit generates a driver that calls
+- File/module naming: pFUnit generates a driver that calls
    <pf_basename>_suite(), where <pf_basename> is the .pf filename without
    extension. For a smooth link:
    - Keep the module name inside each .pf file identical to the file’s basename
@@ -160,13 +169,6 @@ code. Here is the list of things you need to check.
     similar), the constructor must begin with calling the destructor.
   - All procedures, including type-bound, must have Doxygen documentation,
     including @param for each dummy argument.
-- For *all* files changed in the PR / branch.
-  - Check for typos in the English in the documentation and the docstrings.
-  - Check the copyright statement in the header at the top of the Fortran files,
-    make sure it is the correct year(s).
-  - If the new code adds or modifies JSON parameters in the case file, this must
-    be documented in the User Guide. You can detect that by seeing lines that
-    use subroutines from the `json_utils` module, or directly using the
-    `json_file` type-bound procedures.
-- If CHANGELOG.md is not changed, and the PR at least seems to introduce
-  meaningful changes, issue a reminder.
+- By default, you should also review documentation. The rules for that are
+  found under `doc/AGENTS.md`. If explicitly asked to skip this, follow that
+  directive.

--- a/doc/AGENTS.md
+++ b/doc/AGENTS.md
@@ -1,0 +1,62 @@
+# Neko documentation guide for AI agents
+
+## Overview
+
+Neko's documentation consists of the following:
+
+- A repo-level README.md file.
+- README.md files inside individual folders in `examples` that document the
+  example provided.
+- AGENTS.md files, written for LLM-based agents, but potentially useful for a
+  human reader.
+- A CHANGELOG.md, which accumulates changes introduced in PRs.
+- Docstrings for modules, types and procedures inside the source code, written
+  in Doxygen style.
+- Markdown pages located under `doc/pages`, comprising the user and developer
+  guides, appendices, etc.
+
+Doxygen is used to produce HTML pages combining the automatically parsed
+docstrings and all the manually written pages, see `doc/Doxyfile.in`.
+
+## Rules
+
+- All documentation is written in British English.
+- In source code, docstrings should respect the max line length of 80 columns.
+  In markdown, this should be respected whenever possible, but exceptions are
+  allowed, for example for large tables.
+- In markdown files, section headers should contain a tag so that they can be
+  referenced, for example, `{#user-file}`. AGENTS.md files are exempt from this
+  rule.
+- Whenever applicable, one should use a relevant link when referencing a section
+  or type. For example, "see the [examples](@ref programming-examples) section".
+- The same applies for types, for example `[space_t](#space::space_t)`.
+- Shell commands, paths, and similar things should be written in `monospace`.
+
+## Reviewing documentation
+
+If you are asked to review documentation in a PR or for new code, you should
+do the following.
+
+- Make sure the documentation follows the rules above.
+- Check for typos.
+- Check for grammatical or syntactical mistakes.
+- Check that each new procedure, type, and module has a docstring.
+  - For procedures, each dummy argument should be documented with a @param
+    annotation.
+  - For types, the bare minimum is a docstring above the type declaration.
+    Ideally, each procedure declaration inside the type should have a docstring
+    matching the first sentence of the procedure's docstring at its
+    implementation. Ideally, each component of the type should be documented.
+    Sometimes a group of components can be documented by one docstring when it
+    makes logical sense.
+  - If you feel very confident, you can try to provide a suggestion for the
+    docstrings. If you are unsure, just point out that they are missing.
+- Check whether the new source code introduces new parameters for the Neko case
+  file, or changes the behaviour or presence of existing ones. This is typically
+  done with subroutines from the `json_utils` module or directly with the
+  capabilities of `json_fortran`. If so, make sure that new parameters or the
+  identified changes are documented. Make sure that the documentation follows
+  what is actually implemented in the source.
+- Make sure that the CHANGELOG.md is relevantly updated.
+- Check that the copyright statement in the header of the source files is
+  correctly updated to include the year of the reviewed contribution.


### PR DESCRIPTION
Introduces a new documentation review agent and adds AGENTS.md for `doc`. My thinking is that we can ramp up LLM reviews, starting with documentation only. Maybe later on we can get rid of the specialized agent.

Change list:
* Added `.github/agents/shakespeare.agent.md` to define a new agent focused solely on reviewing documentation quality and consistency in pull requests. The agent uses `doc/AGENTS.md` as the source of truth for review criteria and scope.
* Added `doc/AGENTS.md` to provide a guide for documentation standards.
* Updated documentation review instructions in `AGENTS.md` to refer to `doc/AGENTS.md`.
* Expanded the repository structure section in `AGENTS.md` to describe the purpose of major folders (`src`, `doc`, `examples`, `tests`, `contrib`).