### PR TITLE
First batch of multithreaded kernels

### DIFF
--- a/src/math/bcknd/cpu/fdm_cpu.f90
+++ b/src/math/bcknd/cpu/fdm_cpu.f90
@@ -19,6 +19,7 @@ contains
 
     nn = nl**ldim
     if (.not. ldim .eq. 3) then
+       !$omp parallel do private(ie, i)
        do ie = 1, nelv
           call tnsr2d_el_cpu(e(1, ie), nl, r(1, ie), nl, s(1, 2, 1, ie), &
                s(1, 1, 2, ie))
@@ -28,7 +29,9 @@ contains
           call tnsr2d_el_cpu(e(1, ie), nl, r(1, ie), nl, s(1, 1, 1, ie), &
                s(1, 2, 2, ie))
        end do
+       !$omp end parallel do
     else
+       !$omp parallel do private(ie, i)
        do ie = 1, nelv
           call tnsr3d_el_cpu(e(1, ie), nl, r(1, ie), nl, &
                s(1, 2, 1, ie), s(1, 1, 2, ie), s(1, 1, 3, ie))
@@ -38,6 +41,7 @@ contains
           call tnsr3d_el_cpu(e(1, ie), nl, r(1, ie), nl, &
                s(1, 1, 1, ie), s(1, 2, 2, ie), s(1, 2, 3, ie))
        end do
+       !$omp end parallel do
     end if
   end subroutine fdm_do_fast_cpu
 

--- a/src/math/bcknd/cpu/tensor_cpu.f90
+++ b/src/math/bcknd/cpu/tensor_cpu.f90
@@ -76,6 +76,7 @@ contains
 
   end subroutine tnsr3d_el_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_nvnu_cpu(v, nv, u, nu, A, Bt, Ct)
     integer, intent(in) :: nv, nu
     real(kind=rp), intent(inout) :: v(nv*nv*nv), u(nu*nu*nu)
@@ -127,6 +128,7 @@ contains
 
   end subroutine tnsr3d_el_nvnu_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_1_nu_cpu(v, u, nu, A, Bt, Ct)
     integer, intent(in) :: nu
     real(kind=rp), intent(inout) :: v(1)
@@ -163,6 +165,7 @@ contains
 
   end subroutine tnsr3d_el_1_nu_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_1_4_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 4
     integer, parameter :: nn = n**2
@@ -193,6 +196,7 @@ contains
 
   end subroutine tnsr3d_el_1_4_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_1_6_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 6
     integer, parameter :: nn = n**2
@@ -229,6 +233,7 @@ contains
 
   end subroutine tnsr3d_el_1_6_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_1_8_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 8
     integer, parameter :: nn = n**2
@@ -272,7 +277,7 @@ contains
 
   end subroutine tnsr3d_el_1_8_cpu
 
-
+  !OCL SERIAL
   subroutine tnsr3d_el_1_10_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 10
     integer, parameter :: nn = n**2
@@ -321,7 +326,7 @@ contains
 
   end subroutine tnsr3d_el_1_10_cpu
 
-
+  !OCL SERIAL
   subroutine tnsr3d_el_1_12_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 12
     integer, parameter :: nn = n**2
@@ -376,8 +381,7 @@ contains
 
   end subroutine tnsr3d_el_1_12_cpu
 
-
-
+  !OCL SERIAL
   subroutine tnsr3d_el_n_cpu(v, u, A, Bt, Ct, n)
     integer, intent(in) :: n
     real(kind=rp), intent(inout) :: v(n*n*n), u(n*n*n)
@@ -425,6 +429,7 @@ contains
 
   end subroutine tnsr3d_el_n_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_n14_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 14
     integer, parameter :: nn = n**2
@@ -498,6 +503,7 @@ contains
 
   end subroutine tnsr3d_el_n14_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_n13_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 13
     integer, parameter :: nn = n**2
@@ -568,6 +574,7 @@ contains
 
   end subroutine tnsr3d_el_n13_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_n12_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 12
     integer, parameter :: nn = n**2
@@ -635,6 +642,7 @@ contains
 
   end subroutine tnsr3d_el_n12_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_n11_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 11
     integer, parameter :: nn = n**2
@@ -699,6 +707,7 @@ contains
 
   end subroutine tnsr3d_el_n11_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_n10_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 10
     integer, parameter :: nn = n**2
@@ -760,6 +769,7 @@ contains
 
   end subroutine tnsr3d_el_n10_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_n9_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 9
     integer, parameter :: nn = n**2
@@ -818,6 +828,7 @@ contains
 
   end subroutine tnsr3d_el_n9_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_n8_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 8
     integer, parameter :: nn = n**2
@@ -873,6 +884,7 @@ contains
 
   end subroutine tnsr3d_el_n8_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_n7_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 7
     integer, parameter :: nn = n**2
@@ -925,6 +937,7 @@ contains
 
   end subroutine tnsr3d_el_n7_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_n6_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 6
     integer, parameter :: nn = n**2
@@ -974,6 +987,7 @@ contains
 
   end subroutine tnsr3d_el_n6_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_n5_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 5
     integer, parameter :: nn = n**2
@@ -1020,6 +1034,7 @@ contains
 
   end subroutine tnsr3d_el_n5_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_n4_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 4
     integer, parameter :: nn = n**2
@@ -1063,6 +1078,7 @@ contains
 
   end subroutine tnsr3d_el_n4_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_n3_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 3
     integer, parameter :: nn = n**2
@@ -1103,6 +1119,7 @@ contains
 
   end subroutine tnsr3d_el_n3_cpu
 
+  !OCL SERIAL
   subroutine tnsr3d_el_n2_cpu(v, u, A, Bt, Ct)
     integer, parameter :: n = 2
     integer, parameter :: nn = n**2
@@ -1169,6 +1186,7 @@ contains
     nunu = nu * nu
     nvnv = nv * nv
 
+    !$omp parallel do private(ie, i, j, k, l, ii, jj, tmp, work, work2)
     do ie = 1, nelv
        do j = 1, nunu
           do i = 1, nv
@@ -1207,6 +1225,7 @@ contains
           end do
        end do
     end do
+    !$omp end parallel do
 
   end subroutine tnsr3d_nvnu_cpu
 
@@ -1223,6 +1242,7 @@ contains
     real(kind=rp) :: work(nu**2*nv), work2(nu*nv**2), tmp
     integer :: ie, i, j, k, l, ii, jj
 
+    !$omp parallel do private(ie, i, j, k, l, ii, jj, tmp, work, work2)
     do ie = 1, nelv
        do j = 1, nunu
           do i = 1, nv
@@ -1254,6 +1274,7 @@ contains
           end do
        end do
     end do
+    !$omp end parallel do
 
   end subroutine tnsr3d_nu2nv4_cpu
 
@@ -1271,6 +1292,7 @@ contains
     nvnu = nv * nu
     nvnv = nv * nv
 
+    !$omp parallel do private(ie, i, j, k, l, ii, tmp, work, work2)
     do ie = 1, nelv
        do j = 1, nunu
           do i = 1, nv
@@ -1306,6 +1328,7 @@ contains
           end do
        end do
     end do
+    !$omp end parallel do
 
   end subroutine tnsr3d_nu4_cpu
 
@@ -1349,6 +1372,7 @@ contains
     nu3 = nu**3
     nv3 = nv**3
 
+    !$omp parallel do private(e,iu,iv,i,j,k,l,ii,jj,kk,work,work2,tmp)
     do e = e0, ee, es
        iu = (e-1)*nu3
        iv = (e-1)*nv3
@@ -1391,7 +1415,7 @@ contains
           end do
        end do
     end do
-
+    !$omp end parallel do
   end subroutine tnsr1_3d_nvnu_cpu
 
   subroutine tnsr1_3d_nu4nv2_cpu(v, A, Bt, Ct, nelv)
@@ -1410,6 +1434,7 @@ contains
     integer :: i, j, k, l, ii, jj
     real(kind=rp) :: tmp
 
+    !$omp parallel do private(e,iu,iv,i,j,k,l,ii,jj, work, work2, tmp)
     do e = 1, nelv
        iu = (e-1)*nununu
        iv = (e-1)*nvnvnv
@@ -1449,7 +1474,7 @@ contains
           end do
        end do
     end do
-
+    !$omp end parallel do
   end subroutine tnsr1_3d_nu4nv2_cpu
 
 end module tensor_cpu

--- a/src/math/schwarz.f90
+++ b/src/math/schwarz.f90
@@ -215,8 +215,8 @@ contains
   subroutine schwarz_setup_wt(this)
     class(schwarz_t), intent(inout) :: this
     integer :: enx, eny, enz, n, ie, k, ns
-    real(kind=rp), parameter :: zero = 0.0
-    real(kind=rp), parameter :: one = 1.0
+    real(kind=rp), parameter :: zero = 0.0_rp
+    real(kind=rp), parameter :: one = 1.0_rp
     associate(work1 => this%work1, work2 => this%work2, msh => this%msh, &
          Xh => this%Xh, Xh_schwarz => this%Xh_schwarz)
 
@@ -344,6 +344,7 @@ contains
     real(kind=rp), intent(inout) :: a(0:n+1, 0:n+1, 0:n+1, nelv)
     real(kind=rp), intent(inout) :: b(n, n, n, nelv)
     integer :: i, j, k, ie
+    !$omp parallel do private(ie, i, j, k)
     do ie = 1, nelv
        do k = 1, n
           do j = 1, n
@@ -353,6 +354,7 @@ contains
           end do
        end do
     end do
+    !$omp end parallel do
   end subroutine schwarz_toreg3d
 
   !> convert array a from original size to size extended array with border
@@ -363,6 +365,7 @@ contains
     integer :: i, j, k, ie
 
     call rzero(a, (n+2)*(n+2)*(n+2)*nelv)
+    !$omp parallel do private(ie, i, j, k)
     do ie = 1, nelv
        do k = 1, n
           do j = 1, n
@@ -372,6 +375,7 @@ contains
           end do
        end do
     end do
+    !$omp end parallel do
   end subroutine schwarz_toext3d
 
   !> Sum values along rows l1, l2 with weights f1, f2 and store along row l1.
@@ -387,6 +391,7 @@ contains
     i1 = nx - 1
 
     if (nz .eq. 1) then
+       !$omp parallel do private(ie, i, j)
        do ie = 1, nelv
           do j = i0, i1
              arr1(l1 + 1, j, 1, ie) = f1 * arr1(l1 + 1, j, 1, ie) &
@@ -401,7 +406,9 @@ contains
                   + f2 * arr2(i, nx - l2, 1, ie)
           end do
        end do
+       !$omp end parallel do
     else
+       !$omp parallel do private(ie, i, j, k)
        do ie = 1, nelv
           do k = i0, i1
              do j = i0, i1
@@ -428,6 +435,7 @@ contains
              end do
           end do
        end do
+       !$omp end parallel do
     end if
   end subroutine schwarz_extrude
 
@@ -528,6 +536,7 @@ contains
     real(kind=rp), intent(inout) :: wt(n, n, 4, 3, nelv)
     integer :: ie, i, j, k
 
+    !$omp parallel do private(ie, i, j, k)
     do ie = 1, nelv
        do k = 1, n
           do j = 1, n
@@ -554,5 +563,6 @@ contains
           end do
        end do
     end do
+    !$omp end parallel do
   end subroutine schwarz_wt3d
 end module schwarz

--- a/src/sem/coef.f90
+++ b/src/sem/coef.f90
@@ -776,6 +776,7 @@ contains
               DEVICE_TO_HOST, sync=.true.)
 
       else
+         !$omp parallel do private(i)
          do e = 1, c%msh%nelv
             call mxm(dx, lx, x(1,1,1,e), lx, dxdr(1,1,1,e), lyz)
             call mxm(dx, lx, y(1,1,1,e), lx, dydr(1,1,1,e), lyz)
@@ -798,6 +799,7 @@ contains
                call rone(dzdt(1,1,1,e), lxy)
             end if
          end do
+         !$omp end parallel do
 
          if (c%msh%gdim .eq. 2) then
             call rzero (jac, ntot)
@@ -813,11 +815,13 @@ contains
             call rzero (dsdz, ntot)
             call rone (dtdz, ntot)
          else
-
+            !$omp parallel private(i)
+            !$omp do
             do i = 1, ntot
                c%jac(i, 1, 1, 1) = 0.0_rp
             end do
-
+            !$omp end do
+            !$omp do
             do i = 1, ntot
                c%jac(i, 1, 1, 1) = c%jac(i, 1, 1, 1) + ( c%dxdr(i, 1, 1, 1) &
                     * c%dyds(i, 1, 1, 1) * c%dzdt(i, 1, 1, 1) )
@@ -828,7 +832,8 @@ contains
                c%jac(i, 1, 1, 1) = c%jac(i, 1, 1, 1) + ( c%dxds(i, 1, 1, 1) &
                     * c%dydt(i, 1, 1, 1) * c%dzdr(i, 1, 1, 1) )
             end do
-
+            !$omp end do
+            !$omp do
             do i = 1, ntot
                c%jac(i, 1, 1, 1) = c%jac(i, 1, 1, 1) - ( c%dxdr(i, 1, 1, 1) &
                     * c%dydt(i, 1, 1, 1) * c%dzds(i, 1, 1, 1) )
@@ -839,7 +844,8 @@ contains
                c%jac(i, 1, 1, 1) = c%jac(i, 1, 1, 1) - ( c%dxdt(i, 1, 1, 1) &
                     * c%dyds(i, 1, 1, 1) * c%dzdr(i, 1, 1, 1) )
             end do
-
+            !$omp end do
+            !$omp do
             do i = 1, ntot
                c%drdx(i, 1, 1, 1) = c%dyds(i, 1, 1, 1) * c%dzdt(i, 1, 1, 1) &
                     - c%dydt(i, 1, 1, 1) * c%dzds(i, 1, 1, 1)
@@ -850,7 +856,8 @@ contains
                c%drdz(i, 1, 1, 1) = c%dxds(i, 1, 1, 1) * c%dydt(i, 1, 1, 1) &
                     - c%dxdt(i, 1, 1, 1) * c%dyds(i, 1, 1, 1)
             end do
-
+            !$omp end do
+            !$omp do
             do i = 1, ntot
                c%dsdx(i, 1, 1, 1) = c%dydt(i, 1, 1, 1) * c%dzdr(i, 1, 1, 1) &
                     - c%dydr(i, 1, 1, 1) * c%dzdt(i, 1, 1, 1)
@@ -861,7 +868,8 @@ contains
                c%dsdz(i, 1, 1, 1) = c%dxdt(i, 1, 1, 1) * c%dydr(i, 1, 1, 1) &
                     - c%dxdr(i, 1, 1, 1) * c%dydt(i, 1, 1, 1)
             end do
-
+            !$omp end do
+            !$omp do
             do i = 1, ntot
                c%dtdx(i, 1, 1, 1) = c%dydr(i, 1, 1, 1) * c%dzds(i, 1, 1, 1) &
                     - c%dyds(i, 1, 1, 1) * c%dzdr(i, 1, 1, 1)
@@ -872,7 +880,8 @@ contains
                c%dtdz(i, 1, 1, 1) = c%dxdr(i, 1, 1, 1) * c%dyds(i, 1, 1, 1) &
                     - c%dxds(i, 1, 1, 1) * c%dydr(i, 1, 1, 1)
             end do
-
+            !$omp end do
+            !$omp end parallel
          end if
          call invers2(jacinv, jac, ntot)
       end if
@@ -938,7 +947,8 @@ contains
           end do
 
        else
-
+          !$omp parallel private(i)
+          !$omp do
           do i = 1, ntot
              c%G11(i, 1, 1, 1) = c%drdx(i, 1, 1, 1) * c%drdx(i, 1, 1, 1) &
                   + c%drdy(i, 1, 1, 1) * c%drdy(i, 1, 1, 1) &
@@ -952,13 +962,15 @@ contains
                   + c%dtdy(i, 1, 1, 1) * c%dtdy(i, 1, 1, 1) &
                   + c%dtdz(i, 1, 1, 1) * c%dtdz(i, 1, 1, 1)
           end do
-
+          !$omp end do
+          !$omp do
           do i = 1, ntot
              c%G11(i, 1, 1, 1) = c%G11(i, 1, 1, 1) * c%jacinv(i, 1, 1, 1)
              c%G22(i, 1, 1, 1) = c%G22(i, 1, 1, 1) * c%jacinv(i, 1, 1, 1)
              c%G33(i, 1, 1, 1) = c%G33(i, 1, 1, 1) * c%jacinv(i, 1, 1, 1)
           end do
-
+          !$omp end do
+          !$omp do
           do i = 1, ntot
              c%G12(i, 1, 1, 1) = c%drdx(i, 1, 1, 1) * c%dsdx(i, 1, 1, 1) &
                   + c%drdy(i, 1, 1, 1) * c%dsdy(i, 1, 1, 1) &
@@ -972,14 +984,16 @@ contains
                   + c%dsdy(i, 1, 1, 1) * c%dtdy(i, 1, 1, 1) &
                   + c%dsdz(i, 1, 1, 1) * c%dtdz(i, 1, 1, 1)
           end do
-
+          !$omp end do
+          !$omp do
           do i = 1, ntot
              c%G12(i, 1, 1, 1) = c%G12(i, 1, 1, 1) * c%jacinv(i, 1, 1, 1)
              c%G13(i, 1, 1, 1) = c%G13(i, 1, 1, 1) * c%jacinv(i, 1, 1, 1)
              c%G23(i, 1, 1, 1) = c%G23(i, 1, 1, 1) * c%jacinv(i, 1, 1, 1)
           end do
-
-          do concurrent (e = 1:c%msh%nelv)
+          !$omp end do
+          !$omp do
+          do e = 1, c%msh%nelv
              do concurrent (i = 1:lxyz)
                 c%G11(i,1,1,e) = c%G11(i,1,1,e) * c%Xh%w3(i,1,1)
                 c%G22(i,1,1,e) = c%G22(i,1,1,e) * c%Xh%w3(i,1,1)
@@ -990,7 +1004,8 @@ contains
                 c%G23(i,1,1,e) = c%G23(i,1,1,e) * c%Xh%w3(i,1,1)
              end do
           end do
-
+          !$omp end do
+          !$omp end parallel
        end if
     end if
 

--- a/src/sem/dofmap.f90
+++ b/src/sem/dofmap.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2020-2023, The Neko Authors
+! Copyright (c) 2020-2026, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -251,6 +251,7 @@ contains
     num_dofs_edges(3) = int(Xh%lz - 2, i8)
     edge_offset = int(msh%glb_mpts, i8) + int(1, i8)
 
+    !$omp parallel do private(i,j,k,global_id,edge,edge_id,shared_dof)
     do i = 1, msh%nelv
 
        select type (ep => msh%elements(i)%e)
@@ -563,6 +564,7 @@ contains
        end select
 
     end do
+    !$omp end parallel do
   end subroutine dofmap_number_edges
 
   !> Assign numbers to dofs on faces
@@ -589,6 +591,7 @@ contains
     num_dofs_faces(2) = int((Xh%lx - 2) * (Xh%lz - 2), i8)
     num_dofs_faces(3) = int((Xh%lx - 2) * (Xh%ly - 2), i8)
 
+    !$omp parallel do private(i,j,k,global_id,face,face_order,facet_id, shared_dof)
     do i = 1, msh%nelv
 
        !
@@ -668,6 +671,7 @@ contains
           this%shared_dof(j, k, Xh%lz, i) = shared_dof
        end do
     end do
+    !$omp end parallel do
 
   end subroutine dofmap_number_faces
 
@@ -747,10 +751,13 @@ contains
        n_edge = 4
     end if
 
+    !$omp parallel do
     do i = 1, msh%nelv
        call dofmap_xyzlin(Xh, msh, msh%elements(i)%e, this%x(1,1,1,i), &
             this%y(1,1,1,i), this%z(1,1,1,i))
     end do
+    !$omp end parallel do
+
     do i = 1, msh%curve%size
        midpoint = .false.
        el_idx = msh%curve%curve_el(i)%el_idx
@@ -868,6 +875,7 @@ contains
     end if
   end subroutine dofmap_xyzlin
 
+  !OCL SERIAL
   subroutine dofmap_xyzquad(Xh, msh, element, x, y, z, curve_type, curve_data)
     type(mesh_t), pointer, intent(in) :: msh
     type(space_t), intent(in) :: Xh
@@ -943,6 +951,8 @@ contains
     call Xh3%free()
   end subroutine dofmap_xyzquad
 
+ 
+  !OCL SERIAL
   !> Extend faces into interior via gordon hall
   !! gh_type:  1 - vertex only
   !!           2 - vertex and edges
@@ -1057,6 +1067,7 @@ contains
 
   end subroutine gh_face_extend_3d
 
+  !OCL SERIAL
   !> Extend 2D faces into interior via gordon hall
   !! gh_type:  1 - vertex only
   !!           2 - vertex and faces
@@ -1209,6 +1220,7 @@ contains
     end if
   end subroutine arc_surface
 
+  !OCL SERIAL
   subroutine compute_h(h, zgml, gdim, lx)
     integer, intent(in) :: lx, gdim
     real(kind=rp), intent(inout) :: h(lx, 3, 2)

--- a/src/sem/dofmap.f90
+++ b/src/sem/dofmap.f90
@@ -951,7 +951,7 @@ contains
     call Xh3%free()
   end subroutine dofmap_xyzquad
 
- 
+
   !OCL SERIAL
   !> Extend faces into interior via gordon hall
   !! gh_type:  1 - vertex only


### PR DESCRIPTION
This PR adds the first batch of performant multithreaded kernels towards #2336.

This is an intermediate step (see #2335), designed to be used together with auto parallelisation and OpenMP with the Fujitsu compiler, thus the need for Fujitsu specific pragmas (`OCL SERIAL`) to mark necessary serial sections.

However, the OpenMP pragmas in `coef` and `dofmap` will speed up initialisation for configurations using accelerators + OpenMP.