### PR TITLE
Add merge strategy for changelog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 *.py.in linguist-language=Python
 *.case linguist-language=json
 
+CHANGELOG.md merge=union


### PR DESCRIPTION
Introduce a merge strategy for the CHANGELOG.md file to ensure consistent handling during local merges.

Github does not care but local merges do.