### PR TITLE
Unmap: Fix logic to determine if array is mapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Develop
 
+- Bugfix: Fixed a bug in the `unmap` subroutine, where the device pointer was
+  used to check if the field was mapped, which lead to a crash when trying to
+  unmap an array that was not associated with a device. Correctly does nothing
+  now.
 - Added an AI policy to the contribution guidelines.
 - Added simple support for VTKHDF. For now it can be used for fluid outputs.
   Simple restarts are supported with fixed mesh and MPI configuration. 

--- a/src/device/device.F90
+++ b/src/device/device.F90
@@ -893,14 +893,19 @@ contains
     type(c_ptr) :: dev
     logical :: mapped
 
-    ! Device pointer associated with x, should be same as x_d if mapped
-    dev = device_get_ptr(x)
     ! Whether dev has a non-null address, meaning that x is mapped.
-    mapped = c_associated(dev)
+    mapped = device_associated(x)
 
     ! Repeated calls to this routine do nothing
     if ((.not. mapped) .and. (.not. c_associated(x_d))) then
        return
+    end if
+
+    ! Device pointer associated with x, should be same as x_d if mapped
+    if (mapped) then
+       dev = device_get_ptr(x)
+    else
+       dev = c_null_ptr
     end if
 
     ! Error if:
@@ -925,14 +930,19 @@ contains
     type(c_ptr) :: dev
     logical :: mapped
 
-    ! Device pointer associated with x, should be same as x_d if mapped
-    dev = device_get_ptr(x)
     ! Whether dev has a non-null address, meaning that x is mapped.
-    mapped = c_associated(dev)
+    mapped = device_associated(x)
 
     ! Repeated calls to this routine do nothing
     if ((.not. mapped) .and. (.not. c_associated(x_d))) then
        return
+    end if
+
+    ! Device pointer associated with x, should be same as x_d if mapped
+    if (mapped) then
+       dev = device_get_ptr(x)
+    else
+       dev = c_null_ptr
     end if
 
     ! Error if:
@@ -957,14 +967,19 @@ contains
     type(c_ptr) :: dev
     logical :: mapped
 
-    ! Device pointer associated with x, should be same as x_d if mapped
-    dev = device_get_ptr(x)
     ! Whether dev has a non-null address, meaning that x is mapped.
-    mapped = c_associated(dev)
+    mapped = device_associated(x)
 
     ! Repeated calls to this routine do nothing
     if ((.not. mapped) .and. (.not. c_associated(x_d))) then
        return
+    end if
+
+    ! Device pointer associated with x, should be same as x_d if mapped
+    if (mapped) then
+       dev = device_get_ptr(x)
+    else
+       dev = c_null_ptr
     end if
 
     ! Error if:
@@ -989,14 +1004,19 @@ contains
     type(c_ptr) :: dev
     logical :: mapped
 
-    ! Device pointer associated with x, should be same as x_d if mapped
-    dev = device_get_ptr(x)
     ! Whether dev has a non-null address, meaning that x is mapped.
-    mapped = c_associated(dev)
+    mapped = device_associated(x)
 
     ! Repeated calls to this routine do nothing
     if ((.not. mapped) .and. (.not. c_associated(x_d))) then
        return
+    end if
+
+    ! Device pointer associated with x, should be same as x_d if mapped
+    if (mapped) then
+       dev = device_get_ptr(x)
+    else
+       dev = c_null_ptr
     end if
 
     ! Error if:


### PR DESCRIPTION
Update the logic for determining if an array is mapped by using `device_associated` instead of checking the device pointer directly. This change avoid the error thrown when attempting to fetch the associated pointer to a non-associated array.