### PR TITLE
Improve vectorisation and autoparallelisation of bc apply

### DIFF
--- a/src/bc/blasius.f90
+++ b/src/bc/blasius.f90
@@ -201,6 +201,7 @@ contains
          nz => this%coef%nz, lx => this%coef%Xh%lx)
       m = this%msk(0)
       if (strong_) then
+         !$omp parallel do private(k, facet, idx)
          do i = 1, m
             k = this%msk(i)
             facet = this%facet(i)
@@ -223,6 +224,7 @@ contains
                     this%delta, this%uinf(3))
             end select
          end do
+         !$omp end parallel do
       end if
     end associate
   end subroutine blasius_apply_vector
@@ -269,7 +271,7 @@ contains
          call device_alloc(blax_d, s)
          call device_alloc(blay_d, s)
          call device_alloc(blaz_d, s)
-
+         !$omp parallel do private(k, facet, idx)
          do i = 1, m
             k = this%msk(i)
             facet = this%facet(i)
@@ -292,6 +294,7 @@ contains
                     this%delta, this%uinf(3))
             end select
          end do
+         !$omp end parallel do
 
          call device_memcpy(bla_x, blax_d, m, HOST_TO_DEVICE, sync = .false.)
          call device_memcpy(bla_y, blay_d, m, HOST_TO_DEVICE, sync = .false.)

--- a/src/bc/dirichlet.f90
+++ b/src/bc/dirichlet.f90
@@ -113,7 +113,7 @@ contains
 
     if (strong_) then
        m = this%msk(0)
-       do i = 1, m
+       do concurrent (i = 1:m)
           k = this%msk(i)
           x(k) = this%g
        end do
@@ -141,7 +141,7 @@ contains
 
     if (strong_) then
        m = this%msk(0)
-       do i = 1, m
+       do concurrent (i = 1:m)
           k = this%msk(i)
           x(k) = this%g
           y(k) = this%g

--- a/src/bc/dong_outflow.f90
+++ b/src/bc/dong_outflow.f90
@@ -116,6 +116,7 @@ contains
     !Im actually not sure what to do if one has two dong that share a corner.
     if (strong_) then
        m = this%msk(0)
+       !$omp parallel do private(k, facet, ux, uy, uz, idx, normal_xyz, vn, S0)
        do i = 1, m
           k = this%msk(i)
           facet = this%facet(i)
@@ -130,6 +131,7 @@ contains
 
           x(k) = -0.5*(ux*ux+uy*uy+uz*uz)*S0
        end do
+       !$omp end parallel do
     end if
   end subroutine dong_outflow_apply_scalar
 
@@ -245,6 +247,7 @@ contains
        allocate(temp_x(m))
        allocate(temp_y(m))
        allocate(temp_z(m))
+       !$omp parallel do private(k, facet, idx, normal_xyz)
        do i = 1, m
           k = this%msk(i)
           facet = this%facet(i)
@@ -255,6 +258,7 @@ contains
           temp_y(i) = normal_xyz(2)
           temp_z(i) = normal_xyz(3)
        end do
+       !$omp end parallel do
        call device_memcpy(temp_x, this%normal_x_d, m, HOST_TO_DEVICE, &
             sync = .false.)
        call device_memcpy(temp_y, this%normal_y_d, m, HOST_TO_DEVICE, &

--- a/src/bc/inflow.f90
+++ b/src/bc/inflow.f90
@@ -114,7 +114,7 @@ contains
     m = this%msk(0)
 
     if (strong_) then
-       do i = 1, m
+       do concurrent (i = 1:m)
           k = this%msk(i)
           x(k) = this%x(1)
           y(k) = this%x(2)

--- a/src/bc/neumann.f90
+++ b/src/bc/neumann.f90
@@ -182,7 +182,8 @@ contains
 
     m = this%msk(0)
     if (.not. strong_) then
-       do i = 1, m
+       !$omp parallel do private(k, facet, idx)
+       do i = 1,m
           k = this%msk(i)
           facet = this%facet(i)
           idx = nonlinear_index(k, this%coef%Xh%lx, this%coef%Xh%lx, &
@@ -202,6 +203,7 @@ contains
                   this%coef%area(idx(1), idx(2), facet, idx(4))
           end select
        end do
+       !$omp end parallel do
     end if
   end subroutine neumann_apply_scalar
 
@@ -228,6 +230,7 @@ contains
 
     m = this%msk(0)
     if (.not. strong_) then
+       !$omp parallel do private(k, facet, idx)
        do i = 1, m
           k = this%msk(i)
           facet = this%facet(i)
@@ -266,6 +269,7 @@ contains
                   this%coef%area(idx(1), idx(2), facet, idx(4))
           end select
        end do
+       !$omp end parallel do
     end if
   end subroutine neumann_apply_vector
 

--- a/src/bc/zero_dirichlet.f90
+++ b/src/bc/zero_dirichlet.f90
@@ -135,7 +135,7 @@ contains
 
     if (strong_) then
        m = this%msk(0)
-       do i = 1, m
+       do concurrent (i = 1:m)
           k = this%msk(i)
           x(k) = 0d0
           y(k) = 0d0


### PR DESCRIPTION
This adds do concurrent and OpenMP pragmas (where needed) to ensure good vectorisation, and optimial autoparallelisation (ref #2335)
