### PR TITLE
Add a bunch of "lookup" statements useful for ABL simulations

### DIFF
--- a/src/les/bcknd/device/hip/deardorff_nut.hip
+++ b/src/les/bcknd/device/hip/deardorff_nut.hip
@@ -52,7 +52,7 @@ extern "C" {
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     hipLaunchKernelGGL(HIP_KERNEL_NAME(deardorff_nut_compute<real>),
                     nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,
-                    (real *) TKE, (real *) dTdz, (real *) dTdx, (real *) dTdy,
+                    (real *) TKE, (real *) dTdx, (real *) dTdy, (real *) dTdz,
                     (real *) a11, (real *) a12, (real *) a13,
                     (real *) a21, (real *) a22, (real *) a23,
                     (real *) a31, (real *) a32, (real *) a33,

--- a/src/les/deardorff.f90
+++ b/src/les/deardorff.f90
@@ -38,7 +38,8 @@ module deardorff
   use field, only : field_t
   use fluid_scheme_base, only : fluid_scheme_base_t
   use les_model, only : les_model_t
-  use json_utils, only : json_get_or_default, json_get, json_get_or_lookup
+  use json_utils, only : json_get_or_default, json_get, &
+      json_get_or_lookup, json_get_or_lookup_or_default
   use json_module, only : json_file
   use neko_config, only : NEKO_BCKND_DEVICE
   use deardorff_cpu, only : deardorff_compute_cpu
@@ -108,8 +109,8 @@ contains
     call json_get_or_default(json, "TKE_source_field", TKE_source_name, &
          "TKE_source")
     call json_get_or_default(json, "delta_type", delta_type, "pointwise")
-    call json_get_or_default(json, "c_k", c_k, 0.10_rp)
-    call json_get(json, "T0", T0)
+    call json_get_or_lookup_or_default(json, "c_k", c_k, 0.10_rp)
+    call json_get_or_lookup(json, "T0", T0)
     call json_get_or_lookup(json, "g", g)
     if (.not. size(g) == 3) then
        call neko_error("The gravity vector should have 3 components")

--- a/src/simulation_components/fluid_sgs_stats_simcomp.f90
+++ b/src/simulation_components/fluid_sgs_stats_simcomp.f90
@@ -45,7 +45,8 @@ module fluid_sgs_stats_simcomp
   use coefs, only : coef_t
   use utils, only : NEKO_FNAME_LEN, filename_suffix, filename_tslash_pos
   use logger, only : LOG_SIZE, neko_log
-  use json_utils, only : json_get, json_get_or_default
+  use json_utils, only : json_get, json_get_or_default, &
+     json_get_or_lookup_or_default
   use comm, only : NEKO_COMM
   use mpi_f08, only : MPI_WTIME, MPI_Barrier
   implicit none
@@ -103,7 +104,7 @@ contains
     call this%init_base(json, case)
     call json_get_or_default(json, 'avg_direction', &
          hom_dir, 'none')
-    call json_get_or_default(json, 'start_time', &
+    call json_get_or_lookup_or_default(json, 'start_time', &
          start_time, 0.0_rp)
     call json_get_or_default(json, 'nut_field', &
          nut_field, 'nut')

--- a/src/simulation_components/fluid_stats_simcomp.f90
+++ b/src/simulation_components/fluid_stats_simcomp.f90
@@ -45,7 +45,8 @@ module fluid_stats_simcomp
   use coefs, only : coef_t
   use utils, only : NEKO_FNAME_LEN, filename_suffix, filename_tslash_pos
   use logger, only : LOG_SIZE, neko_log
-  use json_utils, only : json_get, json_get_or_default
+  use json_utils, only : json_get, json_get_or_default, &
+     json_get_or_lookup_or_default
   use comm, only : NEKO_COMM
   use mpi_f08, only : MPI_WTIME, MPI_Barrier
   implicit none
@@ -109,7 +110,7 @@ contains
     call this%init_base(json, case)
     call json_get_or_default(json, 'avg_direction', &
          hom_dir, 'none')
-    call json_get_or_default(json, 'start_time', &
+    call json_get_or_lookup_or_default(json, 'start_time', &
          start_time, 0.0_rp)
     call json_get_or_default(json, 'set_of_stats', &
          stat_set, 'full')

--- a/src/simulation_components/scalar_sgs_stats_simcomp.f90
+++ b/src/simulation_components/scalar_sgs_stats_simcomp.f90
@@ -45,7 +45,8 @@ module scalar_sgs_stats_simcomp
   use coefs, only : coef_t
   use utils, only : NEKO_FNAME_LEN, filename_suffix, filename_tslash_pos
   use logger, only : LOG_SIZE, neko_log
-  use json_utils, only : json_get, json_get_or_default
+  use json_utils, only : json_get, json_get_or_default, &
+     json_get_or_lookup_or_default, json_get_or_lookup
   use comm, only : NEKO_COMM
   use mpi_f08, only : MPI_WTIME, MPI_Barrier
   implicit none
@@ -113,7 +114,7 @@ contains
     call this%init_base(json, case)
     call json_get_or_default(json, 'avg_direction', &
          hom_dir, 'none')
-    call json_get_or_default(json, 'start_time', &
+    call json_get_or_lookup_or_default(json, 'start_time', &
          start_time, 0.0_rp)
     call json_get_or_default(json, 'field', &
          sname, 's')
@@ -121,7 +122,7 @@ contains
     call json_get(json, 'alphat', json_subdict)
     call json_get(json_subdict, 'nut_dependency', nut_dependency)
     if (nut_dependency) then
-       call json_get(json_subdict, 'Pr_t', pr_turb)
+       call json_get_or_lookup(json_subdict, 'Pr_t', pr_turb)
        call json_get(json_subdict, 'nut_field', nut_field)
     else
        call json_get(json_subdict, 'alphat_field', alphat_field)

--- a/src/simulation_components/scalar_stats_simcomp.f90
+++ b/src/simulation_components/scalar_stats_simcomp.f90
@@ -45,7 +45,8 @@ module scalar_stats_simcomp
   use coefs, only : coef_t
   use utils, only : NEKO_FNAME_LEN, filename_suffix, filename_tslash_pos
   use logger, only : LOG_SIZE, neko_log
-  use json_utils, only : json_get, json_get_or_default
+  use json_utils, only : json_get, json_get_or_default, &
+     json_get_or_lookup_or_default
   use comm, only : NEKO_COMM
   use mpi_f08, only : MPI_WTIME, MPI_Barrier
   implicit none
@@ -119,7 +120,7 @@ contains
     call this%init_base(json, case)
     call json_get_or_default(json, 'avg_direction', &
          hom_dir, 'none')
-    call json_get_or_default(json, 'start_time', &
+    call json_get_or_lookup_or_default(json, 'start_time', &
          start_time, 0.0_rp)
     call json_get_or_default(json, 'set_of_stats', &
          stat_set, 'full')

--- a/src/source_terms/boussinesq_source_term.f90
+++ b/src/source_terms/boussinesq_source_term.f90
@@ -37,7 +37,7 @@ module boussinesq_source_term
   use field, only : field_t
   use json_module, only : json_file
   use json_utils, only: json_get, json_get_or_default, &
-       json_get_or_lookup
+       json_get_or_lookup, json_get_or_lookup_or_default
   use source_term, only : source_term_t
   use coefs, only : coef_t
   use neko_config, only : NEKO_BCKND_DEVICE
@@ -114,7 +114,7 @@ contains
     end if
 
     call json_get_or_lookup(json, "reference_value", ref_value)
-    call json_get_or_default(json, "beta", beta, 1.0_rp/ref_value)
+    call json_get_or_lookup_or_default(json, "beta", beta, 1.0_rp/ref_value)
 
     call boussinesq_source_term_init_from_components(this, fields, scalar_name,&
          ref_value, g, beta, coef, start_time, end_time)

--- a/src/source_terms/sponge_source_term.f90
+++ b/src/source_terms/sponge_source_term.f90
@@ -190,7 +190,7 @@ contains
        ! Constant base flow
     case ("constant")
 
-       call json_get(baseflow_subdict, "value", constant_value)
+       call json_get_or_lookup(baseflow_subdict, "value", constant_value)
        if (size(constant_value) .lt. 3) then
           call neko_error("(SPONGE) Expected 3 elements for 'value'")
        end if


### PR DESCRIPTION
A small PR to add a bunch of `json_*_lookup` statements for some variables for which it can be handy to use the `constants` register in the case file.

One example could be `T_ref` in the TKE model (`deardorf.f90`): `T_ref` is often equal to other reference temperature values used as input in the `.case` file, so one might as well use a `lookup` statement for that.

Similarly, often the `start_time` and output frequencies of scalar and fluid statistics are the same, so again it'd be handy to specify that only once in the `constants` group. Hence a `lookup` statement was added there as well.
(This is not specific to ABL simulations but I don't see it as a possible cause of problems for other users...?)