### PR TITLE
Add memory free for neko_simcomps

### DIFF
--- a/src/neko.f90
+++ b/src/neko.f90
@@ -274,6 +274,8 @@ contains
        call C%free()
     end if
 
+    call neko_simcomps%free()
+
     call neko_registry%free()
     call neko_user_access%free()
     call neko_log%free()


### PR DESCRIPTION
Free memory for neko_simcomps before freeing other resources.

Please piggyback if this needs to be done in other places in the code. @njansson I haven't look at the neko_api code but I suspect it should also be added there?