### PR TITLE
Change loops to do concurrent to improve auto-parallelisation, and restructure dealiasing for better omp threading

### DIFF
--- a/src/fluid/bcknd/advection/adv_dealias.f90
+++ b/src/fluid/bcknd/advection/adv_dealias.f90
@@ -310,7 +310,7 @@ contains
          call sub2(fz%x, this%temp, n)
 
       else
-
+         !$omp parallel do private(e, i, idx)
          do e = 1, coef%msh%nelv
             call this%GLL_to_GL%map(tx, vx%x(1,1,1,e), 1, this%Xh_GL)
             call this%GLL_to_GL%map(ty, vy%x(1,1,1,e), 1, this%Xh_GL)
@@ -342,6 +342,7 @@ contains
                fz%x(i+idx,1,1,1) = fz%x(i+idx,1,1,1) - tempz(i+1)
             end do
          end do
+         !$omp end parallel do
       end if
     end associate
 
@@ -427,6 +428,7 @@ contains
          call sub2(fs%x, this%temp, n)
 
       else
+         !$omp parallel do private (e, i, idx)
          do e = 1, coef%msh%nelv
             ! Map advecting velocity onto the higher-order space
             call this%GLL_to_GL%map(vx_GL, vx%x(1,1,1,e), 1, this%Xh_GL)
@@ -451,6 +453,7 @@ contains
 
             call sub2(fs%x(idx, 1, 1, 1), temp, this%Xh_GLL%lxyz)
          end do
+         !$omp end parallel do
       end if
     end associate
 
@@ -506,6 +509,7 @@ contains
          call neko_error("ALE advection with dealiasing not " // &
               "implemented yet for device")
       else
+         !$omp parallel do private(e, i, flux_GL, total_div_GL, idx)
          do e = 1, coef%msh%nelv
             ! Map advecting velocity and mesh velocity onto the higher-order space
             call this%GLL_to_GL%map(vx_GL, vx%x(1,1,1,e), 1, this%Xh_GL)
@@ -579,6 +583,7 @@ contains
                fz%x(i+idx,1,1,1) = fz%x(i+idx,1,1,1) + temp_z(i+1)
             end do
          end do
+        !$omp end parallel do
       end if
     end associate
 

--- a/src/fluid/bcknd/advection/adv_dealias.f90
+++ b/src/fluid/bcknd/advection/adv_dealias.f90
@@ -583,7 +583,7 @@ contains
                fz%x(i+idx,1,1,1) = fz%x(i+idx,1,1,1) + temp_z(i+1)
             end do
          end do
-        !$omp end parallel do
+         !$omp end parallel do
       end if
     end associate
 

--- a/src/fluid/bcknd/cpu/pnpn_res_cpu.f90
+++ b/src/fluid/bcknd/cpu/pnpn_res_cpu.f90
@@ -65,7 +65,7 @@ contains
     ! We assume the material properties are constant
     rho_val = rho%x(1,1,1,1)
     mu_val = mu%x(1,1,1,1)
-    do i = 1, n
+    do concurrent (i = 1:n)
        c_Xh%h1(i,1,1,1) = 1.0_rp / rho_val
        c_Xh%h2(i,1,1,1) = 0.0_rp
     end do

--- a/src/math/math.f90
+++ b/src/math/math.f90
@@ -207,7 +207,7 @@ contains
     real(kind=rp), dimension(n), intent(inout) :: a
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = 0.0_rp
     end do
   end subroutine rzero
@@ -218,7 +218,7 @@ contains
     integer, dimension(n), intent(inout) :: a
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = 0
     end do
   end subroutine izero
@@ -229,7 +229,7 @@ contains
     real(kind=rp), intent(inout) :: a(m,n)
     integer :: j
 
-    do j = 1,n
+    do concurrent (j = 1:n)
        a(e,j) = 0.0_rp
     end do
   end subroutine row_zero
@@ -240,7 +240,7 @@ contains
     real(kind=rp), dimension(n), intent(inout) :: a
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = 1.0_rp
     end do
   end subroutine rone
@@ -252,7 +252,7 @@ contains
     real(kind=rp), dimension(n), intent(inout) :: a
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = b(i)
     end do
 
@@ -272,7 +272,7 @@ contains
     integer, dimension(0:n_mask) :: mask
     integer :: i, j
 
-    do i = 1, n_mask
+    do concurrent (i = 1:n_mask)
        j = mask(i)
        a(j) = b(j)
     end do
@@ -293,7 +293,7 @@ contains
     integer, dimension(n_mask) :: mask
     integer :: i, j
 
-    do i = 1, n_mask
+    do concurrent (i = 1:n_mask)
        j = mask(i)
        a(j) = b(j)
     end do
@@ -316,7 +316,7 @@ contains
     integer, dimension(0:n_mask) :: mask
     integer :: i, j
 
-    do i = 1, n_mask
+    do concurrent (i = 1:n_mask)
        j = mask(i)
        a(i) = b(j)
     end do
@@ -339,7 +339,7 @@ contains
     integer, dimension(n_mask) :: mask
     integer :: i, j
 
-    do i = 1, n_mask
+    do concurrent (i = 1:n_mask)
        j = mask(i)
        a(i) = b(j)
     end do
@@ -362,7 +362,7 @@ contains
     integer, dimension(0:n_mask) :: mask
     integer :: i, j
 
-    do i = 1, n_mask
+    do concurrent (i = 1:n_mask)
        j = mask(i)
        a(j) = b(i)
     end do
@@ -385,7 +385,7 @@ contains
     integer, dimension(n_mask) :: mask
     integer :: i, j
 
-    do i = 1, n_mask
+    do concurrent (i = 1:n_mask)
        j = mask(i)
        a(j) = b(i)
     end do
@@ -401,7 +401,7 @@ contains
     integer, dimension(n_mask), intent(in) :: mask
     integer :: i
 
-    do i = 1, n_mask
+    do concurrent (i = 1:n_mask)
        a(mask(i)) = c
     end do
 
@@ -414,7 +414,7 @@ contains
     real(kind=rp), intent(in) :: c
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = c * a(i)
     end do
   end subroutine cmult
@@ -427,7 +427,7 @@ contains
     real(kind=rp), intent(in) :: c
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = c * b(i)
     end do
 
@@ -440,7 +440,7 @@ contains
     real(kind=rp), intent(in) :: c
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = c / a(i)
     end do
   end subroutine cdiv
@@ -453,7 +453,7 @@ contains
     real(kind=rp), intent(in) :: c
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = c / b(i)
     end do
   end subroutine cdiv2
@@ -465,7 +465,7 @@ contains
     real(kind=rp), intent(in) :: s
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = a(i) + s
     end do
   end subroutine cadd
@@ -478,7 +478,7 @@ contains
     real(kind=rp), intent(in) :: s
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = b(i) + s
     end do
   end subroutine cadd2
@@ -490,7 +490,7 @@ contains
     real(kind=rp), intent(in) :: c
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = c
     end do
   end subroutine cfill
@@ -581,7 +581,7 @@ contains
     real(kind=rp), dimension(n), intent(inout) :: a
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = -a(i)
     end do
 
@@ -616,7 +616,7 @@ contains
     real(kind=rp), dimension(n), intent(inout) :: a
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = 1.0_xp / real(a(i), xp)
     end do
 
@@ -629,7 +629,7 @@ contains
     real(kind=rp), dimension(n), intent(in) :: b, c
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = real(b(i), xp) / c(i)
     end do
 
@@ -642,7 +642,7 @@ contains
     real(kind=rp), dimension(n), intent(in) :: b
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = 1.0_xp / real(b(i), xp)
     end do
 
@@ -657,7 +657,7 @@ contains
     real(kind=rp), dimension(n), intent(out) :: u1, u2, u3
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        u1(i) = v2(i)*w3(i) - v3(i)*w2(i)
        u2(i) = v3(i)*w1(i) - v1(i)*w3(i)
        u3(i) = v1(i)*w2(i) - v2(i)*w1(i)
@@ -673,7 +673,7 @@ contains
     real(kind=rp), dimension(n), intent(in) :: v1, v2
     real(kind=rp), dimension(n), intent(out) :: dot
     integer :: i
-    do i = 1, n
+    do concurrent (i = 1:n)
        dot(i) = u1(i)*v1(i) + u2(i)*v2(i)
     end do
 
@@ -688,7 +688,7 @@ contains
     real(kind=rp), dimension(n), intent(out) :: dot
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        dot(i) = u1(i)*v1(i) + u2(i)*v2(i) + u3(i)*v3(i)
     end do
 
@@ -729,7 +729,7 @@ contains
     real(kind=rp), dimension(n), intent(in) :: b
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = a(i) + b(i)
     end do
 
@@ -743,7 +743,7 @@ contains
     real(kind=rp), dimension(n), intent(in) :: c
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = b(i) + c(i)
     end do
 
@@ -758,7 +758,7 @@ contains
     real(kind=rp), dimension(n), intent(in) :: b
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = b(i) + c(i) + d(i)
     end do
 
@@ -771,7 +771,7 @@ contains
     real(kind=rp), dimension(n), intent(in) :: b
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = a(i) - b(i)
     end do
 
@@ -785,7 +785,7 @@ contains
     real(kind=rp), dimension(n), intent(in) :: c
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = b(i) - c(i)
     end do
 
@@ -801,7 +801,7 @@ contains
     real(kind=rp), intent(in) :: c1
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = c1 * a(i) + b(i)
     end do
 
@@ -816,7 +816,7 @@ contains
     real(kind=rp), intent(in) :: c1
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = a(i) + c1 * b(i)
     end do
 
@@ -830,7 +830,7 @@ contains
     real(kind=rp), intent(in) :: c1
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = a(i) + c1 * ( b(i) * b(i) )
     end do
 
@@ -843,7 +843,7 @@ contains
     real(kind=rp), dimension(n), intent(in) :: b
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = real(a(i), xp) / b(i)
     end do
 
@@ -857,7 +857,7 @@ contains
     real(kind=rp), dimension(n), intent(in) :: b
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = a(i) * b(i)
     end do
 
@@ -871,7 +871,7 @@ contains
     real(kind=rp), dimension(n), intent(in) :: c
     integer :: i
 
-    do i = 1, n
+    do concurrent (i = 1:n)
        a(i) = b(i) * c(i)
     end do
 
@@ -885,7 +885,7 @@ contains
     real(kind=rp), dimension(n), intent(in) :: c
     integer :: i
 
-    do i = 1,n
+    do concurrent (i = 1:n)
        a(i) = a(i) - b(i) * c(i)
     end do
 
@@ -900,7 +900,7 @@ contains
     real(kind=rp), intent(in) :: c1, c2
     integer :: i
 
-    do i = 1,n
+    do concurrent (i = 1:n)
        a(i) = c1 * b(i) + c2 * c(i)
     end do
 
@@ -916,7 +916,7 @@ contains
     real(kind=rp), intent(in) :: c1, c2, c3
     integer :: i
 
-    do i = 1,n
+    do concurrent (i = 1:n)
        a(i) = c1 * b(i) + c2 * c(i) + c3 * d(i)
     end do
 
@@ -933,7 +933,7 @@ contains
     real(kind=rp), intent(in) :: c1, c2, c3, c4
     integer :: i
 
-    do i = 1,n
+    do concurrent (i = 1:n)
        a(i) = a(i) + c1 * b(i) + c2 * c(i) + c3 * d(i) + c4 * e(i)
     end do
 
@@ -948,7 +948,7 @@ contains
     real(kind=rp), dimension(n), intent(in) :: d
     integer :: i
 
-    do i = 1,n
+    do concurrent (i = 1:n)
        a(i) = a(i) - b(i) * c(i) * d(i)
     end do
 
@@ -962,7 +962,7 @@ contains
     real(kind=rp), dimension(n), intent(in) :: c
     integer :: i
 
-    do i = 1,n
+    do concurrent (i = 1:n)
        a(i) = a(i) + b(i) * c(i)
     end do
 
@@ -977,7 +977,7 @@ contains
     real(kind=rp), dimension(n), intent(in) :: d
     integer :: i
 
-    do i = 1,n
+    do concurrent (i = 1:n)
        a(i) = a(i) + b(i) * c(i) * d(i)
     end do
 
@@ -992,7 +992,7 @@ contains
     real(kind=rp), intent(in) :: s
     integer :: i
 
-    do i = 1,n
+    do concurrent (i = 1:n)
        a(i) = a(i) + s * b(i) * c(i)
     end do
 
@@ -1008,8 +1008,8 @@ contains
     real(kind=rp), dimension(n), intent(in) :: e
     integer :: i
 
-    do i = 1,n
-       a(i) = b(i)*c(i)-d(i)*e(i)
+    do concurrent (i = 1:n)
+       a(i) = b(i)*c(i) - d(i)*e(i)
     end do
 
   end subroutine ascol5
@@ -1023,7 +1023,7 @@ contains
     real(kind=rp), intent(in) :: c1, c2
     integer :: i
 
-    do i = 1,n
+    do concurrent (i = 1:n)
        a(i) = b(i) + c1*(a(i)-c2*c(i))
     end do
 
@@ -1038,7 +1038,7 @@ contains
     real(kind=rp), intent(in) :: c1, c2
     integer :: i
 
-    do i = 1,n
+    do concurrent (i = 1:n)
        a(i) = a(i) + c1*b(i)+c2*c(i)
     end do
 

--- a/src/math/mathops.f90
+++ b/src/math/mathops.f90
@@ -78,13 +78,13 @@ contains
     integer :: i
 
     if (gdim .eq. 3) then
-       do i = 1, n
+       do concurrent (i = 1:n)
           a1(i) = -a1(i)
           a2(i) = -a2(i)
           a3(i) = -a3(i)
        end do
     else
-       do i = 1, n
+       do concurrent (i = 1:n)
           a1(i) = -a1(i)
           a2(i) = -a2(i)
        end do
@@ -100,13 +100,13 @@ contains
     integer :: i
 
     if (gdim .eq. 3) then
-       do i = 1, n
+       do concurrent (i = 1:n)
           a1(i) = a1(i)*c(i)
           a2(i) = a2(i)*c(i)
           a3(i) = a3(i)*c(i)
        end do
     else
-       do i = 1, n
+       do concurrent (i = 1:n)
           a1(i) = a1(i)*c(i)
           a2(i) = a2(i)*c(i)
        end do
@@ -123,13 +123,13 @@ contains
     integer :: i
 
     if (gdim .eq. 3) then
-       do i = 1, n
+       do concurrent (i = 1:n)
           a1(i) = b1(i)*c(i)*d
           a2(i) = b2(i)*c(i)*d
           a3(i) = b3(i)*c(i)*d
        end do
     else
-       do i = 1, n
+       do concurrent (i = 1:n)
           a1(i) =  b1(i)*c(i)*d
           a2(i) =  b2(i)*c(i)*d
        end do
@@ -146,13 +146,13 @@ contains
     integer :: i
 
     if (gdim .eq. 3) then
-       do i = 1, n
+       do concurrent (i = 1:n)
           a1(i) = a1(i) + b1(i)*c
           a2(i) = a2(i) + b2(i)*c
           a3(i) = a3(i) + b3(i)*c
        end do
     else
-       do i = 1, n
+       do concurrent (i = 1:n)
           a1(i) = a1(i) + b1(i)*c
           a2(i) = a2(i) + b2(i)*c
        end do
@@ -169,13 +169,13 @@ contains
     integer :: i
 
     if (gdim .eq. 3) then
-       do i = 1, n
+       do concurrent (i = 1:n)
           a1(i) = a1(i) + b1(i)*c(i)
           a2(i) = a2(i) + b2(i)*c(i)
           a3(i) = a3(i) + b3(i)*c(i)
        end do
     else
-       do i = 1, n
+       do concurrent (i = 1:n)
           a1(i) = a1(i) + b1(i)*c(i)
           a2(i) = a2(i) + b2(i)*c(i)
        end do

--- a/src/math/mathops.f90
+++ b/src/math/mathops.f90
@@ -68,7 +68,7 @@ module mathops
   private
 
   public :: opchsign, opcolv, opcolv3c, opadd2cm, opadd2col
-  
+
 contains
 
   !> \f$ a_i(j) = -a_i(j) \f$ for \f$j=1 \ldots n\f$ and \f$i=1 \ldots gdim\f$.
@@ -130,8 +130,8 @@ contains
        end do
     else
        do concurrent (i = 1:n)
-          a1(i) =  b1(i)*c(i)*d
-          a2(i) =  b2(i)*c(i)*d
+          a1(i) = b1(i)*c(i)*d
+          a2(i) = b2(i)*c(i)*d
        end do
     end if
 

--- a/src/sem/coef.f90
+++ b/src/sem/coef.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2020-2024, The Neko Authors
+! Copyright (c) 2020-2026, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -876,12 +876,12 @@ contains
             call rone (dtdz, ntot)
          else
             !$omp parallel private(i)
-            !$omp do
+            !$omp do simd
             do i = 1, ntot
                c%jac(i, 1, 1, 1) = 0.0_rp
             end do
-            !$omp end do
-            !$omp do
+            !$omp end do simd
+            !$omp do simd
             do i = 1, ntot
                c%jac(i, 1, 1, 1) = c%jac(i, 1, 1, 1) + ( c%dxdr(i, 1, 1, 1) &
                     * c%dyds(i, 1, 1, 1) * c%dzdt(i, 1, 1, 1) )
@@ -892,8 +892,8 @@ contains
                c%jac(i, 1, 1, 1) = c%jac(i, 1, 1, 1) + ( c%dxds(i, 1, 1, 1) &
                     * c%dydt(i, 1, 1, 1) * c%dzdr(i, 1, 1, 1) )
             end do
-            !$omp end do
-            !$omp do
+            !$omp end do simd
+            !$omp do simd
             do i = 1, ntot
                c%jac(i, 1, 1, 1) = c%jac(i, 1, 1, 1) - ( c%dxdr(i, 1, 1, 1) &
                     * c%dydt(i, 1, 1, 1) * c%dzds(i, 1, 1, 1) )
@@ -904,8 +904,8 @@ contains
                c%jac(i, 1, 1, 1) = c%jac(i, 1, 1, 1) - ( c%dxdt(i, 1, 1, 1) &
                     * c%dyds(i, 1, 1, 1) * c%dzdr(i, 1, 1, 1) )
             end do
-            !$omp end do
-            !$omp do
+            !$omp end do simd
+            !$omp do simd
             do i = 1, ntot
                c%drdx(i, 1, 1, 1) = c%dyds(i, 1, 1, 1) * c%dzdt(i, 1, 1, 1) &
                     - c%dydt(i, 1, 1, 1) * c%dzds(i, 1, 1, 1)
@@ -916,8 +916,8 @@ contains
                c%drdz(i, 1, 1, 1) = c%dxds(i, 1, 1, 1) * c%dydt(i, 1, 1, 1) &
                     - c%dxdt(i, 1, 1, 1) * c%dyds(i, 1, 1, 1)
             end do
-            !$omp end do
-            !$omp do
+            !$omp end do simd
+            !$omp do simd
             do i = 1, ntot
                c%dsdx(i, 1, 1, 1) = c%dydt(i, 1, 1, 1) * c%dzdr(i, 1, 1, 1) &
                     - c%dydr(i, 1, 1, 1) * c%dzdt(i, 1, 1, 1)
@@ -928,8 +928,8 @@ contains
                c%dsdz(i, 1, 1, 1) = c%dxdt(i, 1, 1, 1) * c%dydr(i, 1, 1, 1) &
                     - c%dxdr(i, 1, 1, 1) * c%dydt(i, 1, 1, 1)
             end do
-            !$omp end do
-            !$omp do
+            !$omp end do simd
+            !$omp do simd
             do i = 1, ntot
                c%dtdx(i, 1, 1, 1) = c%dydr(i, 1, 1, 1) * c%dzds(i, 1, 1, 1) &
                     - c%dyds(i, 1, 1, 1) * c%dzdr(i, 1, 1, 1)
@@ -940,7 +940,7 @@ contains
                c%dtdz(i, 1, 1, 1) = c%dxdr(i, 1, 1, 1) * c%dyds(i, 1, 1, 1) &
                     - c%dxds(i, 1, 1, 1) * c%dydr(i, 1, 1, 1)
             end do
-            !$omp end do
+            !$omp end do simd
             !$omp end parallel
          end if
          call invers2(jacinv, jac, ntot)
@@ -1169,7 +1169,10 @@ contains
     allocate(c(coef%Xh%lx, coef%Xh%lx, coef%Xh%lx, coef%msh%nelv))
     allocate(dot(coef%Xh%lx, coef%Xh%lx, coef%Xh%lx, coef%msh%nelv))
 
+    !$omp parallel private (e, i, j, k, weight, len)
+
     ! ds x dt
+    !$omp do simd
     do i = 1, n
        a(i, 1, 1, 1) = coef%dyds(i, 1, 1, 1) * coef%dzdt(i, 1, 1, 1) &
             - coef%dzds(i, 1, 1, 1) * coef%dydt(i, 1, 1, 1)
@@ -1180,14 +1183,16 @@ contains
        c(i, 1, 1, 1) = coef%dxds(i, 1, 1, 1) * coef%dydt(i, 1, 1, 1) &
             - coef%dyds(i, 1, 1, 1) * coef%dxdt(i, 1, 1, 1)
     end do
-
+    !$omp end do simd
+    !$omp do simd
     do i = 1, n
        dot(i, 1, 1, 1) = a(i, 1, 1, 1) * a(i, 1, 1, 1) &
             + b(i, 1, 1, 1) * b(i, 1, 1, 1) &
             + c(i, 1, 1, 1) * c(i, 1, 1, 1)
     end do
-
-    do concurrent (e = 1:coef%msh%nelv)
+    !$omp end do simd
+    !$omp do
+    do e = 1, coef%msh%nelv
        do concurrent (k = 1:coef%Xh%lx)
           do concurrent (j = 1:coef%Xh%lx)
              weight = coef%Xh%wy(j) * coef%Xh%wz(k)
@@ -1202,8 +1207,10 @@ contains
           end do
        end do
     end do
+    !$omp end do
 
     ! dr x dt
+    !$omp do simd
     do i = 1, n
        a(i, 1, 1, 1) = coef%dydr(i, 1, 1, 1) * coef%dzdt(i, 1, 1, 1) &
             - coef%dzdr(i, 1, 1, 1) * coef%dydt(i, 1, 1, 1)
@@ -1214,14 +1221,16 @@ contains
        c(i, 1, 1, 1) = coef%dxdr(i, 1, 1, 1) * coef%dydt(i, 1, 1, 1) &
             - coef%dydr(i, 1, 1, 1) * coef%dxdt(i, 1, 1, 1)
     end do
-
+    !$omp end do simd
+    !$omp do simd
     do i = 1, n
        dot(i, 1, 1, 1) = a(i, 1, 1, 1) * a(i, 1, 1, 1) &
             + b(i, 1, 1, 1) * b(i, 1, 1, 1) &
             + c(i, 1, 1, 1) * c(i, 1, 1, 1)
     end do
-
-    do concurrent (e = 1:coef%msh%nelv)
+    !$omp end do simd
+    !$omp do
+    do e = 1, coef%msh%nelv
        do concurrent (k = 1:coef%Xh%lx)
           do concurrent (j = 1:coef%Xh%lx)
              weight = coef%Xh%wx(j) * coef%Xh%wz(k)
@@ -1236,8 +1245,9 @@ contains
           end do
        end do
     end do
-
+    !$omp end do
     ! dr x ds
+    !$omp do simd
     do i = 1, n
        a(i, 1, 1, 1) = coef%dydr(i, 1, 1, 1) * coef%dzds(i, 1, 1, 1) &
             - coef%dzdr(i, 1, 1, 1) * coef%dyds(i, 1, 1, 1)
@@ -1248,14 +1258,16 @@ contains
        c(i, 1, 1, 1) = coef%dxdr(i, 1, 1, 1) * coef%dyds(i, 1, 1, 1) &
             - coef%dydr(i, 1, 1, 1) * coef%dxds(i, 1, 1, 1)
     end do
-
+    !$omp end do simd
+    !$omp do simd
     do i = 1, n
        dot(i, 1, 1, 1) = a(i, 1, 1, 1) * a(i, 1, 1, 1) &
             + b(i, 1, 1, 1) * b(i, 1, 1, 1) &
             + c(i, 1, 1, 1) * c(i, 1, 1, 1)
     end do
-
-    do concurrent (e = 1:coef%msh%nelv)
+    !$omp end do simd
+    !$omp do
+    do e = 1, coef%msh%nelv
        do concurrent (k = 1:coef%Xh%lx)
           do concurrent (j = 1:coef%Xh%lx)
              weight = coef%Xh%wx(j) * coef%Xh%wy(k)
@@ -1270,8 +1282,9 @@ contains
           end do
        end do
     end do
-
+    !$omp end do
     ! Normalize
+    !$omp do
     do j = 1, size(coef%nz)
        len = sqrt(coef%nx(j,1,1,1)**2 + &
             coef%ny(j,1,1,1)**2 + coef%nz(j,1,1,1)**2)
@@ -1281,6 +1294,8 @@ contains
           coef%nz(j,1,1,1) = coef%nz(j,1,1,1) / len
        end if
     end do
+    !$omp end do
+    !$omp end parallel
 
     deallocate(dot)
     deallocate(c)


### PR DESCRIPTION
This PR changes performance critical loops to `do concurrent` such that restrictive compilers will vectorise and also provide software pipelining. Furthermore, threading in dealiasing is also improved by explicitly add an OpenMP region around each independent element loop, instead of the short loops the auto-parallelisation identified. (refs #2335)