### PR TITLE
Memcpy pressure in set_flow_ic_common

### DIFF
--- a/src/fluid/flow_ic.f90
+++ b/src/fluid/flow_ic.f90
@@ -435,11 +435,10 @@ contains
 
     ! If we are on GPU we need to move (u,v,w) back to the host
     ! since set_flow_ic_common copies it again to the device.
-    ! NOTE: p can stay on the device since it is not copied by
-    ! set_flow_ic_common
-    call u%copy_from(device_to_host, .false.)
-    call v%copy_from(device_to_host, .false.)
-    call w%copy_from(device_to_host, .true.)
+    call u%copy_from(device_to_host, sync = .false.)
+    call v%copy_from(device_to_host, sync = .false.)
+    call w%copy_from(device_to_host, sync = .false.)
+    call p%copy_from(device_to_host, sync = .true.)
 
   end subroutine set_flow_ic_fld
 

--- a/src/fluid/flow_ic.f90
+++ b/src/fluid/flow_ic.f90
@@ -433,7 +433,7 @@ contains
 
     nullify(us, vs, ws, ps)
 
-    ! If we are on GPU we need to move (u,v,w) back to the host
+    ! If we are on GPU we need to move (u,v,w) and p back to the host
     ! since set_flow_ic_common copies it again to the device.
     call u%copy_from(device_to_host, sync = .false.)
     call v%copy_from(device_to_host, sync = .false.)

--- a/src/fluid/flow_ic.f90
+++ b/src/fluid/flow_ic.f90
@@ -238,9 +238,9 @@ contains
        call u%copy_from(HOST_TO_DEVICE, sync = .false.)
        call v%copy_from(HOST_TO_DEVICE, sync = .false.)
        call w%copy_from(HOST_TO_DEVICE, sync = .false.)
-       
+
        ! also copy pressure for consistency
-       call p%copy_from(HOST_TO_DEVICE, sync = .true.) 
+       call p%copy_from(HOST_TO_DEVICE, sync = .true.)
     end if
 
     ! Ensure continuity across elements for initial conditions

--- a/src/fluid/flow_ic.f90
+++ b/src/fluid/flow_ic.f90
@@ -235,12 +235,12 @@ contains
     n = u%dof%size()
 
     if (NEKO_BCKND_DEVICE .eq. 1) then
-       call device_memcpy(u%x, u%x_d, n, &
-            HOST_TO_DEVICE, sync = .false.)
-       call device_memcpy(v%x, v%x_d, n, &
-            HOST_TO_DEVICE, sync = .false.)
-       call device_memcpy(w%x, w%x_d, n, &
-            HOST_TO_DEVICE, sync = .false.)
+       call u%copy_from(HOST_TO_DEVICE, sync = .false.)
+       call v%copy_from(HOST_TO_DEVICE, sync = .false.)
+       call w%copy_from(HOST_TO_DEVICE, sync = .false.)
+       
+       ! also copy pressure for consistency
+       call p%copy_from(HOST_TO_DEVICE, sync = .true.) 
     end if
 
     ! Ensure continuity across elements for initial conditions


### PR DESCRIPTION
I thought it was annoying that if I use user initial condition and set a pressure field, I have to memcpy the pressure but not the velocities. Also the [documentation of user initial condition](https://neko.cfd/docs/develop/d6/def/user-file.html#user-file_user-ic) is a bit misleading: 

> There is no need to add the transfer to GPU memory in this user routine, it will be done under the hood afterwards.

But apart from this, why aren't we doing the `gs%op` on the pressure? Clearly it is done in the compressible initial condition..