### PR TITLE
Contrain Python in pixi.toml to allow flint and pFunit together

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -115,12 +115,14 @@ blas = "*"
 lapack = "*"
 
 [feature.python.dependencies]
-python = "3.14.*"
+python = "3.11.*"
 pytest = "*"
 findent = "*"
 
 [feature.python.pypi-dependencies]
 flinter = "==0.4.0"
+setuptools = "<81"
+nobvisual = "==0.2.0"
 
 [environments]
 default = []


### PR DESCRIPTION
flint has very sad Python requirements, so we have to roll back the pixi environment to those. Otherwise, flint crashes, including when you try to run make check (that executes flint if it is installed).