### PR TITLE
Update JSON-Fortran version requirement to 8.3.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -331,7 +331,7 @@ fi
 
 
 # JSON-Fortran
-PKG_CHECK_MODULES([JSON_Fortran],[json-fortran >= 7.1.0])
+PKG_CHECK_MODULES([JSON_Fortran],[json-fortran >= 8.3.0])
 LIBS="$JSON_Fortran_LIBS $LIBS"
 NEKO_PKG_FCFLAGS="$NEKO_PKG_FCFLAGS $JSON_Fortran_CFLAGS"
 


### PR DESCRIPTION
As far as I saw in the tests, this is the version that gets tested by default. In lumi, this one (8.3.0) compiles, the current requirement doesn't.

If this is the incorrect version, then we can change it to be a new one, but configure should have the correct one.