### PR TITLE
Handle unallocated field size correctly

### DIFF
--- a/src/field/field_list.f90
+++ b/src/field/field_list.f90
@@ -61,15 +61,21 @@ contains
     integer, intent(in) :: size
 
     call this%free()
-
     allocate(this%items(size))
+
   end subroutine field_list_init
 
   !> Get number of items in the list.
   pure function field_list_size(this) result(n)
     class(field_list_t), intent(in) :: this
     integer :: n
-    n = size(this%items)
+
+    if (allocated(this%items)) then
+       n = size(this%items)
+    else
+       n = 0
+    end if
+
   end function field_list_size
 
   !> Get an item pointer by array index


### PR DESCRIPTION
Ensure the function returns a size of zero when the field is unallocated, preventing potential errors in size retrieval.

This resulted in segmentation faults when compiling Neko-TOP with optimization flags.