### PR TITLE
VTKHDF output after restart

### DIFF
--- a/src/common/utils.f90
+++ b/src/common/utils.f90
@@ -45,7 +45,7 @@ module utils
 
   public :: neko_error, neko_warning, nonlinear_index, filename_chsuffix, &
        filename_path, filename_name, filename_suffix, &
-       filename_suffix_pos, filename_tslash_pos, &
+       filename_suffix_pos, filename_tslash_pos, filename_split, &
        linear_index, split_string, NEKO_FNAME_LEN, index_is_on_facet, &
        concat_string_array, extract_fld_file_index, neko_type_error, &
        neko_type_registration_error

--- a/src/io/vtkhdf_file.F90
+++ b/src/io/vtkhdf_file.F90
@@ -104,7 +104,7 @@ contains
     fname = trim(this%get_base_fname())
     call filename_split(fname, path, name, suffix)
 
-    write(base_fname, '(A,A,".",I0,A)') &
+    write(base_fname, '(A,A,"_",I0,A)') &
          trim(path), trim(name), this%get_start_counter(), trim(suffix)
 
   end function vtkhdf_file_get_fname

--- a/src/io/vtkhdf_file.F90
+++ b/src/io/vtkhdf_file.F90
@@ -398,57 +398,38 @@ contains
     call h5pcreate_f(H5P_DATASET_XFER_F, xf_id, ierr)
     call h5pset_dxpl_mpio_f(xf_id, H5FD_MPIO_COLLECTIVE_F, ierr)
 
-    ! --- Shared sizes for 1D datasets ---
-    dcount = 1_hsize_t
-    vdims = int(pe_size, hsize_t)
-    chunkdims = int(pe_size, hsize_t)
-    doffset = int(pe_rank, hsize_t)
+    ! --- NumberOfPoints, NumberOfCells, NumberOfConnectivityIds ---
+    ! These datasets must accumulate nPieces entries per timestep,
+    ! giving a total size of nSteps * nPieces. VTK's reader computes
+    ! numberOfPieces = dims[0] / nSteps, so missing entries cause
+    ! garbage reads.
+    block
+      integer(hsize_t), dimension(1) :: nof_dims, nof_maxdims
+      integer(hsize_t), dimension(1) :: nof_count, nof_offset, nof_chunk
+      integer(hid_t) :: nof_filespace, nof_memspace, nof_dcpl
+      integer :: nof_values(3)
 
-    ! --- Create filespaces and memspaces for 1D datasets ---
-    call h5screate_simple_f(1, vdims, filespace, ierr)
-    call h5screate_simple_f(1, dcount, memspace, ierr)
-    call h5pcreate_f(H5P_DATASET_CREATE_F, dcpl_id, ierr)
-    call h5sselect_hyperslab_f(filespace, H5S_SELECT_SET_F, &
-         doffset, dcount, ierr)
-    call h5pset_chunk_f(dcpl_id, 1, chunkdims, ierr)
+      nof_count(1) = 1_hsize_t
+      nof_offset(1) = int(counter, hsize_t) * int(pe_size, hsize_t) &
+           + int(pe_rank, hsize_t)
+      nof_chunk(1) = max(1_hsize_t, int(pe_size, hsize_t))
+      nof_values = [local_points, local_cells, local_conn]
 
-    ! --- NumberOfPoints dataset (per-partition) ---
-    call h5lexists_f(vtkhdf_grp, "NumberOfPoints", link_exists, ierr)
-    if (.not. link_exists) then
-       call h5dcreate_f(vtkhdf_grp, "NumberOfPoints", H5T_NATIVE_INTEGER, &
-            filespace, dset_id, ierr, dcpl_id = dcpl_id)
-       call h5dwrite_f(dset_id, H5T_NATIVE_INTEGER, local_points, &
-            dcount, ierr, file_space_id = filespace, &
-            mem_space_id = memspace, xfer_prp = xf_id)
-       call h5dclose_f(dset_id, ierr)
-    end if
+      call h5pcreate_f(H5P_DATASET_CREATE_F, nof_dcpl, ierr)
+      call h5pset_chunk_f(nof_dcpl, 1, nof_chunk, ierr)
 
-    ! --- NumberOfCells dataset (per-partition) ---
-    call h5lexists_f(vtkhdf_grp, "NumberOfCells", link_exists, ierr)
-    if (.not. link_exists) then
-       call h5dcreate_f(vtkhdf_grp, "NumberOfCells", H5T_NATIVE_INTEGER, &
-            filespace, dset_id, ierr, dcpl_id = dcpl_id)
-       call h5dwrite_f(dset_id, H5T_NATIVE_INTEGER, local_cells, &
-            dcount, ierr, file_space_id = filespace, &
-            mem_space_id = memspace, xfer_prp = xf_id)
-       call h5dclose_f(dset_id, ierr)
-    end if
+      call vtkhdf_write_numberof(vtkhdf_grp, "NumberOfPoints", &
+           nof_values(1), nof_offset, nof_count, nof_dcpl, &
+           counter, xf_id, ierr)
+      call vtkhdf_write_numberof(vtkhdf_grp, "NumberOfCells", &
+           nof_values(2), nof_offset, nof_count, nof_dcpl, &
+           counter, xf_id, ierr)
+      call vtkhdf_write_numberof(vtkhdf_grp, "NumberOfConnectivityIds", &
+           nof_values(3), nof_offset, nof_count, nof_dcpl, &
+           counter, xf_id, ierr)
 
-    ! --- NumberOfConnectivityIds dataset (per-partition) ---
-    call h5lexists_f(vtkhdf_grp, "NumberOfConnectivityIds", link_exists, ierr)
-    if (.not. link_exists) then
-       call h5dcreate_f(vtkhdf_grp, "NumberOfConnectivityIds", &
-            H5T_NATIVE_INTEGER, filespace, dset_id, ierr, dcpl_id = dcpl_id)
-       call h5dwrite_f(dset_id, H5T_NATIVE_INTEGER, local_conn, &
-            dcount, ierr, file_space_id = filespace, &
-            mem_space_id = memspace, xfer_prp = xf_id)
-       call h5dclose_f(dset_id, ierr)
-    end if
-
-    ! --- Close the mempory and file spaces ---
-    call h5sclose_f(memspace, ierr)
-    call h5sclose_f(filespace, ierr)
-    call h5pclose_f(dcpl_id, ierr)
+      call h5pclose_f(nof_dcpl, ierr)
+    end block
 
     ! --- Points dataset (global coordinates) ---
     call h5lexists_f(vtkhdf_grp, "Points", link_exists, ierr)
@@ -638,6 +619,55 @@ contains
     call h5pclose_f(xf_id, ierr)
 
   end subroutine vtkhdf_write_mesh
+
+  !> Create-or-extend a 1D NumberOf* dataset, then write one entry.
+  !! On step 0 the dataset is created with unlimited max extent.
+  !! On subsequent steps it is extended to (counter+1)*nPieces.
+  !! @param grp        Parent HDF5 group (VTKHDF root)
+  !! @param dset_name  Dataset name, e.g. "NumberOfPoints"
+  !! @param value      The integer value to write for this rank
+  !! @param offset     1-element array: counter*pe_size + pe_rank
+  !! @param cnt        1-element array, always [1]
+  !! @param dcpl       Dataset creation property list (chunked)
+  !! @param counter    Current timestep counter (0-based)
+  !! @param xf_id      Collective transfer property list
+  !! @param ierr       HDF5 error code (output)
+  subroutine vtkhdf_write_numberof(grp, dset_name, value, offset, cnt, &
+       dcpl, counter, xf_id, ierr)
+    integer(hid_t), intent(in) :: grp, dcpl, xf_id
+    character(len=*), intent(in) :: dset_name
+    integer, intent(in) :: value, counter
+    integer(hsize_t), dimension(1), intent(in) :: offset, cnt
+    integer, intent(out) :: ierr
+
+    integer(hid_t) :: dset_id, fspace, mspace
+    integer(hsize_t), dimension(1) :: dims, maxdims
+    logical :: link_exists
+
+    call h5lexists_f(grp, dset_name, link_exists, ierr)
+    if (link_exists) then
+       call h5dopen_f(grp, dset_name, dset_id, ierr)
+       dims(1) = (int(counter, hsize_t) + 1_hsize_t) &
+            * int(pe_size, hsize_t)
+       call h5dset_extent_f(dset_id, dims, ierr)
+    else
+       dims(1) = int(pe_size, hsize_t)
+       maxdims(1) = H5S_UNLIMITED_F
+       call h5screate_simple_f(1, dims, fspace, ierr, maxdims)
+       call h5dcreate_f(grp, dset_name, H5T_STD_I64LE, &
+            fspace, dset_id, ierr, dcpl_id = dcpl)
+       call h5sclose_f(fspace, ierr)
+    end if
+
+    call h5dget_space_f(dset_id, fspace, ierr)
+    call h5sselect_hyperslab_f(fspace, H5S_SELECT_SET_F, offset, cnt, ierr)
+    call h5screate_simple_f(1, cnt, mspace, ierr)
+    call h5dwrite_f(dset_id, H5T_NATIVE_INTEGER, value, cnt, ierr, &
+         file_space_id = fspace, mem_space_id = mspace, xfer_prp = xf_id)
+    call h5sclose_f(mspace, ierr)
+    call h5sclose_f(fspace, ierr)
+    call h5dclose_f(dset_id, ierr)
+  end subroutine vtkhdf_write_numberof
 
   !> Write temporal Steps group metadata to the VTKHDF group.
   !! Writes Values, NumberOfParts, PartOffsets, PointOffsets,

--- a/src/io/vtkhdf_file.F90
+++ b/src/io/vtkhdf_file.F90
@@ -35,7 +35,7 @@ module vtkhdf_file
   use num_types, only : rp, sp, dp
   use generic_file, only : generic_file_t
   use checkpoint, only : chkp_t
-  use utils, only : neko_error, neko_warning, filename_suffix_pos, &
+  use utils, only : neko_error, neko_warning, filename_split, &
        nonlinear_index
   use mesh, only : mesh_t
   use field, only : field_t, field_ptr_t
@@ -59,6 +59,7 @@ module vtkhdf_file
      logical :: amr_enabled = .false.
      integer :: precision = 0
    contains
+     procedure :: get_vtkhdf_fname => vtkhdf_file_get_fname
      procedure :: read => vtkhdf_file_read
      procedure :: write => vtkhdf_file_write
      procedure :: set_overwrite => vtkhdf_file_set_overwrite
@@ -92,6 +93,21 @@ contains
     integer, intent(in) :: precision
     this%precision = precision
   end subroutine vtkhdf_file_set_precision
+
+  !> Return the file name with the start counter.
+  function vtkhdf_file_get_fname(this) result(base_fname)
+    class(vtkhdf_file_t), intent(in) :: this
+    character(len=1024) :: base_fname
+    character(len=1024) :: fname
+    character(len=1024) :: path, name, suffix
+
+    fname = trim(this%get_base_fname())
+    call filename_split(fname, path, name, suffix)
+
+    write(base_fname, '(A,A,".",I0,A)') &
+         trim(path), trim(name), this%get_start_counter(), trim(suffix)
+
+  end function vtkhdf_file_get_fname
 
 #ifdef HAVE_HDF5
   ! -------------------------------------------------------------------------- !
@@ -168,8 +184,8 @@ contains
     end if
 
     call this%increment_counter()
-    fname = trim(this%get_base_fname())
-    counter = this%get_counter()
+    fname = trim(this%get_vtkhdf_fname())
+    counter = this%get_counter() - this%get_start_counter()
 
     mpi_info = MPI_INFO_NULL%mpi_val
     mpi_comm = NEKO_COMM%mpi_val

--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -66,7 +66,7 @@ time_scheme_controller/time_scheme_controller_test
 time_based_controller/time_based_controller_test
 json_utils/json_utils_test
 point_interpolation/point_interpolation_suite
-**/test_write.*.vtkhdf
-**/test_write_time.*.vtkhdf
+**/test_write_*.vtkhdf
+**/test_write_time_*.vtkhdf
 templates/parallel/parallel_suite
 templates/serial/serial_test

--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -66,7 +66,7 @@ time_scheme_controller/time_scheme_controller_test
 time_based_controller/time_based_controller_test
 json_utils/json_utils_test
 point_interpolation/point_interpolation_suite
-**/test_write.vtkhdf
-**/test_write_time.vtkhdf
+**/test_write.*.vtkhdf
+**/test_write_time.*.vtkhdf
 templates/parallel/parallel_suite
 templates/serial/serial_test

--- a/tests/unit/vtkhdf/vtkhdf_parallel.pf
+++ b/tests/unit/vtkhdf/vtkhdf_parallel.pf
@@ -32,6 +32,7 @@ contains
 
   subroutine setUp(this)
     class(test_vtkhdf), intent(inout) :: this
+    integer :: ierr
 
     call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
     pe_rank = this%getProcessRank()
@@ -396,7 +397,7 @@ contains
     integer(hsize_t), dimension(2) :: h5dims, h5maxdims
     integer :: hdferr, h5rank
     integer :: version_read(2)
-    integer :: nop_read(2), noc_read(2), noci_read(2)
+    integer :: nop_read(4), noc_read(4), noci_read(4)
     integer :: nsteps_read(1)
     integer :: nparts_read(2), partoffs_read(2)
     integer :: ptoffs_read(2), celloffs_read(2)
@@ -404,7 +405,12 @@ contains
     real(rp) :: values_read(2)
     logical :: link_exists
 
-    ! Expected values: same geometry as non-temporal, 2 timesteps
+    ! Expected values: each rank has 2 elements, LX=4, 3D
+    ! subcells_per_el = (lx-1)*(ly-1)*(lz-1) = 27, nodes_per_cell = 8
+    ! local_points = 2*64 = 128, total_points = 256
+    ! local_cells = 2*27 = 54, total_cells = 108
+    ! local_conn = 54*8 = 432, total_conn = 864
+    ! total_offsets = 108 + 2 = 110
     integer, parameter :: EXP_LOCAL_POINTS = 128
     integer, parameter :: EXP_LOCAL_CELLS = 54
     integer, parameter :: EXP_LOCAL_CONN = 432
@@ -457,9 +463,6 @@ contains
 
     message = "Version must be at least 2.0 for Temporal UnstructuredGrid"
     @assertGreaterThanOrEqual(version_read(1), 2, message = message)
-    if (version_read(1) .eq. 2) then
-       @assertGreaterThanOrEqual(version_read(2), 0, message = message)
-    end if
     call h5aclose_f(attr_id, hdferr)
 
     ! -- Type attribute --
@@ -475,47 +478,56 @@ contains
     call h5dopen_f(vtkhdf_grp, "NumberOfPoints", dset_id, hdferr)
     call h5dget_space_f(dset_id, filespace, hdferr)
     call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
-    message = "NumberOfPoints size (temporal)"
-    @assertEqual(EXP_NUM_PARTS, int(h5dims(1)), message = message)
+    message = "NumberOfPoints size"
+    @assertEqual(EXP_NUM_PARTS * EXP_NUM_STEPS, int(h5dims(1)), message = message)
     call h5dread_f(dset_id, H5T_NATIVE_INTEGER, nop_read, h5dims(1:1), hdferr)
-    message = "NumberOfPoints part 0 (temporal)"
+    message = "NumberOfPoints step0 part0"
     @assertEqual(EXP_LOCAL_POINTS, nop_read(1), message = message)
-    message = "NumberOfPoints part 1 (temporal)"
+    message = "NumberOfPoints step0 part1"
     @assertEqual(EXP_LOCAL_POINTS, nop_read(2), message = message)
+    message = "NumberOfPoints step1 part0"
+    @assertEqual(EXP_LOCAL_POINTS, nop_read(3), message = message)
+    message = "NumberOfPoints step1 part1"
+    @assertEqual(EXP_LOCAL_POINTS, nop_read(4), message = message)
     call h5sclose_f(filespace, hdferr)
     call h5dclose_f(dset_id, hdferr)
 
-    ! -- NumberOfCells dataset --
+    ! -- NumberOfCells dataset: NUM_PARTS entries per step --
     call h5lexists_f(vtkhdf_grp, "NumberOfCells", link_exists, hdferr)
     message = "NumberOfCells must exist (temporal)"
     @assertTrue(link_exists, message = message)
     call h5dopen_f(vtkhdf_grp, "NumberOfCells", dset_id, hdferr)
     call h5dget_space_f(dset_id, filespace, hdferr)
     call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
-    message = "NumberOfCells size (temporal)"
-    @assertEqual(EXP_NUM_PARTS, int(h5dims(1)), message = message)
+    message = "NumberOfCells size"
+    @assertEqual(EXP_NUM_PARTS * EXP_NUM_STEPS, int(h5dims(1)), message = message)
     call h5dread_f(dset_id, H5T_NATIVE_INTEGER, noc_read, h5dims(1:1), hdferr)
-    message = "NumberOfCells part 0 (temporal)"
+    message = "NumberOfCells step0 part0"
     @assertEqual(EXP_LOCAL_CELLS, noc_read(1), message = message)
-    message = "NumberOfCells part 1 (temporal)"
+    message = "NumberOfCells step0 part1"
     @assertEqual(EXP_LOCAL_CELLS, noc_read(2), message = message)
+    message = "NumberOfCells step1 part0"
+    @assertEqual(EXP_LOCAL_CELLS, noc_read(3), message = message)
+    message = "NumberOfCells step1 part1"
+    @assertEqual(EXP_LOCAL_CELLS, noc_read(4), message = message)
     call h5sclose_f(filespace, hdferr)
     call h5dclose_f(dset_id, hdferr)
 
-    ! -- NumberOfConnectivityIds dataset --
-    call h5lexists_f(vtkhdf_grp, "NumberOfConnectivityIds", link_exists, hdferr)
-    message = "NumberOfConnectivityIds must exist (temporal)"
-    @assertTrue(link_exists, message = message)
+    ! -- NumberOfConnectivityIds dataset: NUM_PARTS entries per step --
     call h5dopen_f(vtkhdf_grp, "NumberOfConnectivityIds", dset_id, hdferr)
     call h5dget_space_f(dset_id, filespace, hdferr)
     call h5sget_simple_extent_dims_f(filespace, h5dims, h5maxdims, hdferr)
-    message = "NumberOfConnectivityIds size (temporal)"
-    @assertEqual(EXP_NUM_PARTS, int(h5dims(1)), message = message)
+    message = "NumberOfConnectivityIds size"
+    @assertEqual(EXP_NUM_PARTS * EXP_NUM_STEPS, int(h5dims(1)), message = message)
     call h5dread_f(dset_id, H5T_NATIVE_INTEGER, noci_read, h5dims(1:1), hdferr)
-    message = "NumberOfConnectivityIds part 0 (temporal)"
+    message = "NumberOfConnectivityIds step0 part0"
     @assertEqual(EXP_LOCAL_CONN, noci_read(1), message = message)
-    message = "NumberOfConnectivityIds part 1 (temporal)"
+    message = "NumberOfConnectivityIds step0 part1"
     @assertEqual(EXP_LOCAL_CONN, noci_read(2), message = message)
+    message = "NumberOfConnectivityIds step1 part0"
+    @assertEqual(EXP_LOCAL_CONN, noci_read(3), message = message)
+    message = "NumberOfConnectivityIds step1 part1"
+    @assertEqual(EXP_LOCAL_CONN, noci_read(4), message = message)
     call h5sclose_f(filespace, hdferr)
     call h5dclose_f(dset_id, hdferr)
 

--- a/tests/unit/vtkhdf/vtkhdf_parallel.pf
+++ b/tests/unit/vtkhdf/vtkhdf_parallel.pf
@@ -48,15 +48,15 @@ contains
     logical :: exists
     integer :: unit
 
-    inquire(file='test_write.vtkhdf', exist=exists)
+    inquire(file='test_write.0.vtkhdf', exist=exists)
     if (exists .and. pe_rank .eq. 0) then
-       open(newunit=unit, file='test_write.vtkhdf')
+       open(newunit=unit, file='test_write.0.vtkhdf')
        close(unit, status='delete')
     end if
 
-    inquire(file='test_write_time.vtkhdf', exist=exists)
+    inquire(file='test_write_time.0.vtkhdf', exist=exists)
     if (exists .and. pe_rank .eq. 0) then
-       open(newunit=unit, file='test_write_time.vtkhdf')
+       open(newunit=unit, file='test_write_time.0.vtkhdf')
        close(unit, status='delete')
     end if
 
@@ -116,7 +116,7 @@ contains
     integer :: ierr
     character(len=:), allocatable :: message
 
-    fname = "test_init.vtkhdf"
+    fname = "test_init.0.vtkhdf"
     call file%init(fname)
     message = "File must be allocated"
     @assertTrue(allocated(file%file_type), message = message)
@@ -192,7 +192,7 @@ contains
     call file%free()
 
     ! Test that the file exists
-    inquire(file=fname, exist=exists)
+    inquire(file="test_write.0.vtkhdf", exist=exists)
     message = "Output file must exist"
     @assertTrue(exists, message = message)
 
@@ -200,7 +200,7 @@ contains
     ! Validate HDF5 file contents
     ! ================================================================
     call h5open_f(hdferr)
-    call h5fopen_f(fname, H5F_ACC_RDONLY_F, file_id, hdferr)
+    call h5fopen_f("test_write.0.vtkhdf", H5F_ACC_RDONLY_F, file_id, hdferr)
     message = "Must open HDF5 file"
     @assertEqual(0, hdferr, message = message)
 
@@ -436,7 +436,7 @@ contains
     call file%free()
 
     ! Test that the file exists
-    inquire(file=fname, exist=exists)
+    inquire(file="test_write_time.0.vtkhdf", exist=exists)
     message = "Temporal output file must exist"
     @assertTrue(exists, message = message)
 
@@ -444,7 +444,7 @@ contains
     ! Validate HDF5 file contents
     ! ================================================================
     call h5open_f(hdferr)
-    call h5fopen_f(fname, H5F_ACC_RDONLY_F, file_id, hdferr)
+    call h5fopen_f("test_write_time.0.vtkhdf", H5F_ACC_RDONLY_F, file_id, hdferr)
     message = "Must open temporal HDF5 file"
     @assertEqual(0, hdferr, message = message)
 

--- a/tests/unit/vtkhdf/vtkhdf_parallel.pf
+++ b/tests/unit/vtkhdf/vtkhdf_parallel.pf
@@ -48,15 +48,15 @@ contains
     logical :: exists
     integer :: unit
 
-    inquire(file='test_write.0.vtkhdf', exist=exists)
+    inquire(file='test_write_0.vtkhdf', exist=exists)
     if (exists .and. pe_rank .eq. 0) then
-       open(newunit=unit, file='test_write.0.vtkhdf')
+       open(newunit=unit, file='test_write_0.vtkhdf')
        close(unit, status='delete')
     end if
 
-    inquire(file='test_write_time.0.vtkhdf', exist=exists)
+    inquire(file='test_write_time_0.vtkhdf', exist=exists)
     if (exists .and. pe_rank .eq. 0) then
-       open(newunit=unit, file='test_write_time.0.vtkhdf')
+       open(newunit=unit, file='test_write_time_0.vtkhdf')
        close(unit, status='delete')
     end if
 
@@ -116,7 +116,7 @@ contains
     integer :: ierr
     character(len=:), allocatable :: message
 
-    fname = "test_init.0.vtkhdf"
+    fname = "test_init_0.vtkhdf"
     call file%init(fname)
     message = "File must be allocated"
     @assertTrue(allocated(file%file_type), message = message)
@@ -192,7 +192,7 @@ contains
     call file%free()
 
     ! Test that the file exists
-    inquire(file="test_write.0.vtkhdf", exist=exists)
+    inquire(file="test_write_0.vtkhdf", exist=exists)
     message = "Output file must exist"
     @assertTrue(exists, message = message)
 
@@ -200,7 +200,7 @@ contains
     ! Validate HDF5 file contents
     ! ================================================================
     call h5open_f(hdferr)
-    call h5fopen_f("test_write.0.vtkhdf", H5F_ACC_RDONLY_F, file_id, hdferr)
+    call h5fopen_f("test_write_0.vtkhdf", H5F_ACC_RDONLY_F, file_id, hdferr)
     message = "Must open HDF5 file"
     @assertEqual(0, hdferr, message = message)
 
@@ -436,7 +436,7 @@ contains
     call file%free()
 
     ! Test that the file exists
-    inquire(file="test_write_time.0.vtkhdf", exist=exists)
+    inquire(file="test_write_time_0.vtkhdf", exist=exists)
     message = "Temporal output file must exist"
     @assertTrue(exists, message = message)
 
@@ -444,7 +444,7 @@ contains
     ! Validate HDF5 file contents
     ! ================================================================
     call h5open_f(hdferr)
-    call h5fopen_f("test_write_time.0.vtkhdf", H5F_ACC_RDONLY_F, file_id, hdferr)
+    call h5fopen_f("test_write_time_0.vtkhdf", H5F_ACC_RDONLY_F, file_id, hdferr)
     message = "Must open temporal HDF5 file"
     @assertEqual(0, hdferr, message = message)
 


### PR DESCRIPTION
Change the VTKHDF default name. Now the name is constructed from the start iteration, similar to how `.nek5000` files were handled. This solves issues with writing after a restart if the vtkhdf format was not used from the start.

Please note this approach comes at a cost. Timesteps between end of the first simulation and beginning of the restarted run will be stored in both files and not overwritten. This have pros and cons, but is worth noting.