### PR TITLE
Fix gradient order in TKE model

### DIFF
--- a/src/les/bcknd/device/hip/deardorff_nut.hip
+++ b/src/les/bcknd/device/hip/deardorff_nut.hip
@@ -52,7 +52,7 @@ extern "C" {
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     hipLaunchKernelGGL(HIP_KERNEL_NAME(deardorff_nut_compute<real>),
                     nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                    (real *) TKE, (real *) dTdz, (real *) dTdx, (real *) dTdy,
+                    (real *) TKE, (real *) dTdx, (real *) dTdy, (real *) dTdz,
                     (real *) a11, (real *) a12, (real *) a13,
                     (real *) a21, (real *) a22, (real *) a23,
                     (real *) a31, (real *) a32, (real *) a33,


### PR DESCRIPTION
Just a small PR to fix a bug in the TKE SGS model.

In the `device` file for `hip`, the order of the gradients input in the kernel was wrong and this leads to an error when the model is run on GPU with hip.

