### PR TITLE
Vtkhdf/lagrange vtk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Develop
 
+- Added `Arbitrary Lagrange Cell` support for the VTKHDF output. This moves the
+  existing subdivision-based output to an optional setting under
+  `output_subdivide`. The default output will now be in the VTKHDF format with
+  `Arbitrary Lagrange Cell`s, which correctly represent our higher-order
+  elements. 
 - Added an AI policy to the contribution guidelines.
 - Added simple support for VTKHDF. For now it can be used for fluid outputs.
   Simple restarts are supported with fixed mesh and MPI configuration. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Added `Arbitrary Lagrange Cell` support for the VTKHDF output. This moves the
   existing subdivision-based output to an optional setting under
   `output_subdivide`. The default output will now be in the VTKHDF format with
-  `Arbitrary Lagrange Cell`s, which correctly represent our higher-order
+  `Arbitrary Lagrange Cells`, which correctly represent our higher-order
   elements. 
 - Bugfix: Fixed a bug in the `unmap` subroutine, where the device pointer was
   used to check if the field was mapped, which lead to a crash when trying to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 ## Develop
 
-- Added `Arbitrary Lagrange Cell` support for the VTKHDF output. This moves the
-  existing subdivision-based output to an optional setting under
-  `output_subdivide`. The default output will now be in the VTKHDF format with
-  `Arbitrary Lagrange Cells`, which correctly represent our higher-order
-  elements. 
+- Added `Arbitrary Lagrange Cell` support for VTK HDF output. This makes the
+  existing subdivision-based output optional under `output_subdivide`. By
+  default, output is now written in VTKHDF using `Arbitrary Lagrange Cells`,
+  which correctly represent higher-order elements.
 - Bugfix: Fixed a bug in the `unmap` subroutine, where the device pointer was
   used to check if the field was mapped, which lead to a crash when trying to
   unmap an array that was not associated with a device. Correctly does nothing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Develop
 
-- Added `Arbitrary Lagrange Cell` support for VTK HDF output. This makes the
-  existing subdivision-based output optional under `output_subdivide`. By
-  default, output is now written in VTKHDF using `Arbitrary Lagrange Cells`,
-  which correctly represent higher-order elements.
 - Added a script to add new unit tests under `contrib/add_unit_test`. The same
   script can add a .pf file to an existing suite.
 - Bugfix: Fixed a bug in the `unmap` subroutine, where the device pointer was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,12 @@
 
 ## Develop
 
-<<<<<<< vtkhdf/lagrange_vtk
 - Added `Arbitrary Lagrange Cell` support for VTK HDF output. This makes the
   existing subdivision-based output optional under `output_subdivide`. By
   default, output is now written in VTKHDF using `Arbitrary Lagrange Cells`,
   which correctly represent higher-order elements.
-=======
 - Added a script to add new unit tests under `contrib/add_unit_test`. The same
   script can add a .pf file to an existing suite.
->>>>>>> develop
 - Bugfix: Fixed a bug in the `unmap` subroutine, where the device pointer was
   used to check if the field was mapped, which lead to a crash when trying to
   unmap an array that was not associated with a device. Correctly does nothing

--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -78,7 +78,6 @@ but also defines several parameters that pertain to the simulation as a whole.
 | `output_format`       | The file format of field data.                                                                        | `nek5000`, `adios2`, or `vtkhdf`                | `nek5000`     |
 | `output_precision`    | Whether to output snapshots in single or double precision                                             | `single` or `double`                            | `single`      |
 | `output_layout`       | Data layout for `adios2` files. (Choose `2` or `3` for ADIOS2 supported compressors BigWhoop or ZFP.) | Positive integer `1`, `2`, `3`                  | `1`           |
-| `output_subdivide`    | Whether to subdivide spectral elements into linear sub-cells for VTKHDF output.                       | `true` or `false`                               | `false`       |
 | `load_balancing`      | Whether to apply load balancing.                                                                      | `true` or `false`                               | `false`       |
 | `output_partitions`   | Whether to write a `partitions.vtk` file with domain partitioning.                                    | `true` or `false`                               | `false`       |
 | `output_checkpoints`  | Whether to output checkpoints, i.e. restart files.                                                    | `true` or `false`                               | -             |
@@ -1202,6 +1201,7 @@ concisely directly in the table.
 | `output_value`                                     | The frequency of sampling in terms of `output_control`.                                           | Positive real or integer                                    | -             |
 | `output_mesh_in_all_files`                         | Indicates if the mesh should be written in every output fld file.                                 | `true` or `false`                                           | `false`       |
 | `output_filename`                                  | The output filename.                                                                              | String                                                      | `field`       |
+| `output_subdivide`                                 | Whether to subdivide spectral elements into linear sub-cells for VTKHDF output.                   | `true` or `false`                                           | `false`       |
 | `inflow_condition.type`                            | Velocity inflow condition type.                                                                   | `user`, `uniform`, `blasius`                                | -             |
 | `inflow_condition.value`                           | Value of the inflow velocity.                                                                     | Vector of 3 reals                                           | -             |
 | `initial_condition.type`                           | Initial condition type.                                                                           | `user`, `uniform`, `blasius`, `field`                       | -             |

--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -78,6 +78,7 @@ but also defines several parameters that pertain to the simulation as a whole.
 | `output_format`       | The file format of field data.                                                                        | `nek5000`, `adios2`, or `vtkhdf`                | `nek5000`     |
 | `output_precision`    | Whether to output snapshots in single or double precision                                             | `single` or `double`                            | `single`      |
 | `output_layout`       | Data layout for `adios2` files. (Choose `2` or `3` for ADIOS2 supported compressors BigWhoop or ZFP.) | Positive integer `1`, `2`, `3`                  | `1`           |
+| `output_subdivide`    | Whether to subdivide spectral elements into linear sub-cells for VTKHDF output.                       | `true` or `false`                               | `false`       |
 | `load_balancing`      | Whether to apply load balancing.                                                                      | `true` or `false`                               | `false`       |
 | `output_partitions`   | Whether to write a `partitions.vtk` file with domain partitioning.                                    | `true` or `false`                               | `false`       |
 | `output_checkpoints`  | Whether to output checkpoints, i.e. restart files.                                                    | `true` or `false`                               | -             |

--- a/doc/pages/user-guide/io.md
+++ b/doc/pages/user-guide/io.md
@@ -176,8 +176,10 @@ object of the case file:
 ```json
 {
   "case": {
-    "output_format": "vtkhdf",
-    "output_subdivide": true
+    "fluid": {
+      "output_format": "vtkhdf",
+      "output_subdivide": true
+    }
   }
 }
 ```

--- a/doc/pages/user-guide/io.md
+++ b/doc/pages/user-guide/io.md
@@ -70,7 +70,7 @@ Please refer to the documentation of ADIOS2 (and the specific compression
 library) to configure the data "operators" of the parallel I/O library.
 
 The tool `adios2_to_nek5000` can be used to decompress the field data for
-postprocessing and visualization with the conventional nek5000 format.
+postprocessing and visualisation with the conventional nek5000 format.
 Additionally, the data can be compressed using this tool as a postprocessing
 step using the `adios2.xml` configuration and a given uncompressed data set as
 input.
@@ -93,10 +93,10 @@ workflow to compare and find an optimal compression rate with an acceptable
 accuracy loss. The value of the PSNR decreases with increasing accuracy loss.
 Tune the compression by increasing the compression ratio until a desired lower
 limiting value for the PSNR is reached. As a rule of thumb, target values of 60
-or 40 can be used as lower limit for accurate postprocessing or visualization,
+or 40 can be used as lower limit for accurate postprocessing or visualisation,
 respectively.  Separately, it is recommended to check for compression errors
 from lossy compressors in the specific quantities of interest in postprocessing
-and visualization.
+and visualisation.
 
 ## Checkpoint files
 Simulations cannot be restarted from `.fld` files (although you can use an `fld`
@@ -169,7 +169,7 @@ Alternatively, spectral elements can be subdivided into linear sub-cells
 sub-cell vertex. This results in larger files but may offer broader
 compatibility with visualisation tools that have limited support for high-order
 Lagrange cells. This subdivision mimics more closely how tools like ParaView
-read the Nek5000 fld files, and may be necessary for visualizing the output.
+read the Nek5000 fld files, and may be necessary for visualising the output.
 Subdivision is enabled by setting `output_subdivide` to `true` in the `case`
 object of the case file:
 
@@ -184,8 +184,8 @@ object of the case file:
 
 ### Limitations {#vtkhdf-limitations}
 
-- High order Lagrange cells are not supported by all visualization tools. If you
-  encounter issues visualizing the output, try enabling subdivision into linear
+- High order Lagrange cells are not supported by all visualisation tools. If you
+  encounter issues visualising the output, try enabling subdivision into linear
   sub-cells as described above.
 - Reading `.vtkhdf` files back into Neko is not currently supported.
 - Adaptive mesh refinement (AMR) output is not yet implemented.

--- a/doc/pages/user-guide/io.md
+++ b/doc/pages/user-guide/io.md
@@ -157,10 +157,35 @@ top-level `VTKHDF` group with the following structure:
   of steps written, and offset arrays that allow ParaView to locate each time
   step's data within the concatenated datasets.
 
+### Cell representation {#vtkhdf-cell-representation}
+
+By default, each spectral element is written as a single high-order VTK
+Lagrange cell (`VTK_LAGRANGE_HEXAHEDRON` in 3D, `VTK_LAGRANGE_QUADRILATERAL`
+in 2D). This preserves the polynomial basis of the spectral element and
+produces compact output files.
+
+Alternatively, spectral elements can be subdivided into linear sub-cells
+(`VTK_HEXAHEDRON` in 3D, `VTK_QUAD` in 2D), writing one degree of freedom per
+sub-cell vertex. This results in larger files but may offer broader
+compatibility with visualisation tools that have limited support for high-order
+Lagrange cells. This subdivision mimics more closely how tools like ParaView
+read the Nek5000 fld files, and may be necessary for visualizing the output.
+Subdivision is enabled by setting `output_subdivide` to `true` in the `case`
+object of the case file:
+
+```json
+{
+  "case": {
+    "output_format": "vtkhdf",
+    "output_subdivide": true
+  }
+}
+```
+
 ### Limitations {#vtkhdf-limitations}
 
-- The VTKHDF writer performs a linear sub-division of spectral elements, writing
-  one degree of freedom per sub-cell vertex. The high-order polynomial
-  representation is not preserved in the output.
+- High order Lagrange cells are not supported by all visualization tools. If you
+  encounter issues visualizing the output, try enabling subdivision into linear
+  sub-cells as described above.
 - Reading `.vtkhdf` files back into Neko is not currently supported.
 - Adaptive mesh refinement (AMR) output is not yet implemented.

--- a/src/.depends
+++ b/src/.depends
@@ -6,6 +6,7 @@ io/format/nmsh.lo : io/format/nmsh.f90 config/num_types.lo
 io/format/re2.lo : io/format/re2.f90 config/num_types.lo 
 io/format/map.lo : io/format/map.f90 mesh/mesh.lo 
 io/format/stl.lo : io/format/stl.f90 config/num_types.lo 
+io/format/vtk.lo : io/format/vtk.f90 common/utils.lo 
 io/buffer/buffer.lo : io/buffer/buffer.F90 math/vector.lo config/num_types.lo 
 io/buffer/buffer_1d.lo : io/buffer/buffer_1d.F90 io/buffer/buffer.lo math/vector.lo config/num_types.lo 
 io/buffer/buffer_4d.lo : io/buffer/buffer_4d.F90 io/buffer/buffer.lo math/vector.lo config/num_types.lo 
@@ -146,7 +147,7 @@ io/nmsh_file.lo : io/nmsh_file.f90 common/log.lo comm/mpi_types.lo common/datadi
 io/chkp_file.lo : io/chkp_file.f90 comm/comm.lo common/log.lo global_interpolation/global_interpolation.lo comm/mpi_types.lo sem/interpolation.lo math/math.lo mesh/mesh.lo sem/space.lo common/utils.lo sem/dofmap.lo field/field.lo config/num_types.lo common/checkpoint.lo field/field_series.lo io/generic_file.lo 
 io/csv_file.lo : io/csv_file.f90 comm/comm.lo common/log.lo config/num_types.lo common/utils.lo io/generic_file.lo math/matrix.lo math/vector.lo 
 io/hdf5_file.lo : io/hdf5_file.F90 comm/comm.lo common/log.lo sem/dofmap.lo field/field_series.lo field/field_list.lo field/field.lo mesh/mesh.lo common/utils.lo common/checkpoint.lo io/generic_file.lo config/num_types.lo 
-io/vtkhdf_file.lo : io/vtkhdf_file.F90 device/device.lo comm/comm.lo common/log.lo sem/dofmap.lo field/field_series.lo field/field_list.lo field/field.lo mesh/mesh.lo common/utils.lo common/checkpoint.lo io/generic_file.lo config/num_types.lo 
+io/vtkhdf_file.lo : io/vtkhdf_file.F90 io/format/vtk.lo device/device.lo comm/comm.lo common/log.lo sem/dofmap.lo field/field_series.lo field/field_list.lo field/field.lo mesh/mesh.lo common/utils.lo common/checkpoint.lo io/generic_file.lo config/num_types.lo 
 io/file.lo : io/file.f90 io/hdf5_file.lo io/csv_file.lo io/stl_file.lo io/vtkhdf_file.lo io/vtk_file.lo io/fld_file_data.lo io/fld_file.lo io/bp_file.lo io/re2_file.lo io/rea_file.lo io/map_file.lo io/chkp_file.lo io/nmsh_file.lo io/generic_file.lo config/num_types.lo common/utils.lo 
 io/output.lo : io/output.f90 io/file.lo config/num_types.lo 
 io/fluid_output.lo : io/fluid_output.f90 io/fld_file.lo field/field.lo registries/registry.lo scalar/scalars.lo io/output.lo device/device.lo config/neko_config.lo field/field_list.lo scalar/scalar_scheme.lo fluid/fluid_scheme_base.lo fluid/fluid_scheme_compressible.lo fluid/fluid_scheme_incompressible.lo config/num_types.lo 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,6 +9,7 @@ neko_fortran_SOURCES = \
 	io/format/re2.f90\
 	io/format/map.f90\
 	io/format/stl.f90\
+	io/format/vtk.f90\
 	io/buffer/buffer.F90\
 	io/buffer/buffer_1d.F90\
 	io/buffer/buffer_4d.F90\

--- a/src/case.f90
+++ b/src/case.f90
@@ -512,6 +512,10 @@ contains
             always_write_mesh = logical_val)
     end if
 
+    call json_get_or_default(this%params, &
+         'case.fluid.output_lagrange', logical_val, .false.)
+    if (logical_val) call this%f_out%file_%set_lagrange(.true.)
+
     call json_get(this%params, 'case.fluid.output_control', string_val)
 
     if (trim(string_val) .eq. 'org') then

--- a/src/case.f90
+++ b/src/case.f90
@@ -512,7 +512,7 @@ contains
             always_write_mesh = logical_val)
     end if
 
-    call json_get_or_default(this%params, 'case.output_subdivide', &
+    call json_get_or_default(this%params, 'case.fluid.output_subdivide', &
          logical_val, .false.)
     call this%f_out%file_%set_subdivide(logical_val)
 

--- a/src/case.f90
+++ b/src/case.f90
@@ -512,8 +512,8 @@ contains
             always_write_mesh = logical_val)
     end if
 
-    call json_get_or_default(this%params, &
-         'case.fluid.output_subdivide', logical_val, .false.)
+    call json_get_or_default(this%params, 'case.output_subdivide', &
+         logical_val, .false.)
     call this%f_out%file_%set_subdivide(logical_val)
 
     call json_get(this%params, 'case.fluid.output_control', string_val)

--- a/src/case.f90
+++ b/src/case.f90
@@ -513,8 +513,8 @@ contains
     end if
 
     call json_get_or_default(this%params, &
-         'case.fluid.output_lagrange', logical_val, .false.)
-    if (logical_val) call this%f_out%file_%set_lagrange(.true.)
+         'case.fluid.output_subdivide', logical_val, .false.)
+    call this%f_out%file_%set_subdivide(logical_val)
 
     call json_get(this%params, 'case.fluid.output_control', string_val)
 

--- a/src/io/file.f90
+++ b/src/io/file.f90
@@ -80,6 +80,8 @@ module file
      procedure :: set_layout => file_set_layout
      !> Sets the file's overwrite flag.
      procedure, pass (this) :: set_overwrite => file_set_overwrite
+     !> Enable or disable Lagrange element output.
+     procedure :: set_lagrange => file_set_lagrange
      !> File operation destructor.
      procedure, pass(this) :: free => file_free
   end type file_t
@@ -316,5 +318,23 @@ contains
        call ft%set_overwrite(overwrite)
     end select
   end subroutine file_set_overwrite
+
+  !> Enable or disable Lagrange element output.
+  !! Only has effect for VTKHDF files; warns for other formats.
+  !! @param lagrange Whether to enable Lagrange output.
+  subroutine file_set_lagrange(this, lagrange)
+    class(file_t), intent(inout) :: this
+    logical, intent(in) :: lagrange
+    character(len=80) :: suffix
+
+    select type (ft => this%file_type)
+    type is (vtkhdf_file_t)
+       call ft%set_lagrange(lagrange)
+    class default
+       call filename_suffix(this%file_type%get_fname(), suffix)
+       call neko_warning("Lagrange output not supported for " // &
+            trim(suffix) // " files")
+    end select
+  end subroutine file_set_lagrange
 
 end module file

--- a/src/io/file.f90
+++ b/src/io/file.f90
@@ -331,9 +331,11 @@ contains
     type is (vtkhdf_file_t)
        call ft%set_subdivide(subdivide)
     class default
-       call filename_suffix(this%file_type%get_fname(), suffix)
-       call neko_warning("Subdivide output not supported for " // &
-            trim(suffix) // " files")
+       if (subdivide) then
+          call filename_suffix(this%file_type%get_fname(), suffix)
+          call neko_warning("Subdivide output not supported for " // &
+               trim(suffix) // " files")
+       end if
     end select
   end subroutine file_set_subdivide
 

--- a/src/io/file.f90
+++ b/src/io/file.f90
@@ -80,8 +80,8 @@ module file
      procedure :: set_layout => file_set_layout
      !> Sets the file's overwrite flag.
      procedure, pass (this) :: set_overwrite => file_set_overwrite
-     !> Enable or disable Lagrange element output.
-     procedure :: set_lagrange => file_set_lagrange
+     !> Enable or disable subdivision of spectral elements.
+     procedure :: set_subdivide => file_set_subdivide
      !> File operation destructor.
      procedure, pass(this) :: free => file_free
   end type file_t
@@ -319,22 +319,22 @@ contains
     end select
   end subroutine file_set_overwrite
 
-  !> Enable or disable Lagrange element output.
+  !> Enable or disable subdivision of spectral elements into linear sub-cells.
   !! Only has effect for VTKHDF files; warns for other formats.
-  !! @param lagrange Whether to enable Lagrange output.
-  subroutine file_set_lagrange(this, lagrange)
+  !! @param subdivide Whether to subdivide into linear sub-cells.
+  subroutine file_set_subdivide(this, subdivide)
     class(file_t), intent(inout) :: this
-    logical, intent(in) :: lagrange
+    logical, intent(in) :: subdivide
     character(len=80) :: suffix
 
     select type (ft => this%file_type)
     type is (vtkhdf_file_t)
-       call ft%set_lagrange(lagrange)
+       call ft%set_subdivide(subdivide)
     class default
        call filename_suffix(this%file_type%get_fname(), suffix)
-       call neko_warning("Lagrange output not supported for " // &
+       call neko_warning("Subdivide output not supported for " // &
             trim(suffix) // " files")
     end select
-  end subroutine file_set_lagrange
+  end subroutine file_set_subdivide
 
 end module file

--- a/src/io/format/vtk.f90
+++ b/src/io/format/vtk.f90
@@ -29,8 +29,13 @@
 ! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 ! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 ! POSSIBILITY OF SUCH DAMAGE.
-!
+
 !> VTK Module containing utilities for VTK file handling
+!!
+!! References:
+!! - https://vtk.org/doc/nightly/html/vtkCellType_8h_source.html
+!! - https://scicomp.stackexchange.com/questions/42092/vtk-arbitrary-order-lagrange-elements-node-positions-ordering-on-reference-tri
+!! - https://www.kitware.com/modeling-arbitrary-order-lagrange-finite-elements-in-the-visualization-toolkit/#:%7E:text=The%20new%20cells%20in%20VTK,may%20vary%20in%20Lagrange%20cells.
 module vtk
   use utils, only: linear_index, neko_error
   implicit none

--- a/src/io/format/vtk.f90
+++ b/src/io/format/vtk.f90
@@ -1,0 +1,210 @@
+! Copyright (c) 2026, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> VTK Module containing utilities for VTK file handling
+module vtk
+  use utils, only: linear_index, neko_error
+  implicit none
+  private
+
+  public :: vtk_ordering
+
+contains
+
+  !> Get the VTK node ordering for a given cell type.
+  !! For Lagrange cells, returns an array mapping VTK node position to the
+  !! 0-based tensor-product index (i + lx*j + lx*ly*k).
+  !! @param cell_type VTK cell type (e.g. 72 for hexahedron)
+  !! @param lx Number of points per edge in x-direction (polynomial order + 1)
+  !! @param ly Number of points per edge in y-direction (polynomial order + 1)
+  !! @param lz Number of points per edge in z-direction (polynomial order + 1)
+  !! @return Array of 0-based tensor-product indices in VTK order
+  function vtk_ordering(cell_type, lx, ly, lz) result(ordering)
+    integer(kind=1), intent(in) :: cell_type
+    integer, intent(in), optional :: lx, ly, lz
+    integer, allocatable :: ordering(:)
+
+    if (allocated(ordering)) deallocate(ordering)
+
+    select case (cell_type)
+    case (70) ! VTK_LAGRANGE_QUADRILATERAL
+       ordering = vtk_lagrange_quad_ordering(lx, ly)
+    case (72) ! VTK_LAGRANGE_HEXAHEDRON
+       ordering = vtk_lagrange_hex_ordering(lx, ly, lz)
+    case default
+       call neko_error('Unsupported VTK cell type in vtk_ordering')
+    end select
+
+  end function vtk_ordering
+
+  !> Build the VTK Lagrange hexahedron node ordering for a given lx.
+  !! Returns an array of size lx*ly*lz mapping VTK node position to the
+  !! 0-based tensor-product index (i + lx*j + lx*ly*k).
+  !! Implements VTK's PointIndexFromIJK for Lagrange hexahedra.
+  !! Node ordering: 8 corners, 4 * (lx - 2 + ly - 2 + lz - 2) edge interiors,
+  !! 6*(lx - 2)*(ly - 2) face interiors, (lx - 2)*(ly - 2)*(lz - 2) body
+  !! interior.
+  !! @param lx Number of points per edge in x-direction (polynomial order + 1)
+  !! @param ly Number of points per edge in y-direction (polynomial order + 1)
+  !! @param lz Number of points per edge in z-direction (polynomial order + 1)
+  !! @return Array of 0-based tensor-product indices in VTK order
+  pure function vtk_lagrange_hex_ordering(lx, ly, lz) result(ordering)
+    integer, intent(in) :: lx, ly, lz
+    integer :: ordering(lx * ly * lz)
+    integer :: i, j, k, vtk_idx
+    integer :: ibdy, jbdy, kbdy, nbdy, offset
+    integer :: n_corners, n_edges, n_faces
+
+    n_corners = 8
+    n_edges = 4 * ((lx - 2) + (ly - 2) + (lz - 2))
+    n_faces = 2 * ((lx - 2) * (ly - 2) + (lx - 2) * (lz - 2) &
+         + (ly - 2) * (lz - 2))
+
+    do concurrent (i = 1:lx, j = 1:ly, k = 1:lz)
+       ibdy = merge(1, 0, i .eq. 1 .or. i .eq. lx)
+       jbdy = merge(1, 0, j .eq. 1 .or. j .eq. ly)
+       kbdy = merge(1, 0, k .eq. 1 .or. k .eq. lz)
+       nbdy = ibdy + jbdy + kbdy
+
+       if (nbdy .eq. 3) then
+          ! Corner node
+          vtk_idx = merge( &
+               merge(2, 1, j .ne. 1), &
+               merge(3, 0, j .ne. 1), i .ne. 1) &
+               + merge(4, 0, k .ne. 1)
+
+       else if (nbdy .eq. 2) then
+          ! Edge interior node
+          offset = n_corners
+          if (ibdy .eq. 0) then
+             vtk_idx = (i - 2) &
+                  + merge((lx - 2) + (ly - 2), 0, j .ne. 1) &
+                  + merge(2 * ((lx - 2) + (ly - 2)), 0, k .ne. 1) &
+                  + offset
+          else if (jbdy .eq. 0) then
+             vtk_idx = (j - 2) &
+                  + merge(lx - 2, 2 * (lx - 2) + (ly - 2), i .ne. 1) &
+                  + merge(2 * ((lx - 2) + (ly - 2)), 0, k .ne. 1) &
+                  + offset
+          else
+             vtk_idx = (k - 2) + (lz - 2) &
+                  * merge(merge(2, 1, j .ne. 1), &
+                  merge(3, 0, j .ne. 1), i .ne. 1) &
+                  + offset + 4 * ((lx - 2) + (ly - 2))
+          end if
+
+       else if (nbdy .eq. 1) then
+          ! Face interior node
+          offset = n_corners + n_edges
+          if (ibdy .eq. 1) then
+             vtk_idx = (j - 2) + (ly - 2) * (k - 2) &
+                  + merge((ly - 2) * (lz - 2), 0, i .ne. 1) &
+                  + offset
+          else if (jbdy .eq. 1) then
+             offset = offset + 2 * (ly - 2) * (lz - 2)
+             vtk_idx = (i - 2) + (lx - 2) * (k - 2) &
+                  + merge((lx - 2) * (lz - 2), 0, j .ne. 1) &
+                  + offset
+          else if (kbdy .eq. 1) then
+             offset = offset + 2 * (ly - 2) * (lz - 2) + 2 * (lx - 2) * (lz - 2)
+             vtk_idx = (i - 2) + (lx - 2) * (j - 2) &
+                  + merge((lx - 2) * (ly - 2), 0, k .ne. 1) &
+                  + offset
+          end if
+
+       else
+          ! Body interior node
+          offset = n_corners + n_edges + n_faces
+          vtk_idx = offset &
+               + (i - 2) + (lx - 2) * ((j - 2) + (ly - 2) * (k - 2))
+       end if
+
+       ! ordering(vtk_position + 1) = tensor-product index
+       ordering(vtk_idx + 1) = linear_index(i, j, k, 1, lx, ly, lz) - 1
+    end do
+
+  end function vtk_lagrange_hex_ordering
+
+  !> Build the VTK Lagrange quadrilateral node ordering for a given lx, ly.
+  !! Returns an array of size lx*ly mapping VTK node position to the
+  !! 0-based tensor-product index (i + lx*j).
+  !! Implements VTK's PointIndexFromIJK for Lagrange quadrilaterals.
+  !! Node ordering: 4 corners, 2*(lx-2) + 2*(ly-2) edge interiors,
+  !! (lx-2)*(ly-2) face interior.
+  !! @param lx Number of points per edge in x-direction (polynomial order + 1)
+  !! @param ly Number of points per edge in y-direction (polynomial order + 1)
+  !! @return Array of 0-based tensor-product indices in VTK order
+  pure function vtk_lagrange_quad_ordering(lx, ly) result(ordering)
+    integer, intent(in) :: lx, ly
+    integer :: ordering(lx * ly)
+    integer :: i, j, vtk_idx
+    integer :: ibdy, jbdy, nbdy, offset
+    integer :: n_corners, n_edges
+
+    n_corners = 4
+    n_edges = 2 * ((lx - 2) + (ly - 2))
+
+    do concurrent (i = 1:lx, j = 1:ly)
+       ibdy = merge(1, 0, i .eq. 1 .or. i .eq. lx)
+       jbdy = merge(1, 0, j .eq. 1 .or. j .eq. ly)
+       nbdy = ibdy + jbdy
+
+       if (nbdy .eq. 2) then
+          ! Corner node
+          vtk_idx = merge( &
+               merge(2, 1, j .ne. 1), &
+               merge(3, 0, j .ne. 1), i .ne. 1)
+
+       else if (nbdy .eq. 1) then
+          ! Edge interior node
+          offset = n_corners
+          if (ibdy .eq. 0) then
+             vtk_idx = (i - 2) &
+                  + merge((lx - 2) + (ly - 2), 0, j .ne. 1) &
+                  + offset
+          else
+             vtk_idx = (j - 2) &
+                  + merge(lx - 2, 2 * (lx - 2) + (ly - 2), i .ne. 1) &
+                  + offset
+          end if
+
+       else
+          ! Face interior node
+          offset = n_corners + n_edges
+          vtk_idx = offset + (i - 2) + (lx - 2) * (j - 2)
+       end if
+
+       ordering(vtk_idx + 1) = linear_index(i, j, 1, 1, lx, ly, 1) - 1
+    end do
+
+  end function vtk_lagrange_quad_ordering
+end module vtk

--- a/src/io/format/vtk.f90
+++ b/src/io/format/vtk.f90
@@ -35,9 +35,10 @@
 !! References:
 !! - https://vtk.org/doc/nightly/html/vtkCellType_8h_source.html
 !! - https://scicomp.stackexchange.com/questions/42092/vtk-arbitrary-order-
-!!           lagrange-elements-node-positions-ordering-on-reference-tri
+!!   lagrange-elements-node-positions-ordering-on-reference-tri
 !! - https://www.kitware.com/modeling-arbitrary-order-lagrange-finite-elements-
-!!           in-the-visualization-toolkit/#:%7E:text=The%20new%20cells%20in%20VTK,may%20vary%20in%20Lagrange%20cells.
+!!   in-the-visualization-toolkit/#:%7E:text=The%20new%20cells%20in%20VTK,
+!!   may%20vary%20in%20Lagrange%20cells.
 module vtk
   use utils, only: linear_index, neko_error
   implicit none
@@ -59,8 +60,6 @@ contains
     integer(kind=1), intent(in) :: cell_type
     integer, intent(in), optional :: lx, ly, lz
     integer, allocatable :: ordering(:)
-
-    if (allocated(ordering)) deallocate(ordering)
 
     select case (cell_type)
     case (70) ! VTK_LAGRANGE_QUADRILATERAL

--- a/src/io/format/vtk.f90
+++ b/src/io/format/vtk.f90
@@ -34,8 +34,10 @@
 !!
 !! References:
 !! - https://vtk.org/doc/nightly/html/vtkCellType_8h_source.html
-!! - https://scicomp.stackexchange.com/questions/42092/vtk-arbitrary-order-lagrange-elements-node-positions-ordering-on-reference-tri
-!! - https://www.kitware.com/modeling-arbitrary-order-lagrange-finite-elements-in-the-visualization-toolkit/#:%7E:text=The%20new%20cells%20in%20VTK,may%20vary%20in%20Lagrange%20cells.
+!! - https://scicomp.stackexchange.com/questions/42092/vtk-arbitrary-order-
+!!           lagrange-elements-node-positions-ordering-on-reference-tri
+!! - https://www.kitware.com/modeling-arbitrary-order-lagrange-finite-elements-
+!!           in-the-visualization-toolkit/#:%7E:text=The%20new%20cells%20in%20VTK,may%20vary%20in%20Lagrange%20cells.
 module vtk
   use utils, only: linear_index, neko_error
   implicit none
@@ -62,9 +64,19 @@ contains
 
     select case (cell_type)
     case (70) ! VTK_LAGRANGE_QUADRILATERAL
-       ordering = vtk_lagrange_quad_ordering(lx, ly)
+       if (present(lx) .and. present(ly)) then
+          ordering = vtk_lagrange_quad_ordering(lx, ly)
+       else
+          call neko_error('lx and ly must be provided for arbitrary lagrange ' &
+               // 'quadrilateral cells')
+       end if
     case (72) ! VTK_LAGRANGE_HEXAHEDRON
-       ordering = vtk_lagrange_hex_ordering(lx, ly, lz)
+       if (present(lx) .and. present(ly) .and. present(lz)) then
+          ordering = vtk_lagrange_hex_ordering(lx, ly, lz)
+       else
+          call neko_error('lx, ly, and lz must be provided for arbitrary ' &
+               // 'lagrange hexahedron cells')
+       end if
     case default
        call neko_error('Unsupported VTK cell type in vtk_ordering')
     end select

--- a/src/io/vtkhdf_file.F90
+++ b/src/io/vtkhdf_file.F90
@@ -148,7 +148,7 @@ contains
     integer, allocatable :: part_points(:), part_cells(:), part_conns(:)
     character(len=1024) :: fname
     character(len=16) :: type_str
-    logical :: link_exists, file_exists
+    logical :: link_exists, file_exists, subdivide
     integer(kind=1) :: VTK_cell_type
     integer :: counter
 
@@ -191,19 +191,7 @@ contains
        this%precision = rp
     end if
 
-    if (this%lagrange) then
-       if (msh%gdim .eq. 3) then
-          VTK_cell_type = 72 ! VTK_LAGRANGE_HEXAHEDRON
-       else
-          VTK_cell_type = 70 ! VTK_LAGRANGE_QUADRILATERAL
-       end if
-    else
-       if (msh%gdim .eq. 3) then
-          VTK_cell_type = 12 ! VTK_HEXAHEDRON
-       else
-          VTK_cell_type = 9 ! VTK_QUAD
-       end if
-    end if
+    subdivide = .not. this%lagrange
 
     call this%increment_counter()
     fname = trim(this%get_vtkhdf_fname())
@@ -263,8 +251,8 @@ contains
     end if
 
     if (associated(msh)) then
-       call vtkhdf_write_mesh(vtkhdf_grp, dof, msh, VTK_cell_type, &
-            this%amr_enabled, counter, t)
+       call vtkhdf_write_mesh(vtkhdf_grp, dof, msh, &
+            this%amr_enabled, counter, subdivide, t)
     end if
 
     ! Write field data in PointData group
@@ -291,35 +279,39 @@ contains
   !! @param msh Mesh object containing element information
   !! @param dof Dofmap containing the lx, ly, lz dimensions of the spectral
   !!            element grid
-  subroutine vtkhdf_build_connectivity(conn, vtk_type, msh, dof)
+  !! @param subdivide Logical flag indicating whether to subdivide to linear
+  !!        elements
+  subroutine vtkhdf_build_connectivity(conn, vtk_type, msh, dof, subdivide)
     integer, intent(out) :: conn(:)
     integer(kind=1), intent(in) :: vtk_type
-    type(mesh_t) :: msh
-    type(dofmap_t) :: dof
+    type(mesh_t), intent(in) :: msh
+    type(dofmap_t), intent(in) :: dof
+    logical, intent(in) :: subdivide
     integer :: lx, ly, lz, nelv
-    integer :: ie, ii, base, idx, npts_per_cell, n_conn_per_elem
+    integer :: ie, ii, base, idx, n_pts_per_cell, n_conn_per_elem
     integer, allocatable :: node_order(:)
 
     nelv = msh%nelv
     lx = dof%Xh%lx
     ly = dof%Xh%ly
     lz = dof%Xh%lz
-    npts_per_cell = lx * ly * lz
+    n_pts_per_cell = lx * ly * lz
     idx = 0
 
-    select case (vtk_type)
-    case (12) ! VTK_HEXAHEDRON
-       node_order = vtkhdf_hex_node_order(lx, ly, lz)
-    case (9) ! VTK_QUAD
-       node_order = vtkhdf_quad_node_order(lx, ly)
-    case default ! Standard VTK node types (Lagrange etc.)
+    if (subdivide) then
+       if (msh%gdim .eq. 3) then
+          node_order = vtkhdf_hex_node_order(lx, ly, lz)
+       else
+          node_order = vtkhdf_quad_node_order(lx, ly)
+       end if
+    else
        node_order = vtk_ordering(vtk_type, lx, ly, lz)
-    end select
+    end if
 
     n_conn_per_elem = size(node_order)
 
     do ie = 1, nelv
-       base = (ie - 1) * npts_per_cell
+       base = (ie - 1) * n_pts_per_cell
        do ii = 1, n_conn_per_elem
           conn(idx + ii) = base + node_order(ii)
        end do
@@ -330,87 +322,26 @@ contains
 
   end subroutine vtkhdf_build_connectivity
 
-  !> Build linear hexahedron sub-cell node ordering for a spectral element.
-  !! Returns an array of 0-based tensor-product indices that subdivides
-  !! the lx*ly*lz grid into (lx-1)*(ly-1)*(lz-1) linear hexahedra
-  !! (VTK_HEXAHEDRON, type 12), with 8 nodes per sub-cell.
-  !! @param lx Number of points in x-direction
-  !! @param ly Number of points in y-direction
-  !! @param lz Number of points in z-direction
-  !! @return Array of size 8*(lx-1)*(ly-1)*(lz-1) with 0-based indices
-  pure function vtkhdf_hex_node_order(lx, ly, lz) result(node_order)
-    integer, intent(in) :: lx, ly, lz
-    integer, allocatable :: node_order(:)
-    integer :: ii, jj, kk, idx
-
-    allocate(node_order(8 * (lx - 1) * (ly - 1) * (lz - 1)))
-    idx = 0
-
-    do ii = 1, lx - 1
-       do jj = 1, ly - 1
-          do kk = 1, lz - 1
-             node_order(idx + 1) = (kk - 1) * lx * ly + (jj - 1) * lx + ii - 1
-             node_order(idx + 2) = (kk - 1) * lx * ly + (jj - 1) * lx + ii
-             node_order(idx + 3) = (kk - 1) * lx * ly + jj * lx + ii
-             node_order(idx + 4) = (kk - 1) * lx * ly + jj * lx + ii - 1
-             node_order(idx + 5) = kk * lx * ly + (jj - 1) * lx + ii - 1
-             node_order(idx + 6) = kk * lx * ly + (jj - 1) * lx + ii
-             node_order(idx + 7) = kk * lx * ly + jj * lx + ii
-             node_order(idx + 8) = kk * lx * ly + jj * lx + ii - 1
-             idx = idx + 8
-          end do
-       end do
-    end do
-
-  end function vtkhdf_hex_node_order
-
-  !> Build linear quadrilateral sub-cell node ordering for a spectral element.
-  !! Returns an array of 0-based tensor-product indices that subdivides
-  !! the lx*ly grid into (lx-1)*(ly-1) linear quadrilaterals
-  !! (VTK_QUAD, type 9), with 4 nodes per sub-cell.
-  !! @param lx Number of points in x-direction
-  !! @param ly Number of points in y-direction
-  !! @return Array of size 4*(lx-1)*(ly-1) with 0-based indices
-  pure function vtkhdf_quad_node_order(lx, ly) result(node_order)
-    integer, intent(in) :: lx, ly
-    integer, allocatable :: node_order(:)
-    integer :: ii, jj, idx
-
-    allocate(node_order(4 * (lx - 1) * (ly - 1)))
-    idx = 0
-
-    do jj = 1, ly - 1
-       do ii = 1, lx - 1
-          node_order(idx + 1) = (jj - 1) * lx + ii - 1
-          node_order(idx + 2) = (jj - 1) * lx + ii
-          node_order(idx + 3) = jj * lx + ii
-          node_order(idx + 4) = jj * lx + ii - 1
-          idx = idx + 4
-       end do
-    end do
-
-  end function vtkhdf_quad_node_order
-
   !> Write mesh geometry datasets to the VTKHDF group.
   !! Writes NumberOfPoints, NumberOfCells, NumberOfConnectivityIds,
   !! Points, Connectivity, Offsets, and Types datasets.
   !! @param vtkhdf_grp HDF5 group ID for VTKHDF root group
   !! @param dof Dofmap for coordinate data
   !! @param msh Mesh object
-  !! @param VTK_cell_type VTK cell type (e.g. 12 for hexahedra, 9 for quads)
   !! @param amr AMR flag to determine if mesh should be rewritten at every time
   !!            step
   !! @param t Optional time value for time-dependent mesh output (e.g. for AMR)
-  subroutine vtkhdf_write_mesh(vtkhdf_grp, dof, msh, VTK_cell_type, amr, &
-       counter, t)
+  subroutine vtkhdf_write_mesh(vtkhdf_grp, dof, msh, amr, &
+       counter, subdivide, t)
     type(dofmap_t), intent(in) :: dof
     type(mesh_t), intent(in) :: msh
     integer(hid_t), intent(in) :: vtkhdf_grp
-    integer(kind=1), intent(in) :: VTK_cell_type
     logical, intent(in) :: amr
     integer, intent(in) :: counter
+    logical, intent(in) :: subdivide
     real(kind=rp), intent(in), optional :: t
 
+    integer(kind=1) :: VTK_cell_type
     integer :: ierr, i, ii, jj, kk, el, local_idx
     integer :: lx, ly, lz, npts_per_cell, nodes_per_cell, cells_per_element
     integer :: local_points, local_cells, local_conn
@@ -433,22 +364,24 @@ contains
     lz = dof%Xh%lz
     npts_per_cell = lx * ly * lz
 
-    select case(VTK_cell_type)
-    case(12)
+    if (subdivide .and. msh%gdim .eq. 3) then
+       VTK_cell_type = 12 ! VTK_HEXAHEDRON
        cells_per_element = (lx - 1) * (ly - 1) * (lz - 1)
        nodes_per_cell = 8
-    case(9)
+    else if (subdivide .and. msh%gdim .eq. 2) then
+       VTK_cell_type = 9 ! VTK_QUAD
        cells_per_element = (lx - 1) * (ly - 1)
        nodes_per_cell = 4
-    case(72) ! VTK_LAGRANGE_HEXAHEDRON
+    else if (msh%gdim .eq. 3) then
+       VTK_cell_type = 72 ! VTK_LAGRANGE_HEXAHEDRON
        cells_per_element = 1
        nodes_per_cell = lx * ly * lz
-    case(70) ! VTK_LAGRANGE_QUADRILATERAL
+    else if (msh%gdim .eq. 2) then
+       VTK_cell_type = 70 ! VTK_LAGRANGE_QUADRILATERAL
        cells_per_element = 1
        nodes_per_cell = lx * ly
-    case default
-       call neko_error('Unsupported VTK cell type')
-    end select
+    end if
+
 
     ! --- Build the number of cells and the connectivity
     local_points = dof%size()
@@ -583,8 +516,9 @@ contains
       integer, allocatable :: connectivity(:)
 
       allocate(connectivity(local_conn))
-      call vtkhdf_build_connectivity(connectivity, VTK_cell_type, msh, dof)
-      call h5dwrite_f(dset_id, H5T_NATIVE_INTEGER, connectivity, dcount, &
+      call vtkhdf_build_connectivity(connectivity, VTK_cell_type, msh, dof, &
+           subdivide)
+      call h5dwrite_f(dset_id, H5T_NATIVE_INTEGER, connectivity, dcount(1:1), &
            ierr, file_space_id = filespace, mem_space_id = memspace, &
            xfer_prp = xf_id)
       deallocate(connectivity)
@@ -1336,5 +1270,67 @@ contains
   end subroutine vtkhdf_file_read
 
 #endif
+
+  ! -------------------------------------------------------------------------- !
+  ! Sub-cell node ordering functions for VTK compatibility
+
+  !> Build linear hexahedron sub-cell node ordering for a spectral element.
+  !! Returns an array of 0-based tensor-product indices that subdivides
+  !! the lx*ly*lz grid into (lx-1)*(ly-1)*(lz-1) linear hexahedra
+  !! (VTK_HEXAHEDRON, type 12), with 8 nodes per sub-cell.
+  !! @param lx Number of points in x-direction
+  !! @param ly Number of points in y-direction
+  !! @param lz Number of points in z-direction
+  !! @return Array of size 8*(lx-1)*(ly-1)*(lz-1) with 0-based indices
+  pure function vtkhdf_hex_node_order(lx, ly, lz) result(node_order)
+    integer, intent(in) :: lx, ly, lz
+    integer :: node_order(8 * (lx - 1) * (ly - 1) * (lz - 1))
+    integer :: ii, jj, kk, idx
+
+    idx = 0
+
+    do ii = 1, lx - 1
+       do jj = 1, ly - 1
+          do kk = 1, lz - 1
+             node_order(idx + 1) = (kk - 1) * lx * ly + (jj - 1) * lx + ii - 1
+             node_order(idx + 2) = (kk - 1) * lx * ly + (jj - 1) * lx + ii
+             node_order(idx + 3) = (kk - 1) * lx * ly + jj * lx + ii
+             node_order(idx + 4) = (kk - 1) * lx * ly + jj * lx + ii - 1
+             node_order(idx + 5) = kk * lx * ly + (jj - 1) * lx + ii - 1
+             node_order(idx + 6) = kk * lx * ly + (jj - 1) * lx + ii
+             node_order(idx + 7) = kk * lx * ly + jj * lx + ii
+             node_order(idx + 8) = kk * lx * ly + jj * lx + ii - 1
+             idx = idx + 8
+          end do
+       end do
+    end do
+
+  end function vtkhdf_hex_node_order
+
+  !> Build linear quadrilateral sub-cell node ordering for a spectral element.
+  !! Returns an array of 0-based tensor-product indices that subdivides
+  !! the lx*ly grid into (lx-1)*(ly-1) linear quadrilaterals
+  !! (VTK_QUAD, type 9), with 4 nodes per sub-cell.
+  !! @param lx Number of points in x-direction
+  !! @param ly Number of points in y-direction
+  !! @return Array of size 4*(lx-1)*(ly-1) with 0-based indices
+  pure function vtkhdf_quad_node_order(lx, ly) result(node_order)
+    integer, intent(in) :: lx, ly
+    integer :: node_order(4 * (lx - 1) * (ly - 1))
+    integer :: ii, jj, idx
+
+    idx = 0
+
+    do jj = 1, ly - 1
+       do ii = 1, lx - 1
+          node_order(idx + 1) = (jj - 1) * lx + ii - 1
+          node_order(idx + 2) = (jj - 1) * lx + ii
+          node_order(idx + 3) = jj * lx + ii
+          node_order(idx + 4) = jj * lx + ii - 1
+          idx = idx + 4
+       end do
+    end do
+
+  end function vtkhdf_quad_node_order
 
 end module vtkhdf_file

--- a/src/io/vtkhdf_file.F90
+++ b/src/io/vtkhdf_file.F90
@@ -286,7 +286,7 @@ contains
     type(dofmap_t), intent(in) :: dof
     logical, intent(in) :: subdivide
     integer :: lx, ly, lz, nelv
-    integer :: ie, ii, base, idx, n_pts_per_cell, n_conn_per_elem
+    integer :: ie, ii, n_pts_per_cell, n_conn_per_elem
     integer, allocatable :: node_order(:)
 
     nelv = msh%nelv
@@ -294,26 +294,24 @@ contains
     ly = dof%Xh%ly
     lz = dof%Xh%lz
     n_pts_per_cell = lx * ly * lz
-    idx = 0
 
-    if (subdivide) then
-       if (msh%gdim .eq. 3) then
-          node_order = vtkhdf_hex_node_order(lx, ly, lz)
-       else
-          node_order = vtkhdf_quad_node_order(lx, ly)
-       end if
+    if (subdivide .and. vtk_type .eq. 12) then
+       node_order = subdivide_to_hex_ordering(lx, ly, lz)
+    else if (subdivide .and. vtk_type .eq. 9) then
+       node_order = subdivide_to_quad_ordering(lx, ly)
     else
        node_order = vtk_ordering(vtk_type, lx, ly, lz)
     end if
 
     n_conn_per_elem = size(node_order)
 
-    do ie = 1, nelv
-       base = (ie - 1) * n_pts_per_cell
-       do ii = 1, n_conn_per_elem
-          conn(idx + ii) = base + node_order(ii)
-       end do
-       idx = idx + n_conn_per_elem
+    do concurrent (ie = 1:nelv, ii = 1:n_conn_per_elem)
+       block
+         integer :: idx, base
+         idx = (ie - 1) * n_conn_per_elem
+         base = (ie - 1) * n_pts_per_cell
+         conn(idx + ii) = base + node_order(ii)
+       end block
     end do
 
     deallocate(node_order)
@@ -1280,7 +1278,7 @@ contains
   !! @param ly Number of points in y-direction
   !! @param lz Number of points in z-direction
   !! @return Array of size 8*(lx-1)*(ly-1)*(lz-1) with 0-based indices
-  pure function vtkhdf_hex_node_order(lx, ly, lz) result(node_order)
+  pure function subdivide_to_hex_ordering(lx, ly, lz) result(node_order)
     integer, intent(in) :: lx, ly, lz
     integer :: node_order(8 * (lx - 1) * (ly - 1) * (lz - 1))
     integer :: ii, jj, kk, idx
@@ -1303,7 +1301,7 @@ contains
        end do
     end do
 
-  end function vtkhdf_hex_node_order
+  end function subdivide_to_hex_ordering
 
   !> Build linear quadrilateral sub-cell node ordering for a spectral element.
   !! Returns an array of 0-based tensor-product indices that subdivides
@@ -1312,7 +1310,7 @@ contains
   !! @param lx Number of points in x-direction
   !! @param ly Number of points in y-direction
   !! @return Array of size 4*(lx-1)*(ly-1) with 0-based indices
-  pure function vtkhdf_quad_node_order(lx, ly) result(node_order)
+  pure function subdivide_to_quad_ordering(lx, ly) result(node_order)
     integer, intent(in) :: lx, ly
     integer :: node_order(4 * (lx - 1) * (ly - 1))
     integer :: ii, jj, idx
@@ -1329,6 +1327,6 @@ contains
        end do
     end do
 
-  end function vtkhdf_quad_node_order
+  end function subdivide_to_quad_ordering
 
 end module vtkhdf_file

--- a/src/io/vtkhdf_file.F90
+++ b/src/io/vtkhdf_file.F90
@@ -57,6 +57,7 @@ module vtkhdf_file
   !> Interface for HDF5 files
   type, public, extends(generic_file_t) :: vtkhdf_file_t
      logical :: amr_enabled = .false.
+     logical :: lagrange = .false.
      integer :: precision = 0
    contains
      procedure :: get_vtkhdf_fname => vtkhdf_file_get_fname
@@ -65,6 +66,7 @@ module vtkhdf_file
      procedure :: set_overwrite => vtkhdf_file_set_overwrite
      procedure :: enable_amr => vtkhdf_file_enable_amr
      procedure :: set_precision => vtkhdf_file_set_precision
+     procedure :: set_lagrange => vtkhdf_file_set_lagrange
   end type vtkhdf_file_t
 
   integer, dimension(2), parameter :: vtkhdf_version = [2, 6]
@@ -108,6 +110,17 @@ contains
          trim(path), trim(name), this%get_start_counter(), trim(suffix)
 
   end function vtkhdf_file_get_fname
+
+  !> Enable or disable high-order Lagrange element output.
+  !! When enabled, each spectral element is written as a single
+  !! VTK_LAGRANGE_HEXAHEDRON (type 72) or VTK_LAGRANGE_QUADRILATERAL
+  !! (type 70) cell instead of being subdivided into linear sub-cells.
+  !! @param lagrange Whether to enable Lagrange element output.
+  subroutine vtkhdf_file_set_lagrange(this, lagrange)
+    class(vtkhdf_file_t), intent(inout) :: this
+    logical, intent(in) :: lagrange
+    this%lagrange = lagrange
+  end subroutine vtkhdf_file_set_lagrange
 
 #ifdef HAVE_HDF5
   ! -------------------------------------------------------------------------- !
@@ -177,10 +190,18 @@ contains
        this%precision = rp
     end if
 
-    if (msh%gdim .eq. 3) then
-       VTK_cell_type = 12 ! VTK_HEXAHEDRON
+    if (this%lagrange) then
+       if (msh%gdim .eq. 3) then
+          VTK_cell_type = 72 ! VTK_LAGRANGE_HEXAHEDRON
+       else
+          VTK_cell_type = 70 ! VTK_LAGRANGE_QUADRILATERAL
+       end if
     else
-       VTK_cell_type = 9 ! VTK_QUAD
+       if (msh%gdim .eq. 3) then
+          VTK_cell_type = 12 ! VTK_HEXAHEDRON
+       else
+          VTK_cell_type = 9 ! VTK_QUAD
+       end if
     end if
 
     call this%increment_counter()
@@ -259,11 +280,13 @@ contains
 
   end subroutine vtkhdf_file_write
 
-  !> Build local connectivity for VTK sub-cells from a spectral element
-  !! tensor-product grid. Subdivides each spectral element into linear
-  !! sub-cells based on the GLL node positions.
+  !> Build local connectivity for VTK cells from a spectral element
+  !! tensor-product grid. For linear types (12, 9) subdivides each spectral
+  !! element into linear sub-cells. For Lagrange types (72, 70) writes one
+  !! high-order cell per element with VTK node ordering.
   !! @param conn Output connectivity array (pre-allocated)
-  !! @param vtk_type VTK cell type: 12 = VTK_HEXAHEDRON, 9 = VTK_QUAD
+  !! @param vtk_type VTK cell type: 12 = VTK_HEXAHEDRON, 9 = VTK_QUAD,
+  !!        72 = VTK_LAGRANGE_HEXAHEDRON, 70 = VTK_LAGRANGE_QUADRILATERAL
   !! @param msh Mesh object containing element information
   !! @param dof Dofmap containing the lx, ly, lz dimensions of the spectral
   !!            element grid
@@ -273,7 +296,7 @@ contains
     type(mesh_t) :: msh
     type(dofmap_t) :: dof
     integer :: lx, ly, lz, nelv
-    integer :: ie, ii, jj, kk, base, idx, npts_per_cell
+    integer :: ie, ii, jj, kk, base, idx, npts_per_cell, p
 
     nelv = msh%nelv
     lx = dof%Xh%lx
@@ -321,6 +344,28 @@ contains
                 idx = idx + 4
              end do
           end do
+
+       case (72) ! VTK_LAGRANGE_HEXAHEDRON
+          block
+            integer, allocatable :: node_order(:)
+            node_order = vtk_lagrange_hex_ordering(lx)
+            do ii = 1, lx * ly * lz
+               conn(idx + ii) = base + node_order(ii)
+            end do
+            deallocate(node_order)
+          end block
+          idx = idx + lx * ly * lz
+
+       case (70) ! VTK_LAGRANGE_QUADRILATERAL
+          block
+            integer, allocatable :: node_order(:)
+            node_order = vtk_lagrange_quad_ordering(lx)
+            do ii = 1, lx * ly
+               conn(idx + ii) = base + node_order(ii)
+            end do
+            deallocate(node_order)
+          end block
+          idx = idx + lx * ly
 
        case default
           call neko_error('Unsupported VTK cell type')
@@ -378,6 +423,12 @@ contains
     case(9)
        cells_per_element = (lx - 1) * (ly - 1)
        nodes_per_cell = 4
+    case(72) ! VTK_LAGRANGE_HEXAHEDRON
+       cells_per_element = 1
+       nodes_per_cell = lx * ly * lz
+    case(70) ! VTK_LAGRANGE_QUADRILATERAL
+       cells_per_element = 1
+       nodes_per_cell = lx * ly
     case default
        call neko_error('Unsupported VTK cell type')
     end select
@@ -1268,5 +1319,145 @@ contains
   end subroutine vtkhdf_file_read
 
 #endif
+
+  ! -------------------------------------------------------------------------- !
+  ! Pure functions for VTK Lagrange node ordering
+  ! These are HDF5-independent and placed outside the preprocessor block.
+
+  !> Build the VTK Lagrange hexahedron node ordering for a given lx.
+  !! Returns an array of size lx^3 mapping VTK node position to the
+  !! 0-based tensor-product index (i + lx*j + lx*ly*k).
+  !! Implements VTK's PointIndexFromIJK for Lagrange hexahedra.
+  !! Node ordering: 8 corners, 12*(p-1) edge interiors,
+  !! 6*(p-1)^2 face interiors, (p-1)^3 body interior.
+  !! @param lx Number of points per edge (polynomial order + 1)
+  !! @return Array of 0-based tensor-product indices in VTK order
+  pure function vtk_lagrange_hex_ordering(lx) result(ordering)
+    integer, intent(in) :: lx
+    integer, allocatable :: ordering(:)
+    integer :: i, j, k, p, vtk_idx
+    integer :: ibdy, jbdy, kbdy, nbdy, offset
+
+    p = lx - 1
+    allocate(ordering(lx * lx * lx))
+
+    do k = 0, p
+       do j = 0, p
+          do i = 0, p
+             ibdy = merge(1, 0, i == 0 .or. i == p)
+             jbdy = merge(1, 0, j == 0 .or. j == p)
+             kbdy = merge(1, 0, k == 0 .or. k == p)
+             nbdy = ibdy + jbdy + kbdy
+
+             ! Corner node
+             if (nbdy == 3) then
+                vtk_idx = merge( &
+                     merge(2, 1, j /= 0), &
+                     merge(3, 0, j /= 0), i /= 0) &
+                     + merge(4, 0, k /= 0)
+
+                ! Edge interior node
+             else if (nbdy == 2) then
+                offset = 8
+                if (ibdy == 0) then
+                   vtk_idx = (i - 1) &
+                        + merge(2 * (p - 1), 0, j /= 0) &
+                        + merge(4 * (p - 1), 0, k /= 0) &
+                        + offset
+                else if (jbdy == 0) then
+                   vtk_idx = (j - 1) &
+                        + merge(p - 1, 3 * (p - 1), i /= 0) &
+                        + merge(4 * (p - 1), 0, k /= 0) &
+                        + offset
+                else
+                   vtk_idx = (k - 1) + (p - 1) &
+                        * merge(merge(2, 1, j /= 0), &
+                        merge(3, 0, j /= 0), i /= 0) &
+                        + offset + 8 * (p - 1)
+                end if
+
+                ! Face interior node
+             else if (nbdy == 1) then
+                offset = 8 + 12 * (p - 1)
+                if (ibdy == 1) then
+                   vtk_idx = (j - 1) + (p - 1) * (k - 1) &
+                        + merge((p - 1) * (p - 1), 0, i /= 0) &
+                        + offset
+                else if (jbdy == 1) then
+                   vtk_idx = (i - 1) + (p - 1) * (k - 1) &
+                        + merge((p - 1) * (p - 1), 0, j /= 0) &
+                        + offset + 2 * (p - 1) * (p - 1)
+                else
+                   vtk_idx = (i - 1) + (p - 1) * (j - 1) &
+                        + merge((p - 1) * (p - 1), 0, k /= 0) &
+                        + offset + 4 * (p - 1) * (p - 1)
+                end if
+
+                ! Body interior node
+             else
+                vtk_idx = 8 + 12 * (p - 1) + 6 * (p - 1) * (p - 1) &
+                     + (i - 1) + (p - 1) * ((j - 1) + (p - 1) * (k - 1))
+             end if
+
+             ! ordering(vtk_position + 1) = tensor-product index
+             ordering(vtk_idx + 1) = k * lx * lx + j * lx + i
+          end do
+       end do
+    end do
+
+  end function vtk_lagrange_hex_ordering
+
+  !> Build the VTK Lagrange quadrilateral node ordering for a given lx.
+  !! Returns an array of size lx^2 mapping VTK node position to the
+  !! 0-based tensor-product index (i + lx*j).
+  !! Implements VTK's PointIndexFromIJK for Lagrange quadrilaterals.
+  !! Node ordering: 4 corners, 4*(p-1) edge interiors,
+  !! (p-1)^2 face interior.
+  !! @param lx Number of points per edge (polynomial order + 1)
+  !! @return Array of 0-based tensor-product indices in VTK order
+  pure function vtk_lagrange_quad_ordering(lx) result(ordering)
+    integer, intent(in) :: lx
+    integer, allocatable :: ordering(:)
+    integer :: i, j, p, vtk_idx
+    integer :: ibdy, jbdy, nbdy, offset
+
+    p = lx - 1
+    allocate(ordering(lx * lx))
+
+    do j = 0, p
+       do i = 0, p
+          ibdy = merge(1, 0, i == 0 .or. i == p)
+          jbdy = merge(1, 0, j == 0 .or. j == p)
+          nbdy = ibdy + jbdy
+
+          ! Corner node
+          if (nbdy == 2) then
+             vtk_idx = merge( &
+                  merge(2, 1, j /= 0), &
+                  merge(3, 0, j /= 0), i /= 0)
+
+             ! Edge interior node
+          else if (nbdy == 1) then
+             offset = 4
+             if (ibdy == 0) then
+                vtk_idx = (i - 1) &
+                     + merge(2 * (p - 1), 0, j /= 0) &
+                     + offset
+             else
+                vtk_idx = (j - 1) &
+                     + merge(p - 1, 3 * (p - 1), i /= 0) &
+                     + offset
+             end if
+
+             ! Face interior node
+          else
+             vtk_idx = (i - 1) + (p - 1) * (j - 1) + 4 + 4 * (p - 1)
+          end if
+
+          ordering(vtk_idx + 1) = j * lx + i
+       end do
+    end do
+
+  end function vtk_lagrange_quad_ordering
 
 end module vtkhdf_file

--- a/src/io/vtkhdf_file.F90
+++ b/src/io/vtkhdf_file.F90
@@ -297,7 +297,7 @@ contains
     type(mesh_t) :: msh
     type(dofmap_t) :: dof
     integer :: lx, ly, lz, nelv
-    integer :: ie, ii, jj, kk, base, idx, npts_per_cell, p
+    integer :: ie, ii, base, idx, npts_per_cell, n_conn_per_elem
     integer, allocatable :: node_order(:)
 
     nelv = msh%nelv
@@ -308,76 +308,88 @@ contains
     idx = 0
 
     select case (vtk_type)
-    case (9) ! VTK_QUAD
-       ! No special ordering needed for linear quads
     case (12) ! VTK_HEXAHEDRON
-       ! No special ordering needed for linear hexes
-    case default ! Standard VTK node types
+       node_order = vtkhdf_hex_node_order(lx, ly, lz)
+    case (9) ! VTK_QUAD
+       node_order = vtkhdf_quad_node_order(lx, ly)
+    case default ! Standard VTK node types (Lagrange etc.)
        node_order = vtk_ordering(vtk_type, lx, ly, lz)
     end select
 
+    n_conn_per_elem = size(node_order)
+
     do ie = 1, nelv
        base = (ie - 1) * npts_per_cell
-
-       select case (vtk_type)
-       case (12) ! VTK_HEXAHEDRON
-          do ii = 1, lx - 1
-             do jj = 1, ly - 1
-                do kk = 1, lz - 1
-                   conn(idx + 1) = base + &
-                        (kk - 1) * lx * ly + (jj - 1) * lx + ii - 1
-                   conn(idx + 2) = base + &
-                        (kk - 1) * lx * ly + (jj - 1) * lx + (ii + 1) - 1
-                   conn(idx + 3) = base + &
-                        (kk - 1) * lx * ly + jj * lx + (ii + 1) - 1
-                   conn(idx + 4) = base + &
-                        (kk - 1) * lx * ly + jj * lx + ii - 1
-                   conn(idx + 5) = base + &
-                        kk * lx * ly + (jj - 1) * lx + ii - 1
-                   conn(idx + 6) = base + &
-                        kk * lx * ly + (jj - 1) * lx + (ii + 1) - 1
-                   conn(idx + 7) = base + &
-                        kk * lx * ly + jj * lx + (ii + 1) - 1
-                   conn(idx + 8) = base + &
-                        kk * lx * ly + jj * lx + ii - 1
-                   idx = idx + 8
-                end do
-             end do
-          end do
-
-       case (9) ! VTK_QUAD
-          do jj = 1, ly - 1
-             do ii = 1, lx - 1
-                conn(idx + 1) = base + (jj - 1) * lx + ii - 1
-                conn(idx + 2) = base + (jj - 1) * lx + (ii + 1) - 1
-                conn(idx + 3) = base + jj * lx + (ii + 1) - 1
-                conn(idx + 4) = base + jj * lx + ii - 1
-                idx = idx + 4
-             end do
-          end do
-
-       case (72) ! VTK_LAGRANGE_HEXAHEDRON
-
-          do ii = 1, lx * ly * lz
-             conn(idx + ii) = base + node_order(ii)
-          end do
-          idx = idx + lx * ly * lz
-
-       case (70) ! VTK_LAGRANGE_QUADRILATERAL
-
-          do ii = 1, lx * ly
-             conn(idx + ii) = base + node_order(ii)
-          end do
-          idx = idx + lx * ly
-
-       case default
-          call neko_error('Unsupported VTK cell type')
-       end select
+       do ii = 1, n_conn_per_elem
+          conn(idx + ii) = base + node_order(ii)
+       end do
+       idx = idx + n_conn_per_elem
     end do
 
-    if (allocated(node_order)) deallocate(node_order)
+    deallocate(node_order)
 
   end subroutine vtkhdf_build_connectivity
+
+  !> Build linear hexahedron sub-cell node ordering for a spectral element.
+  !! Returns an array of 0-based tensor-product indices that subdivides
+  !! the lx*ly*lz grid into (lx-1)*(ly-1)*(lz-1) linear hexahedra
+  !! (VTK_HEXAHEDRON, type 12), with 8 nodes per sub-cell.
+  !! @param lx Number of points in x-direction
+  !! @param ly Number of points in y-direction
+  !! @param lz Number of points in z-direction
+  !! @return Array of size 8*(lx-1)*(ly-1)*(lz-1) with 0-based indices
+  pure function vtkhdf_hex_node_order(lx, ly, lz) result(node_order)
+    integer, intent(in) :: lx, ly, lz
+    integer, allocatable :: node_order(:)
+    integer :: ii, jj, kk, idx
+
+    allocate(node_order(8 * (lx - 1) * (ly - 1) * (lz - 1)))
+    idx = 0
+
+    do ii = 1, lx - 1
+       do jj = 1, ly - 1
+          do kk = 1, lz - 1
+             node_order(idx + 1) = (kk - 1) * lx * ly + (jj - 1) * lx + ii - 1
+             node_order(idx + 2) = (kk - 1) * lx * ly + (jj - 1) * lx + ii
+             node_order(idx + 3) = (kk - 1) * lx * ly + jj * lx + ii
+             node_order(idx + 4) = (kk - 1) * lx * ly + jj * lx + ii - 1
+             node_order(idx + 5) = kk * lx * ly + (jj - 1) * lx + ii - 1
+             node_order(idx + 6) = kk * lx * ly + (jj - 1) * lx + ii
+             node_order(idx + 7) = kk * lx * ly + jj * lx + ii
+             node_order(idx + 8) = kk * lx * ly + jj * lx + ii - 1
+             idx = idx + 8
+          end do
+       end do
+    end do
+
+  end function vtkhdf_hex_node_order
+
+  !> Build linear quadrilateral sub-cell node ordering for a spectral element.
+  !! Returns an array of 0-based tensor-product indices that subdivides
+  !! the lx*ly grid into (lx-1)*(ly-1) linear quadrilaterals
+  !! (VTK_QUAD, type 9), with 4 nodes per sub-cell.
+  !! @param lx Number of points in x-direction
+  !! @param ly Number of points in y-direction
+  !! @return Array of size 4*(lx-1)*(ly-1) with 0-based indices
+  pure function vtkhdf_quad_node_order(lx, ly) result(node_order)
+    integer, intent(in) :: lx, ly
+    integer, allocatable :: node_order(:)
+    integer :: ii, jj, idx
+
+    allocate(node_order(4 * (lx - 1) * (ly - 1)))
+    idx = 0
+
+    do jj = 1, ly - 1
+       do ii = 1, lx - 1
+          node_order(idx + 1) = (jj - 1) * lx + ii - 1
+          node_order(idx + 2) = (jj - 1) * lx + ii
+          node_order(idx + 3) = jj * lx + ii
+          node_order(idx + 4) = jj * lx + ii - 1
+          idx = idx + 4
+       end do
+    end do
+
+  end function vtkhdf_quad_node_order
 
   !> Write mesh geometry datasets to the VTKHDF group.
   !! Writes NumberOfPoints, NumberOfCells, NumberOfConnectivityIds,

--- a/src/io/vtkhdf_file.F90
+++ b/src/io/vtkhdf_file.F90
@@ -297,6 +297,7 @@ contains
     type(dofmap_t) :: dof
     integer :: lx, ly, lz, nelv
     integer :: ie, ii, jj, kk, base, idx, npts_per_cell, p
+    integer, allocatable :: node_order(:)
 
     nelv = msh%nelv
     lx = dof%Xh%lx
@@ -304,6 +305,19 @@ contains
     lz = dof%Xh%lz
     npts_per_cell = lx * ly * lz
     idx = 0
+
+    select case (vtk_type)
+    case (12) ! VTK_HEXAHEDRON
+       ! No special ordering needed for linear hexes
+    case (9) ! VTK_QUAD
+       ! No special ordering needed for linear quads
+    case (72) ! VTK_LAGRANGE_HEXAHEDRON
+       node_order = vtk_lagrange_hex_ordering(lx, ly, lz)
+    case (70) ! VTK_LAGRANGE_QUADRILATERAL
+       node_order = vtk_lagrange_quad_ordering(lx, ly)
+    case default
+       call neko_error('Unsupported VTK cell type')
+    end select
 
     do ie = 1, nelv
        base = (ie - 1) * npts_per_cell
@@ -346,31 +360,25 @@ contains
           end do
 
        case (72) ! VTK_LAGRANGE_HEXAHEDRON
-          block
-            integer, allocatable :: node_order(:)
-            node_order = vtk_lagrange_hex_ordering(lx)
-            do ii = 1, lx * ly * lz
-               conn(idx + ii) = base + node_order(ii)
-            end do
-            deallocate(node_order)
-          end block
+
+          do ii = 1, lx * ly * lz
+             conn(idx + ii) = base + node_order(ii)
+          end do
           idx = idx + lx * ly * lz
 
        case (70) ! VTK_LAGRANGE_QUADRILATERAL
-          block
-            integer, allocatable :: node_order(:)
-            node_order = vtk_lagrange_quad_ordering(lx)
-            do ii = 1, lx * ly
-               conn(idx + ii) = base + node_order(ii)
-            end do
-            deallocate(node_order)
-          end block
+
+          do ii = 1, lx * ly
+             conn(idx + ii) = base + node_order(ii)
+          end do
           idx = idx + lx * ly
 
        case default
           call neko_error('Unsupported VTK cell type')
        end select
     end do
+
+    if (allocated(node_order)) deallocate(node_order)
 
   end subroutine vtkhdf_build_connectivity
 
@@ -1325,133 +1333,140 @@ contains
   ! These are HDF5-independent and placed outside the preprocessor block.
 
   !> Build the VTK Lagrange hexahedron node ordering for a given lx.
-  !! Returns an array of size lx^3 mapping VTK node position to the
+  !! Returns an array of size lx*ly*lz mapping VTK node position to the
   !! 0-based tensor-product index (i + lx*j + lx*ly*k).
   !! Implements VTK's PointIndexFromIJK for Lagrange hexahedra.
-  !! Node ordering: 8 corners, 12*(p-1) edge interiors,
-  !! 6*(p-1)^2 face interiors, (p-1)^3 body interior.
-  !! @param lx Number of points per edge (polynomial order + 1)
+  !! Node ordering: 8 corners, 4 * (lx - 2 + ly - 2 + lz - 2) edge interiors,
+  !! 6*(lx - 2)*(ly - 2) face interiors, (lx - 2)*(ly - 2)*(lz - 2) body
+  !! interior.
+  !! @param lx Number of points per edge in x-direction (polynomial order + 1)
+  !! @param ly Number of points per edge in y-direction (polynomial order + 1)
+  !! @param lz Number of points per edge in z-direction (polynomial order + 1)
   !! @return Array of 0-based tensor-product indices in VTK order
-  pure function vtk_lagrange_hex_ordering(lx) result(ordering)
-    integer, intent(in) :: lx
+  pure function vtk_lagrange_hex_ordering(lx, ly, lz) result(ordering)
+    integer, intent(in) :: lx, ly, lz
     integer, allocatable :: ordering(:)
-    integer :: i, j, k, p, vtk_idx
+    integer :: i, j, k, vtk_idx
     integer :: ibdy, jbdy, kbdy, nbdy, offset
+    integer :: n_corners, n_edges, n_faces, n_interior, n_total
 
-    p = lx - 1
-    allocate(ordering(lx * lx * lx))
+    n_corners = 8
+    n_edges = 4 * ((lx - 2) + (ly - 2) + (lz - 2))
+    n_faces = 2 * ((lx - 2)*(ly - 2) + (lx - 2)*(lz - 2) + (ly - 2)*(lz - 2))
+    n_interior = (lx - 2) * (ly - 2) * (lz - 2)
+    n_total = n_corners + n_edges + n_faces + n_interior
+    allocate(ordering(lx * ly * lz))
 
-    do k = 0, p
-       do j = 0, p
-          do i = 0, p
-             ibdy = merge(1, 0, i == 0 .or. i == p)
-             jbdy = merge(1, 0, j == 0 .or. j == p)
-             kbdy = merge(1, 0, k == 0 .or. k == p)
-             nbdy = ibdy + jbdy + kbdy
+    do concurrent (i = 0:(lx - 1), j = 0:(ly - 1), k = 0:(lz - 1))
+       ibdy = merge(1, 0, i .eq. 0 .or. i .eq. lx - 1)
+       jbdy = merge(1, 0, j .eq. 0 .or. j .eq. ly - 1)
+       kbdy = merge(1, 0, k .eq. 0 .or. k .eq. lz - 1)
+       nbdy = ibdy + jbdy + kbdy
 
-             ! Corner node
-             if (nbdy == 3) then
-                vtk_idx = merge( &
-                     merge(2, 1, j /= 0), &
-                     merge(3, 0, j /= 0), i /= 0) &
-                     + merge(4, 0, k /= 0)
+       if (nbdy .eq. 3) then
+          ! Corner node
+          vtk_idx = merge( &
+               merge(2, 1, j .ne. 0), &
+               merge(3, 0, j .ne. 0), i .ne. 0) &
+               + merge(4, 0, k .ne. 0)
 
-                ! Edge interior node
-             else if (nbdy == 2) then
-                offset = 8
-                if (ibdy == 0) then
-                   vtk_idx = (i - 1) &
-                        + merge(2 * (p - 1), 0, j /= 0) &
-                        + merge(4 * (p - 1), 0, k /= 0) &
-                        + offset
-                else if (jbdy == 0) then
-                   vtk_idx = (j - 1) &
-                        + merge(p - 1, 3 * (p - 1), i /= 0) &
-                        + merge(4 * (p - 1), 0, k /= 0) &
-                        + offset
-                else
-                   vtk_idx = (k - 1) + (p - 1) &
-                        * merge(merge(2, 1, j /= 0), &
-                        merge(3, 0, j /= 0), i /= 0) &
-                        + offset + 8 * (p - 1)
-                end if
+       else if (nbdy .eq. 2) then
+          ! Edge interior node
+          offset = n_corners
+          if (ibdy .eq. 0) then
+             vtk_idx = (i - 1) &
+                  + merge((lx - 2) + (ly - 2), 0, j .ne. 0) &
+                  + merge(2 * ((lx - 2) + (ly - 2)), 0, k .ne. 0) &
+                  + offset
+          else if (jbdy .eq. 0) then
+             vtk_idx = (j - 1) &
+                  + merge(lx - 2, 2 * (lx - 2) + (ly - 2), i .ne. 0) &
+                  + merge(2 * ((lx - 2) + (ly - 2)), 0, k .ne. 0) &
+                  + offset
+          else
+             vtk_idx = (k - 1) + (lz - 2) &
+                  * merge(merge(2, 1, j .ne. 0), &
+                  merge(3, 0, j .ne. 0), i .ne. 0) &
+                  + offset + 4 * ((lx - 2) + (ly - 2))
+          end if
 
-                ! Face interior node
-             else if (nbdy == 1) then
-                offset = 8 + 12 * (p - 1)
-                if (ibdy == 1) then
-                   vtk_idx = (j - 1) + (p - 1) * (k - 1) &
-                        + merge((p - 1) * (p - 1), 0, i /= 0) &
-                        + offset
-                else if (jbdy == 1) then
-                   vtk_idx = (i - 1) + (p - 1) * (k - 1) &
-                        + merge((p - 1) * (p - 1), 0, j /= 0) &
-                        + offset + 2 * (p - 1) * (p - 1)
-                else
-                   vtk_idx = (i - 1) + (p - 1) * (j - 1) &
-                        + merge((p - 1) * (p - 1), 0, k /= 0) &
-                        + offset + 4 * (p - 1) * (p - 1)
-                end if
+       else if (nbdy .eq. 1) then
+          ! Face interior node
+          offset = n_corners + n_edges
+          if (ibdy .eq. 1) then
+             vtk_idx = (j - 1) + (ly - 2) * (k - 1) &
+                  + merge((ly - 2) * (lz - 2), 0, i .ne. 0) &
+                  + offset
+          else if (jbdy .eq. 1) then
+             vtk_idx = (i - 1) + (lx - 2) * (k - 1) &
+                  + merge((lx - 2) * (lz - 2), 0, j .ne. 0) &
+                  + offset + 2 * (ly - 2) * (lz - 2)
+          else if (kbdy .eq. 1) then
+             vtk_idx = (i - 1) + (lx - 2) * (j - 1) &
+                  + merge((lx - 2) * (ly - 2), 0, k .ne. 0) &
+                  + offset + 2 * (ly - 2) * (lz - 2) &
+                  + 2 * (lx - 2) * (lz - 2)
+          end if
 
-                ! Body interior node
-             else
-                vtk_idx = 8 + 12 * (p - 1) + 6 * (p - 1) * (p - 1) &
-                     + (i - 1) + (p - 1) * ((j - 1) + (p - 1) * (k - 1))
-             end if
+       else
+          ! Body interior node
+          offset = n_corners + n_edges + n_faces
+          vtk_idx = offset &
+               + (i - 1) + (lx - 2) * ((j - 1) + (ly - 2) * (k - 1))
+       end if
 
-             ! ordering(vtk_position + 1) = tensor-product index
-             ordering(vtk_idx + 1) = k * lx * lx + j * lx + i
-          end do
-       end do
+       ! ordering(vtk_position + 1) = tensor-product index
+       ordering(vtk_idx + 1) = k * lx * ly + j * lx + i
     end do
 
   end function vtk_lagrange_hex_ordering
 
-  !> Build the VTK Lagrange quadrilateral node ordering for a given lx.
-  !! Returns an array of size lx^2 mapping VTK node position to the
+  !> Build the VTK Lagrange quadrilateral node ordering for a given lx, ly.
+  !! Returns an array of size lx*ly mapping VTK node position to the
   !! 0-based tensor-product index (i + lx*j).
   !! Implements VTK's PointIndexFromIJK for Lagrange quadrilaterals.
-  !! Node ordering: 4 corners, 4*(p-1) edge interiors,
-  !! (p-1)^2 face interior.
-  !! @param lx Number of points per edge (polynomial order + 1)
+  !! Node ordering: 4 corners, 2*(lx-2) + 2*(ly-2) edge interiors,
+  !! (lx-2)*(ly-2) face interior.
+  !! @param lx Number of points per edge in x-direction (polynomial order + 1)
+  !! @param ly Number of points per edge in y-direction (polynomial order + 1)
   !! @return Array of 0-based tensor-product indices in VTK order
-  pure function vtk_lagrange_quad_ordering(lx) result(ordering)
-    integer, intent(in) :: lx
+  pure function vtk_lagrange_quad_ordering(lx, ly) result(ordering)
+    integer, intent(in) :: lx, ly
     integer, allocatable :: ordering(:)
-    integer :: i, j, p, vtk_idx
+    integer :: i, j, vtk_idx
     integer :: ibdy, jbdy, nbdy, offset
 
-    p = lx - 1
-    allocate(ordering(lx * lx))
+    allocate(ordering(lx * ly))
 
-    do j = 0, p
-       do i = 0, p
-          ibdy = merge(1, 0, i == 0 .or. i == p)
-          jbdy = merge(1, 0, j == 0 .or. j == p)
+    do j = 0, ly - 1
+       do i = 0, lx - 1
+          ibdy = merge(1, 0, i .eq. 0 .or. i .eq. lx - 1)
+          jbdy = merge(1, 0, j .eq. 0 .or. j .eq. ly - 1)
           nbdy = ibdy + jbdy
 
           ! Corner node
-          if (nbdy == 2) then
+          if (nbdy .eq. 2) then
              vtk_idx = merge( &
-                  merge(2, 1, j /= 0), &
-                  merge(3, 0, j /= 0), i /= 0)
+                  merge(2, 1, j .ne. 0), &
+                  merge(3, 0, j .ne. 0), i .ne. 0)
 
              ! Edge interior node
-          else if (nbdy == 1) then
+          else if (nbdy .eq. 1) then
              offset = 4
-             if (ibdy == 0) then
+             if (ibdy .eq. 0) then
                 vtk_idx = (i - 1) &
-                     + merge(2 * (p - 1), 0, j /= 0) &
+                     + merge((lx - 2) + (ly - 2), 0, j .ne. 0) &
                      + offset
              else
                 vtk_idx = (j - 1) &
-                     + merge(p - 1, 3 * (p - 1), i /= 0) &
+                     + merge(lx - 2, 2 * (lx - 2) + (ly - 2), i .ne. 0) &
                      + offset
              end if
 
              ! Face interior node
           else
-             vtk_idx = (i - 1) + (p - 1) * (j - 1) + 4 + 4 * (p - 1)
+             vtk_idx = (i - 1) + (lx - 2) * (j - 1) &
+                  + 4 + 2 * ((lx - 2) + (ly - 2))
           end if
 
           ordering(vtk_idx + 1) = j * lx + i

--- a/src/io/vtkhdf_file.F90
+++ b/src/io/vtkhdf_file.F90
@@ -48,6 +48,7 @@ module vtkhdf_file
   use mpi_f08, only : MPI_INFO_NULL, MPI_Allreduce, MPI_Allgather, &
        MPI_IN_PLACE, MPI_INTEGER, MPI_SUM, MPI_MAX, MPI_Comm_size, MPI_Exscan, &
        MPI_Barrier
+  use vtk, only: vtk_ordering
 #ifdef HAVE_HDF5
   use hdf5
 #endif
@@ -307,16 +308,12 @@ contains
     idx = 0
 
     select case (vtk_type)
-    case (12) ! VTK_HEXAHEDRON
-       ! No special ordering needed for linear hexes
     case (9) ! VTK_QUAD
        ! No special ordering needed for linear quads
-    case (72) ! VTK_LAGRANGE_HEXAHEDRON
-       node_order = vtk_lagrange_hex_ordering(lx, ly, lz)
-    case (70) ! VTK_LAGRANGE_QUADRILATERAL
-       node_order = vtk_lagrange_quad_ordering(lx, ly)
-    case default
-       call neko_error('Unsupported VTK cell type')
+    case (12) ! VTK_HEXAHEDRON
+       ! No special ordering needed for linear hexes
+    case default ! Standard VTK node types
+       node_order = vtk_ordering(vtk_type, lx, ly, lz)
     end select
 
     do ie = 1, nelv
@@ -1327,156 +1324,5 @@ contains
   end subroutine vtkhdf_file_read
 
 #endif
-
-  ! -------------------------------------------------------------------------- !
-  ! Pure functions for VTK Lagrange node ordering
-  ! These are HDF5-independent and placed outside the preprocessor block.
-
-  !> Build the VTK Lagrange hexahedron node ordering for a given lx.
-  !! Returns an array of size lx*ly*lz mapping VTK node position to the
-  !! 0-based tensor-product index (i + lx*j + lx*ly*k).
-  !! Implements VTK's PointIndexFromIJK for Lagrange hexahedra.
-  !! Node ordering: 8 corners, 4 * (lx - 2 + ly - 2 + lz - 2) edge interiors,
-  !! 6*(lx - 2)*(ly - 2) face interiors, (lx - 2)*(ly - 2)*(lz - 2) body
-  !! interior.
-  !! @param lx Number of points per edge in x-direction (polynomial order + 1)
-  !! @param ly Number of points per edge in y-direction (polynomial order + 1)
-  !! @param lz Number of points per edge in z-direction (polynomial order + 1)
-  !! @return Array of 0-based tensor-product indices in VTK order
-  pure function vtk_lagrange_hex_ordering(lx, ly, lz) result(ordering)
-    integer, intent(in) :: lx, ly, lz
-    integer, allocatable :: ordering(:)
-    integer :: i, j, k, vtk_idx
-    integer :: ibdy, jbdy, kbdy, nbdy, offset
-    integer :: n_corners, n_edges, n_faces, n_interior, n_total
-
-    n_corners = 8
-    n_edges = 4 * ((lx - 2) + (ly - 2) + (lz - 2))
-    n_faces = 2 * ((lx - 2) * (ly - 2) + (lx - 2) * (lz - 2) + (ly - 2) * (lz - 2))
-    n_interior = (lx - 2) * (ly - 2) * (lz - 2)
-    n_total = n_corners + n_edges + n_faces + n_interior
-    allocate(ordering(lx * ly * lz))
-
-    do concurrent (i = 1:lx, j = 1:ly, k = 1:lz)
-       ibdy = merge(1, 0, i .eq. 1 .or. i .eq. lx)
-       jbdy = merge(1, 0, j .eq. 1 .or. j .eq. ly)
-       kbdy = merge(1, 0, k .eq. 1 .or. k .eq. lz)
-       nbdy = ibdy + jbdy + kbdy
-
-       if (nbdy .eq. 3) then
-          ! Corner node
-          vtk_idx = merge( &
-               merge(2, 1, j .ne. 1), &
-               merge(3, 0, j .ne. 1), i .ne. 1) &
-               + merge(4, 0, k .ne. 1)
-
-       else if (nbdy .eq. 2) then
-          ! Edge interior node
-          offset = n_corners
-          if (ibdy .eq. 0) then
-             vtk_idx = (i - 2) &
-                  + merge((lx - 2) + (ly - 2), 0, j .ne. 1) &
-                  + merge(2 * ((lx - 2) + (ly - 2)), 0, k .ne. 1) &
-                  + offset
-          else if (jbdy .eq. 0) then
-             vtk_idx = (j - 2) &
-                  + merge(lx - 2, 2 * (lx - 2) + (ly - 2), i .ne. 1) &
-                  + merge(2 * ((lx - 2) + (ly - 2)), 0, k .ne. 1) &
-                  + offset
-          else
-             vtk_idx = (k - 2) + (lz - 2) &
-                  * merge(merge(2, 1, j .ne. 1), &
-                  merge(3, 0, j .ne. 1), i .ne. 1) &
-                  + offset + 4 * ((lx - 2) + (ly - 2))
-          end if
-
-       else if (nbdy .eq. 1) then
-          ! Face interior node
-          offset = n_corners + n_edges
-          if (ibdy .eq. 1) then
-             vtk_idx = (j - 2) + (ly - 2) * (k - 2) &
-                  + merge((ly - 2) * (lz - 2), 0, i .ne. 1) &
-                  + offset
-          else if (jbdy .eq. 1) then
-             offset = offset + 2 * (ly - 2) * (lz - 2)
-             vtk_idx = (i - 2) + (lx - 2) * (k - 2) &
-                  + merge((lx - 2) * (lz - 2), 0, j .ne. 1) &
-                  + offset
-          else if (kbdy .eq. 1) then
-             offset = offset + 2 * (ly - 2) * (lz - 2) + 2 * (lx - 2) * (lz - 2)
-             vtk_idx = (i - 2) + (lx - 2) * (j - 2) &
-                  + merge((lx - 2) * (ly - 2), 0, k .ne. 1) &
-                  + offset
-          end if
-
-       else
-          ! Body interior node
-          offset = n_corners + n_edges + n_faces
-          vtk_idx = offset &
-               + (i - 2) + (lx - 2) * ((j - 2) + (ly - 2) * (k - 2))
-       end if
-
-       ! ordering(vtk_position + 1) = tensor-product index
-       ordering(vtk_idx + 1) = linear_index(i, j, k, 1, lx, ly, lz) - 1
-    end do
-
-  end function vtk_lagrange_hex_ordering
-
-  !> Build the VTK Lagrange quadrilateral node ordering for a given lx, ly.
-  !! Returns an array of size lx*ly mapping VTK node position to the
-  !! 0-based tensor-product index (i + lx*j).
-  !! Implements VTK's PointIndexFromIJK for Lagrange quadrilaterals.
-  !! Node ordering: 4 corners, 2*(lx-2) + 2*(ly-2) edge interiors,
-  !! (lx-2)*(ly-2) face interior.
-  !! @param lx Number of points per edge in x-direction (polynomial order + 1)
-  !! @param ly Number of points per edge in y-direction (polynomial order + 1)
-  !! @return Array of 0-based tensor-product indices in VTK order
-  pure function vtk_lagrange_quad_ordering(lx, ly) result(ordering)
-    integer, intent(in) :: lx, ly
-    integer, allocatable :: ordering(:)
-    integer :: i, j, vtk_idx
-    integer :: ibdy, jbdy, nbdy, offset
-    integer :: n_corners, n_edges, n_faces, n_total
-
-    n_corners = 4
-    n_edges = 2 * ((lx - 2) + (ly - 2))
-    n_faces = (lx - 2) * (ly - 2)
-    n_total = n_corners + n_edges + n_faces
-    allocate(ordering(lx * ly))
-
-    do concurrent (i = 1:lx, j = 1:ly)
-       ibdy = merge(1, 0, i .eq. 1 .or. i .eq. lx)
-       jbdy = merge(1, 0, j .eq. 1 .or. j .eq. ly)
-       nbdy = ibdy + jbdy
-
-       if (nbdy .eq. 2) then
-          ! Corner node
-          vtk_idx = merge( &
-               merge(2, 1, j .ne. 1), &
-               merge(3, 0, j .ne. 1), i .ne. 1)
-
-       else if (nbdy .eq. 1) then
-          ! Edge interior node
-          offset = n_corners
-          if (ibdy .eq. 0) then
-             vtk_idx = (i - 2) &
-                  + merge((lx - 2) + (ly - 2), 0, j .ne. 1) &
-                  + offset
-          else
-             vtk_idx = (j - 2) &
-                  + merge(lx - 2, 2 * (lx - 2) + (ly - 2), i .ne. 1) &
-                  + offset
-          end if
-
-       else
-          ! Face interior node
-          offset = n_corners + n_edges
-          vtk_idx = offset + (i - 2) + (lx - 2) * (j - 2)
-       end if
-
-       ordering(vtk_idx + 1) = linear_index(i, j, 1, 1, lx, ly, 1) - 1
-    end do
-
-  end function vtk_lagrange_quad_ordering
 
 end module vtkhdf_file

--- a/src/io/vtkhdf_file.F90
+++ b/src/io/vtkhdf_file.F90
@@ -36,7 +36,7 @@ module vtkhdf_file
   use generic_file, only : generic_file_t
   use checkpoint, only : chkp_t
   use utils, only : neko_error, neko_warning, filename_split, &
-       nonlinear_index
+       nonlinear_index, linear_index
   use mesh, only : mesh_t
   use field, only : field_t, field_ptr_t
   use field_list, only : field_list_t
@@ -1352,41 +1352,41 @@ contains
 
     n_corners = 8
     n_edges = 4 * ((lx - 2) + (ly - 2) + (lz - 2))
-    n_faces = 2 * ((lx - 2)*(ly - 2) + (lx - 2)*(lz - 2) + (ly - 2)*(lz - 2))
+    n_faces = 2 * ((lx - 2) * (ly - 2) + (lx - 2) * (lz - 2) + (ly - 2) * (lz - 2))
     n_interior = (lx - 2) * (ly - 2) * (lz - 2)
     n_total = n_corners + n_edges + n_faces + n_interior
     allocate(ordering(lx * ly * lz))
 
-    do concurrent (i = 0:(lx - 1), j = 0:(ly - 1), k = 0:(lz - 1))
-       ibdy = merge(1, 0, i .eq. 0 .or. i .eq. lx - 1)
-       jbdy = merge(1, 0, j .eq. 0 .or. j .eq. ly - 1)
-       kbdy = merge(1, 0, k .eq. 0 .or. k .eq. lz - 1)
+    do concurrent (i = 1:lx, j = 1:ly, k = 1:lz)
+       ibdy = merge(1, 0, i .eq. 1 .or. i .eq. lx)
+       jbdy = merge(1, 0, j .eq. 1 .or. j .eq. ly)
+       kbdy = merge(1, 0, k .eq. 1 .or. k .eq. lz)
        nbdy = ibdy + jbdy + kbdy
 
        if (nbdy .eq. 3) then
           ! Corner node
           vtk_idx = merge( &
-               merge(2, 1, j .ne. 0), &
-               merge(3, 0, j .ne. 0), i .ne. 0) &
-               + merge(4, 0, k .ne. 0)
+               merge(2, 1, j .ne. 1), &
+               merge(3, 0, j .ne. 1), i .ne. 1) &
+               + merge(4, 0, k .ne. 1)
 
        else if (nbdy .eq. 2) then
           ! Edge interior node
           offset = n_corners
           if (ibdy .eq. 0) then
-             vtk_idx = (i - 1) &
-                  + merge((lx - 2) + (ly - 2), 0, j .ne. 0) &
-                  + merge(2 * ((lx - 2) + (ly - 2)), 0, k .ne. 0) &
+             vtk_idx = (i - 2) &
+                  + merge((lx - 2) + (ly - 2), 0, j .ne. 1) &
+                  + merge(2 * ((lx - 2) + (ly - 2)), 0, k .ne. 1) &
                   + offset
           else if (jbdy .eq. 0) then
-             vtk_idx = (j - 1) &
-                  + merge(lx - 2, 2 * (lx - 2) + (ly - 2), i .ne. 0) &
-                  + merge(2 * ((lx - 2) + (ly - 2)), 0, k .ne. 0) &
+             vtk_idx = (j - 2) &
+                  + merge(lx - 2, 2 * (lx - 2) + (ly - 2), i .ne. 1) &
+                  + merge(2 * ((lx - 2) + (ly - 2)), 0, k .ne. 1) &
                   + offset
           else
-             vtk_idx = (k - 1) + (lz - 2) &
-                  * merge(merge(2, 1, j .ne. 0), &
-                  merge(3, 0, j .ne. 0), i .ne. 0) &
+             vtk_idx = (k - 2) + (lz - 2) &
+                  * merge(merge(2, 1, j .ne. 1), &
+                  merge(3, 0, j .ne. 1), i .ne. 1) &
                   + offset + 4 * ((lx - 2) + (ly - 2))
           end if
 
@@ -1394,29 +1394,30 @@ contains
           ! Face interior node
           offset = n_corners + n_edges
           if (ibdy .eq. 1) then
-             vtk_idx = (j - 1) + (ly - 2) * (k - 1) &
-                  + merge((ly - 2) * (lz - 2), 0, i .ne. 0) &
+             vtk_idx = (j - 2) + (ly - 2) * (k - 2) &
+                  + merge((ly - 2) * (lz - 2), 0, i .ne. 1) &
                   + offset
           else if (jbdy .eq. 1) then
-             vtk_idx = (i - 1) + (lx - 2) * (k - 1) &
-                  + merge((lx - 2) * (lz - 2), 0, j .ne. 0) &
-                  + offset + 2 * (ly - 2) * (lz - 2)
+             offset = offset + 2 * (ly - 2) * (lz - 2)
+             vtk_idx = (i - 2) + (lx - 2) * (k - 2) &
+                  + merge((lx - 2) * (lz - 2), 0, j .ne. 1) &
+                  + offset
           else if (kbdy .eq. 1) then
-             vtk_idx = (i - 1) + (lx - 2) * (j - 1) &
-                  + merge((lx - 2) * (ly - 2), 0, k .ne. 0) &
-                  + offset + 2 * (ly - 2) * (lz - 2) &
-                  + 2 * (lx - 2) * (lz - 2)
+             offset = offset + 2 * (ly - 2) * (lz - 2) + 2 * (lx - 2) * (lz - 2)
+             vtk_idx = (i - 2) + (lx - 2) * (j - 2) &
+                  + merge((lx - 2) * (ly - 2), 0, k .ne. 1) &
+                  + offset
           end if
 
        else
           ! Body interior node
           offset = n_corners + n_edges + n_faces
           vtk_idx = offset &
-               + (i - 1) + (lx - 2) * ((j - 1) + (ly - 2) * (k - 1))
+               + (i - 2) + (lx - 2) * ((j - 2) + (ly - 2) * (k - 2))
        end if
 
        ! ordering(vtk_position + 1) = tensor-product index
-       ordering(vtk_idx + 1) = k * lx * ly + j * lx + i
+       ordering(vtk_idx + 1) = linear_index(i, j, k, 1, lx, ly, lz) - 1
     end do
 
   end function vtk_lagrange_hex_ordering
@@ -1435,42 +1436,45 @@ contains
     integer, allocatable :: ordering(:)
     integer :: i, j, vtk_idx
     integer :: ibdy, jbdy, nbdy, offset
+    integer :: n_corners, n_edges, n_faces, n_total
 
+    n_corners = 4
+    n_edges = 2 * ((lx - 2) + (ly - 2))
+    n_faces = (lx - 2) * (ly - 2)
+    n_total = n_corners + n_edges + n_faces
     allocate(ordering(lx * ly))
 
-    do j = 0, ly - 1
-       do i = 0, lx - 1
-          ibdy = merge(1, 0, i .eq. 0 .or. i .eq. lx - 1)
-          jbdy = merge(1, 0, j .eq. 0 .or. j .eq. ly - 1)
-          nbdy = ibdy + jbdy
+    do concurrent (i = 1:lx, j = 1:ly)
+       ibdy = merge(1, 0, i .eq. 1 .or. i .eq. lx)
+       jbdy = merge(1, 0, j .eq. 1 .or. j .eq. ly)
+       nbdy = ibdy + jbdy
 
+       if (nbdy .eq. 2) then
           ! Corner node
-          if (nbdy .eq. 2) then
-             vtk_idx = merge( &
-                  merge(2, 1, j .ne. 0), &
-                  merge(3, 0, j .ne. 0), i .ne. 0)
+          vtk_idx = merge( &
+               merge(2, 1, j .ne. 1), &
+               merge(3, 0, j .ne. 1), i .ne. 1)
 
-             ! Edge interior node
-          else if (nbdy .eq. 1) then
-             offset = 4
-             if (ibdy .eq. 0) then
-                vtk_idx = (i - 1) &
-                     + merge((lx - 2) + (ly - 2), 0, j .ne. 0) &
-                     + offset
-             else
-                vtk_idx = (j - 1) &
-                     + merge(lx - 2, 2 * (lx - 2) + (ly - 2), i .ne. 0) &
-                     + offset
-             end if
-
-             ! Face interior node
+       else if (nbdy .eq. 1) then
+          ! Edge interior node
+          offset = n_corners
+          if (ibdy .eq. 0) then
+             vtk_idx = (i - 2) &
+                  + merge((lx - 2) + (ly - 2), 0, j .ne. 1) &
+                  + offset
           else
-             vtk_idx = (i - 1) + (lx - 2) * (j - 1) &
-                  + 4 + 2 * ((lx - 2) + (ly - 2))
+             vtk_idx = (j - 2) &
+                  + merge(lx - 2, 2 * (lx - 2) + (ly - 2), i .ne. 1) &
+                  + offset
           end if
 
-          ordering(vtk_idx + 1) = j * lx + i
-       end do
+       else
+          ! Face interior node
+          offset = n_corners + n_edges
+          vtk_idx = offset + (i - 2) + (lx - 2) * (j - 2)
+       end if
+
+       ordering(vtk_idx + 1) = linear_index(i, j, 1, 1, lx, ly, 1) - 1
     end do
 
   end function vtk_lagrange_quad_ordering

--- a/src/io/vtkhdf_file.F90
+++ b/src/io/vtkhdf_file.F90
@@ -58,7 +58,7 @@ module vtkhdf_file
   !> Interface for HDF5 files
   type, public, extends(generic_file_t) :: vtkhdf_file_t
      logical :: amr_enabled = .false.
-     logical :: lagrange = .false.
+     logical :: subdivide = .false.
      integer :: precision = 0
    contains
      procedure :: get_vtkhdf_fname => vtkhdf_file_get_fname
@@ -67,7 +67,7 @@ module vtkhdf_file
      procedure :: set_overwrite => vtkhdf_file_set_overwrite
      procedure :: enable_amr => vtkhdf_file_enable_amr
      procedure :: set_precision => vtkhdf_file_set_precision
-     procedure :: set_lagrange => vtkhdf_file_set_lagrange
+     procedure :: set_subdivide => vtkhdf_file_set_subdivide
   end type vtkhdf_file_t
 
   integer, dimension(2), parameter :: vtkhdf_version = [2, 6]
@@ -112,16 +112,16 @@ contains
 
   end function vtkhdf_file_get_fname
 
-  !> Enable or disable high-order Lagrange element output.
-  !! When enabled, each spectral element is written as a single
-  !! VTK_LAGRANGE_HEXAHEDRON (type 72) or VTK_LAGRANGE_QUADRILATERAL
-  !! (type 70) cell instead of being subdivided into linear sub-cells.
-  !! @param lagrange Whether to enable Lagrange element output.
-  subroutine vtkhdf_file_set_lagrange(this, lagrange)
+  !> Enable or disable subdivision of spectral elements into linear sub-cells.
+  !! When subdivision is enabled, each spectral element is written as multiple
+  !! linear VTK cells (VTK_HEXAHEDRON in 3D, VTK_QUAD in 2D) with connectivity
+  !! corresponding to the tensor-product grid of the spectral element.
+  !! @param subdivide Whether to subdivide into linear sub-cells.
+  subroutine vtkhdf_file_set_subdivide(this, subdivide)
     class(vtkhdf_file_t), intent(inout) :: this
-    logical, intent(in) :: lagrange
-    this%lagrange = lagrange
-  end subroutine vtkhdf_file_set_lagrange
+    logical, intent(in) :: subdivide
+    this%subdivide = subdivide
+  end subroutine vtkhdf_file_set_subdivide
 
 #ifdef HAVE_HDF5
   ! -------------------------------------------------------------------------- !
@@ -148,7 +148,7 @@ contains
     integer, allocatable :: part_points(:), part_cells(:), part_conns(:)
     character(len=1024) :: fname
     character(len=16) :: type_str
-    logical :: link_exists, file_exists, subdivide
+    logical :: link_exists, file_exists
     integer(kind=1) :: VTK_cell_type
     integer :: counter
 
@@ -190,8 +190,6 @@ contains
     else if (this%precision .eq. 0) then
        this%precision = rp
     end if
-
-    subdivide = .not. this%lagrange
 
     call this%increment_counter()
     fname = trim(this%get_vtkhdf_fname())
@@ -252,7 +250,7 @@ contains
 
     if (associated(msh)) then
        call vtkhdf_write_mesh(vtkhdf_grp, dof, msh, &
-            this%amr_enabled, counter, subdivide, t)
+            this%amr_enabled, counter, this%subdivide, t)
     end if
 
     ! Write field data in PointData group

--- a/src/io/vtkhdf_file.F90
+++ b/src/io/vtkhdf_file.F90
@@ -149,7 +149,6 @@ contains
     character(len=1024) :: fname
     character(len=16) :: type_str
     logical :: link_exists, file_exists
-    integer(kind=1) :: VTK_cell_type
     integer :: counter
 
     ! Determine mesh and field data
@@ -181,6 +180,9 @@ contains
     end if
     if (msh%gdim .eq. 3 .and. dof%Xh%lz < 2) then
        call neko_error('VTKHDF linear output requires lz >= 2 in 3D')
+    end if
+    if (msh%gdim .lt. 2 .or. msh%gdim .gt. 3) then
+       call neko_error('VTKHDF output only supports 2D and 3D meshes')
     end if
 
     ! Ensure precision is set and are valid.

--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -67,6 +67,5 @@ time_based_controller/time_based_controller_test
 json_utils/json_utils_test
 point_interpolation/point_interpolation_suite
 **/test_write_*.vtkhdf
-**/test_write_time_*.vtkhdf
 templates/parallel/parallel_suite
 templates/serial/serial_test

--- a/tests/unit/vtkhdf/vtkhdf_parallel.pf
+++ b/tests/unit/vtkhdf/vtkhdf_parallel.pf
@@ -45,8 +45,6 @@ contains
 
   subroutine tearDown(this)
     class(test_vtkhdf), intent(inout) :: this
-    logical :: exists
-    integer :: unit
 
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_finalize
@@ -654,7 +652,7 @@ contains
     call h5sclose_f(filespace, hdferr)
     call h5dclose_f(dset_id, hdferr)
 
-    ! -- PartOffsets dataset: shape (NUM_STEPS,) with [0, NUM_PARTS] --
+    ! -- PartOffsets dataset: shape (NUM_STEPS,) with [0, 0] --
     call h5lexists_f(steps_grp, "PartOffsets", link_exists, hdferr)
     message = "Steps/PartOffsets must exist"
     @assertTrue(link_exists, message = message)

--- a/tests/unit/vtkhdf/vtkhdf_parallel.pf
+++ b/tests/unit/vtkhdf/vtkhdf_parallel.pf
@@ -48,18 +48,6 @@ contains
     logical :: exists
     integer :: unit
 
-    inquire(file='test_write_0.vtkhdf', exist=exists)
-    if (exists .and. pe_rank .eq. 0) then
-       open(newunit=unit, file='test_write_0.vtkhdf')
-       close(unit, status='delete')
-    end if
-
-    inquire(file='test_write_time_0.vtkhdf', exist=exists)
-    if (exists .and. pe_rank .eq. 0) then
-       open(newunit=unit, file='test_write_time_0.vtkhdf')
-       close(unit, status='delete')
-    end if
-
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_finalize
     end if
@@ -145,7 +133,7 @@ contains
     type(field_t) :: f
     character(len=80) :: fname
     type(file_t) :: file
-    integer :: ierr
+    integer :: unit, ierr
     logical :: exists
     character(len=:), allocatable :: message
 
@@ -159,19 +147,20 @@ contains
     logical :: link_exists
     character(len=16) :: type_read
 
-    ! Expected values: each rank has 2 elements (mesh not distributed), LX=4, 3D:
-    ! npts_per_cell = 64, subcells_per_el = 27, nodes_per_cell = 8
+    ! Expected values: each rank has 2 elements (mesh not distributed), LX=4, 3D
+    ! No subdivision (Lagrange): 1 VTK cell per element,
+    ! nodes_per_cell = lx*ly*lz = 64
     ! local_points = 2*64 = 128, total_points = 256
-    ! local_cells = 2*27 = 54, total_cells = 108
-    ! local_conn = 54*8 = 432, total_conn = 864
-    ! total_offsets = 108 + 2 = 110
+    ! local_cells = 2*1 = 2, total_cells = 4
+    ! local_conn = 2*64 = 128, total_conn = 256
+    ! total_offsets = 4 + 2 = 6
     integer, parameter :: EXP_LOCAL_POINTS = 128
-    integer, parameter :: EXP_LOCAL_CELLS = 54
-    integer, parameter :: EXP_LOCAL_CONN = 432
+    integer, parameter :: EXP_LOCAL_CELLS = 2
+    integer, parameter :: EXP_LOCAL_CONN = 128
     integer, parameter :: EXP_TOTAL_POINTS = 256
-    integer, parameter :: EXP_TOTAL_CELLS = 108
-    integer, parameter :: EXP_TOTAL_CONN = 864
-    integer, parameter :: EXP_TOTAL_OFFSETS = 110
+    integer, parameter :: EXP_TOTAL_CELLS = 4
+    integer, parameter :: EXP_TOTAL_CONN = 256
+    integer, parameter :: EXP_TOTAL_OFFSETS = 6
     integer, parameter :: EXP_NUM_PARTS = 2
 
     ! Prepare the environment for the test
@@ -375,6 +364,11 @@ contains
     call h5fclose_f(file_id, hdferr)
     call h5close_f(hdferr)
 
+    inquire(file='test_write_0.vtkhdf', exist=exists)
+    if (exists .and. pe_rank .eq. 0) then
+       open(newunit=unit, file='test_write_0.vtkhdf')
+       close(unit, status='delete')
+    end if
 
   end subroutine test_vtkhdf_write
 
@@ -387,7 +381,7 @@ contains
     type(field_t) :: f
     character(len=80) :: fname
     type(file_t) :: file
-    integer :: ierr
+    integer :: unit, ierr
     logical :: exists
     character(len=:), allocatable :: message
 
@@ -405,19 +399,14 @@ contains
     real(rp) :: values_read(2)
     logical :: link_exists
 
-    ! Expected values: each rank has 2 elements, LX=4, 3D
-    ! subcells_per_el = (lx-1)*(ly-1)*(lz-1) = 27, nodes_per_cell = 8
-    ! local_points = 2*64 = 128, total_points = 256
-    ! local_cells = 2*27 = 54, total_cells = 108
-    ! local_conn = 54*8 = 432, total_conn = 864
-    ! total_offsets = 108 + 2 = 110
+    ! Expected values: same Lagrange geometry as non-temporal, 2 timesteps
     integer, parameter :: EXP_LOCAL_POINTS = 128
-    integer, parameter :: EXP_LOCAL_CELLS = 54
-    integer, parameter :: EXP_LOCAL_CONN = 432
+    integer, parameter :: EXP_LOCAL_CELLS = 2
+    integer, parameter :: EXP_LOCAL_CONN = 128
     integer, parameter :: EXP_TOTAL_POINTS = 256
-    integer, parameter :: EXP_TOTAL_CELLS = 108
-    integer, parameter :: EXP_TOTAL_CONN = 864
-    integer, parameter :: EXP_TOTAL_OFFSETS = 110
+    integer, parameter :: EXP_TOTAL_CELLS = 4
+    integer, parameter :: EXP_TOTAL_CONN = 256
+    integer, parameter :: EXP_TOTAL_OFFSETS = 6
     integer, parameter :: EXP_NUM_PARTS = 2
     integer, parameter :: EXP_NUM_STEPS = 2
 
@@ -471,7 +460,7 @@ contains
     @assertEqual(0, hdferr, message = message)
     call h5aclose_f(attr_id, hdferr)
 
-    ! -- NumberOfPoints dataset --
+    ! -- NumberOfPoints dataset: NUM_PARTS entries per step --
     call h5lexists_f(vtkhdf_grp, "NumberOfPoints", link_exists, hdferr)
     message = "NumberOfPoints must exist (temporal)"
     @assertTrue(link_exists, message = message)
@@ -665,7 +654,7 @@ contains
     call h5sclose_f(filespace, hdferr)
     call h5dclose_f(dset_id, hdferr)
 
-    ! -- PartOffsets dataset: shape (NUM_STEPS,) with [0, 0] (static mesh) --
+    ! -- PartOffsets dataset: shape (NUM_STEPS,) with [0, NUM_PARTS] --
     call h5lexists_f(steps_grp, "PartOffsets", link_exists, hdferr)
     message = "Steps/PartOffsets must exist"
     @assertTrue(link_exists, message = message)
@@ -763,6 +752,350 @@ contains
     call h5fclose_f(file_id, hdferr)
     call h5close_f(hdferr)
 
+    inquire(file='test_write_time_0.vtkhdf', exist=exists)
+    if (exists .and. pe_rank .eq. 0) then
+       open(newunit=unit, file='test_write_time_0.vtkhdf')
+       close(unit, status='delete')
+    end if
+
   end subroutine test_vtkhdf_write_time
+
+  @test(npes=[2])
+  subroutine test_vtkhdf_write_time_subdivide(this)
+    class (test_vtkhdf), intent(inout) :: this
+    type(space_t) :: Xh
+    type(mesh_t) :: msh
+    integer, parameter :: LX = 4
+    type(field_t) :: f
+    character(len=80) :: fname
+    type(file_t) :: file
+    integer :: unit, ierr
+    logical :: exists
+    character(len=:), allocatable :: message
+
+    ! HDF5 variables for validation
+    integer(hid_t) :: file_id, vtkhdf_grp, attr_id, dset_id
+    integer(hid_t) :: filespace, pointdata_grp, steps_grp, pdo_grp
+    integer(hsize_t), dimension(2) :: h5dims, h5maxdims
+    integer :: hdferr, h5rank
+    integer :: version_read(2)
+    integer :: nop_read(4), noc_read(4), noci_read(4)
+    integer :: nsteps_read(1)
+    integer :: nparts_read(2), partoffs_read(2)
+    integer :: ptoffs_read(2), celloffs_read(2)
+    integer :: connoffs_read(2), pdoffs_read(2)
+    real(rp) :: values_read(2)
+    logical :: link_exists
+
+    ! Expected values with subdivision: each rank has 2 elements, LX=4, 3D
+    ! subcells_per_el = (lx-1)*(ly-1)*(lz-1) = 27, nodes_per_cell = 8
+    ! local_points = 2*64 = 128, total_points = 256
+    ! local_cells = 2*27 = 54, total_cells = 108
+    ! local_conn = 54*8 = 432, total_conn = 864
+    ! total_offsets = 108 + 2 = 110
+    integer, parameter :: EXP_LOCAL_POINTS = 128
+    integer, parameter :: EXP_LOCAL_CELLS = 54
+    integer, parameter :: EXP_LOCAL_CONN = 432
+    integer, parameter :: EXP_TOTAL_POINTS = 256
+    integer, parameter :: EXP_TOTAL_CELLS = 108
+    integer, parameter :: EXP_TOTAL_CONN = 864
+    integer, parameter :: EXP_TOTAL_OFFSETS = 110
+    integer, parameter :: EXP_NUM_PARTS = 2
+    integer, parameter :: EXP_NUM_STEPS = 2
+
+    ! Create the test mesh and field
+    call test_vtkhdf_gen_msh(msh)
+    call Xh%init(GLL, lx, lx, lx)
+    call f%init(msh, Xh, 'test')
+    call field_cfill(f, 1.0_rp)
+
+    ! Enable subdivision and perform write: 2 timesteps at t=0.0 and t=1.0
+    fname = "test_write_time_subdivide.vtkhdf"
+    call file%init(fname)
+    select type(ft => file%file_type)
+    class is (vtkhdf_file_t)
+       call ft%set_subdivide(.true.)
+    end select
+    call file%write(f, 0.0_rp)
+    call field_cfill(f, 2.0_rp)
+    call file%write(f, 1.0_rp)
+    call file%free()
+
+    ! Test that the file exists
+    inquire(file='test_write_time_subdivide_0.vtkhdf', exist=exists)
+    message = "Temporal subdivided output file must exist"
+    @assertTrue(exists, message = message)
+
+    ! ================================================================
+    ! Validate HDF5 file contents
+    ! ================================================================
+    call h5open_f(hdferr)
+    call h5fopen_f('test_write_time_subdivide_0.vtkhdf', H5F_ACC_RDONLY_F, &
+         file_id, hdferr)
+    message = "Must open temporal subdivided HDF5 file"
+    @assertEqual(0, hdferr, message = message)
+
+    ! -- VTKHDF group --
+    call h5lexists_f(file_id, "VTKHDF", link_exists, hdferr)
+    message = "VTKHDF group must exist (subdivide)"
+    @assertTrue(link_exists, message = message)
+    call h5gopen_f(file_id, "VTKHDF", vtkhdf_grp, hdferr)
+
+    ! -- Version attribute --
+    call h5aopen_f(vtkhdf_grp, "Version", attr_id, hdferr)
+    message = "Version attribute must exist (subdivide)"
+    @assertEqual(0, hdferr, message = message)
+    h5dims(1) = 2
+    call h5aread_f(attr_id, H5T_NATIVE_INTEGER, version_read, h5dims(1:1), hdferr)
+    message = "Version must be at least 2.0 (subdivide)"
+    @assertGreaterThanOrEqual(version_read(1), 2, message = message)
+    call h5aclose_f(attr_id, hdferr)
+
+    ! -- NumberOfPoints dataset: NUM_PARTS entries per step --
+    call h5dopen_f(vtkhdf_grp, "NumberOfPoints", dset_id, hdferr)
+    call h5dget_space_f(dset_id, filespace, hdferr)
+    call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
+    message = "NumberOfPoints size (subdivide)"
+    @assertEqual(EXP_NUM_PARTS * EXP_NUM_STEPS, int(h5dims(1)), message = message)
+    call h5dread_f(dset_id, H5T_NATIVE_INTEGER, nop_read, h5dims(1:1), hdferr)
+    message = "NumberOfPoints step0 part0 (subdivide)"
+    @assertEqual(EXP_LOCAL_POINTS, nop_read(1), message = message)
+    message = "NumberOfPoints step0 part1 (subdivide)"
+    @assertEqual(EXP_LOCAL_POINTS, nop_read(2), message = message)
+    message = "NumberOfPoints step1 part0 (subdivide)"
+    @assertEqual(EXP_LOCAL_POINTS, nop_read(3), message = message)
+    message = "NumberOfPoints step1 part1 (subdivide)"
+    @assertEqual(EXP_LOCAL_POINTS, nop_read(4), message = message)
+    call h5sclose_f(filespace, hdferr)
+    call h5dclose_f(dset_id, hdferr)
+
+    ! -- NumberOfCells dataset: NUM_PARTS entries per step --
+    call h5dopen_f(vtkhdf_grp, "NumberOfCells", dset_id, hdferr)
+    call h5dget_space_f(dset_id, filespace, hdferr)
+    call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
+    message = "NumberOfCells size (subdivide)"
+    @assertEqual(EXP_NUM_PARTS * EXP_NUM_STEPS, int(h5dims(1)), message = message)
+    call h5dread_f(dset_id, H5T_NATIVE_INTEGER, noc_read, h5dims(1:1), hdferr)
+    message = "NumberOfCells step0 part0 (subdivide)"
+    @assertEqual(EXP_LOCAL_CELLS, noc_read(1), message = message)
+    message = "NumberOfCells step0 part1 (subdivide)"
+    @assertEqual(EXP_LOCAL_CELLS, noc_read(2), message = message)
+    message = "NumberOfCells step1 part0 (subdivide)"
+    @assertEqual(EXP_LOCAL_CELLS, noc_read(3), message = message)
+    message = "NumberOfCells step1 part1 (subdivide)"
+    @assertEqual(EXP_LOCAL_CELLS, noc_read(4), message = message)
+    call h5sclose_f(filespace, hdferr)
+    call h5dclose_f(dset_id, hdferr)
+
+    ! -- NumberOfConnectivityIds dataset: NUM_PARTS entries per step --
+    call h5dopen_f(vtkhdf_grp, "NumberOfConnectivityIds", dset_id, hdferr)
+    call h5dget_space_f(dset_id, filespace, hdferr)
+    call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
+    message = "NumberOfConnectivityIds size (subdivide)"
+    @assertEqual(EXP_NUM_PARTS * EXP_NUM_STEPS, int(h5dims(1)), message = message)
+    call h5dread_f(dset_id, H5T_NATIVE_INTEGER, noci_read, h5dims(1:1), hdferr)
+    message = "NumberOfConnectivityIds step0 part0 (subdivide)"
+    @assertEqual(EXP_LOCAL_CONN, noci_read(1), message = message)
+    message = "NumberOfConnectivityIds step0 part1 (subdivide)"
+    @assertEqual(EXP_LOCAL_CONN, noci_read(2), message = message)
+    message = "NumberOfConnectivityIds step1 part0 (subdivide)"
+    @assertEqual(EXP_LOCAL_CONN, noci_read(3), message = message)
+    message = "NumberOfConnectivityIds step1 part1 (subdivide)"
+    @assertEqual(EXP_LOCAL_CONN, noci_read(4), message = message)
+    call h5sclose_f(filespace, hdferr)
+    call h5dclose_f(dset_id, hdferr)
+
+    ! -- Points dataset: shape (3, TOTAL_POINTS) --
+    call h5dopen_f(vtkhdf_grp, "Points", dset_id, hdferr)
+    call h5dget_space_f(dset_id, filespace, hdferr)
+    call h5sget_simple_extent_ndims_f(filespace, h5rank, hdferr)
+    message = "Points must be 2D (subdivide)"
+    @assertEqual(2, h5rank, message = message)
+    call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
+    message = "Points dim 1 must be 3 (subdivide)"
+    @assertEqual(3, int(h5dims(1)), message = message)
+    message = "Points dim 2 (subdivide)"
+    @assertEqual(EXP_TOTAL_POINTS, int(h5dims(2)), message = message)
+    call h5sclose_f(filespace, hdferr)
+    call h5dclose_f(dset_id, hdferr)
+
+    ! -- Connectivity dataset: shape (TOTAL_CONN,) --
+    call h5dopen_f(vtkhdf_grp, "Connectivity", dset_id, hdferr)
+    call h5dget_space_f(dset_id, filespace, hdferr)
+    call h5sget_simple_extent_ndims_f(filespace, h5rank, hdferr)
+    message = "Connectivity must be 1D (subdivide)"
+    @assertEqual(1, h5rank, message = message)
+    call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
+    message = "Connectivity size (subdivide)"
+    @assertEqual(EXP_TOTAL_CONN, int(h5dims(1)), message = message)
+    call h5sclose_f(filespace, hdferr)
+    call h5dclose_f(dset_id, hdferr)
+
+    ! -- Offsets dataset: shape (TOTAL_OFFSETS,) --
+    call h5dopen_f(vtkhdf_grp, "Offsets", dset_id, hdferr)
+    call h5dget_space_f(dset_id, filespace, hdferr)
+    call h5sget_simple_extent_ndims_f(filespace, h5rank, hdferr)
+    message = "Offsets must be 1D (subdivide)"
+    @assertEqual(1, h5rank, message = message)
+    call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
+    message = "Offsets size (subdivide)"
+    @assertEqual(EXP_TOTAL_OFFSETS, int(h5dims(1)), message = message)
+    call h5sclose_f(filespace, hdferr)
+    call h5dclose_f(dset_id, hdferr)
+
+    ! -- Types dataset: shape (TOTAL_CELLS,) --
+    call h5dopen_f(vtkhdf_grp, "Types", dset_id, hdferr)
+    call h5dget_space_f(dset_id, filespace, hdferr)
+    call h5sget_simple_extent_ndims_f(filespace, h5rank, hdferr)
+    message = "Types must be 1D (subdivide)"
+    @assertEqual(1, h5rank, message = message)
+    call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
+    message = "Types size (subdivide)"
+    @assertEqual(EXP_TOTAL_CELLS, int(h5dims(1)), message = message)
+    call h5sclose_f(filespace, hdferr)
+    call h5dclose_f(dset_id, hdferr)
+
+    ! -- PointData/test: 2 timesteps, shape (TOTAL_POINTS * NUM_STEPS) --
+    call h5gopen_f(vtkhdf_grp, "PointData", pointdata_grp, hdferr)
+    call h5dopen_f(pointdata_grp, "test", dset_id, hdferr)
+    call h5dget_space_f(dset_id, filespace, hdferr)
+    call h5sget_simple_extent_ndims_f(filespace, h5rank, hdferr)
+    message = "test field must be 1D (subdivide)"
+    @assertEqual(1, h5rank, message = message)
+    call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
+    message = "test field size (subdivide)"
+    @assertEqual(EXP_TOTAL_POINTS * EXP_NUM_STEPS, int(h5dims(1)), message = message)
+    call h5sclose_f(filespace, hdferr)
+    call h5dclose_f(dset_id, hdferr)
+    call h5gclose_f(pointdata_grp, hdferr)
+
+    ! ================================================================
+    ! Validate Steps group
+    ! ================================================================
+    call h5gopen_f(vtkhdf_grp, "Steps", steps_grp, hdferr)
+
+    ! -- NSteps attribute --
+    call h5aopen_f(steps_grp, "NSteps", attr_id, hdferr)
+    message = "NSteps attribute must exist (subdivide)"
+    @assertEqual(0, hdferr, message = message)
+    h5dims(1) = 1
+    call h5aread_f(attr_id, H5T_NATIVE_INTEGER, nsteps_read, &
+         h5dims(1:1), hdferr)
+    message = "NSteps must be 2 (subdivide)"
+    @assertEqual(EXP_NUM_STEPS, nsteps_read(1), message = message)
+    call h5aclose_f(attr_id, hdferr)
+
+    ! -- Values dataset: shape (NUM_STEPS,) with [0.0, 1.0] --
+    call h5dopen_f(steps_grp, "Values", dset_id, hdferr)
+    call h5dget_space_f(dset_id, filespace, hdferr)
+    call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
+    message = "Values size (subdivide)"
+    @assertEqual(EXP_NUM_STEPS, int(h5dims(1)), message = message)
+    call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, values_read, &
+         h5dims(1:1), hdferr)
+    message = "Values(1) must be 0.0 (subdivide)"
+    @assertEqual(0.0_rp, values_read(1), message = message)
+    message = "Values(2) must be 1.0 (subdivide)"
+    @assertEqual(1.0_rp, values_read(2), message = message)
+    call h5sclose_f(filespace, hdferr)
+    call h5dclose_f(dset_id, hdferr)
+
+    ! -- NumberOfParts dataset --
+    call h5dopen_f(steps_grp, "NumberOfParts", dset_id, hdferr)
+    call h5dget_space_f(dset_id, filespace, hdferr)
+    call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
+    message = "NumberOfParts size (subdivide)"
+    @assertEqual(EXP_NUM_STEPS, int(h5dims(1)), message = message)
+    call h5dread_f(dset_id, H5T_NATIVE_INTEGER, nparts_read, &
+         h5dims(1:1), hdferr)
+    message = "NumberOfParts(1) must be 2 (subdivide)"
+    @assertEqual(EXP_NUM_PARTS, nparts_read(1), message = message)
+    message = "NumberOfParts(2) must be 2 (subdivide)"
+    @assertEqual(EXP_NUM_PARTS, nparts_read(2), message = message)
+    call h5sclose_f(filespace, hdferr)
+    call h5dclose_f(dset_id, hdferr)
+
+    ! -- PartOffsets: [0, 0] (static mesh) --
+    call h5dopen_f(steps_grp, "PartOffsets", dset_id, hdferr)
+    call h5dget_space_f(dset_id, filespace, hdferr)
+    call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
+    call h5dread_f(dset_id, H5T_NATIVE_INTEGER, partoffs_read, &
+         h5dims(1:1), hdferr)
+    message = "PartOffsets(1) must be 0 (subdivide)"
+    @assertEqual(0, partoffs_read(1), message = message)
+    message = "PartOffsets(2) must be 0 (subdivide)"
+    @assertEqual(0, partoffs_read(2), message = message)
+    call h5sclose_f(filespace, hdferr)
+    call h5dclose_f(dset_id, hdferr)
+
+    ! -- PointOffsets: [0, 0] (static mesh) --
+    call h5dopen_f(steps_grp, "PointOffsets", dset_id, hdferr)
+    call h5dget_space_f(dset_id, filespace, hdferr)
+    call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
+    call h5dread_f(dset_id, H5T_NATIVE_INTEGER, ptoffs_read, &
+         h5dims(1:1), hdferr)
+    message = "PointOffsets(1) must be 0 (subdivide)"
+    @assertEqual(0, ptoffs_read(1), message = message)
+    message = "PointOffsets(2) must be 0 (subdivide)"
+    @assertEqual(0, ptoffs_read(2), message = message)
+    call h5sclose_f(filespace, hdferr)
+    call h5dclose_f(dset_id, hdferr)
+
+    ! -- CellOffsets: [0, 0] (static mesh) --
+    call h5dopen_f(steps_grp, "CellOffsets", dset_id, hdferr)
+    call h5dget_space_f(dset_id, filespace, hdferr)
+    call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
+    call h5dread_f(dset_id, H5T_NATIVE_INTEGER, celloffs_read, &
+         h5dims(1:1), hdferr)
+    message = "CellOffsets(1) must be 0 (subdivide)"
+    @assertEqual(0, celloffs_read(1), message = message)
+    message = "CellOffsets(2) must be 0 (subdivide)"
+    @assertEqual(0, celloffs_read(2), message = message)
+    call h5sclose_f(filespace, hdferr)
+    call h5dclose_f(dset_id, hdferr)
+
+    ! -- ConnectivityIdOffsets: [0, 0] (static mesh) --
+    call h5dopen_f(steps_grp, "ConnectivityIdOffsets", dset_id, hdferr)
+    call h5dget_space_f(dset_id, filespace, hdferr)
+    call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
+    call h5dread_f(dset_id, H5T_NATIVE_INTEGER, connoffs_read, &
+         h5dims(1:1), hdferr)
+    message = "ConnectivityIdOffsets(1) must be 0 (subdivide)"
+    @assertEqual(0, connoffs_read(1), message = message)
+    message = "ConnectivityIdOffsets(2) must be 0 (subdivide)"
+    @assertEqual(0, connoffs_read(2), message = message)
+    call h5sclose_f(filespace, hdferr)
+    call h5dclose_f(dset_id, hdferr)
+
+    ! -- PointDataOffsets/test: [0, TOTAL_POINTS] --
+    call h5gopen_f(steps_grp, "PointDataOffsets", pdo_grp, hdferr)
+    call h5dopen_f(pdo_grp, "test", dset_id, hdferr)
+    call h5dget_space_f(dset_id, filespace, hdferr)
+    call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
+    message = "PointDataOffsets/test size (subdivide)"
+    @assertEqual(EXP_NUM_STEPS, int(h5dims(1)), message = message)
+    call h5dread_f(dset_id, H5T_NATIVE_INTEGER, pdoffs_read, &
+         h5dims(1:1), hdferr)
+    message = "PointDataOffsets/test(1) must be 0 (subdivide)"
+    @assertEqual(0, pdoffs_read(1), message = message)
+    message = "PointDataOffsets/test(2) (subdivide)"
+    @assertEqual(EXP_TOTAL_POINTS, pdoffs_read(2), message = message)
+    call h5sclose_f(filespace, hdferr)
+    call h5dclose_f(dset_id, hdferr)
+    call h5gclose_f(pdo_grp, hdferr)
+
+    ! Cleanup
+    call h5gclose_f(steps_grp, hdferr)
+    call h5gclose_f(vtkhdf_grp, hdferr)
+    call h5fclose_f(file_id, hdferr)
+    call h5close_f(hdferr)
+
+    inquire(file='test_write_time_subdivide_0.vtkhdf', exist=exists)
+    if (exists .and. pe_rank .eq. 0) then
+       open(newunit=unit, file='test_write_time_subdivide_0.vtkhdf')
+       close(unit, status='delete')
+    end if
+
+  end subroutine test_vtkhdf_write_time_subdivide
 
 end module vtkhdf_parallel


### PR DESCRIPTION
The goal here is to implement support for the VTK "Arbitrary Lagrange" cell types.
Visualization software such as Paraview, have spotty support for it, but this can give us a lever to be in front of the curve, should things change.
Specifically for paraview, the files can be loaded correctly but colour interpolation is still linear between GLL points, rather than correctly based on the polynomial basis.

Depends on #2342. Fixes #2379