### PR TITLE
Add a workaround patch for the segfaults with recent CCE versions (> 19)

### DIFF
--- a/patches/cce_stack.patch
+++ b/patches/cce_stack.patch
@@ -1,0 +1,12 @@
+diff --git a/src/adt/stack.f90 b/src/adt/stack.f90
+index 5193fcff92c..a1a7b4ef916 100644
+--- a/src/adt/stack.f90
++++ b/src/adt/stack.f90
+@@ -258,6 +258,7 @@ contains
+     class(*), intent(in) :: data !< Arbitrary typed data (same type as stack)
+     class(*), allocatable :: tmp(:)
+     integer :: i
++    !DIR$ OPTIMIZE(-hscalar0)
+ 
+     if (this%top_ .eq. this%size_) then
+        this%size_ = ishft(this%size_, 1)


### PR DESCRIPTION
This PR adds a patch with a workaround for the segmentation faults observed when Neko has been compiled with recent versions of CCE (> 19) (see #2209), allowing for Neko to be compiled with `-O3`.

The patches disables certain optimisations that caused the deep copy when the stack is growing in the `stack_push` routine to be **deleted**, causing data loss (badness...). This will only cause a slightly reduced performance during stack rebuilt, but not reduce any calculation speed during a simulation.