### PR TITLE
Cleanup blocked loops in krylov solvers

### DIFF
--- a/src/krylov/bcknd/cpu/cg.f90
+++ b/src/krylov/bcknd/cpu/cg.f90
@@ -210,7 +210,6 @@ contains
                   x_plus(k) = 0.0_rp
                end do
 
-               !DIR$ UNROLL CG_P_SPACE
                do j = 1, p_cur
                   do concurrent (k = 1:blk_size)
                      x_plus(k) = x_plus(k) + alpha(j) * p(i+k,j)

--- a/src/krylov/bcknd/cpu/cg.f90
+++ b/src/krylov/bcknd/cpu/cg.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2020-2025, The Neko Authors
+! Copyright (c) 2020-2026, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -205,27 +205,17 @@ contains
          if ((p_cur .eq. CG_P_SPACE) .or. &
               (rnorm .lt. this%abs_tol) .or. iter .eq. max_iter) then
             do i = 0, n, NEKO_BLK_SIZE
-               if (i + NEKO_BLK_SIZE .le. n) then
-                  do k = 1, NEKO_BLK_SIZE
-                     x_plus(k) = 0.0_rp
+               do k = 1, min(NEKO_BLK_SIZE, n - i)
+                  x_plus(k) = 0.0_rp
+               end do
+               do j = 1, p_cur
+                  do k = 1, min(NEKO_BLK_SIZE, n - i)
+                     x_plus(k) = x_plus(k) + alpha(j) * p(i+k,j)
                   end do
-                  do j = 1, p_cur
-                     do k = 1, NEKO_BLK_SIZE
-                        x_plus(k) = x_plus(k) + alpha(j) * p(i+k,j)
-                     end do
-                  end do
-                  do k = 1, NEKO_BLK_SIZE
-                     x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
-                  end do
-               else
-                  do k = 1, n-i
-                     x_plus(1) = 0.0_rp
-                     do j = 1, p_cur
-                        x_plus(1) = x_plus(1) + alpha(j) * p(i+k,j)
-                     end do
-                     x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(1)
-                  end do
-               end if
+               end do
+               do k = 1, min(NEKO_BLK_SIZE, n - i)
+                  x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
+               end do
             end do
             p_prev = p_cur
             p_cur = 1
@@ -287,5 +277,3 @@ contains
   end function cg_solve_coupled
 
 end module cg
-
-

--- a/src/krylov/bcknd/cpu/cg.f90
+++ b/src/krylov/bcknd/cpu/cg.f90
@@ -148,7 +148,7 @@ contains
     type(gs_t), intent(inout) :: gs_h
     type(ksp_monitor_t) :: ksp_results
     integer, optional, intent(in) :: niter
-    integer :: iter, max_iter, i, j, k, p_cur, p_prev
+    integer :: iter, max_iter, i, j, k, p_cur, p_prev, blk_size
     real(kind=rp) :: rnorm, rtr, rtz2, rtz1, x_plus(NEKO_BLK_SIZE)
     real(kind=rp) :: beta, pap, norm_fac
 
@@ -205,15 +205,19 @@ contains
          if ((p_cur .eq. CG_P_SPACE) .or. &
               (rnorm .lt. this%abs_tol) .or. iter .eq. max_iter) then
             do i = 0, n, NEKO_BLK_SIZE
-               do k = 1, min(NEKO_BLK_SIZE, n - i)
+               blk_size = min(NEKO_BLK_SIZE, n - i)
+               do concurrent (k = 1:blk_size)
                   x_plus(k) = 0.0_rp
                end do
+
+               !DIR$ UNROLL CG_P_SPACE
                do j = 1, p_cur
-                  do k = 1, min(NEKO_BLK_SIZE, n - i)
+                  do concurrent (k = 1:blk_size)
                      x_plus(k) = x_plus(k) + alpha(j) * p(i+k,j)
                   end do
                end do
-               do k = 1, min(NEKO_BLK_SIZE, n - i)
+
+               do concurrent (k = 1:blk_size)
                   x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
                end do
             end do

--- a/src/krylov/bcknd/cpu/gmres.f90
+++ b/src/krylov/bcknd/cpu/gmres.f90
@@ -235,21 +235,12 @@ contains
             end do
 
             do i = 0, n, NEKO_BLK_SIZE
-               if (i + NEKO_BLK_SIZE .le. n) then
-                  do l = 1, j
-                     do k = 1, NEKO_BLK_SIZE
-                        h(l,j) = h(l,j) + &
-                             w(i+k) * v(i+k,l) * coef%mult(i+k,1,1,1)
-                     end do
+               do l = 1, j
+                  do k = 1, min(NEKO_BLK_SIZE, n - i)
+                     h(l,j) = h(l,j) + &
+                          w(i+k) * v(i+k,l) * coef%mult(i+k,1,1,1)
                   end do
-               else
-                  do k = 1, n-i
-                     do l = 1, j
-                        h(l,j) = h(l,j) + &
-                             w(i+k) * v(i+k,l) * coef%mult(i+k,1,1,1)
-                     end do
-                  end do
-               end if
+               end do
             end do
 
             call MPI_Allreduce(MPI_IN_PLACE, h(1,j), j, &
@@ -257,29 +248,18 @@ contains
 
             alpha2 = 0.0_rp
             do i = 0, n, NEKO_BLK_SIZE
-               if (i + NEKO_BLK_SIZE .le. n) then
-                  do k = 1, NEKO_BLK_SIZE
-                     w_plus(k) = 0.0_rp
+               do k = 1, min(NEKO_BLK_SIZE, n - i)
+                  w_plus(k) = 0.0_rp
+               end do
+               do l = 1, j
+                  do k = 1, min(NEKO_BLK_SIZE, n - i)
+                     w_plus(k) = w_plus(k) - h(l,j) * v(i+k,l)
                   end do
-                  do l = 1,j
-                     do k = 1, NEKO_BLK_SIZE
-                        w_plus(k) = w_plus(k) - h(l,j) * v(i+k,l)
-                     end do
-                  end do
-                  do k = 1, NEKO_BLK_SIZE
-                     w(i+k) = w(i+k) + w_plus(k)
-                     alpha2 = alpha2 + w(i+k)**2 * coef%mult(i+k,1,1,1)
-                  end do
-               else
-                  do k = 1, n-i
-                     w_plus(1) = 0.0_rp
-                     do l = 1, j
-                        w_plus(1) = w_plus(1) - h(l,j) * v(i+k,l)
-                     end do
-                     w(i+k) = w(i+k) + w_plus(1)
-                     alpha2 = alpha2 + (w(i+k)**2) * coef%mult(i+k,1,1,1)
-                  end do
-               end if
+               end do
+               do k = 1, min(NEKO_BLK_SIZE, n - i)
+                  w(i+k) = w(i+k) + w_plus(k)
+                  alpha2 = alpha2 + w(i+k)**2 * coef%mult(i+k,1,1,1)
+               end do
             end do
 
             call MPI_Allreduce(MPI_IN_PLACE,alpha2, 1, &
@@ -330,27 +310,17 @@ contains
          end do
 
          do i = 0, n, NEKO_BLK_SIZE
-            if (i + NEKO_BLK_SIZE .le. n) then
-               do k = 1, NEKO_BLK_SIZE
-                  x_plus(k) = 0.0_rp
+            do k = 1, min(NEKO_BLK_SIZE, n - i)
+               x_plus(k) = 0.0_rp
+            end do
+            do l = 1,j
+               do k = 1, min(NEKO_BLK_SIZE, n - i)
+                  x_plus(k) = x_plus(k) + c(l) * z(i+k,l)
                end do
-               do l = 1,j
-                  do k = 1, NEKO_BLK_SIZE
-                     x_plus(k) = x_plus(k) + c(l) * z(i+k,l)
-                  end do
-               end do
-               do k = 1, NEKO_BLK_SIZE
-                  x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
-               end do
-            else
-               do k = 1, n-i
-                  x_plus(1) = 0.0_rp
-                  do l = 1, j
-                     x_plus(1) = x_plus(1) + c(l) * z(i+k,l)
-                  end do
-                  x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(1)
-               end do
-            end if
+            end do
+            do k = 1, min(NEKO_BLK_SIZE, n - i)
+               x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
+            end do
          end do
       end do
 
@@ -389,5 +359,3 @@ contains
   end function gmres_solve_coupled
 
 end module gmres
-
-

--- a/src/krylov/bcknd/cpu/gmres.f90
+++ b/src/krylov/bcknd/cpu/gmres.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2020-2024, The Neko Authors
+! Copyright (c) 2020-2026, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without

--- a/src/krylov/bcknd/cpu/pipecg.f90
+++ b/src/krylov/bcknd/cpu/pipecg.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2021-2024, The Neko Authors
+! Copyright (c) 2021-2026, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -258,31 +258,17 @@ contains
          tmp2 = 0.0_rp
          tmp3 = 0.0_rp
          do i = 0, n, NEKO_BLK_SIZE
-            if (i + NEKO_BLK_SIZE .le. n) then
-               do k = 1, NEKO_BLK_SIZE
-                  z(i+k) = beta(p_cur) * z(i+k) + ni(i+k)
-                  q(i+k) = beta(p_cur) * q(i+k) + mi(i+k)
-                  s(i+k) = beta(p_cur) * s(i+k) + w(i+k)
-                  r(i+k) = r(i+k) - alpha(p_cur) * s(i+k)
-                  u(i+k,p_cur) = u(i+k,u_prev) - alpha(p_cur) * q(i+k)
-                  w(i+k) = w(i+k) - alpha(p_cur) * z(i+k)
-                  tmp1 = tmp1 + r(i+k) * coef%mult(i+k,1,1,1) * u(i+k,p_cur)
-                  tmp2 = tmp2 + w(i+k) * coef%mult(i+k,1,1,1) * u(i+k,p_cur)
-                  tmp3 = tmp3 + r(i+k) * coef%mult(i+k,1,1,1) * r(i+k)
-               end do
-            else
-               do k = 1, n-i
-                  z(i+k) = beta(p_cur) * z(i+k) + ni(i+k)
-                  q(i+k) = beta(p_cur) * q(i+k) + mi(i+k)
-                  s(i+k) = beta(p_cur) * s(i+k) + w(i+k)
-                  r(i+k) = r(i+k) - alpha(p_cur) * s(i+k)
-                  u(i+k,p_cur) = u(i+k,u_prev) - alpha(p_cur) * q(i+k)
-                  w(i+k) = w(i+k) - alpha(p_cur) * z(i+k)
-                  tmp1 = tmp1 + r(i+k) * coef%mult(i+k,1,1,1) * u(i+k,p_cur)
-                  tmp2 = tmp2 + w(i+k) * coef%mult(i+k,1,1,1) * u(i+k,p_cur)
-                  tmp3 = tmp3 + r(i+k) * coef%mult(i+k,1,1,1) * r(i+k)
-               end do
-            end if
+            do k = 1, min(NEKO_BLK_SIZE, n - i)
+               z(i+k) = beta(p_cur) * z(i+k) + ni(i+k)
+               q(i+k) = beta(p_cur) * q(i+k) + mi(i+k)
+               s(i+k) = beta(p_cur) * s(i+k) + w(i+k)
+               r(i+k) = r(i+k) - alpha(p_cur) * s(i+k)
+               u(i+k,p_cur) = u(i+k,u_prev) - alpha(p_cur) * q(i+k)
+               w(i+k) = w(i+k) - alpha(p_cur) * z(i+k)
+               tmp1 = tmp1 + r(i+k) * coef%mult(i+k,1,1,1) * u(i+k,p_cur)
+               tmp2 = tmp2 + w(i+k) * coef%mult(i+k,1,1,1) * u(i+k,p_cur)
+               tmp3 = tmp3 + r(i+k) * coef%mult(i+k,1,1,1) * r(i+k)
+            end do
          end do
 
          reduction(1) = tmp1
@@ -291,35 +277,21 @@ contains
 
          if (p_cur .eq. PIPECG_P_SPACE) then
             do i = 0, n, NEKO_BLK_SIZE
-               if (i + NEKO_BLK_SIZE .le. n) then
-                  do k = 1, NEKO_BLK_SIZE
-                     x_plus(k) = 0.0_rp
+               do k = 1, min(NEKO_BLK_SIZE, n - i)
+                  x_plus(k) = 0.0_rp
+               end do
+               p_prev = PIPECG_P_SPACE+1
+               do j = 1, p_cur
+                  do k = 1, min(NEKO_BLK_SIZE, n - i)
+                     p(i+k) = beta(j) * p(i+k) + u(i+k,p_prev)
+                     x_plus(k) = x_plus(k) + alpha(j) * p(i+k)
                   end do
-                  p_prev = PIPECG_P_SPACE+1
-                  do j = 1, p_cur
-                     do k = 1, NEKO_BLK_SIZE
-                        p(i+k) = beta(j) * p(i+k) + u(i+k,p_prev)
-                        x_plus(k) = x_plus(k) + alpha(j) * p(i+k)
-                     end do
-                     p_prev = j
-                  end do
-                  do k = 1, NEKO_BLK_SIZE
-                     x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
-                     u(i+k,PIPECG_P_SPACE+1) = u(i+k,PIPECG_P_SPACE)
-                  end do
-               else
-                  do k = 1, n-i
-                     x_plus(1) = 0.0_rp
-                     p_prev = PIPECG_P_SPACE + 1
-                     do j = 1, p_cur
-                        p(i+k) = beta(j) * p(i+k) + u(i+k,p_prev)
-                        x_plus(1) = x_plus(1) + alpha(j) * p(i+k)
-                        p_prev = j
-                     end do
-                     x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(1)
-                     u(i+k,PIPECG_P_SPACE+1) = u(i+k,PIPECG_P_SPACE)
-                  end do
-               end if
+                  p_prev = j
+               end do
+               do k = 1, min(NEKO_BLK_SIZE, n - i)
+                  x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
+                  u(i+k,PIPECG_P_SPACE+1) = u(i+k,PIPECG_P_SPACE)
+               end do
             end do
             p_prev = p_cur
             u_prev = PIPECG_P_SPACE+1
@@ -335,35 +307,21 @@ contains
 
       if ( p_cur .ne. 1) then
          do i = 0, n, NEKO_BLK_SIZE
-            if (i + NEKO_BLK_SIZE .le. n) then
-               do k = 1, NEKO_BLK_SIZE
-                  x_plus(k) = 0.0_rp
+            do k = 1, min(NEKO_BLK_SIZE, n - i)
+               x_plus(k) = 0.0_rp
+            end do
+            p_prev = PIPECG_P_SPACE+1
+            do j = 1, p_cur
+               do k = 1, min(NEKO_BLK_SIZE, n - i)
+                  p(i+k) = beta(j) * p(i+k) + u(i+k,p_prev)
+                  x_plus(k) = x_plus(k) + alpha(j) * p(i+k)
                end do
-               p_prev = PIPECG_P_SPACE+1
-               do j = 1, p_cur
-                  do k = 1, NEKO_BLK_SIZE
-                     p(i+k) = beta(j) * p(i+k) + u(i+k,p_prev)
-                     x_plus(k) = x_plus(k) + alpha(j) * p(i+k)
-                  end do
-                  p_prev = j
-               end do
-               do k = 1, NEKO_BLK_SIZE
-                  x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
-                  u(i+k,PIPECG_P_SPACE+1) = u(i+k,PIPECG_P_SPACE)
-               end do
-            else
-               do k = 1, n-i
-                  x_plus(1) = 0.0_rp
-                  p_prev = PIPECG_P_SPACE + 1
-                  do j = 1, p_cur
-                     p(i+k) = beta(j) * p(i+k) + u(i+k,p_prev)
-                     x_plus(1) = x_plus(1) + alpha(j) * p(i+k)
-                     p_prev = j
-                  end do
-                  x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(1)
-                  u(i+k,PIPECG_P_SPACE+1) = u(i+k,PIPECG_P_SPACE)
-               end do
-            end if
+               p_prev = j
+            end do
+            do k = 1, min(NEKO_BLK_SIZE, n - i)
+               x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
+               u(i+k,PIPECG_P_SPACE+1) = u(i+k,PIPECG_P_SPACE)
+            end do
          end do
       end if
       call this%monitor_stop()
@@ -402,5 +360,3 @@ contains
   end function pipecg_solve_coupled
 
 end module pipecg
-
-


### PR DESCRIPTION
Cleanup blocked loop nests in Krylov solvers (CPU backend), improves readability and ease in parallelisation (ref #2429)

Test has been performed that shows that these refactored nests doesn't affect accuracy (e.g. with hemi)
