### PR TITLE
Extend cleanup script to handle merge queue caches

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -41,3 +41,25 @@ jobs:
             done
           fi
           echo "Done"
+
+      - name: Cleanup Cache from Merge queue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/heads/gh-readonly-queue/${{ github.event.pull_request.base.ref }}/pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.base.sha }}
+
+        run: |
+          echo "Fetching list of cache keys"
+          cacheKeysForMergeQueue=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
+
+          if [ -z "$cacheKeysForMergeQueue" ]; then
+            echo "No caches found for this ref"
+          else
+            echo "Deleting caches..."
+            for cacheKey in $cacheKeysForMergeQueue
+            do
+                echo "Deleting cache with key: $cacheKey"
+                gh cache delete $cacheKey
+            done
+          fi
+          echo "Done"


### PR DESCRIPTION
Add functionality to the cleanup script to delete cache entries associated with the merge queue, improving cache management during the merge process.