### PR TITLE
Add Python, pFUnit and real precision to pixi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Develop
 
-- Improved pixi installation. Added support to create a python environment
+- Improved pixi installation. Added support to create a Python environment
   inside the pixi shell. Added support to choose real precision.
 - Add Deardorff SGS model.
 - Add the optional `expected_size` argument to `json_get_*_array` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Develop
 
+- Improved pixi installation. Added support to create a python environment
+  inside the pixi shell. Added support to choose real precision.
 - Add Deardorff SGS model.
 - Add the optional `expected_size` argument to `json_get_*_array` 
   to throw an error if the parsed array size is incorrect.

--- a/doc/pages/developer-guide/testing.md
+++ b/doc/pages/developer-guide/testing.md
@@ -22,6 +22,8 @@ where again you need to provide the path
 ```
 Make sure that in the output you see it says `pFUnit ... yes` at some point.
 
+Additionally, pFUnit requires a Python interpreter to work.
+
 ## Running the tests
 To run the tests you should execute
 ```bash

--- a/doc/pages/user-guide/installation.md
+++ b/doc/pages/user-guide/installation.md
@@ -89,7 +89,7 @@ $ cd metis && make config prefix=${PARMETIS_INSTALL} && make install && cd ../..
 
 To build the PFunit testing framework, please refers to the \subpage testing page
 
-#### Python
+#### Python (optional) {#deps-python}
 Neko itself does not depend on Python, however, it is necessary for the following:
 
 - Running unit tests; only depends on an interpreter.
@@ -98,9 +98,9 @@ Neko itself does not depend on Python, however, it is necessary for the followin
   and `flinter==0.4.0`.
 - Running Python post-processing scripts for selected examples. A dependency of
   note is [`pySEMtools`](https://github.com/ExtremeFLOW/pySEMTools), which is
-  the package we recommend for post-processing Neko simulation result.
+  the package we recommend for post-processing Neko simulation results.
 
-### Building Neko
+### Building Neko {#building-neko}
 Neko uses autotools as its build system. The first step is to run the `configure` script, located in the top directory.
 
 ``` shell
@@ -237,7 +237,7 @@ pixi run install-neko-cpu
 ```
 
 This will give you a double-precision CPU build charged with optional
-dependencies: hdf5, pFunit, and parmetis. You can, however choose the precision
+dependencies: HDF5, pFUnit, and ParMETIS. You can, however choose the precision
 of reals, by appending either `sp` or `dp` to the command above. Only CPU builds
 are currently supported with pixi.
 
@@ -266,9 +266,9 @@ Running
 ```bash
 pixi shell -e python
 ```
-will drop into a shell, which in addition to Neko has Python interpreter with
-`pytest`, `findent`, and `flinter` installed. Additional packages can be
-insalled manually.
+will drop into a shell, which, in addition to Neko, has a Python interpreter
+with `pytest`, `findent`, and `flinter` installed. Additional packages can be
+installed manually.
 
 
 ## Using a Docker container

--- a/doc/pages/user-guide/installation.md
+++ b/doc/pages/user-guide/installation.md
@@ -237,8 +237,9 @@ pixi run install-neko-cpu
 ```
 
 This will give you a double-precision CPU build charged with optional
-dependencies: hdf5, pFunit, and parmetis. For now, this is the only
-configuration that can be installed automatically with pixi.
+dependencies: hdf5, pFunit, and parmetis. You can, however choose the precision
+of reals, by appending either `sp` or `dp` to the command above. Only CPU builds
+are currently supported with pixi.
 
 To use Neko, you need to drop into a shell, where the pixi environment will be
 activated. For that run

--- a/doc/pages/user-guide/installation.md
+++ b/doc/pages/user-guide/installation.md
@@ -89,6 +89,17 @@ $ cd metis && make config prefix=${PARMETIS_INSTALL} && make install && cd ../..
 
 To build the PFunit testing framework, please refers to the \subpage testing page
 
+#### Python
+Neko itself does not depend on Python, however, it is necessary for the following:
+
+- Running unit tests; only depends on an interpreter.
+- Running integration tests; requires `pytest`.
+- Using the `lint.sh` and `format.sh` tools under `contrib`; requires `findent`
+  and `flinter==0.4.0`.
+- Running Python post-processing scripts for selected examples. A dependency of
+  note is [`pySEMtools`](https://github.com/ExtremeFLOW/pySEMTools), which is
+  the package we recommend for post-processing Neko simulation result.
+
 ### Building Neko
 Neko uses autotools as its build system. The first step is to run the `configure` script, located in the top directory.
 
@@ -225,9 +236,9 @@ and run the following command inside it
 pixi run install-neko-cpu
 ```
 
-This will give you a double-precision CPU build charged with all optional
-dependencies: hdf5, and parmetis. For now, this is the only configuration
-that can be installed automatically with pixi.
+This will give you a double-precision CPU build charged with optional
+dependencies: hdf5, pFunit, and parmetis. For now, this is the only
+configuration that can be installed automatically with pixi.
 
 To use Neko, you need to drop into a shell, where the pixi environment will be
 activated. For that run
@@ -244,6 +255,19 @@ The installed executables, libraries, etc. are all located inside the `install` 
 Note that you can use this pixi environment as you like, including manually
 `configuring` and building Neko (as per instructions for building from source),
 for example, with single precision reals or even with a different backend.
+
+Pixi also provides the option to create a Python environment, which is just an
+ordinary `conda` environment underneath. This can be convenient because Neko's
+unit and integration tests, some post-processing in examples, and developer
+tools like `flinter` require Python.
+
+Running
+```bash
+pixi shell -e python
+```
+will drop into a shell, which in addition to Neko has Python interpreter with
+`pytest`, `findent`, and `flinter` installed. Additional packages can be
+insalled manually.
 
 
 ## Using a Docker container

--- a/pixi.toml
+++ b/pixi.toml
@@ -3,7 +3,7 @@ authors = ["Neko authors"]
 channels = ["conda-forge"]
 name = "neko"
 platforms = ["osx-arm64", "osx-64", "linux-64"]
-version = "0.9.0"
+version = "1.0.x"
 
 [activation.env]
 PREFIX = "$PWD/install"
@@ -101,4 +101,16 @@ pkg-config = "*"
 wget = "*"
 blas = "*"
 lapack = "*"
+
+[feature.python.dependencies]
+python = "3.14.*"
+pytest = "*"
+findent = "*"
+
+[feature.python.pypi-dependencies]
+flinter = "==0.4.0"
+
+[environments]
+default = []
+python = ["python"]
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -13,8 +13,8 @@ LD_LIBRARY_PATH = "$PREFIX/lib:$LD_LIBRARY_PATH"
 LIBRARY_PATH = "$PREFIX/lib:$LIBRARY_PATH"
 CPATH = "$PREFIX/include:$CPATH"
 
-[tasks]
-download-deps = { cmd = [
+[tasks.download-deps]
+cmd = [
   "sh",
   "-c",
   '''
@@ -23,20 +23,22 @@ download-deps = { cmd = [
   git clone https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git -b v4.4.2
   git clone https://github.com/Nek5000/gslib.git gslib
   wget https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_1.14.6.tar.gz
-  '''
-]}
+  ''',
+]
 
-build-gslib = { cmd = [
+[tasks.build-gslib]
+cmd = [
   "sh",
   "-c",
   '''
-  cd $PREFIX/deps/gslib 
-  make CC=mpicc DESTDIR=$PREFIX 
+  cd $PREFIX/deps/gslib
+  make CC=mpicc DESTDIR=$PREFIX
   make install
-  '''
-  ]}
+  ''',
+]
 
-build-pfunit = { cmd = [
+[tasks.build-pfunit]
+cmd = [
   "sh",
   "-c",
   '''
@@ -45,11 +47,13 @@ build-pfunit = { cmd = [
   cd b
   cmake -DCMAKE_INSTALL_PREFIX=$PREFIX ..
   make -j install
-  '''
-  ]}
+  ''',
+]
 
-build-hdf5 = { cmd = [
-  "bash", "-c",
+[tasks.build-hdf5]
+cmd = [
+  "bash",
+  "-c",
   '''
   cd $PREFIX/deps
   tar xvf hdf5_1.14.6.tar.gz
@@ -57,24 +61,33 @@ build-hdf5 = { cmd = [
   cmake -B build -S . -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_Fortran_COMPILER=mpifort -DHDF5_ENABLE_PARALLEL=ON -DHDF5_BUILD_FORTRAN=ON -DCMAKE_BUILD_TYPE=Release
   cmake --build build/ --parallel
   cmake --install build/
-  '''
-  ]}
+  ''',
+]
 
-build-neko-cpu = { cmd = [
+[tasks.build-neko-cpu]
+args = [{ arg = "real_precision", default = "dp" }]
+cmd = [
   "bash",
   "-c",
   '''
   set -e
+  case "{{ real_precision }}" in
+    sp|dp) ;;
+    *) echo "Unsupported real precision: {{ real_precision }}"; exit 1 ;;
+  esac
+
   ./regen.sh
-  ./configure FCFLAGS="-O3 " --prefix=$PREFIX --with-hdf5=$PREFIX --with-parmetis=$PREFIX --with-pfunit=$PREFIX/PFUNIT-4.4
+  ./configure FCFLAGS="-O3" --enable-real={{ real_precision }} --prefix=$PREFIX --with-hdf5=$PREFIX --with-parmetis=$PREFIX --with-pfunit=$PREFIX/PFUNIT-4.4
   grep hdf5 config.log
   grep parmetis config.log
   grep pfunit config.log
   make -j install
-  '''
-  ]}
+  ''',
+]
 
-install-neko-cpu = { cmd = [
+[tasks.install-neko-cpu]
+args = [{ arg = "real_precision", default = "dp" }]
+cmd = [
   "bash",
   "-c",
   '''
@@ -82,18 +95,17 @@ install-neko-cpu = { cmd = [
   pixi run download-deps
   pixi run build-pfunit
   pixi run build-hdf5
-  pixi run build-neko-cpu
-
-  '''
-  ]}
+  pixi run build-neko-cpu {{ real_precision }}
+  ''',
+]
 
 [dependencies]
 gfortran = "14.*"
 openmpi = "5.*"
 cmake = "3.*"
-json-fortran  = "*"
-parmetis  = "4.0.3.*"
-metis  = "5.1.0.*"
+json-fortran = "*"
+parmetis = "4.0.3.*"
+metis = "5.1.0.*"
 libtool = "*"
 autoconf = "*"
 automake = "*"
@@ -113,4 +125,3 @@ flinter = "==0.4.0"
 [environments]
 default = []
 python = ["python"]
-

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,6 +20,7 @@ download-deps = { cmd = [
   '''
   mkdir -p $PREFIX/deps && cd $PREFIX/deps
   rm -rf *
+  git clone https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git -b v4.4.2
   git clone https://github.com/Nek5000/gslib.git gslib
   wget https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_1.14.6.tar.gz
   '''
@@ -32,6 +33,18 @@ build-gslib = { cmd = [
   cd $PREFIX/deps/gslib 
   make CC=mpicc DESTDIR=$PREFIX 
   make install
+  '''
+  ]}
+
+build-pfunit = { cmd = [
+  "sh",
+  "-c",
+  '''
+  cd $PREFIX/deps/pFUnit
+  mkdir b
+  cd b
+  cmake -DCMAKE_INSTALL_PREFIX=$PREFIX ..
+  make -j install
   '''
   ]}
 
@@ -53,10 +66,10 @@ build-neko-cpu = { cmd = [
   '''
   set -e
   ./regen.sh
-  ./configure FCFLAGS="-O3" --prefix=$PREFIX --with-hdf5=$PREFIX --with-parmetis=$PREFIX --with-gslib=$PREFIX
+  ./configure FCFLAGS="-O3 " --prefix=$PREFIX --with-hdf5=$PREFIX --with-parmetis=$PREFIX --with-pfunit=$PREFIX/PFUNIT-4.4
   grep hdf5 config.log
   grep parmetis config.log
-  grep gslib config.log
+  grep pfunit config.log
   make -j install
   '''
   ]}
@@ -67,7 +80,7 @@ install-neko-cpu = { cmd = [
   '''
   set -e
   pixi run download-deps
-  pixi run build-gslib
+  pixi run build-pfunit
   pixi run build-hdf5
   pixi run build-neko-cpu
 


### PR DESCRIPTION
- Adds pFUnit to the pixi install.
- Sunsets gslib for pixi, but I leave a dormant task in case we want it to return.
- Adds support to choose real precision for the CPU install.
- Adds support to install a local python and minimal deps needed for testing, linting, and formtting.
- Updates the pixi install documentation accordingly.
- Documents Python deps in the installation guide.
- Mentions Python dep of pFUnit in the testing guide.