### PR TITLE
Append scalar name to scalar_stats simcomp name and field prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Develop
 
+- If the "field" is provided for `scalar_stats` in the case file, append this
+  name to the `scalar_stats` registry prefix and the default output filename.
 - Added a script to add new unit tests under `contrib/add_unit_test`. Added
   templates for serial and parallel unit tests.
 - Added optional log output from the flow_rate_force, controlled by the `log`

--- a/doc/pages/user-guide/simcomps.md
+++ b/doc/pages/user-guide/simcomps.md
@@ -48,7 +48,8 @@ in Neko. The list will be updated as new simcomps are added.
 - Fluid SGS statistics simcomp, "fluid_sgs_stats", for more details see the
   [statistics guide](@ref statistics-guide)
 - Scalar statistics simcomp, "scalar_stats", for more details see the
-  [statistics guide](@ref statistics-guide)
+  [statistics guide](@ref statistics-guide). If a `field` is specified in the
+  case file, it is appended to the simcomp name as `scalar_stats_{field}`.
 - Scalar SGS statistics simcomp, "scalar_sgs_stats", for more details see the
   [statistics guide](@ref statistics-guide)
 - User statistics simcomp, "user_stats" \ref user_stats

--- a/doc/pages/user-guide/simcomps.md
+++ b/doc/pages/user-guide/simcomps.md
@@ -49,7 +49,8 @@ in Neko. The list will be updated as new simcomps are added.
   [statistics guide](@ref statistics-guide)
 - Scalar statistics simcomp, "scalar_stats", for more details see the
   [statistics guide](@ref statistics-guide). If a `field` is specified in the
-  case file, it is appended to the simcomp name as `scalar_stats_{field}`.
+  case file without `name` being specified, the field name is appended to the 
+  default simcomp name as `scalar_stats_{field}`.
 - Scalar SGS statistics simcomp, "scalar_sgs_stats", for more details see the
   [statistics guide](@ref statistics-guide)
 - User statistics simcomp, "user_stats" \ref user_stats

--- a/doc/pages/user-guide/statistics-guide.md
+++ b/doc/pages/user-guide/statistics-guide.md
@@ -207,7 +207,8 @@ using the `fluid_stats` simulation component (see
 ## Using statistics
 Similar to fluid statistics, scalar statistics are enabled in the case file
 as a simcomp with an additional argument `field` for the name of the scalar
-field to be averaged:
+field to be averaged, which will be appended to the default prefix of the
+`scalar_stats` field registry entries as `scalar_stats_{field}/*`:
 
 | Name              | Description                                                                                                           | Admissible values    | Default value                            |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------- | -------------------- | ---------------------------------------- |
@@ -222,9 +223,10 @@ field to be averaged:
 
 \*The name of the written statistics file will by default be
 `scalar_statsX0.f0000X,..., scalar_statsX0.f0000Y` where X is the number of
-the first outputted statistic of the current run. Note that if you want to
-compute statistics for multiple scalars, you will need to specify an
-independent `output_filename` for each.
+the first outputted statistic of the current run. If `field` is specified,
+it will be appended to the default filename as `scalar_stats_{field}X0.f0000X`.
+Otherwise, you can specify an independent `output_filename` for each scalar you
+compute statistics for.
 
 In addition, one can specify the usual controls for the output, in the same
 manner as for fluid statistics. For example, if one wants to compute only the

--- a/src/scalar/scalar_stats.f90
+++ b/src/scalar/scalar_stats.f90
@@ -192,7 +192,7 @@ contains
 
     ! If a name is specified and is not the default name, add it
     ! as a prefix to the mean field names, followed by a "/".
-    if (present(name) .and. trim(name) .ne. "scalar_stats") then
+    if (present(name)) then
        unique_name = name // "/"
     else
        unique_name = "scalar_stats/"

--- a/src/scalar/scalar_stats.f90
+++ b/src/scalar/scalar_stats.f90
@@ -190,8 +190,6 @@ contains
        this%n_stats = 42
     end if
 
-    ! If a name is specified and is not the default name, add it
-    ! as a prefix to the mean field names, followed by a "/".
     if (present(name)) then
        unique_name = name // "/"
     else

--- a/src/scalar/scalar_stats.f90
+++ b/src/scalar/scalar_stats.f90
@@ -192,8 +192,10 @@ contains
 
     ! If a name is specified and is not the default name, add it
     ! as a prefix to the mean field names, followed by a "/".
-    if (present(name) .and. trim(name) .ne. "fluid_stats") then
+    if (present(name) .and. trim(name) .ne. "scalar_stats") then
        unique_name = name // "/"
+    else
+       unique_name = "scalar_stats/"
     end if
 
     ! Initialize work fields

--- a/src/simulation_components/scalar_stats_simcomp.f90
+++ b/src/simulation_components/scalar_stats_simcomp.f90
@@ -136,6 +136,9 @@ contains
        call json_get(json, "output_filename", filename)
        call scalar_stats_simcomp_init_from_components(this, name, s, u, v, w, &
             p, coef, start_time, hom_dir, stat_set, filename)
+    else if (sname_provided) then
+       call scalar_stats_simcomp_init_from_components(this, name, s, u, v, w, &
+            p, coef, start_time, hom_dir, stat_set, "scalar_stats_" // trim(sname) // "0")
     else
        call scalar_stats_simcomp_init_from_components(this, name, s, u, v, w, &
             p, coef, start_time, hom_dir, stat_set)
@@ -188,7 +191,7 @@ contains
        this%default_fname = .false.
        stats_fname = fname
     else
-       stats_fname = trim(this%name) // "0"
+       stats_fname = "scalar_stats0"
        this%default_fname = .true.
     end if
 

--- a/src/simulation_components/scalar_stats_simcomp.f90
+++ b/src/simulation_components/scalar_stats_simcomp.f90
@@ -103,11 +103,19 @@ contains
     real(kind=rp) :: start_time
     type(field_t), pointer :: s, u, v, w, p
     type(coef_t), pointer :: coef
+    logical :: sname_provided
+
+    sname_provided = json%valid_path('field')
 
     call json_get_or_default(json, 'field', &
          sname, 's')
-    call json_get_or_default(json, "name", &
-         name, "scalar_stats_" // trim(sname))
+    if (sname_provided) then
+       call json_get_or_default(json, "name", &
+            name, "scalar_stats_" // trim(sname))
+    else
+       call json_get_or_default(json, "name", &
+            name, "scalar_stats")
+    endif
     call this%init_base(json, case)
     call json_get_or_default(json, 'avg_direction', &
          hom_dir, 'none')
@@ -180,7 +188,7 @@ contains
        this%default_fname = .false.
        stats_fname = fname
     else
-       stats_fname = "scalar_stats0"
+       stats_fname = trim(this%name) // "0"
        this%default_fname = .true.
     end if
 

--- a/src/simulation_components/scalar_stats_simcomp.f90
+++ b/src/simulation_components/scalar_stats_simcomp.f90
@@ -107,7 +107,7 @@ contains
     call json_get_or_default(json, 'field', &
          sname, 's')
     call json_get_or_default(json, "name", &
-         name, "scalar_stats_" // sname)
+         name, "scalar_stats_" // trim(sname))
     call this%init_base(json, case)
     call json_get_or_default(json, 'avg_direction', &
          hom_dir, 'none')

--- a/src/simulation_components/scalar_stats_simcomp.f90
+++ b/src/simulation_components/scalar_stats_simcomp.f90
@@ -104,7 +104,10 @@ contains
     type(field_t), pointer :: s, u, v, w, p
     type(coef_t), pointer :: coef
 
-    call json_get_or_default(json, "name", name, "scalar_stats")
+    call json_get_or_default(json, 'field', &
+         sname, 's')
+    call json_get_or_default(json, "name", &
+         name, "scalar_stats_" // sname)
     call this%init_base(json, case)
     call json_get_or_default(json, 'avg_direction', &
          hom_dir, 'none')
@@ -112,8 +115,6 @@ contains
          start_time, 0.0_rp)
     call json_get_or_default(json, 'set_of_stats', &
          stat_set, 'full')
-    call json_get_or_default(json, 'field', &
-         sname, 's')
 
     s => neko_registry%get_field_by_name(sname)
     u => neko_registry%get_field("u")

--- a/tests/integration/tests/test_scalar_stats/test_scalar_stats.py
+++ b/tests/integration/tests/test_scalar_stats/test_scalar_stats.py
@@ -113,7 +113,7 @@ def test_scalar_stats(launcher_script, request, log_file, tmp_path):
     #
 
 
-    csv = np.genfromtxt(join("tests", "test_scalar_stats", "1d0.csv"),
+    csv = np.genfromtxt(join("tests", "test_scalar_stats", "scalar_stats0.csv"),
                         delimiter=",")[12, 2:]
 
     quants = ["<s>", "<us>", "<vs>", "<ws>", "<s^2>"]

--- a/tests/integration/tests/test_scalar_stats/test_scalar_stats.py
+++ b/tests/integration/tests/test_scalar_stats/test_scalar_stats.py
@@ -113,7 +113,7 @@ def test_scalar_stats(launcher_script, request, log_file, tmp_path):
     #
 
 
-    csv = np.genfromtxt(join("tests", "test_scalar_stats", "scalar_stats0.csv"),
+    csv = np.genfromtxt(join("tests", "test_scalar_stats", "1d0.csv"),
                         delimiter=",")[12, 2:]
 
     quants = ["<s>", "<us>", "<vs>", "<ws>", "<s^2>"]


### PR DESCRIPTION
Appends the scalar field name to the default name for each `scalar_stats` simcomp as `scalar_stats_{scalar name}`, so that the simcomp names would be `scalar_stats_s`, `scalar_stats_temp` etc., with the `scalar_stats` entries in the field registry having the same style prefix.

This allows users to have statistics for different scalars without needing to specify a different simcomp name for each, and also avoids confusing field registry error messages happening now when the simcomp names are the same. 

Also fixes the default `scalar_stats` field registry prefix to match the `fluid_stats` logic.