### PR TITLE
Fix/mu_msk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Develop
 
+- Fixed a bug (mu_msk) in `device_calc_force_array` in `force_torque.f90`.
 - Added ALE framework.
 - Added masked I/O capabilities for the field_writer via the optional 
   `point_zone` JSON keyword.

--- a/src/simulation_components/force_torque.f90
+++ b/src/simulation_components/force_torque.f90
@@ -613,7 +613,7 @@ contains
                this%n1%x_d, &
                this%n2%x_d, &
                this%n3%x_d, &
-               this%mu%x_d, &
+               this%mu_msk%x_d, &
                n_pts)
           ! Overwriting masked s11, s22, s33 as they are no longer needed
           call device_vcross(this%s11msk%x_d, this%s22msk%x_d, &


### PR DESCRIPTION
Fixed a bug in `device_calc_force_array` in `force_torque.f90`, where `mu` was passed to the subroutine instead of `mu_msk`. This would have led to wrong force calculations for variable viscosity cases.