### PR TITLE
Don't assume glb_cmd_queue is the same as the NULL stream

### DIFF
--- a/src/math/bcknd/device/cuda/ax_helm.cu
+++ b/src/math/bcknd/device/cuda/ax_helm.cu
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2024, The Neko Authors
+ Copyright (c) 2021-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -311,23 +311,28 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
 
-  cudaEventRecord(start,0);
+  /* Warmup */
+  for(int i = 0; i < 10; i++) {
+    CASE_1D(LX);
+  }
+
+  cudaEventRecord(start, stream);
 
   for(int i = 0; i < 100; i++) {
     CASE_1D(LX);
   }
 
-  cudaEventRecord(stop,0);
+  cudaEventRecord(stop, stream);
   cudaEventSynchronize(stop);
   cudaEventElapsedTime(&time1, start, stop);
 
-  cudaEventRecord(start,0);
+  cudaEventRecord(start, stream);
 
   for(int i = 0; i < 100; i++) {
      CASE_KSTEP(LX);
    }
 
-  cudaEventRecord(stop,0);
+  cudaEventRecord(stop, stream);
   cudaEventSynchronize(stop);
   cudaEventElapsedTime(&time2, start, stop);
 
@@ -389,23 +394,28 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
 
-  cudaEventRecord(start,0);
+  /* Warmup */
+  for(int i = 0; i < 10; i++) {
+    CASE_1D(LX);
+  }
+
+  cudaEventRecord(start, stream);
 
   for(int i = 0; i < 100; i++) {
     CASE_1D(LX);
   }
 
-  cudaEventRecord(stop, 0);
+  cudaEventRecord(stop, stream);
   cudaEventSynchronize(stop);
   cudaEventElapsedTime(&time1, start, stop);
 
-  cudaEventRecord(start, 0);
+  cudaEventRecord(start, stream);
 
   for(int i = 0; i < 100; i++) {
     CASE_KSTEP_PADDED(LX);
   }
 
-  cudaEventRecord(stop, 0);
+  cudaEventRecord(stop, stream);
   cudaEventSynchronize(stop);
   cudaEventElapsedTime(&time2, start, stop);
 

--- a/src/math/bcknd/device/cuda/opr_cdtp.cu
+++ b/src/math/bcknd/device/cuda/opr_cdtp.cu
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2023, The Neko Authors
+ Copyright (c) 2021-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -51,16 +51,16 @@ int tune_cdtp(void *dtx, void *x,
 
 extern "C" {
 
-  /** 
+  /**
    * Fortran wrapper for device cuda \f$ D^T X \f$
    */
   void cuda_cdtp(void *dtx, void *x,
                  void *dr, void *ds, void *dt,
                  void *dxt, void *dyt, void *dzt,
                  void *w3, int *nel, int *lx) {
-    
+
     static int autotune[17] = { 0 };
-    
+
     const dim3 nthrds_1d(1024, 1, 1);
     const dim3 nthrds_kstep((*lx), (*lx), 1);
     const dim3 nblcks((*nel), 1, 1);
@@ -102,7 +102,7 @@ extern "C" {
       break
 
 
-    if ((*lx) < 13) {      
+    if ((*lx) < 13) {
       switch(*lx) {
         CASE(2);
         CASE(3);
@@ -133,10 +133,10 @@ extern "C" {
           fprintf(stderr, __FILE__ ": size not supported: %d\n", *lx);
           exit(1);
         }
-      } 
+      }
     }
-  } 
-}    
+  }
+}
 
 template < const int LX >
 int tune_cdtp(void *dtx, void *x,
@@ -151,18 +151,18 @@ int tune_cdtp(void *dtx, void *x,
   const dim3 nthrds_kstep((*lx), (*lx), 1);
   const dim3 nblcks((*nel), 1, 1);
   const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
-  
+
   char *env_value = NULL;
   char neko_log_buf[80];
-  
+
   env_value=getenv("NEKO_AUTOTUNE");
 
   sprintf(neko_log_buf, "Autotune cdtp (lx: %d)", *lx);
   log_section(neko_log_buf);
-  
+
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      CASE_1D(LX);       
+      CASE_1D(LX);
       sprintf(neko_log_buf,"Set by env : 1 (1D)");
       log_message(neko_log_buf);
       log_end_section();
@@ -173,7 +173,7 @@ int tune_cdtp(void *dtx, void *x,
       log_message(neko_log_buf);
       log_end_section();
       return 2;
-    } else {       
+    } else {
        sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
        log_error(neko_log_buf);
     }
@@ -181,27 +181,32 @@ int tune_cdtp(void *dtx, void *x,
 
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
-  
-  cudaEventRecord(start,0);
-   
+
+  /* Warmup */
+  for(int i = 0; i < 10; i++) {
+    CASE_1D(LX);
+  }
+
+  cudaEventRecord(start, stream);
+
   for(int i = 0; i < 100; i++) {
     CASE_1D(LX);
   }
-  
-  cudaEventRecord(stop,0); 
+
+  cudaEventRecord(stop, stream);
   cudaEventSynchronize(stop);
   cudaEventElapsedTime(&time1, start, stop);
-  
-  cudaEventRecord(start,0);
-   
+
+  cudaEventRecord(start, stream);
+
   for(int i = 0; i < 100; i++) {
      CASE_KSTEP(LX);
    }
-  
-  cudaEventRecord(stop,0); 
+
+  cudaEventRecord(stop, stream);
   cudaEventSynchronize(stop);
   cudaEventElapsedTime(&time2, start, stop);
-  
+
   if(time1 < time2) {
      retval = 1;
   } else {

--- a/src/math/bcknd/device/cuda/opr_conv1.cu
+++ b/src/math/bcknd/device/cuda/opr_conv1.cu
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2023, The Neko Authors
+ Copyright (c) 2021-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -54,7 +54,7 @@ int tune_conv1(void *du, void *u,
 
 extern "C" {
 
-  /** 
+  /**
    * Fortran wrapper for device cuda convective terms
    */
   void cuda_conv1(void *du, void *u,
@@ -64,13 +64,13 @@ extern "C" {
                   void *drdy, void *dsdy, void *dtdy,
                   void *drdz, void *dsdz, void *dtdz,
                   void *jacinv, int *nel, int *gdim, int *lx) {
-    
+
     static int autotune[17] = { 0 };
-    
+
     const dim3 nthrds_1d(1024, 1, 1);
     const dim3 nthrds_kstep((*lx), (*lx), 1);
     const dim3 nblcks((*nel), 1, 1);
-    const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;      
+    const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
 #define CASE_1D(LX)                                                             \
     conv1_kernel_1d<real, LX, 1024>                                             \
@@ -83,7 +83,7 @@ extern "C" {
        (real *) drdz, (real *) dsdz, (real *) dtdz,                             \
        (real *) jacinv);                                                        \
     CUDA_CHECK(cudaGetLastError());
-    
+
 #define CASE_KSTEP(LX)                                                          \
     conv1_kernel_kstep<real, LX>                                                \
       <<<nblcks, nthrds_kstep, 0, stream>>>                                     \
@@ -94,7 +94,7 @@ extern "C" {
        (real *) drdy, (real *) dsdy, (real *) dtdy,                             \
        (real *) drdz, (real *) dsdz, (real *) dtdz,                             \
        (real *) jacinv);                                                        \
-    CUDA_CHECK(cudaGetLastError());                                           
+    CUDA_CHECK(cudaGetLastError());
 
 #define CASE(LX)                                                                \
     case LX:                                                                    \
@@ -119,7 +119,7 @@ extern "C" {
       break
 
 
-    if ((*lx) < 11) {      
+    if ((*lx) < 11) {
       switch(*lx) {
         CASE(2);
         CASE(3);
@@ -150,9 +150,9 @@ extern "C" {
           fprintf(stderr, __FILE__ ": size not supported: %d\n", *lx);
           exit(1);
         }
-      } 
+      }
     }
-  } 
+  }
 }
 
 template < const int LX >
@@ -171,18 +171,18 @@ int tune_conv1(void *du, void *u,
   const dim3 nthrds_kstep((*lx), (*lx), 1);
   const dim3 nblcks((*nel), 1, 1);
   const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
-  
+
   char *env_value = NULL;
   char neko_log_buf[80];
-  
+
   env_value=getenv("NEKO_AUTOTUNE");
 
   sprintf(neko_log_buf, "Autotune conv1 (lx: %d)", *lx);
   log_section(neko_log_buf);
-  
+
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      CASE_1D(LX);       
+      CASE_1D(LX);
       sprintf(neko_log_buf,"Set by env : 1 (1D)");
       log_message(neko_log_buf);
       log_end_section();
@@ -193,7 +193,7 @@ int tune_conv1(void *du, void *u,
       log_message(neko_log_buf);
       log_end_section();
       return 2;
-    } else {       
+    } else {
        sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
        log_error(neko_log_buf);
     }
@@ -201,27 +201,32 @@ int tune_conv1(void *du, void *u,
 
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
-  
-  cudaEventRecord(start,0);
-   
+
+  /* Warmup */
+  for(int i = 0; i < 10; i++) {
+    CASE_1D(LX);
+  }
+
+  cudaEventRecord(start, stream);
+
   for(int i = 0; i < 100; i++) {
     CASE_1D(LX);
   }
-  
-  cudaEventRecord(stop,0); 
+
+  cudaEventRecord(stop, stream);
   cudaEventSynchronize(stop);
   cudaEventElapsedTime(&time1, start, stop);
-  
-  cudaEventRecord(start,0);
-   
+
+  cudaEventRecord(start, stream);
+
   for(int i = 0; i < 100; i++) {
      CASE_KSTEP(LX);
    }
-  
-  cudaEventRecord(stop,0); 
+
+  cudaEventRecord(stop, stream);
   cudaEventSynchronize(stop);
   cudaEventElapsedTime(&time2, start, stop);
-  
+
   if(time1 < time2) {
      retval = 1;
   } else {

--- a/src/math/bcknd/device/cuda/opr_dudxyz.cu
+++ b/src/math/bcknd/device/cuda/opr_dudxyz.cu
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2022, The Neko Authors
+ Copyright (c) 2021-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -51,36 +51,36 @@ int tune_dudxyz(void *du, void *u,
 
 extern "C" {
 
-  /** 
+  /**
    * Fortran wrapper for device cuda derivative kernels
    */
   void cuda_dudxyz(void *du, void *u,
                   void *dr, void *ds, void *dt,
                   void *dx, void *dy, void *dz,
                   void *jacinv, int *nel, int *lx) {
-    
+
     static int autotune[16] = { 0 };
-    
+
     const dim3 nthrds_1d(1024, 1, 1);
     const dim3 nthrds_kstep((*lx), (*lx), 1);
     const dim3 nblcks((*nel), 1, 1);
     const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
-          
+
 #define CASE_1D(LX)                                                             \
     dudxyz_kernel_1d<real, LX, 1024>                                            \
       <<<nblcks, nthrds_1d, 0, stream>>>((real *) du, (real *) u,               \
                               (real *) dr, (real *) ds, (real *) dt,            \
                               (real *) dx, (real *) dy, (real *) dz,            \
                               (real *) jacinv);                                 \
-    CUDA_CHECK(cudaGetLastError());                                           
-    
+    CUDA_CHECK(cudaGetLastError());
+
 #define CASE_KSTEP(LX)                                                          \
     dudxyz_kernel_kstep<real, LX>                                               \
       <<<nblcks, nthrds_kstep, 0, stream>>>((real *) du, (real *) u,            \
                                 (real *) dr, (real *) ds, (real *) dt,          \
                                 (real *) dx, (real *) dy, (real *) dz,          \
                                 (real *) jacinv);                               \
-      CUDA_CHECK(cudaGetLastError());                                           
+      CUDA_CHECK(cudaGetLastError());
 
  #define CASE(LX)                                                               \
     case LX:                                                                    \
@@ -102,7 +102,7 @@ extern "C" {
       break
 
 
-    if ((*lx) < 11) {      
+    if ((*lx) < 11) {
       switch(*lx) {
         CASE(2);
         CASE(3);
@@ -133,7 +133,7 @@ extern "C" {
           fprintf(stderr, __FILE__ ": size not supported: %d\n", *lx);
           exit(1);
         }
-      } 
+      }
     }
   }
 }
@@ -151,18 +151,18 @@ int tune_dudxyz(void *du, void *u,
   const dim3 nthrds_kstep((*lx), (*lx), 1);
   const dim3 nblcks((*nel), 1, 1);
   const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
-  
+
   char *env_value = NULL;
   char neko_log_buf[80];
-  
+
   env_value=getenv("NEKO_AUTOTUNE");
 
   sprintf(neko_log_buf, "Autotune dudxyz (lx: %d)", *lx);
   log_section(neko_log_buf);
-  
+
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      CASE_1D(LX);       
+      CASE_1D(LX);
       sprintf(neko_log_buf,"Set by env : 1 (1D)");
       log_message(neko_log_buf);
       log_end_section();
@@ -173,7 +173,7 @@ int tune_dudxyz(void *du, void *u,
       log_message(neko_log_buf);
       log_end_section();
       return 2;
-    } else {       
+    } else {
        sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
        log_error(neko_log_buf);
     }
@@ -181,27 +181,32 @@ int tune_dudxyz(void *du, void *u,
 
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
-  
-  cudaEventRecord(start,0);
-   
+
+  /* Warmup */
+  for(int i = 0; i < 10; i++) {
+    CASE_1D(LX);
+  }
+
+  cudaEventRecord(start, stream);
+
   for(int i = 0; i < 100; i++) {
     CASE_1D(LX);
   }
-  
-  cudaEventRecord(stop,0); 
+
+  cudaEventRecord(stop, stream);
   cudaEventSynchronize(stop);
   cudaEventElapsedTime(&time1, start, stop);
-  
-  cudaEventRecord(start,0);
-   
+
+  cudaEventRecord(start, stream);
+
   for(int i = 0; i < 100; i++) {
      CASE_KSTEP(LX);
    }
-  
-  cudaEventRecord(stop,0); 
+
+  cudaEventRecord(stop, stream);
   cudaEventSynchronize(stop);
   cudaEventElapsedTime(&time2, start, stop);
-  
+
   if(time1 < time2) {
      retval = 1;
   } else {

--- a/src/math/bcknd/device/cuda/opr_opgrad.cu
+++ b/src/math/bcknd/device/cuda/opr_opgrad.cu
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2023, The Neko Authors
+ Copyright (c) 2021-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -53,7 +53,7 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
 
 extern "C" {
 
-  /** 
+  /**
    * Fortran wrapper for device cuda convective terms
    */
   void cuda_opgrad(void *ux, void *uy, void *uz, void *u,
@@ -64,11 +64,11 @@ extern "C" {
                    void *w3, int *nel, int *lx) {
 
     static int autotune[17] = { 0 };
-    
+
     const dim3 nthrds_1d(1024, 1, 1);
     const dim3 nthrds_kstep((*lx), (*lx), 1);
     const dim3 nblcks((*nel), 1, 1);
-    const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;      
+    const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
 #define CASE_1D(LX)                                                             \
     opgrad_kernel_1d<real, LX, 1024>                                            \
@@ -79,7 +79,7 @@ extern "C" {
        (real *) drdy, (real *) dsdy, (real *) dtdy,                             \
        (real *) drdz, (real *) dsdz, (real *) dtdz,                             \
        (real *) w3);                                                            \
-    CUDA_CHECK(cudaGetLastError());                                             
+    CUDA_CHECK(cudaGetLastError());
 
 
 #define CASE_KSTEP(LX)                                                          \
@@ -90,7 +90,7 @@ extern "C" {
        (real *) drdy, (real *) dsdy, (real *) dtdy,                             \
        (real *) drdz, (real *) dsdz, (real *) dtdz,                             \
        (real *) w3);                                                            \
-    CUDA_CHECK(cudaGetLastError());                                             
+    CUDA_CHECK(cudaGetLastError());
 
 #define CASE(LX)                                                                \
     case LX:                                                                    \
@@ -107,7 +107,7 @@ extern "C" {
         CASE_KSTEP(LX);                                                         \
       }                                                                         \
       break
-    
+
     switch(*lx) {
       CASE(2);
       CASE(3);
@@ -130,7 +130,7 @@ extern "C" {
         exit(1);
       }
     }
-  } 
+  }
 }
 
 template < const int LX >
@@ -148,18 +148,18 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
   const dim3 nthrds_kstep((*lx), (*lx), 1);
   const dim3 nblcks((*nel), 1, 1);
   const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
-  
+
   char *env_value = NULL;
   char neko_log_buf[80];
-  
+
   env_value=getenv("NEKO_AUTOTUNE");
 
   sprintf(neko_log_buf, "Autotune opgrad (lx: %d)", *lx);
   log_section(neko_log_buf);
-  
+
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      CASE_1D(LX);       
+      CASE_1D(LX);
       sprintf(neko_log_buf,"Set by env : 1 (1D)");
       log_message(neko_log_buf);
       log_end_section();
@@ -170,7 +170,7 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
       log_message(neko_log_buf);
       log_end_section();
       return 2;
-    } else {       
+    } else {
        sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
        log_error(neko_log_buf);
     }
@@ -178,27 +178,32 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
 
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
-  
-  cudaEventRecord(start,0);
-   
+
+  /* Warmup */
+  for(int i = 0; i < 10; i++) {
+    CASE_1D(LX);
+  }
+
+  cudaEventRecord(start, stream);
+
   for(int i = 0; i < 100; i++) {
     CASE_1D(LX);
   }
-  
-  cudaEventRecord(stop,0); 
+
+  cudaEventRecord(stop, stream);
   cudaEventSynchronize(stop);
   cudaEventElapsedTime(&time1, start, stop);
-  
-  cudaEventRecord(start,0);
-   
+
+  cudaEventRecord(start, stream);
+
   for(int i = 0; i < 100; i++) {
      CASE_KSTEP(LX);
    }
-  
-  cudaEventRecord(stop,0); 
+
+  cudaEventRecord(stop, stream);
   cudaEventSynchronize(stop);
   cudaEventElapsedTime(&time2, start, stop);
-  
+
   if(time1 < time2) {
      retval = 1;
   } else {
@@ -211,4 +216,3 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
   log_end_section();
   return retval;
 }
-

--- a/src/math/bcknd/device/hip/ax_helm.hip
+++ b/src/math/bcknd/device/hip/ax_helm.hip
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2025, The Neko Authors
+ Copyright (c) 2021-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -285,6 +285,7 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
   const dim3 nblcks_1d((*nelv), 1, 1);
   const dim3 nthrds_kstep((*lx), (*lx), 1);
   const dim3 nblcks_kstep((*nelv), 1, 1);
+  const hipStream_t stream = (hipStream_t) glb_cmd_queue;
 
   char *env_value = NULL;
   char neko_log_buf[80];
@@ -316,23 +317,28 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
   HIP_CHECK(hipEventCreate(&start));
   HIP_CHECK(hipEventCreate(&stop));
 
-  HIP_CHECK(hipEventRecord(start,0));
+  /* Warmup */
+  for(int i = 0; i < 10; i++) {
+    CASE_1D(LX);
+  }
+
+  HIP_CHECK(hipEventRecord(start, stream));
 
   for(int i = 0; i < 100; i++) {
     CASE_1D(LX);
   }
 
-  HIP_CHECK(hipEventRecord(stop,0));
+  HIP_CHECK(hipEventRecord(stop, stream));
   HIP_CHECK(hipEventSynchronize(stop));
   HIP_CHECK(hipEventElapsedTime(&time1, start, stop));
 
-  HIP_CHECK(hipEventRecord(start,0));
+  HIP_CHECK(hipEventRecord(start, stream));
 
   for(int i = 0; i < 100; i++) {
      CASE_KSTEP(LX);
    }
 
-  HIP_CHECK(hipEventRecord(stop,0));
+  HIP_CHECK(hipEventRecord(stop, stream));
   HIP_CHECK(hipEventSynchronize(stop));
   HIP_CHECK(hipEventElapsedTime(&time2, start, stop));
 
@@ -362,6 +368,7 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
   const dim3 nblcks_1d((*nelv), 1, 1);
   const dim3 nthrds_kstep((*lx), (*lx), 1);
   const dim3 nblcks_kstep((*nelv), 1, 1);
+  const hipStream_t stream = (hipStream_t) glb_cmd_queue;
 
   char *env_value = NULL;
   char neko_log_buf[80];
@@ -393,23 +400,28 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
   HIP_CHECK(hipEventCreate(&start));
   HIP_CHECK(hipEventCreate(&stop));
 
-  HIP_CHECK(hipEventRecord(start,0));
+  /* Warmup */
+  for(int i = 0; i < 10; i++) {
+    CASE_1D(LX);
+  }
+
+  HIP_CHECK(hipEventRecord(start, stream));
 
   for(int i = 0; i < 100; i++) {
     CASE_1D(LX);
   }
 
-  HIP_CHECK(hipEventRecord(stop, 0));
+  HIP_CHECK(hipEventRecord(stop, stream));
   HIP_CHECK(hipEventSynchronize(stop));
   HIP_CHECK(hipEventElapsedTime(&time1, start, stop));
 
-  HIP_CHECK(hipEventRecord(start, 0));
+  HIP_CHECK(hipEventRecord(start, stream));
 
   for(int i = 0; i < 100; i++) {
     CASE_KSTEP_PADDED(LX);
   }
 
-  HIP_CHECK(hipEventRecord(stop, 0));
+  HIP_CHECK(hipEventRecord(stop, stream));
   HIP_CHECK(hipEventSynchronize(stop));
   HIP_CHECK(hipEventElapsedTime(&time2, start, stop));
 

--- a/src/math/bcknd/device/hip/opr_cdtp.hip
+++ b/src/math/bcknd/device/hip/opr_cdtp.hip
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2023, The Neko Authors
+ Copyright (c) 2021-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -52,16 +52,16 @@ int tune_cdtp(void *dtx, void *x,
 
 extern "C" {
 
-  /** 
+  /**
    * Fortran wrapper for device hip \f$ D^T X \f$
    */
   void hip_cdtp(void *dtx, void *x,
                 void *dr, void *ds, void *dt,
                 void *dxt, void *dyt, void *dzt,
                 void *w3, int *nel, int *lx) {
-    
+
     static int autotune[17] = { 0 };
-    
+
     const dim3 nthrds_1d(1024, 1, 1);
     const dim3 nthrds_kstep((*lx), (*lx), 1);
     const dim3 nblcks((*nel), 1, 1);
@@ -104,7 +104,7 @@ extern "C" {
       break
 
 
-    if ((*lx) < 13) {      
+    if ((*lx) < 13) {
       switch(*lx) {
         CASE(2);
         CASE(3);
@@ -135,10 +135,10 @@ extern "C" {
           fprintf(stderr, __FILE__ ": size not supported: %d\n", *lx);
           exit(1);
         }
-      } 
+      }
     }
-  } 
-}    
+  }
+}
 
 template < const int LX >
 int tune_cdtp(void *dtx, void *x,
@@ -152,18 +152,19 @@ int tune_cdtp(void *dtx, void *x,
   const dim3 nthrds_1d(1024, 1, 1);
   const dim3 nthrds_kstep((*lx), (*lx), 1);
   const dim3 nblcks((*nel), 1, 1);
-  
+  const hipStream_t stream = (hipStream_t) glb_cmd_queue;
+
   char *env_value = NULL;
   char neko_log_buf[80];
-  
+
   env_value=getenv("NEKO_AUTOTUNE");
 
   sprintf(neko_log_buf, "Autotune cdtp (lx: %d)", *lx);
   log_section(neko_log_buf);
-  
+
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      CASE_1D(LX);       
+      CASE_1D(LX);
       sprintf(neko_log_buf,"Set by env : 1 (1D)");
       log_message(neko_log_buf);
       log_end_section();
@@ -174,7 +175,7 @@ int tune_cdtp(void *dtx, void *x,
       log_message(neko_log_buf);
       log_end_section();
       return 2;
-    } else {       
+    } else {
        sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
        log_error(neko_log_buf);
     }
@@ -182,27 +183,32 @@ int tune_cdtp(void *dtx, void *x,
 
   HIP_CHECK(hipEventCreate(&start));
   HIP_CHECK(hipEventCreate(&stop));
-  
-  HIP_CHECK(hipEventRecord(start,0));
-   
+
+  /* Stream */
+  for(int i = 0; i < 10; i++) {
+    CASE_1D(LX);
+  }
+
+  HIP_CHECK(hipEventRecord(start, stream));
+
   for(int i = 0; i < 100; i++) {
     CASE_1D(LX);
   }
-  
-  HIP_CHECK(hipEventRecord(stop,0)); 
+
+  HIP_CHECK(hipEventRecord(stop, stream));
   HIP_CHECK(hipEventSynchronize(stop));
   HIP_CHECK(hipEventElapsedTime(&time1, start, stop));
-  
-  HIP_CHECK(hipEventRecord(start,0));
-   
+
+  HIP_CHECK(hipEventRecord(start, stream));
+
   for(int i = 0; i < 100; i++) {
      CASE_KSTEP(LX);
    }
-  
-  HIP_CHECK(hipEventRecord(stop,0)); 
+
+  HIP_CHECK(hipEventRecord(stop, stream));
   HIP_CHECK(hipEventSynchronize(stop));
   HIP_CHECK(hipEventElapsedTime(&time2, start, stop));
-  
+
   if(time1 < time2) {
      retval = 1;
   } else {

--- a/src/math/bcknd/device/hip/opr_conv1.hip
+++ b/src/math/bcknd/device/hip/opr_conv1.hip
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2023, The Neko Authors
+ Copyright (c) 2021-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -55,7 +55,7 @@ int tune_conv1(void *du, void *u,
 
 extern "C" {
 
-  /** 
+  /**
    * Fortran wrapper for device hip convective terms
    */
   void hip_conv1(void *du, void *u,
@@ -65,9 +65,9 @@ extern "C" {
                  void *drdy, void *dsdy, void *dtdy,
                  void *drdz, void *dsdz, void *dtdz,
                  void *jacinv, int *nel, int *gdim, int *lx) {
-    
+
     static int autotune[17] = { 0 };
-    
+
     const dim3 nthrds_1d(1024, 1, 1);
     const dim3 nthrds_kstep((*lx), (*lx), 1);
     const dim3 nblcks((*nel), 1, 1);
@@ -83,7 +83,7 @@ extern "C" {
                         (real *) drdz, (real *) dsdz, (real *) dtdz,            \
                         (real *) jacinv);                                       \
     HIP_CHECK(hipGetLastError());
-    
+
 #define CASE_KSTEP(LX)                                                          \
     hipLaunchKernelGGL( HIP_KERNEL_NAME(conv1_kernel_kstep<real, LX> ),         \
                         nblcks, nthrds_kstep, 0, (hipStream_t) glb_cmd_queue,   \
@@ -94,7 +94,7 @@ extern "C" {
                         (real *) drdy, (real *) dsdy, (real *) dtdy,            \
                         (real *) drdz, (real *) dsdz, (real *) dtdz,            \
                         (real *) jacinv);                                       \
-    HIP_CHECK(hipGetLastError());                                           
+    HIP_CHECK(hipGetLastError());
 
 #define CASE(LX)                                                                \
     case LX:                                                                    \
@@ -119,7 +119,7 @@ extern "C" {
       break
 
 
-    if ((*lx) < 11) {      
+    if ((*lx) < 11) {
       switch(*lx) {
         CASE(2);
         CASE(3);
@@ -150,9 +150,9 @@ extern "C" {
           fprintf(stderr, __FILE__ ": size not supported: %d\n", *lx);
           exit(1);
         }
-      } 
+      }
     }
-  } 
+  }
 }
 
 template < const int LX >
@@ -170,18 +170,19 @@ int tune_conv1(void *du, void *u,
   const dim3 nthrds_1d(1024, 1, 1);
   const dim3 nthrds_kstep((*lx), (*lx), 1);
   const dim3 nblcks((*nel), 1, 1);
-  
+  const hipStream_t stream = (hipStream_t) glb_cmd_queue;
+
   char *env_value = NULL;
   char neko_log_buf[80];
-  
+
   env_value=getenv("NEKO_AUTOTUNE");
 
   sprintf(neko_log_buf, "Autotune conv1 (lx: %d)", *lx);
   log_section(neko_log_buf);
-  
+
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      CASE_1D(LX);       
+      CASE_1D(LX);
       sprintf(neko_log_buf,"Set by env : 1 (1D)");
       log_message(neko_log_buf);
       log_end_section();
@@ -192,7 +193,7 @@ int tune_conv1(void *du, void *u,
       log_message(neko_log_buf);
       log_end_section();
       return 2;
-    } else {       
+    } else {
        sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
        log_error(neko_log_buf);
     }
@@ -200,27 +201,32 @@ int tune_conv1(void *du, void *u,
 
   HIP_CHECK(hipEventCreate(&start));
   HIP_CHECK(hipEventCreate(&stop));
-  
-  HIP_CHECK(hipEventRecord(start,0));
-   
+
+  /* Warmup */
   for(int i = 0; i < 100; i++) {
     CASE_1D(LX);
   }
-  
-  HIP_CHECK(hipEventRecord(stop,0)); 
+
+  HIP_CHECK(hipEventRecord(start, stream));
+
+  for(int i = 0; i < 100; i++) {
+    CASE_1D(LX);
+  }
+
+  HIP_CHECK(hipEventRecord(stop, stream));
   HIP_CHECK(hipEventSynchronize(stop));
   HIP_CHECK(hipEventElapsedTime(&time1, start, stop));
-  
-  HIP_CHECK(hipEventRecord(start,0));
-   
+
+  HIP_CHECK(hipEventRecord(start, stream));
+
   for(int i = 0; i < 100; i++) {
      CASE_KSTEP(LX);
    }
-  
-  HIP_CHECK(hipEventRecord(stop,0)); 
+
+  HIP_CHECK(hipEventRecord(stop, stream));
   HIP_CHECK(hipEventSynchronize(stop));
   HIP_CHECK(hipEventElapsedTime(&time2, start, stop));
-  
+
   if(time1 < time2) {
      retval = 1;
   } else {

--- a/src/math/bcknd/device/hip/opr_dudxyz.hip
+++ b/src/math/bcknd/device/hip/opr_dudxyz.hip
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2022, The Neko Authors
+ Copyright (c) 2021-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -52,20 +52,20 @@ int tune_dudxyz(void *du, void *u,
 
 extern "C" {
 
-  /** 
+  /**
    * Fortran wrapper for device hip derivative kernels
    */
   void hip_dudxyz(void *du, void *u,
                   void *dr, void *ds, void *dt,
                   void *dx, void *dy, void *dz,
                   void *jacinv, int *nel, int *lx) {
-    
+
     static int autotune[16] = { 0 };
-    
+
     const dim3 nthrds_1d(1024, 1, 1);
     const dim3 nthrds_kstep((*lx), (*lx), 1);
     const dim3 nblcks((*nel), 1, 1);
-    
+
 #define CASE_1D(LX)                                                             \
     hipLaunchKernelGGL( HIP_KERNEL_NAME(dudxyz_kernel_1d<real, LX, 1024> ),     \
                         nblcks, nthrds_1d, 0, (hipStream_t) glb_cmd_queue,      \
@@ -73,8 +73,8 @@ extern "C" {
                         (real *) dr, (real *) ds, (real *) dt,                  \
                         (real *) dx, (real *) dy, (real *) dz,                  \
                         (real *) jacinv);                                       \
-    HIP_CHECK(hipGetLastError());                                           
-    
+    HIP_CHECK(hipGetLastError());
+
 #define CASE_KSTEP(LX)                                                          \
     hipLaunchKernelGGL( HIP_KERNEL_NAME(dudxyz_kernel_kstep<real, LX> ),        \
                         nblcks, nthrds_kstep, 0, (hipStream_t) glb_cmd_queue,   \
@@ -82,7 +82,7 @@ extern "C" {
                         (real *) dr, (real *) ds, (real *) dt,                  \
                         (real *) dx, (real *) dy, (real *) dz,                  \
                         (real *) jacinv);                                       \
-    HIP_CHECK(hipGetLastError());                                           
+    HIP_CHECK(hipGetLastError());
 
  #define CASE(LX)                                                               \
     case LX:                                                                    \
@@ -104,7 +104,7 @@ extern "C" {
       break
 
 
-    if ((*lx) < 11) {      
+    if ((*lx) < 11) {
       switch(*lx) {
         CASE(2);
         CASE(3);
@@ -135,7 +135,7 @@ extern "C" {
           fprintf(stderr, __FILE__ ": size not supported: %d\n", *lx);
           exit(1);
         }
-      } 
+      }
     }
   }
 }
@@ -152,18 +152,19 @@ int tune_dudxyz(void *du, void *u,
   const dim3 nthrds_1d(1024, 1, 1);
   const dim3 nthrds_kstep((*lx), (*lx), 1);
   const dim3 nblcks((*nel), 1, 1);
-  
+  const hipStream_t stream = (hipStream_t) glb_cmd_queue;
+
   char *env_value = NULL;
   char neko_log_buf[80];
-  
+
   env_value=getenv("NEKO_AUTOTUNE");
 
   sprintf(neko_log_buf, "Autotune dudxyz (lx: %d)", *lx);
   log_section(neko_log_buf);
-  
+
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      CASE_1D(LX);       
+      CASE_1D(LX);
       sprintf(neko_log_buf,"Set by env : 1 (1D)");
       log_message(neko_log_buf);
       log_end_section();
@@ -174,7 +175,7 @@ int tune_dudxyz(void *du, void *u,
       log_message(neko_log_buf);
       log_end_section();
       return 2;
-    } else {       
+    } else {
        sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
        log_error(neko_log_buf);
     }
@@ -182,27 +183,32 @@ int tune_dudxyz(void *du, void *u,
 
   HIP_CHECK(hipEventCreate(&start));
   HIP_CHECK(hipEventCreate(&stop));
-  
-  HIP_CHECK(hipEventRecord(start,0));
-   
+
+  /* Warmup */
+  for(int i = 0; i < 10; i++) {
+    CASE_1D(LX);
+  }
+
+  HIP_CHECK(hipEventRecord(start, stream));
+
   for(int i = 0; i < 100; i++) {
     CASE_1D(LX);
   }
-  
-  HIP_CHECK(hipEventRecord(stop,0)); 
+
+  HIP_CHECK(hipEventRecord(stop, stream));
   HIP_CHECK(hipEventSynchronize(stop));
   HIP_CHECK(hipEventElapsedTime(&time1, start, stop));
-  
-  HIP_CHECK(hipEventRecord(start,0));
-   
+
+  HIP_CHECK(hipEventRecord(start, stream));
+
   for(int i = 0; i < 100; i++) {
      CASE_KSTEP(LX);
    }
-  
-  HIP_CHECK(hipEventRecord(stop,0)); 
+
+  HIP_CHECK(hipEventRecord(stop, stream));
   HIP_CHECK(hipEventSynchronize(stop));
   HIP_CHECK(hipEventElapsedTime(&time2, start, stop));
-  
+
   if(time1 < time2) {
      retval = 1;
   } else {

--- a/src/math/bcknd/device/hip/opr_opgrad.hip
+++ b/src/math/bcknd/device/hip/opr_opgrad.hip
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2022, The Neko Authors
+ Copyright (c) 2021-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -54,7 +54,7 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
 
 extern "C" {
 
-  /** 
+  /**
    * Fortran wrapper for device hip convective terms
    */
   void hip_opgrad(void *ux, void *uy, void *uz, void *u,
@@ -65,7 +65,7 @@ extern "C" {
                    void *w3, int *nel, int *lx) {
 
     static int autotune[19] = { 0 };
-    
+
     const dim3 nthrds_1d(1024, 1, 1);
     const dim3 nthrds_kstep((*lx), (*lx), 1);
     const dim3 nblcks((*nel), 1, 1);
@@ -79,7 +79,7 @@ extern "C" {
                         (real *) drdy, (real *) dsdy, (real *) dtdy,            \
                         (real *) drdz, (real *) dsdz, (real *) dtdz,            \
                         (real *) w3);                                           \
-    HIP_CHECK(hipGetLastError());                                             
+    HIP_CHECK(hipGetLastError());
 
 
 #define CASE_KSTEP(LX)                                                          \
@@ -91,7 +91,7 @@ extern "C" {
                         (real *) drdy, (real *) dsdy, (real *) dtdy,            \
                         (real *) drdz, (real *) dsdz, (real *) dtdz,            \
                         (real *) w3);                                           \
-    HIP_CHECK(hipGetLastError());                                             
+    HIP_CHECK(hipGetLastError());
 
 #define CASE(LX)                                                                \
     case LX:                                                                    \
@@ -108,7 +108,7 @@ extern "C" {
         CASE_KSTEP(LX);                                                         \
       }                                                                         \
       break
-    
+
     switch(*lx) {
       CASE(2);
       CASE(3);
@@ -133,7 +133,7 @@ extern "C" {
         exit(1);
       }
     }
-  } 
+  }
 }
 
 template < const int LX >
@@ -150,18 +150,19 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
   const dim3 nthrds_1d(1024, 1, 1);
   const dim3 nthrds_kstep((*lx), (*lx), 1);
   const dim3 nblcks((*nel), 1, 1);
-  
+  const hipStream_t stream = (hipStream_t) glb_cmd_queue;
+
   char *env_value = NULL;
   char neko_log_buf[80];
-  
+
   env_value=getenv("NEKO_AUTOTUNE");
 
   sprintf(neko_log_buf, "Autotune opgrad (lx: %d)", *lx);
   log_section(neko_log_buf);
-  
+
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      CASE_1D(LX);       
+      CASE_1D(LX);
       sprintf(neko_log_buf,"Set by env : 1 (1D)");
       log_message(neko_log_buf);
       log_end_section();
@@ -172,7 +173,7 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
       log_message(neko_log_buf);
       log_end_section();
       return 2;
-    } else {       
+    } else {
        sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
        log_error(neko_log_buf);
     }
@@ -180,27 +181,32 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
 
   HIP_CHECK(hipEventCreate(&start));
   HIP_CHECK(hipEventCreate(&stop));
-  
-  HIP_CHECK(hipEventRecord(start,0));
-   
+
+  /* Warmup */
+  for(int i = 0; i < 10; i++) {
+    CASE_1D(LX);
+  }
+
+  HIP_CHECK(hipEventRecord(start, stream));
+
   for(int i = 0; i < 100; i++) {
     CASE_1D(LX);
   }
-  
-  HIP_CHECK(hipEventRecord(stop,0)); 
+
+  HIP_CHECK(hipEventRecord(stop, stream));
   HIP_CHECK(hipEventSynchronize(stop));
   HIP_CHECK(hipEventElapsedTime(&time1, start, stop));;
-  
-  HIP_CHECK(hipEventRecord(start,0));
-   
+
+  HIP_CHECK(hipEventRecord(start, stream));
+
   for(int i = 0; i < 100; i++) {
      CASE_KSTEP(LX);
    }
-  
-  HIP_CHECK(hipEventRecord(stop,0)); 
+
+  HIP_CHECK(hipEventRecord(stop, stream));
   HIP_CHECK(hipEventSynchronize(stop));
   HIP_CHECK(hipEventElapsedTime(&time2, start, stop));
-  
+
   if(time1 < time2) {
      retval = 1;
   } else {


### PR DESCRIPTION
This PR fixes a measurement issue with CUDA/HIP Autotuner, ensuring that timings are done in the correct stream. Furthermore, it adds a small warmup loop to all tests.
