### PR TITLE
Add OpenMP statements in ksp, to aid auto parallelisation

### DIFF
--- a/src/krylov/bcknd/cpu/cg.f90
+++ b/src/krylov/bcknd/cpu/cg.f90
@@ -204,6 +204,7 @@ contains
 
          if ((p_cur .eq. CG_P_SPACE) .or. &
               (rnorm .lt. this%abs_tol) .or. iter .eq. max_iter) then
+            !$omp parallel do private(blk_size, j, k, x_plus)
             do i = 0, n, NEKO_BLK_SIZE
                blk_size = min(NEKO_BLK_SIZE, n - i)
                do concurrent (k = 1:blk_size)
@@ -220,6 +221,7 @@ contains
                   x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
                end do
             end do
+            !$omp end parallel do
             p_prev = p_cur
             p_cur = 1
             if (rnorm .lt. this%abs_tol) exit
@@ -243,10 +245,12 @@ contains
     integer :: i, ierr
 
     tmp = 0.0_xp
+    !$omp parallel do simd reduction(+:tmp)
     do i = 1, n
        r(i) = r(i) - alpha*w(i)
        tmp = tmp + r(i) * r(i) * mult(i)
     end do
+    !$omp end parallel do simd
     call MPI_Allreduce(MPI_IN_PLACE, tmp, 1, &
          MPI_EXTRA_PRECISION, MPI_SUM, NEKO_COMM, ierr)
     rtr = tmp

--- a/src/krylov/bcknd/cpu/gmres.f90
+++ b/src/krylov/bcknd/cpu/gmres.f90
@@ -176,6 +176,7 @@ contains
     integer :: i, j, k, l, ierr
     real(kind=xp) :: w_plus(NEKO_BLK_SIZE), x_plus(NEKO_BLK_SIZE)
     real(kind=xp) :: alpha, lr, alpha2, norm_fac
+    real(kind=xp) :: hl_priv(this%lgmres)
     real(kind=rp) :: temp, rnorm
     logical :: conv
 
@@ -231,37 +232,50 @@ contains
             call blst%apply(w, n)
 
             do l = 1, j
-               h(l,j) = 0.0_rp
+               h(l,j) = 0.0_xp
             end do
 
+            !$omp parallel private(k, l, hl_priv)
+            do l = 1, j
+               hl_priv(l) = 0.0_xp
+            end do
+            !$omp do
             do i = 0, n, NEKO_BLK_SIZE
                do l = 1, j
-                  do k = 1, min(NEKO_BLK_SIZE, n - i)
-                     h(l,j) = h(l,j) + &
+                  do concurrent (k = 1:min(NEKO_BLK_SIZE, n - i))
+                     hl_priv(l) = hl_priv(l) + &
                           w(i+k) * v(i+k,l) * coef%mult(i+k,1,1,1)
                   end do
                end do
             end do
+            !$omp end do
 
+            do l = 1, j
+               !$omp atomic
+               h(l,j) = h(l,j) + hl_priv(l)
+            end do
+
+            !$omp end parallel
             call MPI_Allreduce(MPI_IN_PLACE, h(1,j), j, &
                  MPI_EXTRA_PRECISION, MPI_SUM, NEKO_COMM, ierr)
 
             alpha2 = 0.0_rp
+            !$omp parallel do private(k, l, w_plus) reduction(+:alpha2)
             do i = 0, n, NEKO_BLK_SIZE
-               do k = 1, min(NEKO_BLK_SIZE, n - i)
+               do concurrent (k = 1:min(NEKO_BLK_SIZE, n - i))
                   w_plus(k) = 0.0_rp
                end do
                do l = 1, j
-                  do k = 1, min(NEKO_BLK_SIZE, n - i)
+                  do concurrent (k = 1:min(NEKO_BLK_SIZE, n - i))
                      w_plus(k) = w_plus(k) - h(l,j) * v(i+k,l)
                   end do
                end do
-               do k = 1, min(NEKO_BLK_SIZE, n - i)
+               do concurrent (k = 1:min(NEKO_BLK_SIZE, n - i))
                   w(i+k) = w(i+k) + w_plus(k)
                   alpha2 = alpha2 + w(i+k)**2 * coef%mult(i+k,1,1,1)
                end do
             end do
-
+            !$omp end parallel do
             call MPI_Allreduce(MPI_IN_PLACE,alpha2, 1, &
                  MPI_EXTRA_PRECISION, MPI_SUM, NEKO_COMM, ierr)
             alpha = sqrt(alpha2)
@@ -309,6 +323,7 @@ contains
             c(k) = temp / h(k,k)
          end do
 
+         !$omp parallel do private(k, l, x_plus)
          do i = 0, n, NEKO_BLK_SIZE
             do k = 1, min(NEKO_BLK_SIZE, n - i)
                x_plus(k) = 0.0_rp
@@ -322,6 +337,7 @@ contains
                x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
             end do
          end do
+         !$omp end parallel do
       end do
 
     end associate

--- a/src/krylov/bcknd/cpu/pipecg.f90
+++ b/src/krylov/bcknd/cpu/pipecg.f90
@@ -217,11 +217,13 @@ contains
       tmp1 = 0.0_rp
       tmp2 = 0.0_rp
       tmp3 = 0.0_rp
+      !$omp parallel do simd reduction(+:tmp1,tmp2,tmp3)
       do i = 1, n
          tmp1 = tmp1 + r(i) * coef%mult(i,1,1,1) * u(i,u_prev)
          tmp2 = tmp2 + w(i) * coef%mult(i,1,1,1) * u(i,u_prev)
          tmp3 = tmp3 + r(i) * coef%mult(i,1,1,1) * r(i)
       end do
+      !$omp end parallel do simd
       reduction(1) = tmp1
       reduction(2) = tmp2
       reduction(3) = tmp3
@@ -257,6 +259,7 @@ contains
          tmp1 = 0.0_rp
          tmp2 = 0.0_rp
          tmp3 = 0.0_rp
+         !$omp parallel do private(k) reduction(+:tmp1,tmp2,tmp3)
          do i = 0, n, NEKO_BLK_SIZE
             do k = 1, min(NEKO_BLK_SIZE, n - i)
                z(i+k) = beta(p_cur) * z(i+k) + ni(i+k)
@@ -270,12 +273,13 @@ contains
                tmp3 = tmp3 + r(i+k) * coef%mult(i+k,1,1,1) * r(i+k)
             end do
          end do
-
+         !$omp end parallel do
          reduction(1) = tmp1
          reduction(2) = tmp2
          reduction(3) = tmp3
 
          if (p_cur .eq. PIPECG_P_SPACE) then
+            !$omp parallel do private(k, j, p_prev, x_plus)
             do i = 0, n, NEKO_BLK_SIZE
                do k = 1, min(NEKO_BLK_SIZE, n - i)
                   x_plus(k) = 0.0_rp
@@ -293,6 +297,7 @@ contains
                   u(i+k,PIPECG_P_SPACE+1) = u(i+k,PIPECG_P_SPACE)
                end do
             end do
+            !$omp end parallel do
             p_prev = p_cur
             u_prev = PIPECG_P_SPACE+1
             alpha(1) = alpha(p_cur)
@@ -306,6 +311,7 @@ contains
       end do
 
       if ( p_cur .ne. 1) then
+         !$omp parallel do private(k, j, p_prev, x_plus)
          do i = 0, n, NEKO_BLK_SIZE
             do k = 1, min(NEKO_BLK_SIZE, n - i)
                x_plus(k) = 0.0_rp
@@ -323,6 +329,7 @@ contains
                u(i+k,PIPECG_P_SPACE+1) = u(i+k,PIPECG_P_SPACE)
             end do
          end do
+         !$omp end parallel do
       end if
       call this%monitor_stop()
       ksp_results%res_final = rnorm


### PR DESCRIPTION
This PR improves multithreaded performance of our linear solvers by adding explicit pragmas to steer the auto-parallelisation, fixes #2429
