### PR TITLE
Decrease blocks/threads from 1024 to 256

### DIFF
--- a/src/wall_models/bcknd/device/cuda/most.cu
+++ b/src/wall_models/bcknd/device/cuda/most.cu
@@ -52,8 +52,8 @@ extern "C" {
           void *q_diagn, void *h_x_idx, void *h_y_idx,
           void *h_z_idx) {
 
-    const dim3 nthrds(1024, 1, 1);
-    const dim3 nblcks(((*n_nodes) + 1024 - 1) / 1024, 1, 1);
+    const dim3 nthrds(256, 1, 1);
+    const dim3 nblcks(((*n_nodes) + 256 - 1) / 256, 1, 1);
     const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
     real g1 = g[0], g2 = g[1], g3 = g[2];

--- a/src/wall_models/bcknd/device/cuda/rough_log_law.cu
+++ b/src/wall_models/bcknd/device/cuda/rough_log_law.cu
@@ -46,8 +46,8 @@ extern "C" {
           void *tau_x_d, void *tau_y_d, void *tau_z_d,
           int *n_nodes, int *lx, real *kappa, real *rho, real *B, real *z0, int *tstep) {
     
-    const dim3 nthrds(1024, 1, 1);
-    const dim3 nblcks(((*n_nodes) + 1024 - 1) / 1024, 1, 1);
+    const dim3 nthrds(256, 1, 1);
+    const dim3 nblcks(((*n_nodes) + 256 - 1) / 256, 1, 1);
     const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
     if (*n_nodes > 0) {


### PR DESCRIPTION
Decreased blocks/threads from 1024 to 256 for CUDA wall models. Works better for testing and hopefully production runs.
Done under the guide of Niclas the wise (I don't know much about this)