### PR TITLE
Propagate setUp and tearDown to all unit tests

### DIFF
--- a/tests/unit/bc/test_bc.pf
+++ b/tests/unit/bc/test_bc.pf
@@ -1,5 +1,32 @@
 module test_bc
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_bc_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_bc_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_bc_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_bc_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 ! @test
 ! subroutine test_bc_init
 !   use pfunit

--- a/tests/unit/device/test_device.pf
+++ b/tests/unit/device/test_device.pf
@@ -32,7 +32,6 @@ contains
 subroutine test_device_init(this)
   use pfunit
   use device
-  implicit none
   class(test_device_case), intent(inout) :: this
 end subroutine test_device_init
 
@@ -40,7 +39,6 @@ end subroutine test_device_init
 subroutine test_device_sync(this)
   use pfunit
   use device
-  implicit none
   class(test_device_case), intent(inout) :: this
   call device_sync()
 
@@ -52,7 +50,6 @@ subroutine test_device_alloc(this)
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
-  implicit none
   class(test_device_case), intent(inout) :: this
   type(c_ptr) :: x_d
   integer(c_size_t) :: size_
@@ -75,7 +72,6 @@ subroutine test_device_free(this)
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
-  implicit none
   class(test_device_case), intent(inout) :: this
   type(c_ptr) :: x_d
   integer(c_size_t) :: size_
@@ -103,7 +99,6 @@ subroutine test_device_associate(this)
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
-  implicit none
   class(test_device_case), intent(inout) :: this
   type(c_ptr) :: x_d
   integer(c_size_t) :: size_
@@ -129,7 +124,6 @@ subroutine test_device_associated(this)
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
-  implicit none
   class(test_device_case), intent(inout) :: this
   type(c_ptr) :: x_d
   integer(c_size_t) :: size_
@@ -155,7 +149,6 @@ subroutine test_device_get_ptr(this)
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
-  implicit none
   class(test_device_case), intent(inout) :: this
   type(c_ptr) :: x_d, dev
   integer(c_size_t) :: size_
@@ -186,7 +179,6 @@ subroutine test_device_map(this)
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
-  implicit none
   class(test_device_case), intent(inout) :: this
   type(c_ptr) :: x_d, dev
   integer(c_size_t) :: size_
@@ -215,7 +207,6 @@ subroutine test_device_unmap(this)
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
-  implicit none
   class(test_device_case), intent(inout) :: this
   type(c_ptr) :: x_d
   integer, dimension(42) :: x
@@ -246,7 +237,6 @@ subroutine test_device_memcpy(this)
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
-  implicit none
   class(test_device_case), intent(inout) :: this
   type(c_ptr) :: x_d, y_d, dev
   integer(c_size_t) :: size_
@@ -299,7 +289,6 @@ subroutine test_device_stream_create(this)
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
-  implicit none
   class(test_device_case), intent(inout) :: this
   type(c_ptr) :: stream
 
@@ -319,7 +308,6 @@ subroutine test_device_stream_destroy(this)
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
-  implicit none
   class(test_device_case), intent(inout) :: this
   type(c_ptr) :: stream
 
@@ -341,7 +329,6 @@ subroutine test_device_sync_stream(this)
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
-  implicit none
   class(test_device_case), intent(inout) :: this
   type(c_ptr) :: stream1, stream2
 

--- a/tests/unit/device/test_device.pf
+++ b/tests/unit/device/test_device.pf
@@ -1,32 +1,59 @@
 module test_device
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_device_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_device_case
+
 contains
 
+  subroutine setUp(this)
+    class(test_device_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_device_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
+
 @test
-subroutine test_device_init
+subroutine test_device_init(this)
   use pfunit
   use device
   implicit none
-  call device_init()
+  class(test_device_case), intent(inout) :: this
 end subroutine test_device_init
 
 @test
-subroutine test_device_sync
+subroutine test_device_sync(this)
   use pfunit
   use device
   implicit none
-
-  call device_init()
+  class(test_device_case), intent(inout) :: this
   call device_sync()
 
 end subroutine test_device_sync
 
 @test
-subroutine test_device_alloc
+subroutine test_device_alloc(this)
   use neko_config
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
   implicit none
+  class(test_device_case), intent(inout) :: this
   type(c_ptr) :: x_d
   integer(c_size_t) :: size_
 
@@ -43,12 +70,13 @@ subroutine test_device_alloc
 end subroutine test_device_alloc
 
 @test
-subroutine test_device_free
+subroutine test_device_free(this)
   use neko_config
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
   implicit none
+  class(test_device_case), intent(inout) :: this
   type(c_ptr) :: x_d
   integer(c_size_t) :: size_
 
@@ -70,12 +98,13 @@ subroutine test_device_free
 end subroutine test_device_free
 
 @test
-subroutine test_device_associate
+subroutine test_device_associate(this)
   use neko_config
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
   implicit none
+  class(test_device_case), intent(inout) :: this
   type(c_ptr) :: x_d
   integer(c_size_t) :: size_
   integer :: x(42)
@@ -95,12 +124,13 @@ subroutine test_device_associate
 end subroutine test_device_associate
 
 @test
-subroutine test_device_associated
+subroutine test_device_associated(this)
   use neko_config
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
   implicit none
+  class(test_device_case), intent(inout) :: this
   type(c_ptr) :: x_d
   integer(c_size_t) :: size_
   integer :: x(42)
@@ -120,12 +150,13 @@ subroutine test_device_associated
 end subroutine test_device_associated
 
 @test
-subroutine test_device_get_ptr
+subroutine test_device_get_ptr(this)
   use neko_config
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
   implicit none
+  class(test_device_case), intent(inout) :: this
   type(c_ptr) :: x_d, dev
   integer(c_size_t) :: size_
   integer :: x(42)
@@ -150,12 +181,13 @@ subroutine test_device_get_ptr
 end subroutine test_device_get_ptr
 
 @test
-subroutine test_device_map
+subroutine test_device_map(this)
   use neko_config
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
   implicit none
+  class(test_device_case), intent(inout) :: this
   type(c_ptr) :: x_d, dev
   integer(c_size_t) :: size_
   integer :: x(42)
@@ -178,12 +210,13 @@ subroutine test_device_map
 end subroutine test_device_map
 
 @test
-subroutine test_device_unmap
+subroutine test_device_unmap(this)
   use neko_config
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
   implicit none
+  class(test_device_case), intent(inout) :: this
   type(c_ptr) :: x_d
   integer, dimension(42) :: x
 
@@ -208,12 +241,13 @@ subroutine test_device_unmap
 end subroutine test_device_unmap
 
 @test
-subroutine test_device_memcpy
+subroutine test_device_memcpy(this)
   use neko_config
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
   implicit none
+  class(test_device_case), intent(inout) :: this
   type(c_ptr) :: x_d, y_d, dev
   integer(c_size_t) :: size_
   integer :: x(42), i
@@ -260,12 +294,13 @@ subroutine test_device_memcpy
 end subroutine test_device_memcpy
 
 @test
-subroutine test_device_stream_create
+subroutine test_device_stream_create(this)
   use neko_config
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
   implicit none
+  class(test_device_case), intent(inout) :: this
   type(c_ptr) :: stream
 
   if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1)) then
@@ -279,12 +314,13 @@ subroutine test_device_stream_create
 end subroutine test_device_stream_create
 
 @test
-subroutine test_device_stream_destroy
+subroutine test_device_stream_destroy(this)
   use neko_config
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
   implicit none
+  class(test_device_case), intent(inout) :: this
   type(c_ptr) :: stream
 
   if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1)) then
@@ -300,12 +336,13 @@ subroutine test_device_stream_destroy
 end subroutine test_device_stream_destroy
 
 @test
-subroutine test_device_sync_stream
+subroutine test_device_sync_stream(this)
   use neko_config
   use pfunit
   use device
   use, intrinsic :: iso_c_binding
   implicit none
+  class(test_device_case), intent(inout) :: this
   type(c_ptr) :: stream1, stream2
 
   if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1)) then

--- a/tests/unit/device/test_device.pf
+++ b/tests/unit/device/test_device.pf
@@ -33,6 +33,8 @@ subroutine test_device_init(this)
   use pfunit
   use device
   class(test_device_case), intent(inout) :: this
+
+  call device_init()
 end subroutine test_device_init
 
 @test

--- a/tests/unit/device_mathops/test_device_mathops.pf
+++ b/tests/unit/device_mathops/test_device_mathops.pf
@@ -1,8 +1,35 @@
 module test_device_mathops
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_device_mathops_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_device_mathops_case
+
 contains
 
+  subroutine setUp(this)
+    class(test_device_mathops_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_device_mathops_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
+
 @test
-subroutine test_mathops_opchsign
+subroutine test_mathops_opchsign(this)
   use pfunit
   use device
   use device_mathops
@@ -10,6 +37,7 @@ subroutine test_mathops_opchsign
   use neko_config
   use, intrinsic :: iso_c_binding
   implicit none 
+  class(test_device_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), dimension(n) :: a1, a2, a3
   type(c_ptr) :: a1_d = C_NULL_PTR
@@ -19,8 +47,6 @@ subroutine test_mathops_opchsign
 
   if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
        (NEKO_BCKND_OPENCL .eq. 1)) then
-     
-     call device_init
      call device_map(a1, a1_d, n)
      call device_map(a2, a2_d, n)
      call device_map(a3, a3_d, n)
@@ -49,15 +75,12 @@ subroutine test_mathops_opchsign
            end if
         end do
      end do
-     
-     call device_finalize
-
   end if
   
 end subroutine test_mathops_opchsign
 
 @test
-subroutine test_mathops_opcolv
+subroutine test_mathops_opcolv(this)
   use pfunit
   use device
   use device_mathops
@@ -65,6 +88,7 @@ subroutine test_mathops_opcolv
   use neko_config
   use, intrinsic :: iso_c_binding
   implicit none 
+  class(test_device_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), dimension(n) :: a1, a2, a3, c
   type(c_ptr) :: a1_d = C_NULL_PTR
@@ -75,8 +99,6 @@ subroutine test_mathops_opcolv
 
   if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
        (NEKO_BCKND_OPENCL .eq. 1)) then
-
-     call device_init
      call device_map(a1, a1_d, n)
      call device_map(a2, a2_d, n)
      call device_map(a3, a3_d, n)
@@ -107,14 +129,12 @@ subroutine test_mathops_opcolv
            end if
         end do
      end do
-
-     call device_finalize
   end if
      
 end subroutine test_mathops_opcolv
 
 @test
-subroutine test_mathops_opcolv3c
+subroutine test_mathops_opcolv3c(this)
   use pfunit
   use device
   use device_mathops
@@ -122,6 +142,7 @@ subroutine test_mathops_opcolv3c
   use neko_config
   use, intrinsic :: iso_c_binding
   implicit none 
+  class(test_device_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), dimension(n):: c(n)
   real(kind=rp), parameter :: d = 1/42.0_rp
@@ -138,8 +159,6 @@ subroutine test_mathops_opcolv3c
 
   if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
        (NEKO_BCKND_OPENCL .eq. 1)) then
-     
-     call device_init
      call device_map(a1, a1_d, n)
      call device_map(a2, a2_d, n)
      call device_map(a3, a3_d, n)
@@ -179,13 +198,12 @@ subroutine test_mathops_opcolv3c
            end if
         end do
      end do
-     call device_finalize
   end if
   
 end subroutine test_mathops_opcolv3c
 
 @test
-subroutine test_mathops_opadd2cm
+subroutine test_mathops_opadd2cm(this)
   use pfunit
   use device
   use device_mathops
@@ -193,6 +211,7 @@ subroutine test_mathops_opadd2cm
   use neko_config
   use, intrinsic :: iso_c_binding
   implicit none 
+  class(test_device_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), parameter :: c = 42.0_rp
   real(kind=rp), dimension(n) :: a1, a2, a3
@@ -207,8 +226,6 @@ subroutine test_mathops_opadd2cm
 
   if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
        (NEKO_BCKND_OPENCL .eq. 1)) then
-     
-     call device_init
      call device_map(a1, a1_d, n)
      call device_map(a2, a2_d, n)
      call device_map(a3, a3_d, n)
@@ -245,13 +262,12 @@ subroutine test_mathops_opadd2cm
            end if
         end do
      end do
-     call device_finalize
   end if
   
 end subroutine test_mathops_opadd2cm
 
 @test
-subroutine test_mathops_opadd2col
+subroutine test_mathops_opadd2col(this)
   use pfunit
   use device
   use device_mathops
@@ -259,6 +275,7 @@ subroutine test_mathops_opadd2col
   use neko_config
   use, intrinsic :: iso_c_binding
   implicit none 
+  class(test_device_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), dimension(n) :: c
   real(kind=rp), dimension(n) :: a1, a2, a3
@@ -274,8 +291,6 @@ subroutine test_mathops_opadd2col
 
   if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
        (NEKO_BCKND_OPENCL .eq. 1)) then
-     
-     call device_init
      call device_map(a1, a1_d, n)
      call device_map(a2, a2_d, n)
      call device_map(a3, a3_d, n)
@@ -315,7 +330,6 @@ subroutine test_mathops_opadd2col
            end if
         end do
      end do
-     call device_finalize
   end if
   
 end subroutine test_mathops_opadd2col

--- a/tests/unit/device_mathops/test_device_mathops.pf
+++ b/tests/unit/device_mathops/test_device_mathops.pf
@@ -36,7 +36,6 @@ subroutine test_mathops_opchsign(this)
   use num_types
   use neko_config
   use, intrinsic :: iso_c_binding
-  implicit none 
   class(test_device_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), dimension(n) :: a1, a2, a3
@@ -87,7 +86,6 @@ subroutine test_mathops_opcolv(this)
   use num_types
   use neko_config
   use, intrinsic :: iso_c_binding
-  implicit none 
   class(test_device_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), dimension(n) :: a1, a2, a3, c
@@ -141,7 +139,6 @@ subroutine test_mathops_opcolv3c(this)
   use num_types
   use neko_config
   use, intrinsic :: iso_c_binding
-  implicit none 
   class(test_device_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), dimension(n):: c(n)
@@ -210,7 +207,6 @@ subroutine test_mathops_opadd2cm(this)
   use num_types
   use neko_config
   use, intrinsic :: iso_c_binding
-  implicit none 
   class(test_device_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), parameter :: c = 42.0_rp
@@ -274,7 +270,6 @@ subroutine test_mathops_opadd2col(this)
   use num_types
   use neko_config
   use, intrinsic :: iso_c_binding
-  implicit none 
   class(test_device_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), dimension(n) :: c

--- a/tests/unit/fast3d/test_fd_weights_full.pf
+++ b/tests/unit/fast3d/test_fd_weights_full.pf
@@ -32,7 +32,6 @@ contains
    use pfunit
    use fast3d
    use num_types
-   implicit none
    class(test_fd_weights_full_case), intent(inout) :: this
    
    integer, parameter :: n=1, m=0
@@ -53,7 +52,6 @@ end subroutine test_linear_midpoint
    use pfunit
    use fast3d
    use num_types
-   implicit none
    class(test_fd_weights_full_case), intent(inout) :: this
    
    integer, parameter :: n=2, m=1

--- a/tests/unit/fast3d/test_fd_weights_full.pf
+++ b/tests/unit/fast3d/test_fd_weights_full.pf
@@ -1,11 +1,39 @@
 module test_fd_weights_full
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_fd_weights_full_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_fd_weights_full_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_fd_weights_full_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_fd_weights_full_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
  @test
- subroutine test_linear_midpoint()
+ subroutine test_linear_midpoint(this)
    use pfunit
    use fast3d
    use num_types
    implicit none
+   class(test_fd_weights_full_case), intent(inout) :: this
    
    integer, parameter :: n=1, m=0
    real(kind=rp) :: xi, x(0:n), c(0:n,0:m)
@@ -21,11 +49,12 @@ contains
 end subroutine test_linear_midpoint
 
  @test
- subroutine test_central_difference()
+ subroutine test_central_difference(this)
    use pfunit
    use fast3d
    use num_types
    implicit none
+   class(test_fd_weights_full_case), intent(inout) :: this
    
    integer, parameter :: n=2, m=1
    real(kind=rp) :: xi, x(0:n), c(0:n,0:m)

--- a/tests/unit/fast3d/test_setup_intp.pf
+++ b/tests/unit/fast3d/test_setup_intp.pf
@@ -1,12 +1,40 @@
 module test_setup_intp
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_setup_intp_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_setup_intp_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_setup_intp_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_setup_intp_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 !> Normal interpolation from space with 2 points to 4
 @test
-subroutine test_setup_intp_basic()
+subroutine test_setup_intp_basic(this)
   use pfunit
   use fast3d, only : setup_intp
   use num_types, only : rp
   implicit none
+  class(test_setup_intp_case), intent(inout) :: this
   
   integer, parameter :: lx = 4
   real(kind=rp) Xh_to_Yh(lx, lx-2)
@@ -51,11 +79,12 @@ end subroutine test_setup_intp_basic
 
 !> Use a single point in the "from" space, expecting weight 1
 @test
-subroutine test_setup_intp_single_n_from()
+subroutine test_setup_intp_single_n_from(this)
   use pfunit
   use fast3d, only : setup_intp
   use num_types, only : rp
   implicit none
+  class(test_setup_intp_case), intent(inout) :: this
   
   integer, parameter :: lx = 4
   real(kind=rp) Xh_to_Yh(lx, 1)

--- a/tests/unit/fast3d/test_setup_intp.pf
+++ b/tests/unit/fast3d/test_setup_intp.pf
@@ -33,7 +33,6 @@ subroutine test_setup_intp_basic(this)
   use pfunit
   use fast3d, only : setup_intp
   use num_types, only : rp
-  implicit none
   class(test_setup_intp_case), intent(inout) :: this
   
   integer, parameter :: lx = 4
@@ -83,7 +82,6 @@ subroutine test_setup_intp_single_n_from(this)
   use pfunit
   use fast3d, only : setup_intp
   use num_types, only : rp
-  implicit none
   class(test_setup_intp_case), intent(inout) :: this
   
   integer, parameter :: lx = 4

--- a/tests/unit/gather_scatter/test_gather_scatter_parallel.pf
+++ b/tests/unit/gather_scatter/test_gather_scatter_parallel.pf
@@ -13,7 +13,6 @@ module test_gather_scatter_parallel
   use datadist
   use gather_scatter
   use device
-  use neko_config, only : NEKO_BCKND_DEVICE
   use neko_config
   use comm, only : NEKO_COMM, pe_rank, pe_size
   implicit none

--- a/tests/unit/gather_scatter/test_gather_scatter_parallel.pf
+++ b/tests/unit/gather_scatter/test_gather_scatter_parallel.pf
@@ -1,7 +1,7 @@
 module test_gather_scatter_parallel
   use mpi
   use pfunit
-  use neko_mpi_types, only : neko_mpi_types_init
+  use neko_mpi_types, only : neko_mpi_types_init, neko_mpi_types_free
   use dofmap
   use space
   use mesh
@@ -42,6 +42,7 @@ contains
 
   subroutine tearDown(this)
     class(test_gather_scatter_parallel_case), intent(inout) :: this
+    call neko_mpi_types_free()
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_finalize
     end if

--- a/tests/unit/gather_scatter/test_gather_scatter_parallel.pf
+++ b/tests/unit/gather_scatter/test_gather_scatter_parallel.pf
@@ -1,6 +1,7 @@
 module test_gather_scatter_parallel
   use mpi
   use pfunit
+  use neko_mpi_types, only : neko_mpi_types_init
   use dofmap
   use space
   use mesh
@@ -12,14 +13,40 @@ module test_gather_scatter_parallel
   use datadist
   use gather_scatter
   use device
+  use neko_config, only : NEKO_BCKND_DEVICE
   use neko_config
   use comm, only : NEKO_COMM, pe_rank, pe_size
   implicit none
 
+
+  @TestCase
+  type, extends(MPITestCase) :: test_gather_scatter_parallel_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_gather_scatter_parallel_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_gather_scatter_parallel_case), intent(inout) :: this
+    integer :: ierr
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    call neko_mpi_types_init()
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_gather_scatter_parallel_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
   @test(npes=[1])
   subroutine test_dofmap_face12(this)
-    class (MpiTestMethod), intent(inout) :: this
+    class(test_gather_scatter_parallel_case), intent(inout) :: this
     type(dofmap_t) :: d
     type(mesh_t) :: m
     type(field_t) :: x
@@ -30,14 +57,6 @@ contains
     integer :: ierr, i,j, lx, n
     integer, parameter :: gdim = 3
     lx = 5
-
-    call device_init
-
-    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
-
-    pe_rank = this%getProcessRank()
-    pe_size = this%getNumProcesses()
-
     dist = linear_dist_t(2, this%getProcessRank(), &
          this%getNumProcesses(), NEKO_COMM)
 
@@ -151,15 +170,12 @@ contains
           @assertEqual(x%x(lx,j,i,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
        end do
     end do
-
-    call device_finalize
-
   end subroutine test_dofmap_face12
 
 
   @test(npes=[1])
   subroutine test_dofmap_face15(this)
-    class (MpiTestMethod), intent(inout) :: this
+    class(test_gather_scatter_parallel_case), intent(inout) :: this
     type(dofmap_t) :: d
     type(mesh_t) :: m
     type(field_t) :: x
@@ -170,14 +186,6 @@ contains
     integer :: ierr, i,j, lx, n
     integer, parameter :: gdim = 3
     lx = 5
-
-    call device_init
-
-    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
-
-    pe_rank = this%getProcessRank()
-    pe_size = this%getNumProcesses()
-
     dist = linear_dist_t(2, this%getProcessRank(), &
          this%getNumProcesses(), NEKO_COMM)
 
@@ -286,14 +294,11 @@ contains
           @assertEqual(x%x(lx+1-i,j,lx,1), x%x(1,j,i,2), tolerance=epsilon(1.0_rp))
        end do
     end do
-
-    call device_finalize
-
   end subroutine test_dofmap_face15
 
   @test(npes=[1])
   subroutine test_dofmap_face11(this)
-    class (MpiTestMethod), intent(inout) :: this
+    class(test_gather_scatter_parallel_case), intent(inout) :: this
     type(dofmap_t) :: d
     type(mesh_t) :: m
     type(field_t) :: x
@@ -304,14 +309,6 @@ contains
     integer :: ierr, i,j, lx, n
     integer, parameter :: gdim = 3
     lx = 5
-
-    call device_init
-
-    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
-
-    pe_rank = this%getProcessRank()
-    pe_size = this%getNumProcesses()
-
     dist = linear_dist_t(2, this%getProcessRank(), &
          this%getNumProcesses(), NEKO_COMM)
 
@@ -420,14 +417,11 @@ contains
           @assertEqual(x%x(1,lx+1-j,lx+1-i,1), x%x(1,j,i,2), tolerance=epsilon(1.0_rp))
        end do
     end do
-
-    call device_finalize
-
   end subroutine test_dofmap_face11
 
   @test(npes=[1])
   subroutine test_dofmap_face11rot(this)
-    class (MpiTestMethod), intent(inout) :: this
+    class(test_gather_scatter_parallel_case), intent(inout) :: this
     type(dofmap_t) :: d
     type(mesh_t) :: m
     type(field_t) :: x
@@ -438,14 +432,6 @@ contains
     integer :: ierr, i,j, lx, n
     integer, parameter :: gdim = 3
     lx = 5
-
-    call device_init
-
-    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
-
-    pe_rank = this%getProcessRank()
-    pe_size = this%getNumProcesses()
-
     dist = linear_dist_t(2, this%getProcessRank(), &
          this%getNumProcesses(), NEKO_COMM)
 
@@ -554,14 +540,11 @@ contains
           @assertEqual(x%x(1,j,lx+1-i,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
        end do
     end do
-
-    call device_finalize
-
   end subroutine test_dofmap_face11rot
 
   @test(npes=[1])
   subroutine test_dofmap_face16(this)
-    class (MpiTestMethod), intent(inout) :: this
+    class(test_gather_scatter_parallel_case), intent(inout) :: this
     type(dofmap_t) :: d
     type(mesh_t) :: m
     type(field_t) :: x
@@ -572,14 +555,6 @@ contains
     integer :: ierr, i,j, lx, n
     integer, parameter :: gdim = 3
     lx = 5
-
-    call device_init
-
-    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
-
-    pe_rank = this%getProcessRank()
-    pe_size = this%getNumProcesses()
-
     dist = linear_dist_t(2, this%getProcessRank(), &
          this%getNumProcesses(), NEKO_COMM)
 
@@ -688,14 +663,11 @@ contains
           @assertEqual(x%x(i,j,1,1), x%x(1,j,i,2), tolerance=epsilon(1.0_rp))
        end do
     end do
-
-    call device_finalize
-
   end subroutine test_dofmap_face16
 
   @test(npes=[1])
   subroutine test_dofmap_face13(this)
-    class (MpiTestMethod), intent(inout) :: this
+    class(test_gather_scatter_parallel_case), intent(inout) :: this
     type(dofmap_t) :: d
     type(mesh_t) :: m
     type(field_t) :: x
@@ -706,14 +678,6 @@ contains
     integer :: ierr, i,j, lx, n
     integer, parameter :: gdim = 3
     lx = 5
-
-    call device_init
-
-    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
-
-    pe_rank = this%getProcessRank()
-    pe_size = this%getNumProcesses()
-
     dist = linear_dist_t(2, this%getProcessRank(), &
          this%getNumProcesses(), NEKO_COMM)
 
@@ -822,14 +786,11 @@ contains
           @assertEqual(x%x(lx+1-j,lx,i,1), x%x(1,j,i,2), tolerance=epsilon(1.0_rp))
        end do
     end do
-
-    call device_finalize
-
   end subroutine test_dofmap_face13
 
   @test(npes=[1])
   subroutine test_dofmap_face14(this)
-    class (MpiTestMethod), intent(inout) :: this
+    class(test_gather_scatter_parallel_case), intent(inout) :: this
     type(dofmap_t) :: d
     type(mesh_t) :: m
     type(field_t) :: x
@@ -840,14 +801,6 @@ contains
     integer :: ierr, i,j, lx, n
     integer, parameter :: gdim = 3
     lx = 5
-
-    call device_init
-
-    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
-
-    pe_rank = this%getProcessRank()
-    pe_size = this%getNumProcesses()
-
     dist = linear_dist_t(2, this%getProcessRank(), &
          this%getNumProcesses(), NEKO_COMM)
 
@@ -956,9 +909,6 @@ contains
           @assertEqual(x%x(j,1,i,1), x%x(1,j,i,2),tolerance=epsilon(1.0_rp))
        end do
     end do
-
-    call device_finalize
-
   end subroutine test_dofmap_face14
 
 end module test_gather_scatter_parallel

--- a/tests/unit/gather_scatter/test_gather_scatter_parallel.pf
+++ b/tests/unit/gather_scatter/test_gather_scatter_parallel.pf
@@ -35,6 +35,8 @@ contains
        call device_init
     end if
     call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
     call neko_mpi_types_init()
   end subroutine setUp
 

--- a/tests/unit/global_interpolation/test_glob_interp_par.pf
+++ b/tests/unit/global_interpolation/test_glob_interp_par.pf
@@ -38,6 +38,7 @@ contains
 
   subroutine tearDown(this)
     class(test_glob_interp), intent(inout) :: this
+    call neko_mpi_types_free
     if (NEKO_BCKND_DEVICE .eq. 1) then
          call device_finalize
    end if

--- a/tests/unit/hex/test_hex.pf
+++ b/tests/unit/hex/test_hex.pf
@@ -33,7 +33,6 @@ subroutine test_hex_init(this)
   use point
   use hex
   use num_types
-  implicit none
   class(test_hex_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   integer :: point_id
@@ -97,7 +96,6 @@ subroutine test_hex_free(this)
   use point
   use hex
   use num_types
-  implicit none
   class(test_hex_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   integer :: point_id
@@ -148,7 +146,6 @@ subroutine test_hex_centroid(this)
   use point
   use hex
   use num_types
-  implicit none
   class(test_hex_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   integer :: point_id
@@ -190,7 +187,6 @@ subroutine test_hex_diameter(this)
   use point
   use hex
   use num_types
-  implicit none
   class(test_hex_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   integer :: point_id
@@ -226,7 +222,6 @@ subroutine test_hex_equal(this)
   use point
   use hex
   use num_types
-  implicit none
   class(test_hex_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   type(point_t) :: pp1, pp2, pp3, pp4, pp5, pp6, pp7, pp8
@@ -301,7 +296,6 @@ subroutine test_hex_facet_id(this)
   use tuple
   use hex
   use num_types
-  implicit none
   class(test_hex_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   integer :: point_id
@@ -390,7 +384,6 @@ subroutine test_hex_edge_id(this)
   use tuple
   use hex
   use num_types
-  implicit none
   class(test_hex_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   integer :: point_id

--- a/tests/unit/hex/test_hex.pf
+++ b/tests/unit/hex/test_hex.pf
@@ -1,12 +1,40 @@
 module test_hex
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_hex_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_hex_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_hex_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_hex_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_hex_init
+subroutine test_hex_init(this)
   use pfunit
   use point
   use hex
   use num_types
   implicit none
+  class(test_hex_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -64,12 +92,13 @@ subroutine test_hex_init
 end subroutine test_hex_init
 
 @test
-subroutine test_hex_free
+subroutine test_hex_free(this)
   use pfunit
   use point
   use hex
   use num_types
   implicit none
+  class(test_hex_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -114,12 +143,13 @@ subroutine test_hex_free
 end subroutine test_hex_free
 
 @test
-subroutine test_hex_centroid
+subroutine test_hex_centroid(this)
   use pfunit
   use point
   use hex
   use num_types
   implicit none
+  class(test_hex_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -155,12 +185,13 @@ subroutine test_hex_centroid
 end subroutine test_hex_centroid
 
 @test
-subroutine test_hex_diameter
+subroutine test_hex_diameter(this)
   use pfunit
   use point
   use hex
   use num_types
   implicit none
+  class(test_hex_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -190,12 +221,13 @@ subroutine test_hex_diameter
 end subroutine test_hex_diameter
 
 @test
-subroutine test_hex_equal
+subroutine test_hex_equal(this)
   use pfunit
   use point
   use hex
   use num_types
   implicit none
+  class(test_hex_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   type(point_t) :: pp1, pp2, pp3, pp4, pp5, pp6, pp7, pp8
   integer :: point_id
@@ -263,13 +295,14 @@ subroutine test_hex_equal
 end subroutine test_hex_equal
 
 @test
-subroutine test_hex_facet_id
+subroutine test_hex_facet_id(this)
   use pfunit
   use point
   use tuple
   use hex
   use num_types
   implicit none
+  class(test_hex_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -351,13 +384,14 @@ subroutine test_hex_facet_id
 end subroutine test_hex_facet_id
 
 @test
-subroutine test_hex_edge_id
+subroutine test_hex_edge_id(this)
   use pfunit
   use point
   use tuple
   use hex
   use num_types
   implicit none
+  class(test_hex_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)

--- a/tests/unit/htable/test_htable_cptr.pf
+++ b/tests/unit/htable/test_htable_cptr.pf
@@ -1,11 +1,39 @@
 module test_htable_cptr
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_htable_cptr_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_htable_cptr_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_htable_cptr_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_htable_cptr_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_htable_cptr_contract
+subroutine test_htable_cptr_contract(this)
   use pfunit
   use htable
   use, intrinsic :: iso_c_binding, only : c_loc, c_associated
   implicit none
+  class(test_htable_cptr_case), intent(inout) :: this
   type(htable_cptr_t) :: h
   type(htable_iter_cptr_t) :: it
   integer, target :: key_targets(2), data_targets(3)

--- a/tests/unit/htable/test_htable_cptr.pf
+++ b/tests/unit/htable/test_htable_cptr.pf
@@ -32,7 +32,6 @@ subroutine test_htable_cptr_contract(this)
   use pfunit
   use htable
   use, intrinsic :: iso_c_binding, only : c_loc, c_associated
-  implicit none
   class(test_htable_cptr_case), intent(inout) :: this
   type(htable_cptr_t) :: h
   type(htable_iter_cptr_t) :: it

--- a/tests/unit/htable/test_htable_i4.pf
+++ b/tests/unit/htable/test_htable_i4.pf
@@ -34,7 +34,6 @@ subroutine test_htable_init_i4(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i4_case), intent(inout) :: this
   type(htable_i4_t) :: h
   integer :: data_i4
@@ -71,7 +70,6 @@ subroutine test_htable_add_i4(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i4_case), intent(inout) :: this
   type(htable_i4_t) :: h1, h2, h3, h4, h5, h6
   integer :: key, i
@@ -144,7 +142,6 @@ end subroutine test_htable_add_i4
 subroutine test_htable_contract_i4(this)
   use pfunit
   use htable
-  implicit none
   class(test_htable_i4_case), intent(inout) :: this
   type(htable_i4_t) :: h
   type(htable_iter_i4_t) :: it
@@ -193,7 +190,6 @@ end subroutine test_htable_contract_i4
 subroutine test_htable_clear_i4(this)
   use pfunit
   use htable
-  implicit none
   class(test_htable_i4_case), intent(inout) :: this
   type(htable_i4_t) :: h
   integer :: key, data, i
@@ -215,7 +211,6 @@ end subroutine test_htable_clear_i4
 subroutine test_htable_free_i4(this)
   use pfunit
   use htable
-  implicit none
   class(test_htable_i4_case), intent(inout) :: this
   type(htable_i4_t) :: h
   integer :: key, data, i
@@ -241,7 +236,6 @@ subroutine test_htable_get_i4(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i4_case), intent(inout) :: this
   type(htable_i4_t) :: h1, h2, h3, h4, h5, h6
   integer :: key, i
@@ -349,7 +343,6 @@ subroutine test_htable_remove_i4(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i4_case), intent(inout) :: this
   type(htable_i4_t) :: h1, h2, h3, h4, h5, h6
   integer :: key, i
@@ -441,7 +434,6 @@ subroutine test_htable_iter_i4(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i4_case), intent(inout) :: this
   type(htable_i4_t) :: h
   type(htable_iter_i4_t) :: it

--- a/tests/unit/htable/test_htable_i4.pf
+++ b/tests/unit/htable/test_htable_i4.pf
@@ -1,13 +1,41 @@
 module test_htable_i4
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_htable_i4_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_htable_i4_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_htable_i4_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_htable_i4_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_htable_init_i4
+subroutine test_htable_init_i4(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i4_case), intent(inout) :: this
   type(htable_i4_t) :: h
   integer :: data_i4
   integer(kind=i8) :: data_i8
@@ -37,13 +65,14 @@ subroutine test_htable_init_i4
 end subroutine test_htable_init_i4
 
 @test
-subroutine test_htable_add_i4
+subroutine test_htable_add_i4(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i4_case), intent(inout) :: this
   type(htable_i4_t) :: h1, h2, h3, h4, h5, h6
   integer :: key, i
   integer :: data_i4
@@ -112,10 +141,11 @@ subroutine test_htable_add_i4
 end subroutine test_htable_add_i4
 
 @test
-subroutine test_htable_contract_i4
+subroutine test_htable_contract_i4(this)
   use pfunit
   use htable
   implicit none
+  class(test_htable_i4_case), intent(inout) :: this
   type(htable_i4_t) :: h
   type(htable_iter_i4_t) :: it
   integer :: key, data_i4, copy_i4
@@ -160,10 +190,11 @@ subroutine test_htable_contract_i4
 end subroutine test_htable_contract_i4
 
 @test
-subroutine test_htable_clear_i4
+subroutine test_htable_clear_i4(this)
   use pfunit
   use htable
   implicit none
+  class(test_htable_i4_case), intent(inout) :: this
   type(htable_i4_t) :: h
   integer :: key, data, i
 
@@ -181,10 +212,11 @@ subroutine test_htable_clear_i4
 end subroutine test_htable_clear_i4
 
 @test
-subroutine test_htable_free_i4
+subroutine test_htable_free_i4(this)
   use pfunit
   use htable
   implicit none
+  class(test_htable_i4_case), intent(inout) :: this
   type(htable_i4_t) :: h
   integer :: key, data, i
 
@@ -203,13 +235,14 @@ end subroutine test_htable_free_i4
 
 
 @test
-subroutine test_htable_get_i4
+subroutine test_htable_get_i4(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i4_case), intent(inout) :: this
   type(htable_i4_t) :: h1, h2, h3, h4, h5, h6
   integer :: key, i
   integer :: data_i4
@@ -310,13 +343,14 @@ end subroutine test_htable_get_i4
 
 
 @test
-subroutine test_htable_remove_i4
+subroutine test_htable_remove_i4(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i4_case), intent(inout) :: this
   type(htable_i4_t) :: h1, h2, h3, h4, h5, h6
   integer :: key, i
   integer :: data_i4
@@ -401,13 +435,14 @@ subroutine test_htable_remove_i4
 end subroutine test_htable_remove_i4
 
 @test
-subroutine test_htable_iter_i4
+subroutine test_htable_iter_i4(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i4_case), intent(inout) :: this
   type(htable_i4_t) :: h
   type(htable_iter_i4_t) :: it
   integer :: key, i, rcode

--- a/tests/unit/htable/test_htable_i4t2.pf
+++ b/tests/unit/htable/test_htable_i4t2.pf
@@ -34,7 +34,6 @@ subroutine test_htable_init_i4t2(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i4t2_case), intent(inout) :: this
   type(htable_i4t2_t) :: h
   integer :: data_i4
@@ -71,7 +70,6 @@ subroutine test_htable_add_i4t2(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i4t2_case), intent(inout) :: this
   type(htable_i4t2_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
@@ -145,7 +143,6 @@ subroutine test_htable_contract_i4t2(this)
   use pfunit
   use htable
   use tuple
-  implicit none
   class(test_htable_i4t2_case), intent(inout) :: this
   type(htable_i4t2_t) :: h
   type(htable_iter_i4t2_t) :: it
@@ -198,7 +195,6 @@ subroutine test_htable_clear_i4t2(this)
   use pfunit
   use htable
   use tuple
-  implicit none
   class(test_htable_i4t2_case), intent(inout) :: this
   type(htable_i4t2_t) :: h
   integer :: i
@@ -222,7 +218,6 @@ subroutine test_htable_free_i4t2(this)
   use pfunit
   use htable
   use tuple
-  implicit none
   class(test_htable_i4t2_case), intent(inout) :: this
   type(htable_i4t2_t) :: h
   integer :: i
@@ -249,7 +244,6 @@ subroutine test_htable_get_i4t2(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i4t2_case), intent(inout) :: this
   type(htable_i4t2_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
@@ -357,7 +351,6 @@ subroutine test_htable_remove_i4t2(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i4t2_case), intent(inout) :: this
   type(htable_i4t2_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
@@ -447,7 +440,6 @@ subroutine test_htable_iter_i4t2(this)
   use pfunit
   use htable
   use tuple
-  implicit none
   class(test_htable_i4t2_case), intent(inout) :: this
   type(htable_i4t2_t) :: h
   type(htable_iter_i4t2_t) :: it

--- a/tests/unit/htable/test_htable_i4t2.pf
+++ b/tests/unit/htable/test_htable_i4t2.pf
@@ -1,13 +1,41 @@
 module test_htable_i4t2
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_htable_i4t2_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_htable_i4t2_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_htable_i4t2_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_htable_i4t2_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_htable_init_i4t2
+subroutine test_htable_init_i4t2(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i4t2_case), intent(inout) :: this
   type(htable_i4t2_t) :: h
   integer :: data_i4
   integer(kind=i8) :: data_i8
@@ -37,13 +65,14 @@ subroutine test_htable_init_i4t2
 end subroutine test_htable_init_i4t2
 
 @test
-subroutine test_htable_add_i4t2
+subroutine test_htable_add_i4t2(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i4t2_case), intent(inout) :: this
   type(htable_i4t2_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
   integer :: data_i4
@@ -112,11 +141,12 @@ subroutine test_htable_add_i4t2
 end subroutine test_htable_add_i4t2
 
 @test
-subroutine test_htable_contract_i4t2
+subroutine test_htable_contract_i4t2(this)
   use pfunit
   use htable
   use tuple
   implicit none
+  class(test_htable_i4t2_case), intent(inout) :: this
   type(htable_i4t2_t) :: h
   type(htable_iter_i4t2_t) :: it
   type(tuple_i4_t) :: key, key_expected, data_ti4, copy_ti4
@@ -164,11 +194,12 @@ subroutine test_htable_contract_i4t2
 end subroutine test_htable_contract_i4t2
 
 @test
-subroutine test_htable_clear_i4t2
+subroutine test_htable_clear_i4t2(this)
   use pfunit
   use htable
   use tuple
   implicit none
+  class(test_htable_i4t2_case), intent(inout) :: this
   type(htable_i4t2_t) :: h
   integer :: i
   type(tuple_i4_t) :: key, data
@@ -187,11 +218,12 @@ subroutine test_htable_clear_i4t2
 end subroutine test_htable_clear_i4t2
 
 @test
-subroutine test_htable_free_i4t2
+subroutine test_htable_free_i4t2(this)
   use pfunit
   use htable
   use tuple
   implicit none
+  class(test_htable_i4t2_case), intent(inout) :: this
   type(htable_i4t2_t) :: h
   integer :: i
   type(tuple_i4_t) :: key, data
@@ -211,13 +243,14 @@ end subroutine test_htable_free_i4t2
 
 
 @test
-subroutine test_htable_get_i4t2
+subroutine test_htable_get_i4t2(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i4t2_case), intent(inout) :: this
   type(htable_i4t2_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
   integer :: data_i4
@@ -318,13 +351,14 @@ end subroutine test_htable_get_i4t2
 
 
 @test
-subroutine test_htable_remove_i4t2
+subroutine test_htable_remove_i4t2(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i4t2_case), intent(inout) :: this
   type(htable_i4t2_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
   integer :: data_i4
@@ -409,11 +443,12 @@ subroutine test_htable_remove_i4t2
 end subroutine test_htable_remove_i4t2
 
 @test
-subroutine test_htable_iter_i4t2
+subroutine test_htable_iter_i4t2(this)
   use pfunit
   use htable
   use tuple
   implicit none
+  class(test_htable_i4t2_case), intent(inout) :: this
   type(htable_i4t2_t) :: h
   type(htable_iter_i4t2_t) :: it
   integer :: i, rcode

--- a/tests/unit/htable/test_htable_i4t4.pf
+++ b/tests/unit/htable/test_htable_i4t4.pf
@@ -34,7 +34,6 @@ subroutine test_htable_init_i4t4(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i4t4_case), intent(inout) :: this
   type(htable_i4t4_t) :: h
   integer :: data_i4
@@ -71,7 +70,6 @@ subroutine test_htable_add_i4t4(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i4t4_case), intent(inout) :: this
   type(htable_i4t4_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
@@ -145,7 +143,6 @@ subroutine test_htable_contract_i4t4(this)
   use pfunit
   use htable
   use tuple
-  implicit none
   class(test_htable_i4t4_case), intent(inout) :: this
   type(htable_i4t4_t) :: h
   type(htable_iter_i4t4_t) :: it
@@ -198,7 +195,6 @@ subroutine test_htable_clear_i4t4(this)
   use pfunit
   use htable
   use tuple
-  implicit none
   class(test_htable_i4t4_case), intent(inout) :: this
   type(htable_i4t4_t) :: h
   integer :: i
@@ -222,7 +218,6 @@ subroutine test_htable_free_i4t4(this)
   use pfunit
   use htable
   use tuple
-  implicit none
   class(test_htable_i4t4_case), intent(inout) :: this
   type(htable_i4t4_t) :: h
   integer :: i
@@ -249,7 +244,6 @@ subroutine test_htable_get_i4t4(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i4t4_case), intent(inout) :: this
   type(htable_i4t4_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
@@ -357,7 +351,6 @@ subroutine test_htable_remove_i4t4(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i4t4_case), intent(inout) :: this
   type(htable_i4t4_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
@@ -447,7 +440,6 @@ subroutine test_htable_iter_i4t4(this)
   use pfunit
   use htable
   use tuple
-  implicit none
   class(test_htable_i4t4_case), intent(inout) :: this
   type(htable_i4t4_t) :: h
   type(htable_iter_i4t4_t) :: it

--- a/tests/unit/htable/test_htable_i4t4.pf
+++ b/tests/unit/htable/test_htable_i4t4.pf
@@ -1,13 +1,41 @@
 module test_htable_i4t4
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_htable_i4t4_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_htable_i4t4_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_htable_i4t4_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_htable_i4t4_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_htable_init_i4t4
+subroutine test_htable_init_i4t4(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i4t4_case), intent(inout) :: this
   type(htable_i4t4_t) :: h
   integer :: data_i4
   integer(kind=i8) :: data_i8
@@ -37,13 +65,14 @@ subroutine test_htable_init_i4t4
 end subroutine test_htable_init_i4t4
 
 @test
-subroutine test_htable_add_i4t4
+subroutine test_htable_add_i4t4(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i4t4_case), intent(inout) :: this
   type(htable_i4t4_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
   integer :: data_i4
@@ -112,11 +141,12 @@ subroutine test_htable_add_i4t4
 end subroutine test_htable_add_i4t4
 
 @test
-subroutine test_htable_contract_i4t4
+subroutine test_htable_contract_i4t4(this)
   use pfunit
   use htable
   use tuple
   implicit none
+  class(test_htable_i4t4_case), intent(inout) :: this
   type(htable_i4t4_t) :: h
   type(htable_iter_i4t4_t) :: it
   type(tuple4_i4_t) :: key, key_expected, data_t4i4, copy_t4i4
@@ -164,11 +194,12 @@ subroutine test_htable_contract_i4t4
 end subroutine test_htable_contract_i4t4
 
 @test
-subroutine test_htable_clear_i4t4
+subroutine test_htable_clear_i4t4(this)
   use pfunit
   use htable
   use tuple
   implicit none
+  class(test_htable_i4t4_case), intent(inout) :: this
   type(htable_i4t4_t) :: h
   integer :: i
   type(tuple4_i4_t) :: key, data
@@ -187,11 +218,12 @@ subroutine test_htable_clear_i4t4
 end subroutine test_htable_clear_i4t4
 
 @test
-subroutine test_htable_free_i4t4
+subroutine test_htable_free_i4t4(this)
   use pfunit
   use htable
   use tuple
   implicit none
+  class(test_htable_i4t4_case), intent(inout) :: this
   type(htable_i4t4_t) :: h
   integer :: i
   type(tuple4_i4_t) :: key, data
@@ -211,13 +243,14 @@ end subroutine test_htable_free_i4t4
 
 
 @test
-subroutine test_htable_get_i4t4
+subroutine test_htable_get_i4t4(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i4t4_case), intent(inout) :: this
   type(htable_i4t4_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
   integer :: data_i4
@@ -318,13 +351,14 @@ end subroutine test_htable_get_i4t4
 
 
 @test
-subroutine test_htable_remove_i4t4
+subroutine test_htable_remove_i4t4(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i4t4_case), intent(inout) :: this
   type(htable_i4t4_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
   integer :: data_i4
@@ -409,11 +443,12 @@ subroutine test_htable_remove_i4t4
 end subroutine test_htable_remove_i4t4
 
 @test
-subroutine test_htable_iter_i4t4
+subroutine test_htable_iter_i4t4(this)
   use pfunit
   use htable
   use tuple
   implicit none
+  class(test_htable_i4t4_case), intent(inout) :: this
   type(htable_i4t4_t) :: h
   type(htable_iter_i4t4_t) :: it
   integer :: i, rcode

--- a/tests/unit/htable/test_htable_i8.pf
+++ b/tests/unit/htable/test_htable_i8.pf
@@ -34,7 +34,6 @@ subroutine test_htable_init_i8(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i8_case), intent(inout) :: this
   type(htable_i8_t) :: h
   integer :: data_i4
@@ -71,7 +70,6 @@ subroutine test_htable_add_i8(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i8_case), intent(inout) :: this
   type(htable_i8_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
@@ -145,7 +143,6 @@ subroutine test_htable_contract_i8(this)
   use pfunit
   use htable
   use num_types, only : i8
-  implicit none
   class(test_htable_i8_case), intent(inout) :: this
   type(htable_i8_t) :: h
   type(htable_iter_i8_t) :: it
@@ -195,7 +192,6 @@ subroutine test_htable_clear_i8(this)
   use pfunit
   use htable
   use num_types, only : i8
-  implicit none
   class(test_htable_i8_case), intent(inout) :: this
   type(htable_i8_t) :: h
   integer :: i
@@ -219,7 +215,6 @@ subroutine test_htable_free_i8(this)
   use pfunit
   use htable
   use num_types, only : i8
-  implicit none
   class(test_htable_i8_case), intent(inout) :: this
   type(htable_i8_t) :: h
   integer :: i
@@ -246,7 +241,6 @@ subroutine test_htable_get_i8(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i8_case), intent(inout) :: this
   type(htable_i8_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
@@ -354,7 +348,6 @@ subroutine test_htable_remove_i8(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_i8_case), intent(inout) :: this
   type(htable_i8_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
@@ -444,7 +437,6 @@ subroutine test_htable_iter_i8(this)
   use pfunit
   use htable
   use num_types
-  implicit none
   class(test_htable_i8_case), intent(inout) :: this
   type(htable_i8_t) :: h
   type(htable_iter_i8_t) :: it

--- a/tests/unit/htable/test_htable_i8.pf
+++ b/tests/unit/htable/test_htable_i8.pf
@@ -1,13 +1,41 @@
 module test_htable_i8
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_htable_i8_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_htable_i8_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_htable_i8_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_htable_i8_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_htable_init_i8
+subroutine test_htable_init_i8(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i8_case), intent(inout) :: this
   type(htable_i8_t) :: h
   integer :: data_i4
   integer(kind=i8) :: data_i8
@@ -37,13 +65,14 @@ subroutine test_htable_init_i8
 end subroutine test_htable_init_i8
 
 @test
-subroutine test_htable_add_i8
+subroutine test_htable_add_i8(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i8_case), intent(inout) :: this
   type(htable_i8_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
   integer :: data_i4
@@ -112,11 +141,12 @@ subroutine test_htable_add_i8
 end subroutine test_htable_add_i8
 
 @test
-subroutine test_htable_contract_i8
+subroutine test_htable_contract_i8(this)
   use pfunit
   use htable
   use num_types, only : i8
   implicit none
+  class(test_htable_i8_case), intent(inout) :: this
   type(htable_i8_t) :: h
   type(htable_iter_i8_t) :: it
   integer(kind=i8) :: key, data_i8, copy_i8
@@ -161,11 +191,12 @@ subroutine test_htable_contract_i8
 end subroutine test_htable_contract_i8
 
 @test
-subroutine test_htable_clear_i8
+subroutine test_htable_clear_i8(this)
   use pfunit
   use htable
   use num_types, only : i8
   implicit none
+  class(test_htable_i8_case), intent(inout) :: this
   type(htable_i8_t) :: h
   integer :: i
   integer(kind=i8) :: key, data
@@ -184,11 +215,12 @@ subroutine test_htable_clear_i8
 end subroutine test_htable_clear_i8
 
 @test
-subroutine test_htable_free_i8
+subroutine test_htable_free_i8(this)
   use pfunit
   use htable
   use num_types, only : i8
   implicit none
+  class(test_htable_i8_case), intent(inout) :: this
   type(htable_i8_t) :: h
   integer :: i
   integer(kind=i8) :: key, data
@@ -208,13 +240,14 @@ end subroutine test_htable_free_i8
 
 
 @test
-subroutine test_htable_get_i8
+subroutine test_htable_get_i8(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i8_case), intent(inout) :: this
   type(htable_i8_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
   integer :: data_i4
@@ -315,13 +348,14 @@ end subroutine test_htable_get_i8
 
 
 @test
-subroutine test_htable_remove_i8
+subroutine test_htable_remove_i8(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_i8_case), intent(inout) :: this
   type(htable_i8_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
   integer :: data_i4
@@ -406,11 +440,12 @@ subroutine test_htable_remove_i8
 end subroutine test_htable_remove_i8
 
 @test
-subroutine test_htable_iter_i8
+subroutine test_htable_iter_i8(this)
   use pfunit
   use htable
   use num_types
   implicit none
+  class(test_htable_i8_case), intent(inout) :: this
   type(htable_i8_t) :: h
   type(htable_iter_i8_t) :: it
   integer :: i, rcode

--- a/tests/unit/htable/test_htable_pt.pf
+++ b/tests/unit/htable/test_htable_pt.pf
@@ -1,13 +1,41 @@
 module test_htable_pt
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_htable_pt_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_htable_pt_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_htable_pt_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_htable_pt_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_htable_init_pt
+subroutine test_htable_init_pt(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_pt_case), intent(inout) :: this
   type(htable_pt_t) :: h
   integer :: data_i4
   integer(kind=i8) :: data_i8
@@ -37,13 +65,14 @@ subroutine test_htable_init_pt
 end subroutine test_htable_init_pt
 
 @test
-subroutine test_htable_add_pt
+subroutine test_htable_add_pt(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_pt_case), intent(inout) :: this
   type(htable_pt_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
   integer :: data_i4
@@ -112,11 +141,12 @@ subroutine test_htable_add_pt
 end subroutine test_htable_add_pt
 
 @test
-subroutine test_htable_contract_pt
+subroutine test_htable_contract_pt(this)
   use pfunit
   use htable
   use point
   implicit none
+  class(test_htable_pt_case), intent(inout) :: this
   type(htable_pt_t) :: h
   type(htable_iter_pt_t) :: it
   type(point_t) :: key, key_expected, data_pt, copy_pt
@@ -164,11 +194,12 @@ subroutine test_htable_contract_pt
 end subroutine test_htable_contract_pt
 
 @test
-subroutine test_htable_clear_pt
+subroutine test_htable_clear_pt(this)
   use pfunit
   use htable
   use point
   implicit none
+  class(test_htable_pt_case), intent(inout) :: this
   type(htable_pt_t) :: h
   integer :: i
   type(point_t) :: key, data
@@ -187,11 +218,12 @@ subroutine test_htable_clear_pt
 end subroutine test_htable_clear_pt
 
 @test
-subroutine test_htable_free_pt
+subroutine test_htable_free_pt(this)
   use pfunit
   use htable
   use point
   implicit none
+  class(test_htable_pt_case), intent(inout) :: this
   type(htable_pt_t) :: h
   integer :: i
   type(point_t) :: key, data
@@ -211,13 +243,14 @@ end subroutine test_htable_free_pt
 
 
 @test
-subroutine test_htable_get_pt
+subroutine test_htable_get_pt(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_pt_case), intent(inout) :: this
   type(htable_pt_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
   integer :: data_i4
@@ -318,13 +351,14 @@ end subroutine test_htable_get_pt
 
 
 @test
-subroutine test_htable_remove_pt
+subroutine test_htable_remove_pt(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_pt_case), intent(inout) :: this
   type(htable_pt_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
   integer :: data_i4
@@ -409,11 +443,12 @@ subroutine test_htable_remove_pt
 end subroutine test_htable_remove_pt
 
 @test
-subroutine test_htable_iter_pt
+subroutine test_htable_iter_pt(this)
   use pfunit
   use htable
   use point
   implicit none
+  class(test_htable_pt_case), intent(inout) :: this
   type(htable_pt_t) :: h
   type(htable_iter_pt_t) :: it
   integer :: i, rcode

--- a/tests/unit/htable/test_htable_pt.pf
+++ b/tests/unit/htable/test_htable_pt.pf
@@ -34,7 +34,6 @@ subroutine test_htable_init_pt(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_pt_case), intent(inout) :: this
   type(htable_pt_t) :: h
   integer :: data_i4
@@ -71,7 +70,6 @@ subroutine test_htable_add_pt(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_pt_case), intent(inout) :: this
   type(htable_pt_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
@@ -145,7 +143,6 @@ subroutine test_htable_contract_pt(this)
   use pfunit
   use htable
   use point
-  implicit none
   class(test_htable_pt_case), intent(inout) :: this
   type(htable_pt_t) :: h
   type(htable_iter_pt_t) :: it
@@ -198,7 +195,6 @@ subroutine test_htable_clear_pt(this)
   use pfunit
   use htable
   use point
-  implicit none
   class(test_htable_pt_case), intent(inout) :: this
   type(htable_pt_t) :: h
   integer :: i
@@ -222,7 +218,6 @@ subroutine test_htable_free_pt(this)
   use pfunit
   use htable
   use point
-  implicit none
   class(test_htable_pt_case), intent(inout) :: this
   type(htable_pt_t) :: h
   integer :: i
@@ -249,7 +244,6 @@ subroutine test_htable_get_pt(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_pt_case), intent(inout) :: this
   type(htable_pt_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
@@ -357,7 +351,6 @@ subroutine test_htable_remove_pt(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_pt_case), intent(inout) :: this
   type(htable_pt_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
@@ -447,7 +440,6 @@ subroutine test_htable_iter_pt(this)
   use pfunit
   use htable
   use point
-  implicit none
   class(test_htable_pt_case), intent(inout) :: this
   type(htable_pt_t) :: h
   type(htable_iter_pt_t) :: it

--- a/tests/unit/htable/test_htable_r8.pf
+++ b/tests/unit/htable/test_htable_r8.pf
@@ -34,7 +34,6 @@ subroutine test_htable_init_r8(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_r8_case), intent(inout) :: this
   type(htable_r8_t) :: h
   integer :: data_i4
@@ -71,7 +70,6 @@ subroutine test_htable_add_r8(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_r8_case), intent(inout) :: this
   type(htable_r8_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
@@ -145,7 +143,6 @@ subroutine test_htable_contract_r8(this)
   use pfunit
   use htable
   use num_types, only : dp
-  implicit none
   class(test_htable_r8_case), intent(inout) :: this
   type(htable_r8_t) :: h
   type(htable_iter_r8_t) :: it
@@ -196,7 +193,6 @@ subroutine test_htable_clear_r8(this)
   use pfunit
   use htable
   use num_types
-  implicit none
   class(test_htable_r8_case), intent(inout) :: this
   type(htable_r8_t) :: h
   integer :: i
@@ -220,7 +216,6 @@ subroutine test_htable_free_r8(this)
   use pfunit
   use htable
   use num_types
-  implicit none
   class(test_htable_r8_case), intent(inout) :: this
   type(htable_r8_t) :: h
   integer :: i
@@ -247,7 +242,6 @@ subroutine test_htable_get_r8(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_r8_case), intent(inout) :: this
   type(htable_r8_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
@@ -355,7 +349,6 @@ subroutine test_htable_remove_r8(this)
   use num_types
   use point
   use tuple
-  implicit none
   class(test_htable_r8_case), intent(inout) :: this
   type(htable_r8_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
@@ -445,7 +438,6 @@ subroutine test_htable_iter_r8(this)
   use pfunit
   use htable
   use num_types
-  implicit none
   class(test_htable_r8_case), intent(inout) :: this
   type(htable_r8_t) :: h
   type(htable_iter_r8_t) :: it

--- a/tests/unit/htable/test_htable_r8.pf
+++ b/tests/unit/htable/test_htable_r8.pf
@@ -1,13 +1,41 @@
 module test_htable_r8
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_htable_r8_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_htable_r8_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_htable_r8_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_htable_r8_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_htable_init_r8
+subroutine test_htable_init_r8(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_r8_case), intent(inout) :: this
   type(htable_r8_t) :: h
   integer :: data_i4
   integer(kind=i8) :: data_i8
@@ -37,13 +65,14 @@ subroutine test_htable_init_r8
 end subroutine test_htable_init_r8
 
 @test
-subroutine test_htable_add_r8
+subroutine test_htable_add_r8(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_r8_case), intent(inout) :: this
   type(htable_r8_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
   integer :: data_i4
@@ -112,11 +141,12 @@ subroutine test_htable_add_r8
 end subroutine test_htable_add_r8
 
 @test
-subroutine test_htable_contract_r8
+subroutine test_htable_contract_r8(this)
   use pfunit
   use htable
   use num_types, only : dp
   implicit none
+  class(test_htable_r8_case), intent(inout) :: this
   type(htable_r8_t) :: h
   type(htable_iter_r8_t) :: it
   real(kind=dp) :: key, key_expected, data_r8, copy_r8
@@ -162,11 +192,12 @@ subroutine test_htable_contract_r8
 end subroutine test_htable_contract_r8
 
 @test
-subroutine test_htable_clear_r8
+subroutine test_htable_clear_r8(this)
   use pfunit
   use htable
   use num_types
   implicit none
+  class(test_htable_r8_case), intent(inout) :: this
   type(htable_r8_t) :: h
   integer :: i
   real(kind=dp) :: key, data
@@ -185,11 +216,12 @@ subroutine test_htable_clear_r8
 end subroutine test_htable_clear_r8
 
 @test
-subroutine test_htable_free_r8
+subroutine test_htable_free_r8(this)
   use pfunit
   use htable
   use num_types
   implicit none
+  class(test_htable_r8_case), intent(inout) :: this
   type(htable_r8_t) :: h
   integer :: i
   real(kind=dp) :: key, data
@@ -209,13 +241,14 @@ end subroutine test_htable_free_r8
 
 
 @test
-subroutine test_htable_get_r8
+subroutine test_htable_get_r8(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_r8_case), intent(inout) :: this
   type(htable_r8_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
   integer :: data_i4
@@ -316,13 +349,14 @@ end subroutine test_htable_get_r8
 
 
 @test
-subroutine test_htable_remove_r8
+subroutine test_htable_remove_r8(this)
   use pfunit
   use htable
   use num_types
   use point
   use tuple
   implicit none
+  class(test_htable_r8_case), intent(inout) :: this
   type(htable_r8_t) :: h1, h2, h3, h4, h5, h6
   integer :: i
   integer :: data_i4
@@ -407,11 +441,12 @@ subroutine test_htable_remove_r8
 end subroutine test_htable_remove_r8
 
 @test
-subroutine test_htable_iter_r8
+subroutine test_htable_iter_r8(this)
   use pfunit
   use htable
   use num_types
   implicit none
+  class(test_htable_r8_case), intent(inout) :: this
   type(htable_r8_t) :: h
   type(htable_iter_r8_t) :: it
   integer :: i, rcode

--- a/tests/unit/jobctrl/test_jobctrl_parallel.pf
+++ b/tests/unit/jobctrl/test_jobctrl_parallel.pf
@@ -4,7 +4,7 @@ module test_jobctrl_parallel
 
   use device, only : device_init, device_finalize
   use neko_config, only : NEKO_BCKND_DEVICE
-  use neko_mpi_types, only : neko_mpi_types_init
+  use neko_mpi_types, only : neko_mpi_types_init, neko_mpi_types_free
   use mesh
   use jobctrl
   use signal
@@ -35,6 +35,7 @@ contains
 
   subroutine tearDown(this)
     class(test_jobctrl_parallel_case), intent(inout) :: this
+    call neko_mpi_types_free()
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_finalize
     end if

--- a/tests/unit/jobctrl/test_jobctrl_parallel.pf
+++ b/tests/unit/jobctrl/test_jobctrl_parallel.pf
@@ -1,24 +1,48 @@
 module test_jobctrl_parallel
   use mpi
   use pfunit
+
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  use neko_mpi_types, only : neko_mpi_types_init
   use mesh
   use jobctrl
   use signal
   use comm, only : NEKO_COMM, pe_rank, pe_size
   implicit none
 
+
+  @TestCase
+  type, extends(MPITestCase) :: test_jobctrl_parallel_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_jobctrl_parallel_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_jobctrl_parallel_case), intent(inout) :: this
+    integer :: ierr
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    call neko_mpi_types_init()
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_jobctrl_parallel_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
 
   @test(npes=[1])
   subroutine test_jobctrl_set_time_limit(this)
-    class (MpiTestMethod), intent(inout) :: this
+    class(test_jobctrl_parallel_case), intent(inout) :: this
     type(mesh_t) :: m ! Dummy type to avoid link issues
     integer :: ierr
-
-     call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
-
-     pe_rank = this%getProcessRank()
-     pe_size = this%getNumProcesses()
 
      call jobctrl_init()
      call jobctrl_set_time_limit(3)

--- a/tests/unit/jobctrl/test_jobctrl_parallel.pf
+++ b/tests/unit/jobctrl/test_jobctrl_parallel.pf
@@ -28,6 +28,8 @@ contains
        call device_init
     end if
     call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
     call neko_mpi_types_init()
   end subroutine setUp
 

--- a/tests/unit/json_utils/test_json_utils.pf
+++ b/tests/unit/json_utils/test_json_utils.pf
@@ -1,19 +1,45 @@
 module test_json_utils
   use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
   use num_types, only : rp, dp
   use json_utils, only : json_get_or_default, json_get, json_no_defaults
   use json_module, only : json_file
   implicit none
 
+  @TestCase
+  type, extends(TestCase) :: test_json_utils_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_json_utils_case
+
 contains
 
+  subroutine setUp(this)
+    class(test_json_utils_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_json_utils_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
+
   @test
-  subroutine test_json_no_defaults_starts_false()
+  subroutine test_json_no_defaults_starts_false(this)
+    class(test_json_utils_case), intent(inout) :: this
     @assertFalse(json_no_defaults)
   end subroutine test_json_no_defaults_starts_false
 
   @test
-  subroutine test_json_get_integer()
+  subroutine test_json_get_integer(this)
+    class(test_json_utils_case), intent(inout) :: this
     type(json_file) :: jf
     integer :: int_value
 
@@ -25,7 +51,8 @@ contains
   end subroutine test_json_get_integer
 
   @test
-  subroutine test_json_get_integer_array_allows_reals()
+  subroutine test_json_get_integer_array_allows_reals(this)
+    class(test_json_utils_case), intent(inout) :: this
     type(json_file) :: jf
     integer, allocatable :: int_value(:)
 

--- a/tests/unit/krylov/test_krylov.pf
+++ b/tests/unit/krylov/test_krylov.pf
@@ -1,10 +1,38 @@
 module test_krylov
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_krylov_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_krylov_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_krylov_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_krylov_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_krylov_init
+subroutine test_krylov_init(this)
   use pfunit
   use krylov
   implicit none
+  class(test_krylov_case), intent(inout) :: this
 
   integer :: i
 
@@ -13,10 +41,11 @@ subroutine test_krylov_init
 end subroutine test_krylov_init
 
 @test
-subroutine test_krylov_free
+subroutine test_krylov_free(this)
   use pfunit
   use krylov
   implicit none
+  class(test_krylov_case), intent(inout) :: this
   integer :: i
 
   ! UPDATE once redesign is done

--- a/tests/unit/krylov/test_krylov.pf
+++ b/tests/unit/krylov/test_krylov.pf
@@ -31,7 +31,6 @@ contains
 subroutine test_krylov_init(this)
   use pfunit
   use krylov
-  implicit none
   class(test_krylov_case), intent(inout) :: this
 
   integer :: i
@@ -44,7 +43,6 @@ end subroutine test_krylov_init
 subroutine test_krylov_free(this)
   use pfunit
   use krylov
-  implicit none
   class(test_krylov_case), intent(inout) :: this
   integer :: i
 

--- a/tests/unit/math/test_math_parallel.pf
+++ b/tests/unit/math/test_math_parallel.pf
@@ -1,15 +1,45 @@
 module test_math_parallel
   use mpi
   use pfunit
+
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  use neko_mpi_types, only : neko_mpi_types_init
   use math
   use num_types
   use comm, only : NEKO_COMM, pe_rank, pe_size
   implicit none
 
+
+  @TestCase
+  type, extends(MPITestCase) :: test_math_parallel_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_math_parallel_case
+
 contains
 
+  subroutine setUp(this)
+    class(test_math_parallel_case), intent(inout) :: this
+    integer :: ierr
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    call neko_mpi_types_init()
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_math_parallel_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
   @test
-  subroutine test_math_abscmp
+  subroutine test_math_abscmp(this)
+    class(test_math_parallel_case), intent(inout) :: this
     real(kind=rp) :: a, b, c, d
 
     a = 17.0_rp
@@ -28,7 +58,8 @@ contains
   end subroutine test_math_abscmp
 
   @test
-  subroutine test_math_rzero
+  subroutine test_math_rzero(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp) :: a(n)
     integer :: i
@@ -50,7 +81,8 @@ contains
   end subroutine test_math_rzero
 
   @test
-  subroutine test_math_izero
+  subroutine test_math_izero(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     integer :: a(n)
     integer :: i
@@ -64,7 +96,8 @@ contains
   end subroutine test_math_izero
 
   @test
-  subroutine test_math_rone
+  subroutine test_math_rone(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp) :: a(n)
     integer :: i
@@ -81,7 +114,8 @@ contains
   end subroutine test_math_rone
 
   @test
-  subroutine test_math_copy
+  subroutine test_math_copy(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp) :: a(n), b(n)
     integer :: i
@@ -100,7 +134,8 @@ contains
   end subroutine test_math_copy
 
   @test
-  subroutine test_math_cadd
+  subroutine test_math_cadd(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp) :: a(n)
     real(kind=rp), parameter :: s = 42
@@ -116,7 +151,8 @@ contains
   end subroutine test_math_cadd
 
   @test
-  subroutine test_math_vcross
+  subroutine test_math_vcross(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp), dimension(n) :: u1, u2, u3, v1, v2, v3, w1, w2, w3
     real(kind=rp), parameter :: s = 42
@@ -147,7 +183,8 @@ contains
   end subroutine test_math_vcross
 
   @test
-  subroutine test_math_vdot2
+  subroutine test_math_vdot2(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp), dimension(n) :: dot, v1, v2, w1, w2
     integer :: i
@@ -172,8 +209,9 @@ contains
 
 
   @test
-  subroutine test_math_vdot3
+  subroutine test_math_vdot3(this)
     implicit none
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp), dimension(n) :: dot, v1, v2, v3, w1, w2, w3
     integer :: i
@@ -199,7 +237,8 @@ contains
   end subroutine test_math_vdot3
 
   @test
-  subroutine test_math_add2
+  subroutine test_math_add2(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp), dimension(n) :: dot, a, b
     integer :: i
@@ -218,7 +257,8 @@ contains
   end subroutine test_math_add2
 
   @test
-  subroutine test_math_add3
+  subroutine test_math_add3(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp), dimension(n) :: dot, a, b, c
     integer :: i
@@ -238,7 +278,8 @@ contains
   end subroutine test_math_add3
 
   @test
-  subroutine test_math_add4
+  subroutine test_math_add4(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp), dimension(n) :: dot, a, b, c, d
     integer :: i
@@ -260,7 +301,8 @@ contains
   end subroutine test_math_add4
 
   @test
-  subroutine test_math_add2s1
+  subroutine test_math_add2s1(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp), dimension(n) :: a, b
     real(kind=rp), parameter :: c1 = 2.0_rp
@@ -280,7 +322,8 @@ contains
   end subroutine test_math_add2s1
 
   @test
-  subroutine test_math_add2s2
+  subroutine test_math_add2s2(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp), dimension(n) :: a, b
     real(kind=rp), parameter :: c1 = 2_rp
@@ -300,7 +343,8 @@ contains
   end subroutine test_math_add2s2
 
   @test
-  subroutine test_math_invcol2
+  subroutine test_math_invcol2(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp), dimension(n) :: a, b
     integer :: i
@@ -319,7 +363,8 @@ contains
   end subroutine test_math_invcol2
 
   @test
-  subroutine test_math_col2
+  subroutine test_math_col2(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp), dimension(n) :: a, b
     integer :: i
@@ -338,7 +383,8 @@ contains
   end subroutine test_math_col2
 
   @test
-  subroutine test_math_col3
+  subroutine test_math_col3(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp), dimension(n) :: a, b, c
     integer :: i
@@ -358,7 +404,8 @@ contains
   end subroutine test_math_col3
 
   @test
-  subroutine test_math_sub3
+  subroutine test_math_sub3(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp), dimension(n) :: a, b, c
     integer :: i
@@ -378,7 +425,8 @@ contains
   end subroutine test_math_sub3
 
   @test
-  subroutine test_math_addcol3
+  subroutine test_math_addcol3(this)
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp), dimension(n) :: a, b, c
     integer :: i
@@ -399,13 +447,11 @@ contains
 
   @test(npes=[1,2])
   subroutine test_math_glsc3(this)
-    class (MpiTestMethod), intent(inout) :: this
+    class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp), dimension(n) :: a, b, c
     real(kind=rp) :: res, expected
     integer :: i, ierr
-
-    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
 
     do i = 1, n
        a(i) = 1.0_rp
@@ -425,7 +471,8 @@ contains
 
   !> Test the point-wise maximum operation
   @test
-  subroutine test_math_pwmax2
+  subroutine test_math_pwmax2(this)
+    class(test_math_parallel_case), intent(inout) :: this
 
     integer, parameter :: n = 4711
     real(kind=rp), dimension(n) :: a, b, c
@@ -451,7 +498,8 @@ contains
 
   !> Test the point-wise maximum operation
   @test
-  subroutine test_math_pwmax3
+  subroutine test_math_pwmax3(this)
+    class(test_math_parallel_case), intent(inout) :: this
 
     integer, parameter :: n = 4711
     real(kind=rp), dimension(n) :: a, b, c, d
@@ -478,7 +526,8 @@ contains
 
   !> Test the point-wise minimum operation
   @test
-  subroutine test_math_pwmin2
+  subroutine test_math_pwmin2(this)
+    class(test_math_parallel_case), intent(inout) :: this
 
     integer, parameter :: n = 4711
     real(kind=rp), dimension(n) :: a, b, c
@@ -504,7 +553,8 @@ contains
 
   !> Test the point-wise minimum operation
   @test
-  subroutine test_math_pwmin3
+  subroutine test_math_pwmin3(this)
+    class(test_math_parallel_case), intent(inout) :: this
 
     integer, parameter :: n = 4711
     real(kind=rp), dimension(n) :: a, b, c, d

--- a/tests/unit/math/test_math_parallel.pf
+++ b/tests/unit/math/test_math_parallel.pf
@@ -212,7 +212,6 @@ contains
 
   @test
   subroutine test_math_vdot3(this)
-    implicit none
     class(test_math_parallel_case), intent(inout) :: this
     integer, parameter :: n = 17
     real(kind=rp), dimension(n) :: dot, v1, v2, v3, w1, w2, w3

--- a/tests/unit/math/test_math_parallel.pf
+++ b/tests/unit/math/test_math_parallel.pf
@@ -4,7 +4,7 @@ module test_math_parallel
 
   use device, only : device_init, device_finalize
   use neko_config, only : NEKO_BCKND_DEVICE
-  use neko_mpi_types, only : neko_mpi_types_init
+  use neko_mpi_types, only : neko_mpi_types_init, neko_mpi_types_free
   use math
   use num_types
   use comm, only : NEKO_COMM, pe_rank, pe_size
@@ -34,6 +34,7 @@ contains
 
   subroutine tearDown(this)
     class(test_math_parallel_case), intent(inout) :: this
+    call neko_mpi_types_free()
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_finalize
     end if

--- a/tests/unit/math/test_math_parallel.pf
+++ b/tests/unit/math/test_math_parallel.pf
@@ -27,6 +27,8 @@ contains
        call device_init
     end if
     call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
     call neko_mpi_types_init()
   end subroutine setUp
 

--- a/tests/unit/mathops/test_mathops.pf
+++ b/tests/unit/mathops/test_mathops.pf
@@ -1,12 +1,40 @@
 module test_mathops
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_mathops_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_mathops_case
+
 contains
 
+  subroutine setUp(this)
+    class(test_mathops_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_mathops_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
+
 @test
-subroutine test_mathops_opchsign
+subroutine test_mathops_opchsign(this)
   use pfunit
   use mathops
   use num_types
   implicit none 
+  class(test_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), dimension(n) :: a1, a2, a3
   integer :: i, gdim
@@ -28,11 +56,12 @@ subroutine test_mathops_opchsign
 end subroutine test_mathops_opchsign
 
 @test
-subroutine test_mathops_opcolv
+subroutine test_mathops_opcolv(this)
   use pfunit
   use mathops
   use num_types
   implicit none 
+  class(test_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), parameter :: c(n) = 42.0_rp
   real(kind=rp), dimension(n) :: a1, a2, a3
@@ -55,11 +84,12 @@ subroutine test_mathops_opcolv
 end subroutine test_mathops_opcolv
 
 @test
-subroutine test_mathops_opcolv3c
+subroutine test_mathops_opcolv3c(this)
   use pfunit
   use mathops
   use num_types
   implicit none 
+  class(test_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), parameter :: c(n) = 42.0_rp
   real(kind=rp), parameter :: d = 1/42.0_rp
@@ -88,11 +118,12 @@ subroutine test_mathops_opcolv3c
 end subroutine test_mathops_opcolv3c
 
 @test
-subroutine test_mathops_opadd2cm
+subroutine test_mathops_opadd2cm(this)
   use pfunit
   use mathops
   use num_types
   implicit none 
+  class(test_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), parameter :: c = 42.0_rp
   real(kind=rp), dimension(n) :: a1, a2, a3
@@ -120,11 +151,12 @@ subroutine test_mathops_opadd2cm
 end subroutine test_mathops_opadd2cm
 
 @test
-subroutine test_mathops_opadd2col
+subroutine test_mathops_opadd2col(this)
   use pfunit
   use mathops
   use num_types
   implicit none 
+  class(test_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), parameter :: c(n) = 42.0_rp
   real(kind=rp), dimension(n) :: a1, a2, a3

--- a/tests/unit/mathops/test_mathops.pf
+++ b/tests/unit/mathops/test_mathops.pf
@@ -33,7 +33,6 @@ subroutine test_mathops_opchsign(this)
   use pfunit
   use mathops
   use num_types
-  implicit none 
   class(test_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), dimension(n) :: a1, a2, a3
@@ -60,7 +59,6 @@ subroutine test_mathops_opcolv(this)
   use pfunit
   use mathops
   use num_types
-  implicit none 
   class(test_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), parameter :: c(n) = 42.0_rp
@@ -88,7 +86,6 @@ subroutine test_mathops_opcolv3c(this)
   use pfunit
   use mathops
   use num_types
-  implicit none 
   class(test_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), parameter :: c(n) = 42.0_rp
@@ -122,7 +119,6 @@ subroutine test_mathops_opadd2cm(this)
   use pfunit
   use mathops
   use num_types
-  implicit none 
   class(test_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), parameter :: c = 42.0_rp
@@ -155,7 +151,6 @@ subroutine test_mathops_opadd2col(this)
   use pfunit
   use mathops
   use num_types
-  implicit none 
   class(test_mathops_case), intent(inout) :: this
   integer, parameter :: n = 17
   real(kind=rp), parameter :: c(n) = 42.0_rp

--- a/tests/unit/mesh/test_mesh_parallel.pf
+++ b/tests/unit/mesh/test_mesh_parallel.pf
@@ -32,6 +32,8 @@ contains
        call device_init
     end if
     call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
     call neko_mpi_types_init()
   end subroutine setUp
 

--- a/tests/unit/mesh/test_mesh_parallel.pf
+++ b/tests/unit/mesh/test_mesh_parallel.pf
@@ -4,7 +4,7 @@ module test_mesh_parallel
 
   use device, only : device_init, device_finalize
   use neko_config, only : NEKO_BCKND_DEVICE
-  use neko_mpi_types, only : neko_mpi_types_init
+  use neko_mpi_types, only : neko_mpi_types_init, neko_mpi_types_free
   use datadist
   use mesh
   use num_types
@@ -39,6 +39,7 @@ contains
 
   subroutine tearDown(this)
     class(test_mesh_parallel_case), intent(inout) :: this
+    call neko_mpi_types_free()
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_finalize
     end if

--- a/tests/unit/mesh/test_mesh_parallel.pf
+++ b/tests/unit/mesh/test_mesh_parallel.pf
@@ -1,6 +1,10 @@
 module test_mesh_parallel
   use mpi
   use pfunit
+
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  use neko_mpi_types, only : neko_mpi_types_init
   use datadist
   use mesh
   use num_types
@@ -11,15 +15,38 @@ module test_mesh_parallel
   use comm, only : NEKO_COMM, pe_rank, pe_size
   implicit none
 
+
+  @TestCase
+  type, extends(MPITestCase) :: test_mesh_parallel_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_mesh_parallel_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_mesh_parallel_case), intent(inout) :: this
+    integer :: ierr
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    call neko_mpi_types_init()
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_mesh_parallel_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
 
   @test(npes=[1,2])
   subroutine test_mesh_init_nelv(this)
-    class (MpiTestMethod), intent(inout) :: this
+    class(test_mesh_parallel_case), intent(inout) :: this
     type(mesh_t) :: m
     integer :: ierr, gdim, nelv, expected
-
-    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
 
     do gdim = 2, 3
        nelv = 42
@@ -42,12 +69,10 @@ contains
 
   @test(npes=[1,2])
   subroutine test_mesh_init_dist(this)
-    class (MpiTestMethod), intent(inout) :: this
+    class(test_mesh_parallel_case), intent(inout) :: this
     type(mesh_t) :: m
     type(linear_dist_t) :: dist
     integer :: ierr, gdim
-
-    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
 
     dist = linear_dist_t(42, this%getProcessRank(), &
          this%getNumProcesses(), NEKO_COMM)
@@ -70,18 +95,13 @@ contains
 
   @test(npes=[1,2])
   subroutine test_mesh_add_element_quad(this)
-    class (MpiTestMethod), intent(inout) :: this
+    class(test_mesh_parallel_case), intent(inout) :: this
     type(mesh_t) :: m
     type(linear_dist_t) :: dist
     type(point_t) :: p(6)
     type(tuple_i4_t) :: t
     integer :: ierr, i
     integer, parameter :: gdim = 2
-
-    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
-
-    pe_rank = this%getProcessRank()
-    pe_size = this%getNumProcesses()
 
     dist = linear_dist_t(2, this%getProcessRank(), &
          this%getNumProcesses(), NEKO_COMM)
@@ -160,15 +180,13 @@ contains
 
   @test(npes=[1,2])
   subroutine test_mesh_add_element_hex(this)
-    class (MpiTestMethod), intent(inout) :: this
+    class(test_mesh_parallel_case), intent(inout) :: this
     type(mesh_t) :: m
     type(linear_dist_t) :: dist
     type(point_t) :: p(12)
     type(tuple4_i4_t) :: t
     integer :: ierr, i
     integer, parameter :: gdim = 3
-
-    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
 
     dist = linear_dist_t(2, this%getProcessRank(), &
          this%getNumProcesses(), NEKO_COMM)
@@ -280,18 +298,13 @@ contains
 
   @test(npes=[1,2])
   subroutine test_mesh_quad_conn(this)
-    class (MpiTestMethod), intent(inout) :: this
+    class(test_mesh_parallel_case), intent(inout) :: this
     type(mesh_t) :: m
     type(linear_dist_t) :: dist
     type(point_t) :: p(6)
     type(tuple_i4_t) :: t
     integer :: ierr, i, p_local_idx
     integer, parameter :: gdim = 2
-
-    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
-
-    pe_rank = this%getProcessRank()
-    pe_size = this%getNumProcesses()
 
     dist = linear_dist_t(2, this%getProcessRank(), &
          this%getNumProcesses(), NEKO_COMM)
@@ -399,18 +412,13 @@ contains
 
   @test(npes=[1,2])
   subroutine test_mesh_hex_conn(this)
-    class (MpiTestMethod), intent(inout) :: this
+    class(test_mesh_parallel_case), intent(inout) :: this
     type(mesh_t) :: m
     type(linear_dist_t) :: dist
     type(point_t) :: p(12)
     type(tuple4_i4_t) :: t
     integer :: ierr, i, p_local_idx
     integer, parameter :: gdim = 3
-
-    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
-
-    pe_rank = this%getProcessRank()
-    pe_size = this%getNumProcesses()
 
     dist = linear_dist_t(2, this%getProcessRank(), &
          this%getNumProcesses(), NEKO_COMM)
@@ -609,7 +617,8 @@ contains
   end subroutine test_mesh_hex_conn
 
   @test
-  subroutine test_paralleliped_signed_volume
+  subroutine test_paralleliped_signed_volume(this)
+    class(test_mesh_parallel_case), intent(inout) :: this
     real(kind=dp),dimension(3) :: p1, p2, p3, origin
     real(kind=dp) :: v
 

--- a/tests/unit/octree/test_octree.pf
+++ b/tests/unit/octree/test_octree.pf
@@ -1,10 +1,38 @@
 module test_octree
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_octree_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_octree_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_octree_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_octree_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_octree_init
+subroutine test_octree_init(this)
   use pfunit
   use octree
   implicit none
+  class(test_octree_case), intent(inout) :: this
 
   type(octree_t) :: t
 
@@ -15,10 +43,11 @@ subroutine test_octree_init
 end subroutine test_octree_init
 
 @test
-subroutine test_octree_free
+subroutine test_octree_free(this)
   use pfunit
   use octree
   implicit none
+  class(test_octree_case), intent(inout) :: this
 
   type(octree_t) :: t
 
@@ -31,11 +60,12 @@ subroutine test_octree_free
 end subroutine test_octree_free
 
 @test
-subroutine test_octree_insert
+subroutine test_octree_insert(this)
   use pfunit
   use octree
   use point
   implicit none
+  class(test_octree_case), intent(inout) :: this
 
   type(octree_t) :: t
   type(point_t) :: p
@@ -52,12 +82,13 @@ subroutine test_octree_insert
 end subroutine test_octree_insert
 
 @test
-subroutine test_octree_find
+subroutine test_octree_find(this)
   use pfunit
   use octree
   use point
   use math
   implicit none
+  class(test_octree_case), intent(inout) :: this
 
   type(octree_t) :: t
   type(point_t) :: p

--- a/tests/unit/octree/test_octree.pf
+++ b/tests/unit/octree/test_octree.pf
@@ -31,7 +31,6 @@ contains
 subroutine test_octree_init(this)
   use pfunit
   use octree
-  implicit none
   class(test_octree_case), intent(inout) :: this
 
   type(octree_t) :: t
@@ -46,7 +45,6 @@ end subroutine test_octree_init
 subroutine test_octree_free(this)
   use pfunit
   use octree
-  implicit none
   class(test_octree_case), intent(inout) :: this
 
   type(octree_t) :: t
@@ -64,7 +62,6 @@ subroutine test_octree_insert(this)
   use pfunit
   use octree
   use point
-  implicit none
   class(test_octree_case), intent(inout) :: this
 
   type(octree_t) :: t
@@ -87,7 +84,6 @@ subroutine test_octree_find(this)
   use octree
   use point
   use math
-  implicit none
   class(test_octree_case), intent(inout) :: this
 
   type(octree_t) :: t

--- a/tests/unit/point/test_point.pf
+++ b/tests/unit/point/test_point.pf
@@ -1,11 +1,39 @@
 module test_point
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_point_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_point_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_point_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_point_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_point_init
+subroutine test_point_init(this)
   use pfunit
   use point
   use num_types
   implicit none
+  class(test_point_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3
   integer :: point_id
   real(kind=dp), parameter :: coords(3) = (/1d0, 2d0, 3d0/)
@@ -38,11 +66,12 @@ subroutine test_point_init
 end subroutine test_point_init
 
 @test
-subroutine test_point_assign
+subroutine test_point_assign(this)
   use pfunit
   use point
   use num_types
   implicit none
+  class(test_point_case), intent(inout) :: this
   type(point_t) :: p1, p2
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/1d0, 2d0, 3d0/)
@@ -79,11 +108,12 @@ subroutine test_point_assign
 end subroutine test_point_assign
 
 @test
-subroutine test_point_eqne
+subroutine test_point_eqne(this)
   use pfunit
   use point
   use num_types
   implicit none
+  class(test_point_case), intent(inout) :: this
   type(point_t) :: p1, p2
   real(kind=dp), parameter :: c1(3) = (/1d0, 2d0, 3d0/)
   real(kind=dp), parameter :: c2(3) = (/4d0, 5d0, 6d0/)
@@ -97,11 +127,12 @@ subroutine test_point_eqne
 end subroutine test_point_eqne
 
 @test
-subroutine test_point_ltgt
+subroutine test_point_ltgt(this)
   use pfunit
   use point
   use num_types
   implicit none
+  class(test_point_case), intent(inout) :: this
   type(point_t) :: p1, p2
   real(kind=dp), parameter :: c1(3) = (/1d0, 0d0, 0d0/)
   real(kind=dp), parameter :: c2(3) = (/2d0, 0d0, 0d0/)

--- a/tests/unit/point/test_point.pf
+++ b/tests/unit/point/test_point.pf
@@ -32,7 +32,6 @@ subroutine test_point_init(this)
   use pfunit
   use point
   use num_types
-  implicit none
   class(test_point_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3
   integer :: point_id
@@ -70,7 +69,6 @@ subroutine test_point_assign(this)
   use pfunit
   use point
   use num_types
-  implicit none
   class(test_point_case), intent(inout) :: this
   type(point_t) :: p1, p2
   integer :: point_id
@@ -112,7 +110,6 @@ subroutine test_point_eqne(this)
   use pfunit
   use point
   use num_types
-  implicit none
   class(test_point_case), intent(inout) :: this
   type(point_t) :: p1, p2
   real(kind=dp), parameter :: c1(3) = (/1d0, 2d0, 3d0/)
@@ -131,7 +128,6 @@ subroutine test_point_ltgt(this)
   use pfunit
   use point
   use num_types
-  implicit none
   class(test_point_case), intent(inout) :: this
   type(point_t) :: p1, p2
   real(kind=dp), parameter :: c1(3) = (/1d0, 0d0, 0d0/)

--- a/tests/unit/point_interpolation/test_point_interpolation_parallel.pf
+++ b/tests/unit/point_interpolation/test_point_interpolation_parallel.pf
@@ -44,7 +44,6 @@ contains
 
   !> Creates 8 points for a cube with diagonal (1, 1) - (2, 2)
   subroutine create_points(p)
-    implicit none
     type(point_t) :: p(8)
 
     call p(1)%init(1d0, 1d0, 1d0)
@@ -66,7 +65,6 @@ contains
   end subroutine create_points
 
   subroutine gen_coef(msh, coef, lx)
-    implicit none
     type(mesh_t), intent(inout) :: msh
     type(coef_t), intent(inout) :: coef
     integer, intent(in) :: lx
@@ -83,7 +81,6 @@ contains
 
   @test(npes=[1])
   subroutine init(this)
-    implicit none
     class (interpolation_test), intent(inout) :: this
     type(point_interpolator_t) :: interp
     type(coef_t) :: coef
@@ -119,7 +116,6 @@ contains
 
   @test(npes=[1])
   subroutine interpolation(this)
-    implicit none
     class (interpolation_test), intent(inout) :: this
     type(point_interpolator_t) :: interp
     type(coef_t) :: coef
@@ -183,7 +179,6 @@ contains
 
   @test(npes=[1])
   subroutine interpolation_single_point(this)
-    implicit none
     class (interpolation_test), intent(inout) :: this
     type(point_interpolator_t) :: interp
     type(coef_t) :: coef

--- a/tests/unit/quad/test_quad.pf
+++ b/tests/unit/quad/test_quad.pf
@@ -33,7 +33,6 @@ subroutine test_quad_init(this)
   use point
   use quad
   use num_types
-  implicit none
   class(test_quad_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
@@ -76,7 +75,6 @@ subroutine test_quad_free(this)
   use point
   use quad
   use num_types
-  implicit none
   class(test_quad_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
@@ -111,7 +109,6 @@ subroutine test_quad_centroid(this)
   use point
   use quad
   use num_types
-  implicit none
   class(test_quad_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
@@ -144,7 +141,6 @@ subroutine test_quad_diameter(this)
   use point
   use quad
   use num_types
-  implicit none
   class(test_quad_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
@@ -174,7 +170,6 @@ subroutine test_quad_equal(this)
   use point
   use quad
   use num_types
-  implicit none
   class(test_quad_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   integer :: point_id
@@ -225,7 +220,6 @@ subroutine test_quad_facet_id(this)
   use quad
   use tuple
   use num_types
-  implicit none
   class(test_quad_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id

--- a/tests/unit/quad/test_quad.pf
+++ b/tests/unit/quad/test_quad.pf
@@ -1,12 +1,40 @@
 module test_quad
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_quad_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_quad_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_quad_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_quad_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_quad_init
+subroutine test_quad_init(this)
   use pfunit
   use point
   use quad
   use num_types
   implicit none
+  class(test_quad_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -43,12 +71,13 @@ subroutine test_quad_init
 end subroutine test_quad_init
 
 @test
-subroutine test_quad_free
+subroutine test_quad_free(this)
   use pfunit
   use point
   use quad
   use num_types
   implicit none
+  class(test_quad_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -77,12 +106,13 @@ subroutine test_quad_free
 end subroutine test_quad_free
 
 @test
-subroutine test_quad_centroid
+subroutine test_quad_centroid(this)
   use pfunit
   use point
   use quad
   use num_types
   implicit none
+  class(test_quad_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -109,12 +139,13 @@ subroutine test_quad_centroid
 end subroutine test_quad_centroid
 
 @test
-subroutine test_quad_diameter
+subroutine test_quad_diameter(this)
   use pfunit
   use point
   use quad
   use num_types
   implicit none
+  class(test_quad_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -138,12 +169,13 @@ subroutine test_quad_diameter
 end subroutine test_quad_diameter
 
 @test
-subroutine test_quad_equal
+subroutine test_quad_equal(this)
   use pfunit
   use point
   use quad
   use num_types
   implicit none
+  class(test_quad_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -187,13 +219,14 @@ subroutine test_quad_equal
 end subroutine test_quad_equal
 
 @test
-subroutine test_quad_facet_id
+subroutine test_quad_facet_id(this)
   use pfunit
   use point
   use quad
   use tuple
   use num_types
   implicit none
+  class(test_quad_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)

--- a/tests/unit/signal/test_signal.pf
+++ b/tests/unit/signal/test_signal.pf
@@ -30,7 +30,6 @@ contains
 @test
 subroutine test_signal_trap_cpulimit(this)
   use signal
-  implicit none
   class(test_signal_case), intent(inout) :: this
 
   call signal_trap_cpulimit()
@@ -42,7 +41,6 @@ subroutine test_signal_timeout(this)
   use signal
   use funit
   use, intrinsic :: iso_c_binding
-  implicit none
   class(test_signal_case), intent(inout) :: this
 
   @assertFalse(signal_timeout())
@@ -54,7 +52,6 @@ subroutine test_signal_set_timeout(this)
   use signal
   use funit
   use, intrinsic :: iso_c_binding
-  implicit none
   class(test_signal_case), intent(inout) :: this
 
   call signal_set_timeout(3)

--- a/tests/unit/signal/test_signal.pf
+++ b/tests/unit/signal/test_signal.pf
@@ -1,30 +1,61 @@
 module test_signal
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_signal_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_signal_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_signal_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_signal_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_signal_trap_cpulimit()
+subroutine test_signal_trap_cpulimit(this)
   use signal
   implicit none
+  class(test_signal_case), intent(inout) :: this
 
   call signal_trap_cpulimit()
   
 end subroutine test_signal_trap_cpulimit
 
 @test
-subroutine test_signal_timeout()
+subroutine test_signal_timeout(this)
   use signal
   use funit
   use, intrinsic :: iso_c_binding
   implicit none
+  class(test_signal_case), intent(inout) :: this
 
   @assertFalse(signal_timeout())
   
 end subroutine test_signal_timeout
 
 @test
-subroutine test_signal_set_timeout()
+subroutine test_signal_set_timeout(this)
   use signal
   use funit
   use, intrinsic :: iso_c_binding
+  implicit none
+  class(test_signal_case), intent(inout) :: this
 
   call signal_set_timeout(3)
   @assertFalse(signal_timeout())

--- a/tests/unit/stack/test_stack_2i4r8t3.pf
+++ b/tests/unit/stack/test_stack_2i4r8t3.pf
@@ -33,7 +33,6 @@ subroutine test_stack_2i4r8t3_init(this)
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only :rp
-  implicit none
   class(test_stack_2i4r8t3_case), intent(inout) :: this
   type(stack_2i4r8t3_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
@@ -71,7 +70,6 @@ end subroutine test_stack_2i4r8t3_init
 subroutine test_stack_2i4r8t3_free(this)
   use pfunit
   use stack
-  implicit none
   class(test_stack_2i4r8t3_case), intent(inout) :: this
   type(stack_2i4r8t3_t) :: s
 
@@ -90,7 +88,6 @@ subroutine test_stack_2i4r8t3_push(this)
   use pfunit
   use stack
   use tuple
-  implicit none
   class(test_stack_2i4r8t3_case), intent(inout) :: this
   type(stack_2i4r8t3_t) :: s
   integer :: i
@@ -128,7 +125,6 @@ subroutine test_stack_2i4r8t3_pop(this)
   use pfunit
   use stack
   use tuple
-  implicit none
   class(test_stack_2i4r8t3_case), intent(inout) :: this
   type(stack_2i4r8t3_t) :: s
   integer :: i
@@ -157,7 +153,6 @@ subroutine test_stack_2i4r8t3_clear(this)
   use pfunit
   use stack
   use tuple
-  implicit none
   class(test_stack_2i4r8t3_case), intent(inout) :: this
   type(stack_2i4r8t3_t) :: s
   integer :: i

--- a/tests/unit/stack/test_stack_2i4r8t3.pf
+++ b/tests/unit/stack/test_stack_2i4r8t3.pf
@@ -1,12 +1,40 @@
 module test_stack_2i4r8t3
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_stack_2i4r8t3_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_stack_2i4r8t3_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_stack_2i4r8t3_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_stack_2i4r8t3_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_stack_2i4r8t3_init
+subroutine test_stack_2i4r8t3_init(this)
   use pfunit
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only :rp
   implicit none
+  class(test_stack_2i4r8t3_case), intent(inout) :: this
   type(stack_2i4r8t3_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
 
@@ -40,10 +68,11 @@ subroutine test_stack_2i4r8t3_init
 end subroutine test_stack_2i4r8t3_init
 
 @test
-subroutine test_stack_2i4r8t3_free
+subroutine test_stack_2i4r8t3_free(this)
   use pfunit
   use stack
   implicit none
+  class(test_stack_2i4r8t3_case), intent(inout) :: this
   type(stack_2i4r8t3_t) :: s
 
   call s%init()
@@ -57,11 +86,12 @@ subroutine test_stack_2i4r8t3_free
 end subroutine test_stack_2i4r8t3_free
 
 @test
-subroutine test_stack_2i4r8t3_push
+subroutine test_stack_2i4r8t3_push(this)
   use pfunit
   use stack
   use tuple
   implicit none
+  class(test_stack_2i4r8t3_case), intent(inout) :: this
   type(stack_2i4r8t3_t) :: s
   integer :: i
   type(tuple_2i4r8_t) :: data
@@ -94,11 +124,12 @@ subroutine test_stack_2i4r8t3_push
 end subroutine test_stack_2i4r8t3_push
 
 @test
-subroutine test_stack_2i4r8t3_pop
+subroutine test_stack_2i4r8t3_pop(this)
   use pfunit
   use stack
   use tuple
   implicit none
+  class(test_stack_2i4r8t3_case), intent(inout) :: this
   type(stack_2i4r8t3_t) :: s
   integer :: i
   type(tuple_2i4r8_t) :: data
@@ -122,11 +153,12 @@ subroutine test_stack_2i4r8t3_pop
 end subroutine test_stack_2i4r8t3_pop
 
 @test 
-subroutine test_stack_2i4r8t3_clear
+subroutine test_stack_2i4r8t3_clear(this)
   use pfunit
   use stack
   use tuple
   implicit none
+  class(test_stack_2i4r8t3_case), intent(inout) :: this
   type(stack_2i4r8t3_t) :: s
   integer :: i
   type(tuple_2i4r8_t) :: data

--- a/tests/unit/stack/test_stack_curve.pf
+++ b/tests/unit/stack/test_stack_curve.pf
@@ -1,12 +1,40 @@
 module test_stack_curve
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_stack_curve_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_stack_curve_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_stack_curve_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_stack_curve_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_stack_curve_init
+subroutine test_stack_curve_init(this)
   use pfunit
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only : rp
   implicit none
+  class(test_stack_curve_case), intent(inout) :: this
   type(stack_curve_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
 
@@ -40,10 +68,11 @@ subroutine test_stack_curve_init
 end subroutine test_stack_curve_init
 
 @test
-subroutine test_stack_curve_free
+subroutine test_stack_curve_free(this)
   use pfunit
   use stack
   implicit none
+  class(test_stack_curve_case), intent(inout) :: this
   type(stack_curve_t) :: s
 
   call s%init()
@@ -57,11 +86,12 @@ subroutine test_stack_curve_free
 end subroutine test_stack_curve_free
 
 @test
-subroutine test_stack_curve_push
+subroutine test_stack_curve_push(this)
   use pfunit
   use stack
   use structs
   implicit none
+  class(test_stack_curve_case), intent(inout) :: this
   type(stack_curve_t) :: s
   integer :: i, j, k
   type(struct_curve_t) :: data
@@ -111,11 +141,12 @@ subroutine test_stack_curve_push
 end subroutine test_stack_curve_push
 
 @test
-subroutine test_stack_curve_pop
+subroutine test_stack_curve_pop(this)
   use pfunit
   use stack
   use structs
   implicit none
+  class(test_stack_curve_case), intent(inout) :: this
   type(stack_curve_t) :: s
   integer :: i, j, k
   type(struct_curve_t) :: data, data2
@@ -151,11 +182,12 @@ subroutine test_stack_curve_pop
 end subroutine test_stack_curve_pop
 
 @test
-subroutine test_stack_curve_clear
+subroutine test_stack_curve_clear(this)
   use pfunit
   use stack
   use structs
   implicit none
+  class(test_stack_curve_case), intent(inout) :: this
   type(stack_curve_t) :: s
   integer :: i
   type(struct_curve_t) :: data

--- a/tests/unit/stack/test_stack_curve.pf
+++ b/tests/unit/stack/test_stack_curve.pf
@@ -33,7 +33,6 @@ subroutine test_stack_curve_init(this)
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only : rp
-  implicit none
   class(test_stack_curve_case), intent(inout) :: this
   type(stack_curve_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
@@ -71,7 +70,6 @@ end subroutine test_stack_curve_init
 subroutine test_stack_curve_free(this)
   use pfunit
   use stack
-  implicit none
   class(test_stack_curve_case), intent(inout) :: this
   type(stack_curve_t) :: s
 
@@ -90,7 +88,6 @@ subroutine test_stack_curve_push(this)
   use pfunit
   use stack
   use structs
-  implicit none
   class(test_stack_curve_case), intent(inout) :: this
   type(stack_curve_t) :: s
   integer :: i, j, k
@@ -145,7 +142,6 @@ subroutine test_stack_curve_pop(this)
   use pfunit
   use stack
   use structs
-  implicit none
   class(test_stack_curve_case), intent(inout) :: this
   type(stack_curve_t) :: s
   integer :: i, j, k
@@ -186,7 +182,6 @@ subroutine test_stack_curve_clear(this)
   use pfunit
   use stack
   use structs
-  implicit none
   class(test_stack_curve_case), intent(inout) :: this
   type(stack_curve_t) :: s
   integer :: i

--- a/tests/unit/stack/test_stack_i4.pf
+++ b/tests/unit/stack/test_stack_i4.pf
@@ -33,7 +33,6 @@ subroutine test_stack_i4_init(this)
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only : rp
-  implicit none
   class(test_stack_i4_case), intent(inout) :: this
   type(stack_i4_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
@@ -71,7 +70,6 @@ end subroutine test_stack_i4_init
 subroutine test_stack_i4_free(this)
   use pfunit
   use stack
-  implicit none
   class(test_stack_i4_case), intent(inout) :: this
   type(stack_i4_t) :: s
 
@@ -89,7 +87,6 @@ end subroutine test_stack_i4_free
 subroutine test_stack_i4_push(this)
   use pfunit
   use stack
-  implicit none
   class(test_stack_i4_case), intent(inout) :: this
   type(stack_i4_t) :: s
   integer :: i, data
@@ -124,7 +121,6 @@ end subroutine test_stack_i4_push
 subroutine test_stack_i4_pop(this)
   use pfunit
   use stack
-  implicit none
   class(test_stack_i4_case), intent(inout) :: this
   type(stack_i4_t) :: s
   integer :: i, data
@@ -150,7 +146,6 @@ end subroutine test_stack_i4_pop
 subroutine test_stack_i4_clear(this)
   use pfunit
   use stack
-  implicit none
   class(test_stack_i4_case), intent(inout) :: this
   type(stack_i4_t) :: s
   integer :: i, data

--- a/tests/unit/stack/test_stack_i4.pf
+++ b/tests/unit/stack/test_stack_i4.pf
@@ -1,12 +1,40 @@
 module test_stack_i4
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_stack_i4_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_stack_i4_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_stack_i4_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_stack_i4_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_stack_i4_init
+subroutine test_stack_i4_init(this)
   use pfunit
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only : rp
   implicit none
+  class(test_stack_i4_case), intent(inout) :: this
   type(stack_i4_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
   
@@ -40,10 +68,11 @@ subroutine test_stack_i4_init
 end subroutine test_stack_i4_init
 
 @test
-subroutine test_stack_i4_free
+subroutine test_stack_i4_free(this)
   use pfunit
   use stack
   implicit none
+  class(test_stack_i4_case), intent(inout) :: this
   type(stack_i4_t) :: s
 
   call s%init()
@@ -57,10 +86,11 @@ subroutine test_stack_i4_free
 end subroutine test_stack_i4_free
 
 @test
-subroutine test_stack_i4_push
+subroutine test_stack_i4_push(this)
   use pfunit
   use stack
   implicit none
+  class(test_stack_i4_case), intent(inout) :: this
   type(stack_i4_t) :: s
   integer :: i, data
   integer, pointer :: dp(:)
@@ -91,10 +121,11 @@ subroutine test_stack_i4_push
 end subroutine test_stack_i4_push
 
 @test
-subroutine test_stack_i4_pop
+subroutine test_stack_i4_pop(this)
   use pfunit
   use stack
   implicit none
+  class(test_stack_i4_case), intent(inout) :: this
   type(stack_i4_t) :: s
   integer :: i, data
 
@@ -116,10 +147,11 @@ subroutine test_stack_i4_pop
 end subroutine test_stack_i4_pop
 
 @test 
-subroutine test_stack_i4_clear
+subroutine test_stack_i4_clear(this)
   use pfunit
   use stack
   implicit none
+  class(test_stack_i4_case), intent(inout) :: this
   type(stack_i4_t) :: s
   integer :: i, data
 

--- a/tests/unit/stack/test_stack_i4r8t2.pf
+++ b/tests/unit/stack/test_stack_i4r8t2.pf
@@ -33,7 +33,6 @@ subroutine test_stack_i4r8t2_init(this)
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only :rp
-  implicit none
   class(test_stack_i4r8t2_case), intent(inout) :: this
   type(stack_i4r8t2_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
@@ -71,7 +70,6 @@ end subroutine test_stack_i4r8t2_init
 subroutine test_stack_i4r8t2_free(this)
   use pfunit
   use stack
-  implicit none
   class(test_stack_i4r8t2_case), intent(inout) :: this
   type(stack_i4r8t2_t) :: s
 
@@ -90,7 +88,6 @@ subroutine test_stack_i4r8t2_push(this)
   use pfunit
   use stack
   use tuple
-  implicit none
   class(test_stack_i4r8t2_case), intent(inout) :: this
   type(stack_i4r8t2_t) :: s
   integer :: i
@@ -128,7 +125,6 @@ subroutine test_stack_i4r8t2_pop(this)
   use pfunit
   use stack
   use tuple
-  implicit none
   class(test_stack_i4r8t2_case), intent(inout) :: this
   type(stack_i4r8t2_t) :: s
   integer :: i
@@ -157,7 +153,6 @@ subroutine test_stack_i4r8t2_clear(this)
   use pfunit
   use stack
   use tuple
-  implicit none
   class(test_stack_i4r8t2_case), intent(inout) :: this
   type(stack_i4r8t2_t) :: s
   integer :: i

--- a/tests/unit/stack/test_stack_i4r8t2.pf
+++ b/tests/unit/stack/test_stack_i4r8t2.pf
@@ -1,12 +1,40 @@
 module test_stack_i4r8t2
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_stack_i4r8t2_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_stack_i4r8t2_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_stack_i4r8t2_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_stack_i4r8t2_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_stack_i4r8t2_init
+subroutine test_stack_i4r8t2_init(this)
   use pfunit
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only :rp
   implicit none
+  class(test_stack_i4r8t2_case), intent(inout) :: this
   type(stack_i4r8t2_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
 
@@ -40,10 +68,11 @@ subroutine test_stack_i4r8t2_init
 end subroutine test_stack_i4r8t2_init
 
 @test
-subroutine test_stack_i4r8t2_free
+subroutine test_stack_i4r8t2_free(this)
   use pfunit
   use stack
   implicit none
+  class(test_stack_i4r8t2_case), intent(inout) :: this
   type(stack_i4r8t2_t) :: s
 
   call s%init()
@@ -57,11 +86,12 @@ subroutine test_stack_i4r8t2_free
 end subroutine test_stack_i4r8t2_free
 
 @test
-subroutine test_stack_i4r8t2_push
+subroutine test_stack_i4r8t2_push(this)
   use pfunit
   use stack
   use tuple
   implicit none
+  class(test_stack_i4r8t2_case), intent(inout) :: this
   type(stack_i4r8t2_t) :: s
   integer :: i
   type(tuple_i4r8_t) :: data
@@ -94,11 +124,12 @@ subroutine test_stack_i4r8t2_push
 end subroutine test_stack_i4r8t2_push
 
 @test
-subroutine test_stack_i4r8t2_pop
+subroutine test_stack_i4r8t2_pop(this)
   use pfunit
   use stack
   use tuple
   implicit none
+  class(test_stack_i4r8t2_case), intent(inout) :: this
   type(stack_i4r8t2_t) :: s
   integer :: i
   type(tuple_i4r8_t) :: data
@@ -122,11 +153,12 @@ subroutine test_stack_i4r8t2_pop
 end subroutine test_stack_i4r8t2_pop
 
 @test 
-subroutine test_stack_i4r8t2_clear
+subroutine test_stack_i4r8t2_clear(this)
   use pfunit
   use stack
   use tuple
   implicit none
+  class(test_stack_i4r8t2_case), intent(inout) :: this
   type(stack_i4r8t2_t) :: s
   integer :: i
   type(tuple_i4r8_t) :: data

--- a/tests/unit/stack/test_stack_i4t2.pf
+++ b/tests/unit/stack/test_stack_i4t2.pf
@@ -1,12 +1,40 @@
 module test_stack_i4t2
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_stack_i4t2_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_stack_i4t2_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_stack_i4t2_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_stack_i4t2_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_stack_i4t2_init
+subroutine test_stack_i4t2_init(this)
   use pfunit
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only :rp
   implicit none
+  class(test_stack_i4t2_case), intent(inout) :: this
   type(stack_i4t2_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
 
@@ -40,10 +68,11 @@ subroutine test_stack_i4t2_init
 end subroutine test_stack_i4t2_init
 
 @test
-subroutine test_stack_i4t2_free
+subroutine test_stack_i4t2_free(this)
   use pfunit
   use stack
   implicit none
+  class(test_stack_i4t2_case), intent(inout) :: this
   type(stack_i4t2_t) :: s
 
   call s%init()
@@ -57,11 +86,12 @@ subroutine test_stack_i4t2_free
 end subroutine test_stack_i4t2_free
 
 @test
-subroutine test_stack_i4t2_push
+subroutine test_stack_i4t2_push(this)
   use pfunit
   use stack
   use tuple
   implicit none
+  class(test_stack_i4t2_case), intent(inout) :: this
   type(stack_i4t2_t) :: s
   integer :: i
   type(tuple_i4_t) :: data
@@ -94,11 +124,12 @@ subroutine test_stack_i4t2_push
 end subroutine test_stack_i4t2_push
 
 @test
-subroutine test_stack_i4t2_pop
+subroutine test_stack_i4t2_pop(this)
   use pfunit
   use stack
   use tuple
   implicit none
+  class(test_stack_i4t2_case), intent(inout) :: this
   type(stack_i4t2_t) :: s
   integer :: i
   type(tuple_i4_t) :: data
@@ -122,11 +153,12 @@ subroutine test_stack_i4t2_pop
 end subroutine test_stack_i4t2_pop
 
 @test 
-subroutine test_stack_i4t2_clear
+subroutine test_stack_i4t2_clear(this)
   use pfunit
   use stack
   use tuple
   implicit none
+  class(test_stack_i4t2_case), intent(inout) :: this
   type(stack_i4t2_t) :: s
   integer :: i
   type(tuple_i4_t) :: data

--- a/tests/unit/stack/test_stack_i4t2.pf
+++ b/tests/unit/stack/test_stack_i4t2.pf
@@ -33,7 +33,6 @@ subroutine test_stack_i4t2_init(this)
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only :rp
-  implicit none
   class(test_stack_i4t2_case), intent(inout) :: this
   type(stack_i4t2_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
@@ -71,7 +70,6 @@ end subroutine test_stack_i4t2_init
 subroutine test_stack_i4t2_free(this)
   use pfunit
   use stack
-  implicit none
   class(test_stack_i4t2_case), intent(inout) :: this
   type(stack_i4t2_t) :: s
 
@@ -90,7 +88,6 @@ subroutine test_stack_i4t2_push(this)
   use pfunit
   use stack
   use tuple
-  implicit none
   class(test_stack_i4t2_case), intent(inout) :: this
   type(stack_i4t2_t) :: s
   integer :: i
@@ -128,7 +125,6 @@ subroutine test_stack_i4t2_pop(this)
   use pfunit
   use stack
   use tuple
-  implicit none
   class(test_stack_i4t2_case), intent(inout) :: this
   type(stack_i4t2_t) :: s
   integer :: i
@@ -157,7 +153,6 @@ subroutine test_stack_i4t2_clear(this)
   use pfunit
   use stack
   use tuple
-  implicit none
   class(test_stack_i4t2_case), intent(inout) :: this
   type(stack_i4t2_t) :: s
   integer :: i

--- a/tests/unit/stack/test_stack_i4t4.pf
+++ b/tests/unit/stack/test_stack_i4t4.pf
@@ -33,7 +33,6 @@ subroutine test_stack_i4t4_init(this)
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only : rp
-  implicit none
   class(test_stack_i4t4_case), intent(inout) :: this
   type(stack_i4t4_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
@@ -71,7 +70,6 @@ end subroutine test_stack_i4t4_init
 subroutine test_stack_i4t4_free(this)
   use pfunit
   use stack
-  implicit none
   class(test_stack_i4t4_case), intent(inout) :: this
   type(stack_i4t4_t) :: s
 
@@ -90,7 +88,6 @@ subroutine test_stack_i4t4_push(this)
   use pfunit
   use stack
   use tuple
-  implicit none
   class(test_stack_i4t4_case), intent(inout) :: this
   type(stack_i4t4_t) :: s
   integer :: i
@@ -128,7 +125,6 @@ subroutine test_stack_i4t4_pop(this)
   use pfunit
   use stack
   use tuple
-  implicit none
   class(test_stack_i4t4_case), intent(inout) :: this
   type(stack_i4t4_t) :: s
   integer :: i
@@ -157,7 +153,6 @@ subroutine test_stack_i4t4_clear(this)
   use pfunit
   use stack
   use tuple
-  implicit none
   class(test_stack_i4t4_case), intent(inout) :: this
   type(stack_i4t4_t) :: s
   integer :: i

--- a/tests/unit/stack/test_stack_i4t4.pf
+++ b/tests/unit/stack/test_stack_i4t4.pf
@@ -1,12 +1,40 @@
 module test_stack_i4t4
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_stack_i4t4_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_stack_i4t4_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_stack_i4t4_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_stack_i4t4_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_stack_i4t4_init
+subroutine test_stack_i4t4_init(this)
   use pfunit
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only : rp
   implicit none
+  class(test_stack_i4t4_case), intent(inout) :: this
   type(stack_i4t4_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
 
@@ -40,10 +68,11 @@ subroutine test_stack_i4t4_init
 end subroutine test_stack_i4t4_init
 
 @test
-subroutine test_stack_i4t4_free
+subroutine test_stack_i4t4_free(this)
   use pfunit
   use stack
   implicit none
+  class(test_stack_i4t4_case), intent(inout) :: this
   type(stack_i4t4_t) :: s
 
   call s%init()
@@ -57,11 +86,12 @@ subroutine test_stack_i4t4_free
 end subroutine test_stack_i4t4_free
 
 @test
-subroutine test_stack_i4t4_push
+subroutine test_stack_i4t4_push(this)
   use pfunit
   use stack
   use tuple
   implicit none
+  class(test_stack_i4t4_case), intent(inout) :: this
   type(stack_i4t4_t) :: s
   integer :: i
   type(tuple4_i4_t) :: data
@@ -94,11 +124,12 @@ subroutine test_stack_i4t4_push
 end subroutine test_stack_i4t4_push
 
 @test
-subroutine test_stack_i4t4_pop
+subroutine test_stack_i4t4_pop(this)
   use pfunit
   use stack
   use tuple
   implicit none
+  class(test_stack_i4t4_case), intent(inout) :: this
   type(stack_i4t4_t) :: s
   integer :: i
   type(tuple4_i4_t) :: data
@@ -122,11 +153,12 @@ subroutine test_stack_i4t4_pop
 end subroutine test_stack_i4t4_pop
 
 @test 
-subroutine test_stack_i4t4_clear
+subroutine test_stack_i4t4_clear(this)
   use pfunit
   use stack
   use tuple
   implicit none
+  class(test_stack_i4t4_case), intent(inout) :: this
   type(stack_i4t4_t) :: s
   integer :: i
   type(tuple4_i4_t) :: data

--- a/tests/unit/stack/test_stack_i8.pf
+++ b/tests/unit/stack/test_stack_i8.pf
@@ -33,7 +33,6 @@ subroutine test_stack_i8_init(this)
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only :rp
-  implicit none
   class(test_stack_i8_case), intent(inout) :: this
   type(stack_i8_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
@@ -71,7 +70,6 @@ end subroutine test_stack_i8_init
 subroutine test_stack_i8_free(this)
   use pfunit
   use stack
-  implicit none
   class(test_stack_i8_case), intent(inout) :: this
   type(stack_i8_t) :: s
 
@@ -90,7 +88,6 @@ subroutine test_stack_i8_push(this)
   use pfunit
   use stack
   use num_types, only : i8
-  implicit none
   class(test_stack_i8_case), intent(inout) :: this
   type(stack_i8_t) :: s
   integer :: i
@@ -127,7 +124,6 @@ subroutine test_stack_i8_pop(this)
   use pfunit
   use stack
   use num_types, only : i8
-  implicit none
   class(test_stack_i8_case), intent(inout) :: this
   type(stack_i8_t) :: s
   integer :: i
@@ -155,7 +151,6 @@ subroutine test_stack_i8_clear(this)
   use pfunit
   use stack
   use num_types, only : i8
-  implicit none
   class(test_stack_i8_case), intent(inout) :: this
   type(stack_i8_t) :: s
   integer :: i

--- a/tests/unit/stack/test_stack_i8.pf
+++ b/tests/unit/stack/test_stack_i8.pf
@@ -1,12 +1,40 @@
 module test_stack_i8
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_stack_i8_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_stack_i8_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_stack_i8_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_stack_i8_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_stack_i8_init
+subroutine test_stack_i8_init(this)
   use pfunit
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only :rp
   implicit none
+  class(test_stack_i8_case), intent(inout) :: this
   type(stack_i8_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
 
@@ -40,10 +68,11 @@ subroutine test_stack_i8_init
 end subroutine test_stack_i8_init
 
 @test
-subroutine test_stack_i8_free
+subroutine test_stack_i8_free(this)
   use pfunit
   use stack
   implicit none
+  class(test_stack_i8_case), intent(inout) :: this
   type(stack_i8_t) :: s
 
   call s%init()
@@ -57,11 +86,12 @@ subroutine test_stack_i8_free
 end subroutine test_stack_i8_free
 
 @test
-subroutine test_stack_i8_push
+subroutine test_stack_i8_push(this)
   use pfunit
   use stack
   use num_types, only : i8
   implicit none
+  class(test_stack_i8_case), intent(inout) :: this
   type(stack_i8_t) :: s
   integer :: i
   integer(kind=i8) :: data
@@ -93,11 +123,12 @@ subroutine test_stack_i8_push
 end subroutine test_stack_i8_push
 
 @test
-subroutine test_stack_i8_pop
+subroutine test_stack_i8_pop(this)
   use pfunit
   use stack
   use num_types, only : i8
   implicit none
+  class(test_stack_i8_case), intent(inout) :: this
   type(stack_i8_t) :: s
   integer :: i
   integer(kind=i8) :: data
@@ -120,11 +151,12 @@ subroutine test_stack_i8_pop
 end subroutine test_stack_i8_pop
 
 @test 
-subroutine test_stack_i8_clear
+subroutine test_stack_i8_clear(this)
   use pfunit
   use stack
   use num_types, only : i8
   implicit none
+  class(test_stack_i8_case), intent(inout) :: this
   type(stack_i8_t) :: s
   integer :: i
   integer(kind=i8) :: data

--- a/tests/unit/stack/test_stack_nc.pf
+++ b/tests/unit/stack/test_stack_nc.pf
@@ -1,12 +1,40 @@
 module test_stack_nc
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_stack_nc_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_stack_nc_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_stack_nc_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_stack_nc_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_stack_nc_init
+subroutine test_stack_nc_init(this)
   use pfunit
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only : rp
   implicit none
+  class(test_stack_nc_case), intent(inout) :: this
   type(stack_nc_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
 
@@ -40,10 +68,11 @@ subroutine test_stack_nc_init
 end subroutine test_stack_nc_init
 
 @test
-subroutine test_stack_nc_free
+subroutine test_stack_nc_free(this)
   use pfunit
   use stack
   implicit none
+  class(test_stack_nc_case), intent(inout) :: this
   type(stack_nc_t) :: s
 
   call s%init()
@@ -57,11 +86,12 @@ subroutine test_stack_nc_free
 end subroutine test_stack_nc_free
 
 @test
-subroutine test_stack_nc_push
+subroutine test_stack_nc_push(this)
   use pfunit
   use stack
   use nmsh
   implicit none
+  class(test_stack_nc_case), intent(inout) :: this
   type(stack_nc_t) :: s
   integer :: i, j, k
   type(nmsh_curve_el_t) :: data
@@ -111,11 +141,12 @@ subroutine test_stack_nc_push
 end subroutine test_stack_nc_push
 
 @test
-subroutine test_stack_nc_pop
+subroutine test_stack_nc_pop(this)
   use pfunit
   use stack
   use nmsh
   implicit none
+  class(test_stack_nc_case), intent(inout) :: this
   type(stack_nc_t) :: s
   integer :: i, j, k
   type(nmsh_curve_el_t) :: data
@@ -151,11 +182,12 @@ subroutine test_stack_nc_pop
 end subroutine test_stack_nc_pop
 
 @test
-subroutine test_stack_nc_clear
+subroutine test_stack_nc_clear(this)
   use pfunit
   use stack
   use nmsh
   implicit none
+  class(test_stack_nc_case), intent(inout) :: this
   type(stack_nc_t) :: s
   integer :: i
   type(nmsh_curve_el_t) :: data

--- a/tests/unit/stack/test_stack_nc.pf
+++ b/tests/unit/stack/test_stack_nc.pf
@@ -33,7 +33,6 @@ subroutine test_stack_nc_init(this)
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only : rp
-  implicit none
   class(test_stack_nc_case), intent(inout) :: this
   type(stack_nc_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
@@ -71,7 +70,6 @@ end subroutine test_stack_nc_init
 subroutine test_stack_nc_free(this)
   use pfunit
   use stack
-  implicit none
   class(test_stack_nc_case), intent(inout) :: this
   type(stack_nc_t) :: s
 
@@ -90,7 +88,6 @@ subroutine test_stack_nc_push(this)
   use pfunit
   use stack
   use nmsh
-  implicit none
   class(test_stack_nc_case), intent(inout) :: this
   type(stack_nc_t) :: s
   integer :: i, j, k
@@ -145,7 +142,6 @@ subroutine test_stack_nc_pop(this)
   use pfunit
   use stack
   use nmsh
-  implicit none
   class(test_stack_nc_case), intent(inout) :: this
   type(stack_nc_t) :: s
   integer :: i, j, k
@@ -186,7 +182,6 @@ subroutine test_stack_nc_clear(this)
   use pfunit
   use stack
   use nmsh
-  implicit none
   class(test_stack_nc_case), intent(inout) :: this
   type(stack_nc_t) :: s
   integer :: i

--- a/tests/unit/stack/test_stack_nh.pf
+++ b/tests/unit/stack/test_stack_nh.pf
@@ -33,7 +33,6 @@ subroutine test_stack_nh_init(this)
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only : rp
-  implicit none
   class(test_stack_nh_case), intent(inout) :: this
   type(stack_nh_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
@@ -71,7 +70,6 @@ end subroutine test_stack_nh_init
 subroutine test_stack_nh_free(this)
   use pfunit
   use stack
-  implicit none
   class(test_stack_nh_case), intent(inout) :: this
   type(stack_nh_t) :: s
 
@@ -90,7 +88,6 @@ subroutine test_stack_nh_push(this)
   use pfunit
   use stack
   use nmsh
-  implicit none
   class(test_stack_nh_case), intent(inout) :: this
   type(stack_nh_t) :: s
   integer :: i, j, k
@@ -143,7 +140,6 @@ subroutine test_stack_nh_pop(this)
   use pfunit
   use stack
   use nmsh
-  implicit none
   class(test_stack_nh_case), intent(inout) :: this
   type(stack_nh_t) :: s
   integer :: i, j, k
@@ -184,7 +180,6 @@ subroutine test_stack_nh_clear(this)
   use pfunit
   use stack
   use nmsh
-  implicit none
   class(test_stack_nh_case), intent(inout) :: this
   type(stack_nh_t) :: s
   integer :: i, j

--- a/tests/unit/stack/test_stack_nh.pf
+++ b/tests/unit/stack/test_stack_nh.pf
@@ -1,12 +1,40 @@
 module test_stack_nh
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_stack_nh_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_stack_nh_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_stack_nh_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_stack_nh_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_stack_nh_init
+subroutine test_stack_nh_init(this)
   use pfunit
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only : rp
   implicit none
+  class(test_stack_nh_case), intent(inout) :: this
   type(stack_nh_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
 
@@ -40,10 +68,11 @@ subroutine test_stack_nh_init
 end subroutine test_stack_nh_init
 
 @test
-subroutine test_stack_nh_free
+subroutine test_stack_nh_free(this)
   use pfunit
   use stack
   implicit none
+  class(test_stack_nh_case), intent(inout) :: this
   type(stack_nh_t) :: s
 
   call s%init()
@@ -57,11 +86,12 @@ subroutine test_stack_nh_free
 end subroutine test_stack_nh_free
 
 @test
-subroutine test_stack_nh_push
+subroutine test_stack_nh_push(this)
   use pfunit
   use stack
   use nmsh
   implicit none
+  class(test_stack_nh_case), intent(inout) :: this
   type(stack_nh_t) :: s
   integer :: i, j, k
   type(nmsh_hex_t) :: data
@@ -109,11 +139,12 @@ subroutine test_stack_nh_push
 end subroutine test_stack_nh_push
 
 @test
-subroutine test_stack_nh_pop
+subroutine test_stack_nh_pop(this)
   use pfunit
   use stack
   use nmsh
   implicit none
+  class(test_stack_nh_case), intent(inout) :: this
   type(stack_nh_t) :: s
   integer :: i, j, k
   type(nmsh_hex_t) :: data, data2
@@ -149,11 +180,12 @@ subroutine test_stack_nh_pop
 end subroutine test_stack_nh_pop
 
 @test 
-subroutine test_stack_nh_clear
+subroutine test_stack_nh_clear(this)
   use pfunit
   use stack
   use nmsh
   implicit none
+  class(test_stack_nh_case), intent(inout) :: this
   type(stack_nh_t) :: s
   integer :: i, j
   type(nmsh_hex_t) :: data

--- a/tests/unit/stack/test_stack_nq.pf
+++ b/tests/unit/stack/test_stack_nq.pf
@@ -33,7 +33,6 @@ subroutine test_stack_nq_init(this)
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only : rp
-  implicit none  
   class(test_stack_nq_case), intent(inout) :: this
   type(stack_nq_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
@@ -71,7 +70,6 @@ end subroutine test_stack_nq_init
 subroutine test_stack_nq_free(this)
   use pfunit
   use stack
-  implicit none
   class(test_stack_nq_case), intent(inout) :: this
   type(stack_nq_t) :: s
 
@@ -90,7 +88,6 @@ subroutine test_stack_nq_push(this)
   use pfunit
   use stack
   use nmsh
-  implicit none
   class(test_stack_nq_case), intent(inout) :: this
   type(stack_nq_t) :: s
   integer :: i, j, k
@@ -143,7 +140,6 @@ subroutine test_stack_nq_pop(this)
   use pfunit
   use stack
   use nmsh
-  implicit none
   class(test_stack_nq_case), intent(inout) :: this
   type(stack_nq_t) :: s
   integer :: i, j, k
@@ -184,7 +180,6 @@ subroutine test_stack_nq_clear(this)
   use pfunit
   use stack
   use nmsh
-  implicit none
   class(test_stack_nq_case), intent(inout) :: this
   type(stack_nq_t) :: s
   integer :: i, j

--- a/tests/unit/stack/test_stack_nq.pf
+++ b/tests/unit/stack/test_stack_nq.pf
@@ -1,12 +1,40 @@
 module test_stack_nq
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_stack_nq_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_stack_nq_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_stack_nq_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_stack_nq_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_stack_nq_init
+subroutine test_stack_nq_init(this)
   use pfunit
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only : rp
   implicit none  
+  class(test_stack_nq_case), intent(inout) :: this
   type(stack_nq_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
 
@@ -40,10 +68,11 @@ subroutine test_stack_nq_init
 end subroutine test_stack_nq_init
 
 @test
-subroutine test_stack_nq_free
+subroutine test_stack_nq_free(this)
   use pfunit
   use stack
   implicit none
+  class(test_stack_nq_case), intent(inout) :: this
   type(stack_nq_t) :: s
 
   call s%init()
@@ -57,11 +86,12 @@ subroutine test_stack_nq_free
 end subroutine test_stack_nq_free
 
 @test
-subroutine test_stack_nq_push
+subroutine test_stack_nq_push(this)
   use pfunit
   use stack
   use nmsh
   implicit none
+  class(test_stack_nq_case), intent(inout) :: this
   type(stack_nq_t) :: s
   integer :: i, j, k
   type(nmsh_quad_t) :: data
@@ -109,11 +139,12 @@ subroutine test_stack_nq_push
 end subroutine test_stack_nq_push
 
 @test
-subroutine test_stack_nq_pop
+subroutine test_stack_nq_pop(this)
   use pfunit
   use stack
   use nmsh
   implicit none
+  class(test_stack_nq_case), intent(inout) :: this
   type(stack_nq_t) :: s
   integer :: i, j, k
   type(nmsh_quad_t) :: data, data2
@@ -149,11 +180,12 @@ subroutine test_stack_nq_pop
 end subroutine test_stack_nq_pop
 
 @test 
-subroutine test_stack_nq_clear
+subroutine test_stack_nq_clear(this)
   use pfunit
   use stack
   use nmsh
   implicit none
+  class(test_stack_nq_case), intent(inout) :: this
   type(stack_nq_t) :: s
   integer :: i, j
   type(nmsh_quad_t) :: data

--- a/tests/unit/stack/test_stack_nz.pf
+++ b/tests/unit/stack/test_stack_nz.pf
@@ -33,7 +33,6 @@ subroutine test_stack_nz_init(this)
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only : rp
-  implicit none
   class(test_stack_nz_case), intent(inout) :: this
   type(stack_nz_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
@@ -71,7 +70,6 @@ end subroutine test_stack_nz_init
 subroutine test_stack_nz_free(this)
   use pfunit
   use stack
-  implicit none
   class(test_stack_nz_case), intent(inout) :: this
   type(stack_nz_t) :: s
 
@@ -90,7 +88,6 @@ subroutine test_stack_nz_push(this)
   use pfunit
   use stack
   use nmsh
-  implicit none
   class(test_stack_nz_case), intent(inout) :: this
   type(stack_nz_t) :: s
   integer :: i
@@ -142,7 +139,6 @@ subroutine test_stack_nz_pop(this)
   use pfunit
   use stack
   use nmsh
-  implicit none
   class(test_stack_nz_case), intent(inout) :: this
   type(stack_nz_t) :: s
   integer :: i
@@ -181,7 +177,6 @@ subroutine test_stack_nz_clear(this)
   use pfunit
   use stack
   use nmsh
-  implicit none
   class(test_stack_nz_case), intent(inout) :: this
   type(stack_nz_t) :: s
   integer :: i

--- a/tests/unit/stack/test_stack_nz.pf
+++ b/tests/unit/stack/test_stack_nz.pf
@@ -1,12 +1,40 @@
 module test_stack_nz
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_stack_nz_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_stack_nz_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_stack_nz_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_stack_nz_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_stack_nz_init
+subroutine test_stack_nz_init(this)
   use pfunit
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only : rp
   implicit none
+  class(test_stack_nz_case), intent(inout) :: this
   type(stack_nz_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
 
@@ -40,10 +68,11 @@ subroutine test_stack_nz_init
 end subroutine test_stack_nz_init
 
 @test
-subroutine test_stack_nz_free
+subroutine test_stack_nz_free(this)
   use pfunit
   use stack
   implicit none
+  class(test_stack_nz_case), intent(inout) :: this
   type(stack_nz_t) :: s
 
   call s%init()
@@ -57,11 +86,12 @@ subroutine test_stack_nz_free
 end subroutine test_stack_nz_free
 
 @test
-subroutine test_stack_nz_push
+subroutine test_stack_nz_push(this)
   use pfunit
   use stack
   use nmsh
   implicit none
+  class(test_stack_nz_case), intent(inout) :: this
   type(stack_nz_t) :: s
   integer :: i
   type(nmsh_zone_t) :: data
@@ -108,11 +138,12 @@ subroutine test_stack_nz_push
 end subroutine test_stack_nz_push
 
 @test
-subroutine test_stack_nz_pop
+subroutine test_stack_nz_pop(this)
   use pfunit
   use stack
   use nmsh
   implicit none
+  class(test_stack_nz_case), intent(inout) :: this
   type(stack_nz_t) :: s
   integer :: i
   type(nmsh_zone_t) :: data
@@ -146,11 +177,12 @@ subroutine test_stack_nz_pop
 end subroutine test_stack_nz_pop
 
 @test
-subroutine test_stack_nz_clear
+subroutine test_stack_nz_clear(this)
   use pfunit
   use stack
   use nmsh
   implicit none
+  class(test_stack_nz_case), intent(inout) :: this
   type(stack_nz_t) :: s
   integer :: i
   type(nmsh_zone_t) :: data

--- a/tests/unit/stack/test_stack_pt.pf
+++ b/tests/unit/stack/test_stack_pt.pf
@@ -1,12 +1,40 @@
 module test_stack_pt
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_stack_pt_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_stack_pt_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_stack_pt_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_stack_pt_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_stack_pt_init
+subroutine test_stack_pt_init(this)
   use pfunit
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only :rp
   implicit none
+  class(test_stack_pt_case), intent(inout) :: this
   type(stack_pt_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
 
@@ -40,10 +68,11 @@ subroutine test_stack_pt_init
 end subroutine test_stack_pt_init
 
 @test
-subroutine test_stack_pt_free
+subroutine test_stack_pt_free(this)
   use pfunit
   use stack
   implicit none
+  class(test_stack_pt_case), intent(inout) :: this
   type(stack_pt_t) :: s
 
   call s%init()
@@ -57,11 +86,12 @@ subroutine test_stack_pt_free
 end subroutine test_stack_pt_free
 
 @test
-subroutine test_stack_pt_push
+subroutine test_stack_pt_push(this)
   use pfunit
   use stack
   use point
   implicit none
+  class(test_stack_pt_case), intent(inout) :: this
   type(stack_pt_t) :: s
   integer :: i
   type(point_t) :: data
@@ -94,11 +124,12 @@ subroutine test_stack_pt_push
 end subroutine test_stack_pt_push
 
 @test
-subroutine test_stack_pt_pop
+subroutine test_stack_pt_pop(this)
   use pfunit
   use stack
   use point
   implicit none
+  class(test_stack_pt_case), intent(inout) :: this
   type(stack_pt_t) :: s
   integer :: i
   type(point_t) :: data
@@ -122,11 +153,12 @@ subroutine test_stack_pt_pop
 end subroutine test_stack_pt_pop
 
 @test 
-subroutine test_stack_pt_clear
+subroutine test_stack_pt_clear(this)
   use pfunit
   use stack
   use point
   implicit none
+  class(test_stack_pt_case), intent(inout) :: this
   type(stack_pt_t) :: s
   integer :: i
   type(point_t) :: data

--- a/tests/unit/stack/test_stack_pt.pf
+++ b/tests/unit/stack/test_stack_pt.pf
@@ -33,7 +33,6 @@ subroutine test_stack_pt_init(this)
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only :rp
-  implicit none
   class(test_stack_pt_case), intent(inout) :: this
   type(stack_pt_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
@@ -71,7 +70,6 @@ end subroutine test_stack_pt_init
 subroutine test_stack_pt_free(this)
   use pfunit
   use stack
-  implicit none
   class(test_stack_pt_case), intent(inout) :: this
   type(stack_pt_t) :: s
 
@@ -90,7 +88,6 @@ subroutine test_stack_pt_push(this)
   use pfunit
   use stack
   use point
-  implicit none
   class(test_stack_pt_case), intent(inout) :: this
   type(stack_pt_t) :: s
   integer :: i
@@ -128,7 +125,6 @@ subroutine test_stack_pt_pop(this)
   use pfunit
   use stack
   use point
-  implicit none
   class(test_stack_pt_case), intent(inout) :: this
   type(stack_pt_t) :: s
   integer :: i
@@ -157,7 +153,6 @@ subroutine test_stack_pt_clear(this)
   use pfunit
   use stack
   use point
-  implicit none
   class(test_stack_pt_case), intent(inout) :: this
   type(stack_pt_t) :: s
   integer :: i

--- a/tests/unit/stack/test_stack_r8.pf
+++ b/tests/unit/stack/test_stack_r8.pf
@@ -33,7 +33,6 @@ subroutine test_stack_r8_init(this)
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only : rp
-  implicit none
   class(test_stack_r8_case), intent(inout) :: this
   type(stack_r8_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
@@ -71,7 +70,6 @@ end subroutine test_stack_r8_init
 subroutine test_stack_r8_free(this)
   use pfunit
   use stack
-  implicit none
   class(test_stack_r8_case), intent(inout) :: this
   type(stack_r8_t) :: s
 
@@ -90,7 +88,6 @@ subroutine test_stack_r8_push(this)
   use pfunit
   use stack
   use num_types
-  implicit none
   class(test_stack_r8_case), intent(inout) :: this
   type(stack_r8_t) :: s
   integer :: i
@@ -127,7 +124,6 @@ subroutine test_stack_r8_pop(this)
   use pfunit
   use stack
   use num_types
-  implicit none
   class(test_stack_r8_case), intent(inout) :: this
   type(stack_r8_t) :: s
   integer :: i
@@ -155,7 +151,6 @@ subroutine test_stack_r8_clear(this)
   use pfunit
   use stack
   use num_types
-  implicit none
   class(test_stack_r8_case), intent(inout) :: this
   type(stack_r8_t) :: s
   integer :: i

--- a/tests/unit/stack/test_stack_r8.pf
+++ b/tests/unit/stack/test_stack_r8.pf
@@ -1,12 +1,40 @@
 module test_stack_r8
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_stack_r8_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_stack_r8_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_stack_r8_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_stack_r8_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_stack_r8_init
+subroutine test_stack_r8_init(this)
   use pfunit
   use stack
   use math, only : NEKO_M_LN2
   use num_types, only : rp
   implicit none
+  class(test_stack_r8_case), intent(inout) :: this
   type(stack_r8_t) :: s1, s2, s3
   integer, parameter :: size_t = ishft(1, ceiling(log(real(32, rp)) / NEKO_M_LN2))
 
@@ -40,10 +68,11 @@ subroutine test_stack_r8_init
 end subroutine test_stack_r8_init
 
 @test
-subroutine test_stack_r8_free
+subroutine test_stack_r8_free(this)
   use pfunit
   use stack
   implicit none
+  class(test_stack_r8_case), intent(inout) :: this
   type(stack_r8_t) :: s
 
   call s%init()
@@ -57,11 +86,12 @@ subroutine test_stack_r8_free
 end subroutine test_stack_r8_free
 
 @test
-subroutine test_stack_r8_push
+subroutine test_stack_r8_push(this)
   use pfunit
   use stack
   use num_types
   implicit none
+  class(test_stack_r8_case), intent(inout) :: this
   type(stack_r8_t) :: s
   integer :: i
   real(kind=dp) :: data
@@ -93,11 +123,12 @@ subroutine test_stack_r8_push
 end subroutine test_stack_r8_push
 
 @test
-subroutine test_stack_r8_pop
+subroutine test_stack_r8_pop(this)
   use pfunit
   use stack
   use num_types
   implicit none
+  class(test_stack_r8_case), intent(inout) :: this
   type(stack_r8_t) :: s
   integer :: i
   real(kind=dp) :: data
@@ -120,11 +151,12 @@ subroutine test_stack_r8_pop
 end subroutine test_stack_r8_pop
 
 @test 
-subroutine test_stack_r8_clear
+subroutine test_stack_r8_clear(this)
   use pfunit
   use stack
   use num_types
   implicit none
+  class(test_stack_r8_case), intent(inout) :: this
   type(stack_r8_t) :: s
   integer :: i
   real(kind=dp) :: data

--- a/tests/unit/templates/parallel/test_parallel.pf
+++ b/tests/unit/templates/parallel/test_parallel.pf
@@ -4,7 +4,7 @@ module test_parallel
   use comm, only : NEKO_COMM, pe_rank, pe_size
   use device, only : device_init, device_finalize
   use neko_config, only : NEKO_BCKND_DEVICE
-  use neko_mpi_types, only : neko_mpi_types_init
+  use neko_mpi_types, only : neko_mpi_types_init, neko_mpi_types_free
   implicit none
 
   @TestCase
@@ -28,6 +28,7 @@ contains
 
   subroutine tearDown(this)
     class(parallel_template_case), intent(inout) :: this
+    call neko_mpi_types_free()
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_finalize
     end if

--- a/tests/unit/tet/test_tet.pf
+++ b/tests/unit/tet/test_tet.pf
@@ -33,7 +33,6 @@ subroutine test_tet_init(this)
   use point
   use tet
   use num_types
-  implicit none
   class(test_tet_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
@@ -77,7 +76,6 @@ subroutine test_tet_free(this)
   use point
   use tet
   use num_types
-  implicit none
   class(test_tet_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
@@ -112,7 +110,6 @@ subroutine test_tet_centroid(this)
   use point
   use tet
   use num_types
-  implicit none
   class(test_tet_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
@@ -145,7 +142,6 @@ subroutine test_tet_diameter(this)
   use point
   use tet
   use num_types
-  implicit none
   class(test_tet_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
@@ -173,7 +169,6 @@ subroutine test_tet_equal(this)
   use point
   use tet
   use num_types
-  implicit none
   class(test_tet_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   integer :: point_id
@@ -224,7 +219,6 @@ subroutine test_tet_facet_id(this)
   use tet
   use tuple
   use num_types
-  implicit none
   class(test_tet_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id

--- a/tests/unit/tet/test_tet.pf
+++ b/tests/unit/tet/test_tet.pf
@@ -1,12 +1,40 @@
 module test_tet
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_tet_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_tet_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_tet_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_tet_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_tet_init
+subroutine test_tet_init(this)
   use pfunit
   use point
   use tet
   use num_types
   implicit none
+  class(test_tet_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -44,12 +72,13 @@ subroutine test_tet_init
 end subroutine test_tet_init
 
 @test
-subroutine test_tet_free
+subroutine test_tet_free(this)
   use pfunit
   use point
   use tet
   use num_types
   implicit none
+  class(test_tet_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -78,12 +107,13 @@ subroutine test_tet_free
 end subroutine test_tet_free
 
 @test
-subroutine test_tet_centroid
+subroutine test_tet_centroid(this)
   use pfunit
   use point
   use tet
   use num_types
   implicit none
+  class(test_tet_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -110,12 +140,13 @@ subroutine test_tet_centroid
 end subroutine test_tet_centroid
 
 @test
-subroutine test_tet_diameter
+subroutine test_tet_diameter(this)
   use pfunit
   use point
   use tet
   use num_types
   implicit none
+  class(test_tet_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -137,12 +168,13 @@ subroutine test_tet_diameter
 end subroutine test_tet_diameter
 
 @test
-subroutine test_tet_equal
+subroutine test_tet_equal(this)
   use pfunit
   use point
   use tet
   use num_types
   implicit none
+  class(test_tet_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4, p5, p6, p7, p8
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -186,13 +218,14 @@ subroutine test_tet_equal
 end subroutine test_tet_equal
 
 @test
-subroutine test_tet_facet_id
+subroutine test_tet_facet_id(this)
   use pfunit
   use point
   use tet
   use tuple
   use num_types
   implicit none
+  class(test_tet_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p4
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)

--- a/tests/unit/time_based_controller/test_time_based_controller.pf
+++ b/tests/unit/time_based_controller/test_time_based_controller.pf
@@ -1,13 +1,41 @@
 module test_time_based_controller
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_time_based_controller_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_time_based_controller_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_time_based_controller_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_time_based_controller_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 !> Test the constructor
 @test
-subroutine test_init()
+subroutine test_init(this)
   use pfunit
   use time_based_controller, only : time_based_controller_t
   use time_state, only : time_state_t
   use num_types, only : rp
   implicit none
+  class(test_time_based_controller_case), intent(inout) :: this
 
   type(time_based_controller_t) ctrl
 
@@ -35,11 +63,12 @@ end subroutine test_init
 
 !> Test assignment
 @test
-subroutine test_assign()
+subroutine test_assign(this)
   use pfunit
   use time_based_controller, only : time_based_controller_t
   use num_types, only : rp
   implicit none
+  class(test_time_based_controller_case), intent(inout) :: this
 
   type(time_based_controller_t) ctrl1
   type(time_based_controller_t) ctrl2
@@ -58,12 +87,13 @@ end subroutine test_assign
 
 !> Test check simulationtime
 @test
-subroutine test_check_simulationtime()
+subroutine test_check_simulationtime(this)
   use pfunit
   use time_based_controller, only : time_based_controller_t
   use num_types, only : rp
   use time_state, only : time_state_t
   implicit none
+  class(test_time_based_controller_case), intent(inout) :: this
 
   type(time_based_controller_t) ctrl
   type(time_state_t) :: time
@@ -100,12 +130,13 @@ end subroutine test_check_simulationtime
 
 !> Test check nsamples
 @test
-subroutine test_check_nsamples()
+subroutine test_check_nsamples(this)
   use pfunit
   use time_based_controller, only : time_based_controller_t
   use num_types, only : rp
   use time_state, only : time_state_t
   implicit none
+  class(test_time_based_controller_case), intent(inout) :: this
 
   type(time_based_controller_t) ctrl
   type(time_state_t) :: time
@@ -128,12 +159,13 @@ end subroutine test_check_nsamples
 
 !> Test check tsteps
 @test
-subroutine test_check_tsteps()
+subroutine test_check_tsteps(this)
   use pfunit
   use time_based_controller, only : time_based_controller_t
   use num_types, only : rp
   use time_state, only : time_state_t
   implicit none
+  class(test_time_based_controller_case), intent(inout) :: this
 
   type(time_based_controller_t) ctrl
   type(time_state_t) :: time
@@ -156,11 +188,12 @@ end subroutine test_check_tsteps
 
 !> Test register
 @test
-subroutine test_register()
+subroutine test_register(this)
   use pfunit
   use time_based_controller, only : time_based_controller_t
   use num_types, only : rp
   implicit none
+  class(test_time_based_controller_case), intent(inout) :: this
 
   type(time_based_controller_t) ctrl
 

--- a/tests/unit/time_based_controller/test_time_based_controller.pf
+++ b/tests/unit/time_based_controller/test_time_based_controller.pf
@@ -34,7 +34,6 @@ subroutine test_init(this)
   use time_based_controller, only : time_based_controller_t
   use time_state, only : time_state_t
   use num_types, only : rp
-  implicit none
   class(test_time_based_controller_case), intent(inout) :: this
 
   type(time_based_controller_t) ctrl
@@ -67,7 +66,6 @@ subroutine test_assign(this)
   use pfunit
   use time_based_controller, only : time_based_controller_t
   use num_types, only : rp
-  implicit none
   class(test_time_based_controller_case), intent(inout) :: this
 
   type(time_based_controller_t) ctrl1
@@ -92,7 +90,6 @@ subroutine test_check_simulationtime(this)
   use time_based_controller, only : time_based_controller_t
   use num_types, only : rp
   use time_state, only : time_state_t
-  implicit none
   class(test_time_based_controller_case), intent(inout) :: this
 
   type(time_based_controller_t) ctrl
@@ -135,7 +132,6 @@ subroutine test_check_nsamples(this)
   use time_based_controller, only : time_based_controller_t
   use num_types, only : rp
   use time_state, only : time_state_t
-  implicit none
   class(test_time_based_controller_case), intent(inout) :: this
 
   type(time_based_controller_t) ctrl
@@ -164,7 +160,6 @@ subroutine test_check_tsteps(this)
   use time_based_controller, only : time_based_controller_t
   use num_types, only : rp
   use time_state, only : time_state_t
-  implicit none
   class(test_time_based_controller_case), intent(inout) :: this
 
   type(time_based_controller_t) ctrl
@@ -192,7 +187,6 @@ subroutine test_register(this)
   use pfunit
   use time_based_controller, only : time_based_controller_t
   use num_types, only : rp
-  implicit none
   class(test_time_based_controller_case), intent(inout) :: this
 
   type(time_based_controller_t) ctrl

--- a/tests/unit/time_scheme/test_ab.pf
+++ b/tests/unit/time_scheme/test_ab.pf
@@ -1,11 +1,39 @@
 module test_ab
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_ab_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_ab_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_ab_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_ab_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
  @test
- subroutine test_ab_constant_dt()
+ subroutine test_ab_constant_dt(this)
    use pfunit
    use ab_time_scheme, only: ab_time_scheme_t
    use num_types, only : rp
    implicit none
+   class(test_ab_case), intent(inout) :: this
    
    type(ab_time_scheme_t) ab
    real(kind=rp) :: dt(10), x, coeffs(4)
@@ -31,11 +59,12 @@ contains
 end subroutine test_ab_constant_dt
 
  @test
- subroutine test_ab_variable_dt()
+ subroutine test_ab_variable_dt(this)
    use pfunit
    use ab_time_scheme, only: ab_time_scheme_t
    use num_types, only : rp
    implicit none
+   class(test_ab_case), intent(inout) :: this
    
    type(ab_time_scheme_t) ab
    real(kind=rp) :: dt(10), coeffs(4)

--- a/tests/unit/time_scheme/test_ab.pf
+++ b/tests/unit/time_scheme/test_ab.pf
@@ -32,7 +32,6 @@ contains
    use pfunit
    use ab_time_scheme, only: ab_time_scheme_t
    use num_types, only : rp
-   implicit none
    class(test_ab_case), intent(inout) :: this
    
    type(ab_time_scheme_t) ab
@@ -63,7 +62,6 @@ end subroutine test_ab_constant_dt
    use pfunit
    use ab_time_scheme, only: ab_time_scheme_t
    use num_types, only : rp
-   implicit none
    class(test_ab_case), intent(inout) :: this
    
    type(ab_time_scheme_t) ab

--- a/tests/unit/time_scheme/test_bdf.pf
+++ b/tests/unit/time_scheme/test_bdf.pf
@@ -32,7 +32,6 @@ contains
    use pfunit
    use bdf_time_scheme, only : bdf_time_scheme_t
    use num_types, only : rp
-   implicit none
    class(test_bdf_case), intent(inout) :: this
    
    type(bdf_time_scheme_t) bdf
@@ -68,7 +67,6 @@ end subroutine test_constant_dt
    use pfunit
    use bdf_time_scheme, only : bdf_time_scheme_t
    use num_types, only : rp
-   implicit none
    class(test_bdf_case), intent(inout) :: this
    
    type(bdf_time_scheme_t) bdf
@@ -115,7 +113,6 @@ end subroutine test_variable_dt
    use bdf_time_scheme, only : bdf_time_scheme_t
    use fast3d, only : fd_weights_full
    use num_types
-   implicit none
    class(test_bdf_case), intent(inout) :: this
    
    type(bdf_time_scheme_t) bdf
@@ -154,7 +151,6 @@ end subroutine test_with_df_weights_full
   subroutine old_bdf(nbd, bd, time_order, dt)
     use num_types
     use math
-    implicit none
     integer, intent(inout) :: nbd
     integer, intent(in) :: time_order
     real(kind=rp), dimension(10) :: bd

--- a/tests/unit/time_scheme/test_bdf.pf
+++ b/tests/unit/time_scheme/test_bdf.pf
@@ -1,11 +1,39 @@
 module test_bdf
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_bdf_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_bdf_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_bdf_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_bdf_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
  @test
- subroutine test_constant_dt()
+ subroutine test_constant_dt(this)
    use pfunit
    use bdf_time_scheme, only : bdf_time_scheme_t
    use num_types, only : rp
    implicit none
+   class(test_bdf_case), intent(inout) :: this
    
    type(bdf_time_scheme_t) bdf
    real(kind=rp) :: dt(10), x
@@ -36,11 +64,12 @@ contains
 end subroutine test_constant_dt
 
  @test
- subroutine test_variable_dt()
+ subroutine test_variable_dt(this)
    use pfunit
    use bdf_time_scheme, only : bdf_time_scheme_t
    use num_types, only : rp
    implicit none
+   class(test_bdf_case), intent(inout) :: this
    
    type(bdf_time_scheme_t) bdf
    real(kind=rp) :: dt(10), coeffs(10), coeffs_new(4)
@@ -81,12 +110,13 @@ end subroutine test_variable_dt
 
 !> Shows that we can use df_weights_full to get a scheme of arbitrary order
  @test
- subroutine test_with_df_weights_full()
+ subroutine test_with_df_weights_full(this)
    use pfunit
    use bdf_time_scheme, only : bdf_time_scheme_t
    use fast3d, only : fd_weights_full
    use num_types
    implicit none
+   class(test_bdf_case), intent(inout) :: this
    
    type(bdf_time_scheme_t) bdf
    integer, parameter :: n=3, m=1

--- a/tests/unit/time_scheme/test_ext.pf
+++ b/tests/unit/time_scheme/test_ext.pf
@@ -1,11 +1,39 @@
 module test_ext
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_ext_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_ext_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_ext_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_ext_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_ext_constant_dt()
+subroutine test_ext_constant_dt(this)
   use pfunit
   use ext_time_scheme
   use num_types
   implicit none
+  class(test_ext_case), intent(inout) :: this
   
   type(ext_time_scheme_t) ext
   real(kind=rp) :: dt(10), x, coeffs(4)
@@ -31,11 +59,12 @@ subroutine test_ext_constant_dt()
 end subroutine test_ext_constant_dt
 
 @test
-subroutine test_ext_variable_dt()
+subroutine test_ext_variable_dt(this)
   use pfunit
   use ext_time_scheme, only: ext_time_scheme_t
   use num_types, only : rp
   implicit none
+  class(test_ext_case), intent(inout) :: this
   
   type(ext_time_scheme_t) ext
   real(kind=rp) :: dt(10), coeffs(4)
@@ -60,11 +89,12 @@ subroutine test_ext_variable_dt()
 end subroutine test_ext_variable_dt
 
 @test
-subroutine test_ext_modified()
+subroutine test_ext_modified(this)
   use pfunit
   use ext_time_scheme
   use num_types
   implicit none
+  class(test_ext_case), intent(inout) :: this
   
   type(ext_time_scheme_t) ext
   real(kind=rp) :: dt(10), x, coeffs(4)

--- a/tests/unit/time_scheme/test_ext.pf
+++ b/tests/unit/time_scheme/test_ext.pf
@@ -32,7 +32,6 @@ subroutine test_ext_constant_dt(this)
   use pfunit
   use ext_time_scheme
   use num_types
-  implicit none
   class(test_ext_case), intent(inout) :: this
   
   type(ext_time_scheme_t) ext
@@ -63,7 +62,6 @@ subroutine test_ext_variable_dt(this)
   use pfunit
   use ext_time_scheme, only: ext_time_scheme_t
   use num_types, only : rp
-  implicit none
   class(test_ext_case), intent(inout) :: this
   
   type(ext_time_scheme_t) ext
@@ -93,7 +91,6 @@ subroutine test_ext_modified(this)
   use pfunit
   use ext_time_scheme
   use num_types
-  implicit none
   class(test_ext_case), intent(inout) :: this
   
   type(ext_time_scheme_t) ext

--- a/tests/unit/tri/test_tri.pf
+++ b/tests/unit/tri/test_tri.pf
@@ -33,7 +33,6 @@ subroutine test_tri_init(this)
   use point
   use tri
   use num_types
-  implicit none
   class(test_tri_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3
   integer :: point_id
@@ -72,7 +71,6 @@ subroutine test_tri_free(this)
   use point
   use tri
   use num_types
-  implicit none
   class(test_tri_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3
   integer :: point_id
@@ -103,7 +101,6 @@ subroutine test_tri_centroid(this)
   use point
   use tri
   use num_types
-  implicit none
   class(test_tri_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3
   integer :: point_id
@@ -134,7 +131,6 @@ subroutine test_tri_diameter(this)
   use point
   use tri
   use num_types
-  implicit none
   class(test_tri_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3
   integer :: point_id
@@ -160,7 +156,6 @@ subroutine test_tri_equal(this)
   use point
   use tri
   use num_types
-  implicit none
   class(test_tri_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p5, p6, p7
   integer :: point_id
@@ -206,7 +201,6 @@ subroutine test_tri_facet_id(this)
   use tri
   use tuple
   use num_types
-  implicit none
   class(test_tri_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3
   integer :: point_id

--- a/tests/unit/tri/test_tri.pf
+++ b/tests/unit/tri/test_tri.pf
@@ -1,12 +1,40 @@
 module test_tri
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_tri_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_tri_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_tri_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_tri_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_tri_init
+subroutine test_tri_init(this)
   use pfunit
   use point
   use tri
   use num_types
   implicit none
+  class(test_tri_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -39,12 +67,13 @@ subroutine test_tri_init
 end subroutine test_tri_init
 
 @test
-subroutine test_tri_free
+subroutine test_tri_free(this)
   use pfunit
   use point
   use tri
   use num_types
   implicit none
+  class(test_tri_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -69,12 +98,13 @@ subroutine test_tri_free
 end subroutine test_tri_free
 
 @test
-subroutine test_tri_centroid
+subroutine test_tri_centroid(this)
   use pfunit
   use point
   use tri
   use num_types
   implicit none
+  class(test_tri_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -99,12 +129,13 @@ subroutine test_tri_centroid
 end subroutine test_tri_centroid
 
 @test
-subroutine test_tri_diameter
+subroutine test_tri_diameter(this)
   use pfunit
   use point
   use tri
   use num_types
   implicit none
+  class(test_tri_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -124,12 +155,13 @@ subroutine test_tri_diameter
 end subroutine test_tri_diameter
 
 @test
-subroutine test_tri_equal
+subroutine test_tri_equal(this)
   use pfunit
   use point
   use tri
   use num_types
   implicit none
+  class(test_tri_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3, p5, p6, p7
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)
@@ -168,13 +200,14 @@ subroutine test_tri_equal
 end subroutine test_tri_equal
 
 @test
-subroutine test_tri_facet_id
+subroutine test_tri_facet_id(this)
   use pfunit
   use point
   use tri
   use tuple
   use num_types
   implicit none
+  class(test_tri_case), intent(inout) :: this
   type(point_t) :: p1, p2, p3
   integer :: point_id
   real(kind=dp), parameter :: c1(3) = (/0d0, 0d0, 0d0/)

--- a/tests/unit/tuple/test_tuple.pf
+++ b/tests/unit/tuple/test_tuple.pf
@@ -31,7 +31,6 @@ contains
 subroutine test_tuple_defaults(this)
   use pfunit
   use tuple
-  implicit none
   class(test_tuple_case), intent(inout) :: this
   type(tuple_i4_t) :: t2i4
   type(tuple3_i4_t) :: t3i4
@@ -52,7 +51,6 @@ end subroutine test_tuple_defaults
 subroutine test_tuple_i4(this)
   use pfunit
   use tuple    
-  implicit none
   class(test_tuple_case), intent(inout) :: this
   type(tuple_i4_t) :: t1, t2
   integer :: i
@@ -85,7 +83,6 @@ end subroutine test_tuple_i4
 subroutine test_tuple3_i4(this)
   use pfunit
   use tuple    
-  implicit none
   class(test_tuple_case), intent(inout) :: this
   type(tuple3_i4_t) :: t1, t2
   integer :: i
@@ -118,7 +115,6 @@ end subroutine test_tuple3_i4
 subroutine test_tuple4_i4(this)
   use pfunit
   use tuple    
-  implicit none
   class(test_tuple_case), intent(inout) :: this
   type(tuple4_i4_t) :: t1, t2
   integer :: i
@@ -152,7 +148,6 @@ subroutine test_tuple_r8(this)
   use pfunit
   use tuple
   use num_types
-  implicit none
   class(test_tuple_case), intent(inout) :: this
   type(tuple_r8_t) :: t1, t2
   integer :: i
@@ -186,7 +181,6 @@ subroutine test_tuple_i4r8(this)
   use pfunit
   use tuple
   use num_types
-  implicit none
   class(test_tuple_case), intent(inout) :: this
   type(tuple_i4r8_t) :: t1, t2
   integer :: i
@@ -220,7 +214,6 @@ subroutine test_tuple_2i4r8(this)
   use pfunit
   use tuple
   use num_types
-  implicit none
   class(test_tuple_case), intent(inout) :: this
   type(tuple_2i4r8_t) :: t1, t2
   integer :: i
@@ -254,7 +247,6 @@ end subroutine test_tuple_2i4r8
 subroutine test_tuple_mixed_type_inequality(this)
   use pfunit
   use tuple
-  implicit none
   class(test_tuple_case), intent(inout) :: this
   type(tuple_i4_t) :: t2i4
   type(tuple3_i4_t) :: t3i4

--- a/tests/unit/tuple/test_tuple.pf
+++ b/tests/unit/tuple/test_tuple.pf
@@ -1,10 +1,38 @@
 module test_tuple
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_tuple_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_tuple_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_tuple_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_tuple_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_tuple_defaults
+subroutine test_tuple_defaults(this)
   use pfunit
   use tuple
   implicit none
+  class(test_tuple_case), intent(inout) :: this
   type(tuple_i4_t) :: t2i4
   type(tuple3_i4_t) :: t3i4
   type(tuple4_i4_t) :: t4i4
@@ -21,10 +49,11 @@ subroutine test_tuple_defaults
 end subroutine test_tuple_defaults
 
 @test
-subroutine test_tuple_i4
+subroutine test_tuple_i4(this)
   use pfunit
   use tuple    
   implicit none
+  class(test_tuple_case), intent(inout) :: this
   type(tuple_i4_t) :: t1, t2
   integer :: i
   integer :: x(2) = (/2, 2/)
@@ -53,10 +82,11 @@ subroutine test_tuple_i4
 end subroutine test_tuple_i4
 
 @test
-subroutine test_tuple3_i4
+subroutine test_tuple3_i4(this)
   use pfunit
   use tuple    
   implicit none
+  class(test_tuple_case), intent(inout) :: this
   type(tuple3_i4_t) :: t1, t2
   integer :: i
   integer :: x(3) = (/2, 2, 2/)
@@ -85,10 +115,11 @@ subroutine test_tuple3_i4
 end subroutine test_tuple3_i4
 
 @test
-subroutine test_tuple4_i4
+subroutine test_tuple4_i4(this)
   use pfunit
   use tuple    
   implicit none
+  class(test_tuple_case), intent(inout) :: this
   type(tuple4_i4_t) :: t1, t2
   integer :: i
   integer :: x(4) = (/2, 2, 2, 2/)
@@ -117,11 +148,12 @@ subroutine test_tuple4_i4
 end subroutine test_tuple4_i4
 
 @test
-subroutine test_tuple_r8
+subroutine test_tuple_r8(this)
   use pfunit
   use tuple
   use num_types
   implicit none
+  class(test_tuple_case), intent(inout) :: this
   type(tuple_r8_t) :: t1, t2
   integer :: i
   real(kind=dp) :: x(2) = (/2d0, 2d0/)
@@ -150,11 +182,12 @@ subroutine test_tuple_r8
 end subroutine test_tuple_r8
 
 @test
-subroutine test_tuple_i4r8
+subroutine test_tuple_i4r8(this)
   use pfunit
   use tuple
   use num_types
   implicit none
+  class(test_tuple_case), intent(inout) :: this
   type(tuple_i4r8_t) :: t1, t2
   integer :: i
   real(kind=dp) :: x(2) = (/2d0, 2d0/)
@@ -183,11 +216,12 @@ subroutine test_tuple_i4r8
 end subroutine test_tuple_i4r8
 
 @test
-subroutine test_tuple_2i4r8
+subroutine test_tuple_2i4r8(this)
   use pfunit
   use tuple
   use num_types
   implicit none
+  class(test_tuple_case), intent(inout) :: this
   type(tuple_2i4r8_t) :: t1, t2
   integer :: i
   real(kind=dp) :: x(3) = (/2d0, 2d0, 2d0/)
@@ -217,10 +251,11 @@ subroutine test_tuple_2i4r8
 end subroutine test_tuple_2i4r8
 
 @test
-subroutine test_tuple_mixed_type_inequality
+subroutine test_tuple_mixed_type_inequality(this)
   use pfunit
   use tuple
   implicit none
+  class(test_tuple_case), intent(inout) :: this
   type(tuple_i4_t) :: t2i4
   type(tuple3_i4_t) :: t3i4
   type(tuple4_i4_t) :: t4i4

--- a/tests/unit/uset/test_uset_i4.pf
+++ b/tests/unit/uset/test_uset_i4.pf
@@ -31,7 +31,6 @@ contains
 subroutine test_uset_init_i4(this)
   use pfunit
   use uset
-  implicit none
   class(test_uset_i4_case), intent(inout) :: this
   type(uset_i4_t) :: s
 
@@ -44,7 +43,6 @@ end subroutine test_uset_init_i4
 subroutine test_uset_free_i4(this)
   use pfunit
   use uset
-  implicit none
   class(test_uset_i4_case), intent(inout) :: this
   type(uset_i4_t) :: s
 
@@ -58,7 +56,6 @@ end subroutine test_uset_free_i4
 subroutine test_uset_size_i4(this)
   use pfunit
   use uset
-  implicit none
   class(test_uset_i4_case), intent(inout) :: this
   type(uset_i4_t) :: s
   integer :: i, data
@@ -89,7 +86,6 @@ end subroutine test_uset_size_i4
 subroutine test_uset_clear_i4(this)
   use pfunit
   use uset
-  implicit none
   class(test_uset_i4_case), intent(inout) :: this
   type(uset_i4_t) :: s
   integer :: i, data
@@ -114,7 +110,6 @@ end subroutine test_uset_clear_i4
 subroutine test_uset_element_i4(this)
   use pfunit
   use uset
-  implicit none
   class(test_uset_i4_case), intent(inout) :: this
   type(uset_i4_t) :: s
   integer :: i, data
@@ -151,7 +146,6 @@ end subroutine test_uset_element_i4
 subroutine test_uset_remove_i4(this)
   use pfunit
   use uset
-  implicit none
   class(test_uset_i4_case), intent(inout) :: this
   type(uset_i4_t) :: s
   integer :: i, data
@@ -201,7 +195,6 @@ end subroutine test_uset_remove_i4
 subroutine test_uset_iter_i4(this)
   use pfunit
   use uset
-  implicit none
   class(test_uset_i4_case), intent(inout) :: this
   type(uset_i4_t) :: s
   integer :: i, data, n_entries

--- a/tests/unit/uset/test_uset_i4.pf
+++ b/tests/unit/uset/test_uset_i4.pf
@@ -1,10 +1,38 @@
 module test_uset_i4
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_uset_i4_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_uset_i4_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_uset_i4_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_uset_i4_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_uset_init_i4
+subroutine test_uset_init_i4(this)
   use pfunit
   use uset
   implicit none
+  class(test_uset_i4_case), intent(inout) :: this
   type(uset_i4_t) :: s
 
   call s%init()
@@ -13,10 +41,11 @@ subroutine test_uset_init_i4
 end subroutine test_uset_init_i4
 
 @test
-subroutine test_uset_free_i4
+subroutine test_uset_free_i4(this)
   use pfunit
   use uset
   implicit none
+  class(test_uset_i4_case), intent(inout) :: this
   type(uset_i4_t) :: s
 
   call s%init()
@@ -26,10 +55,11 @@ subroutine test_uset_free_i4
 end subroutine test_uset_free_i4
 
 @test
-subroutine test_uset_size_i4
+subroutine test_uset_size_i4(this)
   use pfunit
   use uset
   implicit none
+  class(test_uset_i4_case), intent(inout) :: this
   type(uset_i4_t) :: s
   integer :: i, data
 
@@ -56,10 +86,11 @@ subroutine test_uset_size_i4
 end subroutine test_uset_size_i4
 
 @test
-subroutine test_uset_clear_i4
+subroutine test_uset_clear_i4(this)
   use pfunit
   use uset
   implicit none
+  class(test_uset_i4_case), intent(inout) :: this
   type(uset_i4_t) :: s
   integer :: i, data
 
@@ -80,10 +111,11 @@ subroutine test_uset_clear_i4
 end subroutine test_uset_clear_i4
 
 @test
-subroutine test_uset_element_i4
+subroutine test_uset_element_i4(this)
   use pfunit
   use uset
   implicit none
+  class(test_uset_i4_case), intent(inout) :: this
   type(uset_i4_t) :: s
   integer :: i, data
 
@@ -116,10 +148,11 @@ subroutine test_uset_element_i4
 end subroutine test_uset_element_i4
 
 @test
-subroutine test_uset_remove_i4
+subroutine test_uset_remove_i4(this)
   use pfunit
   use uset
   implicit none
+  class(test_uset_i4_case), intent(inout) :: this
   type(uset_i4_t) :: s
   integer :: i, data
 
@@ -165,10 +198,11 @@ subroutine test_uset_remove_i4
 end subroutine test_uset_remove_i4
 
 @test
-subroutine test_uset_iter_i4
+subroutine test_uset_iter_i4(this)
   use pfunit
   use uset
   implicit none
+  class(test_uset_i4_case), intent(inout) :: this
   type(uset_i4_t) :: s
   integer :: i, data, n_entries
 

--- a/tests/unit/uset/test_uset_i8.pf
+++ b/tests/unit/uset/test_uset_i8.pf
@@ -1,10 +1,38 @@
 module test_uset_i8
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_uset_i8_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_uset_i8_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_uset_i8_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_uset_i8_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_uset_init_i8
+subroutine test_uset_init_i8(this)
   use pfunit
   use uset
   implicit none
+  class(test_uset_i8_case), intent(inout) :: this
   type(uset_i8_t) :: s
 
   call s%init()
@@ -13,10 +41,11 @@ subroutine test_uset_init_i8
 end subroutine test_uset_init_i8
 
 @test
-subroutine test_uset_free_i8
+subroutine test_uset_free_i8(this)
   use pfunit
   use uset
   implicit none
+  class(test_uset_i8_case), intent(inout) :: this
   type(uset_i8_t) :: s
 
   call s%init()
@@ -26,11 +55,12 @@ subroutine test_uset_free_i8
 end subroutine test_uset_free_i8
 
 @test
-subroutine test_uset_size_i8
+subroutine test_uset_size_i8(this)
   use pfunit
   use uset
   use num_types, only : i8
   implicit none
+  class(test_uset_i8_case), intent(inout) :: this
   type(uset_i8_t) :: s
   integer :: i
   integer(kind=i8) :: data
@@ -58,11 +88,12 @@ subroutine test_uset_size_i8
 end subroutine test_uset_size_i8
 
 @test
-subroutine test_uset_clear_i8
+subroutine test_uset_clear_i8(this)
   use pfunit
   use uset
   use num_types, only : i8
   implicit none
+  class(test_uset_i8_case), intent(inout) :: this
   type(uset_i8_t) :: s
   integer :: i
   integer(kind=i8) :: data
@@ -84,11 +115,12 @@ subroutine test_uset_clear_i8
 end subroutine test_uset_clear_i8
 
 @test
-subroutine test_uset_element_i8
+subroutine test_uset_element_i8(this)
   use pfunit
   use uset
   use num_types, only : i8
   implicit none
+  class(test_uset_i8_case), intent(inout) :: this
   type(uset_i8_t) :: s
   integer :: i
   integer(kind=i8) :: data
@@ -122,11 +154,12 @@ subroutine test_uset_element_i8
 end subroutine test_uset_element_i8
 
 @test
-subroutine test_uset_remove_i8
+subroutine test_uset_remove_i8(this)
   use pfunit
   use uset
   use num_types, only : i8
   implicit none
+  class(test_uset_i8_case), intent(inout) :: this
   type(uset_i8_t) :: s
   integer :: i
   integer(kind=i8) :: data
@@ -172,11 +205,12 @@ subroutine test_uset_remove_i8
 end subroutine test_uset_remove_i8
 
 @test
-subroutine test_uset_iter_i8
+subroutine test_uset_iter_i8(this)
   use pfunit
   use uset
   use num_types, only : i8
   implicit none
+  class(test_uset_i8_case), intent(inout) :: this
   type(uset_i8_t) :: s
   integer :: i, n_entries
   integer(kind=i8) :: data

--- a/tests/unit/uset/test_uset_i8.pf
+++ b/tests/unit/uset/test_uset_i8.pf
@@ -31,7 +31,6 @@ contains
 subroutine test_uset_init_i8(this)
   use pfunit
   use uset
-  implicit none
   class(test_uset_i8_case), intent(inout) :: this
   type(uset_i8_t) :: s
 
@@ -44,7 +43,6 @@ end subroutine test_uset_init_i8
 subroutine test_uset_free_i8(this)
   use pfunit
   use uset
-  implicit none
   class(test_uset_i8_case), intent(inout) :: this
   type(uset_i8_t) :: s
 
@@ -59,7 +57,6 @@ subroutine test_uset_size_i8(this)
   use pfunit
   use uset
   use num_types, only : i8
-  implicit none
   class(test_uset_i8_case), intent(inout) :: this
   type(uset_i8_t) :: s
   integer :: i
@@ -92,7 +89,6 @@ subroutine test_uset_clear_i8(this)
   use pfunit
   use uset
   use num_types, only : i8
-  implicit none
   class(test_uset_i8_case), intent(inout) :: this
   type(uset_i8_t) :: s
   integer :: i
@@ -119,7 +115,6 @@ subroutine test_uset_element_i8(this)
   use pfunit
   use uset
   use num_types, only : i8
-  implicit none
   class(test_uset_i8_case), intent(inout) :: this
   type(uset_i8_t) :: s
   integer :: i
@@ -158,7 +153,6 @@ subroutine test_uset_remove_i8(this)
   use pfunit
   use uset
   use num_types, only : i8
-  implicit none
   class(test_uset_i8_case), intent(inout) :: this
   type(uset_i8_t) :: s
   integer :: i
@@ -209,7 +203,6 @@ subroutine test_uset_iter_i8(this)
   use pfunit
   use uset
   use num_types, only : i8
-  implicit none
   class(test_uset_i8_case), intent(inout) :: this
   type(uset_i8_t) :: s
   integer :: i, n_entries

--- a/tests/unit/uset/test_uset_r8.pf
+++ b/tests/unit/uset/test_uset_r8.pf
@@ -31,7 +31,6 @@ contains
 subroutine test_uset_init_r8(this)
   use pfunit
   use uset
-  implicit none
   class(test_uset_r8_case), intent(inout) :: this
   type(uset_r8_t) :: s
 
@@ -44,7 +43,6 @@ end subroutine test_uset_init_r8
 subroutine test_uset_free_r8(this)
   use pfunit
   use uset
-  implicit none
   class(test_uset_r8_case), intent(inout) :: this
   type(uset_r8_t) :: s
 
@@ -59,7 +57,6 @@ subroutine test_uset_size_r8(this)
   use pfunit
   use uset
   use num_types
-  implicit none
   class(test_uset_r8_case), intent(inout) :: this
   type(uset_r8_t) :: s
   integer :: i
@@ -92,7 +89,6 @@ subroutine test_uset_clear_r8(this)
   use pfunit
   use uset
   use num_types
-  implicit none
   class(test_uset_r8_case), intent(inout) :: this
   type(uset_r8_t) :: s
   integer :: i
@@ -119,7 +115,6 @@ subroutine test_uset_element_r8(this)
   use pfunit
   use uset
   use num_types
-  implicit none
   class(test_uset_r8_case), intent(inout) :: this
   type(uset_r8_t) :: s
   integer :: i
@@ -158,7 +153,6 @@ subroutine test_uset_remove_r8(this)
   use pfunit
   use uset
   use num_types
-  implicit none
   class(test_uset_r8_case), intent(inout) :: this
   type(uset_r8_t) :: s
   integer :: i
@@ -209,7 +203,6 @@ subroutine test_uset_iter_r8(this)
   use pfunit
   use uset
   use num_types
-  implicit none
   class(test_uset_r8_case), intent(inout) :: this
   type(uset_r8_t) :: s
   integer :: i, n_entries

--- a/tests/unit/uset/test_uset_r8.pf
+++ b/tests/unit/uset/test_uset_r8.pf
@@ -1,10 +1,38 @@
 module test_uset_r8
+  use pfunit
+  use device, only : device_init, device_finalize
+  use neko_config, only : NEKO_BCKND_DEVICE
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: test_uset_r8_case
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_uset_r8_case
+
 contains
+
+  subroutine setUp(this)
+    class(test_uset_r8_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_uset_r8_case), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
 @test
-subroutine test_uset_init_r8
+subroutine test_uset_init_r8(this)
   use pfunit
   use uset
   implicit none
+  class(test_uset_r8_case), intent(inout) :: this
   type(uset_r8_t) :: s
 
   call s%init()
@@ -13,10 +41,11 @@ subroutine test_uset_init_r8
 end subroutine test_uset_init_r8
 
 @test
-subroutine test_uset_free_r8
+subroutine test_uset_free_r8(this)
   use pfunit
   use uset
   implicit none
+  class(test_uset_r8_case), intent(inout) :: this
   type(uset_r8_t) :: s
 
   call s%init()
@@ -26,11 +55,12 @@ subroutine test_uset_free_r8
 end subroutine test_uset_free_r8
 
 @test
-subroutine test_uset_size_r8
+subroutine test_uset_size_r8(this)
   use pfunit
   use uset
   use num_types
   implicit none
+  class(test_uset_r8_case), intent(inout) :: this
   type(uset_r8_t) :: s
   integer :: i
   real(kind=dp) :: data
@@ -58,11 +88,12 @@ subroutine test_uset_size_r8
 end subroutine test_uset_size_r8
 
 @test
-subroutine test_uset_clear_r8
+subroutine test_uset_clear_r8(this)
   use pfunit
   use uset
   use num_types
   implicit none
+  class(test_uset_r8_case), intent(inout) :: this
   type(uset_r8_t) :: s
   integer :: i
   real(kind=dp) :: data
@@ -84,11 +115,12 @@ subroutine test_uset_clear_r8
 end subroutine test_uset_clear_r8
 
 @test
-subroutine test_uset_element_r8
+subroutine test_uset_element_r8(this)
   use pfunit
   use uset
   use num_types
   implicit none
+  class(test_uset_r8_case), intent(inout) :: this
   type(uset_r8_t) :: s
   integer :: i
   real(kind=dp) :: data
@@ -122,11 +154,12 @@ subroutine test_uset_element_r8
 end subroutine test_uset_element_r8
 
 @test
-subroutine test_uset_remove_r8
+subroutine test_uset_remove_r8(this)
   use pfunit
   use uset
   use num_types
   implicit none
+  class(test_uset_r8_case), intent(inout) :: this
   type(uset_r8_t) :: s
   integer :: i
   real(kind=dp) :: data
@@ -172,11 +205,12 @@ subroutine test_uset_remove_r8
 end subroutine test_uset_remove_r8
 
 @test
-subroutine test_uset_iter_r8
+subroutine test_uset_iter_r8(this)
   use pfunit
   use uset
   use num_types
   implicit none
+  class(test_uset_r8_case), intent(inout) :: this
   type(uset_r8_t) :: s
   integer :: i, n_entries
   real(kind=dp) :: data


### PR DESCRIPTION
- Adds the setUp and tearDown routine to all unit test.
- Adds call to the neko_mpi_type_free to the parallel test tearDown template.