### PR TITLE
Update ABL example + minor fixes

### DIFF
--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -1134,7 +1134,7 @@ contains
 
     end do
 
-    wbf%x(:,1,1,1) = 0.0_rp    
+    wbf%x = 0.0_rp    
     
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_memcpy(ubf%x, ubf%x_d, ubf%size(), &

--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -1134,7 +1134,8 @@ contains
 
     end do
 
-    wbf = 0.0_rp
+    wbf%x(:,1,1,1) = 0.0_rp    
+    
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_memcpy(ubf%x, ubf%x_d, ubf%size(), &
             HOST_TO_DEVICE, .false.)

--- a/examples/shear_convection_abl/.gitignore
+++ b/examples/shear_convection_abl/.gitignore
@@ -1,2 +1,7 @@
 *.nmsh
 *.log
+*0.*
+*.log
+log.*
+*.nek5000
+*.csv

--- a/examples/shear_convection_abl/README.md
+++ b/examples/shear_convection_abl/README.md
@@ -1,12 +1,14 @@
 # Simple shear-convection atmospheric boundary layer (ABL) case with 512 and 32768 elements and N=7
 Simulation of a shear-convection atmospheric boundary layer (ABL) in a domain of size $(5000.0, 5000.0, 2000.0) \rm{[m]}$. The case is conditioned with dimensional geostrophic wind $[10.0, 0.0, 0.0] \rm{[m/s]}$, air density $1.0\rm{[kg/m^3]}$ and dynamic viscosity $1e-10 \rm{[kg/(m\cdot s)]}$. This case couples the shear from the geostrophic wind and the vertical convection from the buoyancy and the interior-pointing heat flux at the surface.
 
-The simulation is performed at an LES resolution if one uses the `genmeshbox` command below to generate the mesh, and Deardorff's model [1] is adopted, which solves a scalar equation for turbulent kinetic energy to formulate the eddy viscosity.
+The simulation is performed at an LES resolution if one uses the `genmeshbox` command below to generate the mesh, and Deardorff's SGS model [1] is adopted, which solves a scalar equation for turbulent kinetic energy to formulate the eddy viscosity. The wall model used in this example is MOST [2], and a sponge layer is applied at the top of the domain to prevent reflection of gravity waves down in to the domain.
+More details about the setup can be found in [3].
 
 `./genmeshbox 0 5000 0 5000 0 2000 32 32 32 .true. .true. .false.`
 
 Reference:
-
 [1] Deardorff, J.W. Stratocumulus-capped mixed layers derived from a
 three-dimensional model. Boundary-Layer Meteorol 18, 495–527 (1980).
 https://doi.org/10.1007/BF00119502
+[2] R. B. Stull, An Introduction to Boundary Layer Meteorology. Springer, 1988. [Online]. Available: https://doi.org/10.1007/978-94-009-3027-8
+[3] L. Huusko, T. Mukha, L. L. Donati, P. P. Sullivan, P. Schlatter, and G. Svensson, “Large Eddy Simulation of Canonical Atmospheric Boundary Layer Flows With the Spectral Element Method in Nek5000,” Journal of Advances in Modeling Earth Systems, vol. 17, no. 10, p. e2025MS005233, 2025. https://doi.org/10.1029/2025MS005233 

--- a/examples/shear_convection_abl/shear_convection_abl.case
+++ b/examples/shear_convection_abl/shear_convection_abl.case
@@ -68,7 +68,8 @@
                     "amplitudes": [0.01, 0.01, 0.01],
                     "baseflow": 
                       {
-                        "method": "user"
+                        "method": "constant",
+                        "value": "geo_wind"
                       }
                 }
             ],

--- a/examples/shear_convection_abl/shear_convection_abl.case
+++ b/examples/shear_convection_abl/shear_convection_abl.case
@@ -62,6 +62,14 @@
                         0.5e-4
                     ],
                     "geostrophic_wind": "geo_wind"
+                },
+                {
+                    "type": "sponge",
+                    "amplitudes": [0.01, 0.01, 0.01],
+                    "baseflow": 
+                      {
+                        "method": "user"
+                      }
                 }
             ],
             "boundary_conditions": [
@@ -74,10 +82,16 @@
                 },
                 {
                     "type": "wall_model",
-                    "model": "rough_log_law",
+                    "model": "most",
+                    "scalar_field": "temperature",
                     "kappa": 0.4,
+                    "type_of_temp_bc": "neumann",
+                    "bottom_bc_flux_or_temp": 0.05,
+                    "g": "g_vector",
+                    "time_dependent_temp_bc": false,
                     "z0": 0.1,
-                    "B": 0.0,
+                    "z0h": 0.1,
+                    "Pr": "Pr",
                     "zone_indices": [
                         5
                     ],

--- a/examples/shear_convection_abl/shear_convection_abl.case
+++ b/examples/shear_convection_abl/shear_convection_abl.case
@@ -1,7 +1,7 @@
 {
     "version": 1.0,
     "case": {
-        "mesh_file": "512.nmsh",
+        "mesh_file": "box.nmsh",
         "output_at_end": true,
         "output_checkpoints": false,
         "checkpoint_control": "simulationtime",
@@ -91,7 +91,7 @@
                     "time_dependent_temp_bc": false,
                     "z0": 0.1,
                     "z0h": 0.1,
-                    "Pr": "Pr",
+                    "Pr": 0.74,
                     "zone_indices": [
                         5
                     ],

--- a/examples/shear_convection_abl/shear_convection_abl.f90
+++ b/examples/shear_convection_abl/shear_convection_abl.f90
@@ -13,6 +13,7 @@ contains
     u_geo = 10.0_rp
 
     user%initial_conditions => user_ic
+    user%initialize => user_initialize
   end subroutine user_setup
 
   ! User defined initial condition
@@ -23,8 +24,6 @@ contains
     type(field_t), pointer :: p
     type(dofmap_t), pointer :: dof
     integer :: i
-    type(field_t), pointer :: fringe
-    real(kind=rp) :: zmin_spng, delta_spng, lambda_max
     real(kind=rp) :: x, y, z
     real(kind=rp) :: eps, kx, ky, lx, ly, alpha, beta, gamma, delta, PI
     real(kind=rp) :: z1, z2, ze
@@ -57,23 +56,6 @@ contains
        u => fields%get("u")
        v => fields%get("v")
        w => fields%get("w")
-
-       ! Implement top-mounted sponge l(z) = l*S( (z-z0)/delta )
-       call neko_registry%add_field(u%dof,"sponge_fringe")
-       fringe => neko_registry%get_field("sponge_fringe")
-
-       zmin_spng = 1800.0_rp
-       delta_spng = 150.0_rp
-       fringe%x(:,1,1,1) = 0.0_rp
-
-       do i = 1, fringe%size()
-          z = fringe%dof%z(i,1,1,1)
-
-          if (z .gt. zmin_spng) then
-             fringe%x(i,1,1,1) = stp_fun( (z - zmin_spng)/delta_spng )
-          end if
-
-       end do
 
        do i = 1, u%dof%size()
           u%x(i,1,1,1) = u_geo
@@ -116,6 +98,32 @@ contains
        endif
     endif
   end subroutine user_ic
+
+  subroutine user_initialize(t)
+    type(time_state_t), intent(in) :: t
+    type(field_t), pointer :: fringe, u
+    integer :: i
+    real(kind=rp) :: zmin_spng, delta_spng, z
+      
+    ! Implement top-mounted sponge l(z) = l*S( (z-z0)/delta )
+    u => neko_registry%get_field("u")
+    call neko_registry%add_field(u%dof,"sponge_fringe")
+    fringe => neko_registry%get_field("sponge_fringe")
+ 
+    zmin_spng = 1800.0_rp
+    delta_spng = 150.0_rp
+    fringe%x(:,1,1,1) = 0.0_rp
+ 
+    do i = 1, fringe%size()
+       z = fringe%dof%z(i,1,1,1)
+ 
+       if (z .gt. zmin_spng) then
+          fringe%x(i,1,1,1) = stp_fun( (z - zmin_spng)/delta_spng )
+       end if
+ 
+    end do
+
+  end subroutine user_initialize
 
   ! Smooth step function, 0 if x <= 0, 1 if x >= 1, 1/erp(1/(x-1) + 1/x) between 0 and 1
   function stp_fun(x) result(y)

--- a/examples/shear_convection_abl/shear_convection_abl.f90
+++ b/examples/shear_convection_abl/shear_convection_abl.f90
@@ -1,4 +1,3 @@
-! Linnea Huusko 27/2-2025
 module user
   use neko
   implicit none
@@ -24,6 +23,8 @@ contains
     type(field_t), pointer :: p
     type(dofmap_t), pointer :: dof
     integer :: i
+    type(field_t), pointer :: fringe, ubf, vbf, wbf  
+    real(kind=rp) :: zmin_spng, delta_spng, lambda_max
     real(kind=rp) :: x, y, z
     real(kind=rp) :: eps, kx, ky, lx, ly, alpha, beta, gamma, delta, PI
     real(kind=rp) :: z1, z2, ze
@@ -57,6 +58,46 @@ contains
        u => fields%get("u")
        v => fields%get("v")
        w => fields%get("w")
+
+       ! Implement top-mounted sponge l(z) = l*S( (z-z0)/delta ) 
+       call neko_registry%add_field(u%dof,"sponge_fringe")
+       fringe => neko_registry%get_field("sponge_fringe")
+       call neko_registry%add_field(u%dof,"sponge_bf_u")
+       ubf => neko_registry%get_field("sponge_bf_u")
+       call neko_registry%add_field(u%dof,"sponge_bf_v")
+       vbf => neko_registry%get_field("sponge_bf_v")
+       call neko_registry%add_field(u%dof,"sponge_bf_w")
+       wbf => neko_registry%get_field("sponge_bf_w")
+
+       zmin_spng = 1800.0_rp
+       delta_spng = 150.0_rp
+       fringe%x(:,1,1,1) = 0.0_rp       
+       
+       do i = 1, fringe%size()
+         z = fringe%dof%z(i,1,1,1)
+   
+         if (z .gt. zmin_spng) then
+            fringe%x(i,1,1,1) = stp_fun( (z - zmin_spng)/delta_spng )
+         end if
+
+         ubf%x(i,1,1,1) = u_geo
+         
+       end do
+
+       vbf = 0.0_rp
+       wbf = 0.0_rp
+
+       if (neko_bcknd_device .eq. 1) then
+          call device_memcpy(ubf%x, ubf%x_d, ubf%size(), &
+                host_to_device, .false.)
+          call device_memcpy(vbf%x, vbf%x_d, vbf%size(), &
+                host_to_device, .false.)
+          call device_memcpy(wbf%x, wbf%x_d, wbf%size(), &
+                host_to_device, .false.)
+          call device_memcpy(fringe%x, fringe%x_d, fringe%size(), &
+                host_to_device, .false.)
+       end if
+ 
        do i = 1, u%dof%size()
           u%x(i,1,1,1) = u_geo
           v%x(i,1,1,1) = 0.0_rp
@@ -73,7 +114,7 @@ contains
                   - eps*(gamma * cos(gamma*x)*sin(delta*y))
           endif
        end do
-    else !scalar
+    else !scalars
        s => fields%get(scheme_name)
        if (scheme_name .eq. 'temperature') then
           do i = 1, s%dof%size()
@@ -98,5 +139,20 @@ contains
        endif
     endif
   end subroutine user_ic
+
+  ! Smooth step function, 0 if x <= 0, 1 if x >= 1, 1/erp(1/(x-1) + 1/x) between 0 and 1
+  function stp_fun(x) result(y)
+    real(kind=rp), intent(in) :: x
+    real(kind=rp)             :: y
+ 
+    if ( x.le.0._rp ) then
+       y = 0._rp
+    else if ( x.ge.1._rp ) then
+       y = 1._rp
+    else
+       y = 1._rp / (1._rp + exp( 1._rp/(x-1._rp) + 1._rp/x))
+    end if
+ 
+  end function stp_fun
 
 end module user

--- a/examples/shear_convection_abl/shear_convection_abl.f90
+++ b/examples/shear_convection_abl/shear_convection_abl.f90
@@ -83,9 +83,9 @@ contains
          ubf%x(i,1,1,1) = u_geo
          
        end do
-
-       vbf = 0.0_rp
-       wbf = 0.0_rp
+ 
+       vbf%x(:,1,1,1) = 0.0_rp
+       wbf%x(:,1,1,1) = 0.0_rp
 
        if (neko_bcknd_device .eq. 1) then
           call device_memcpy(ubf%x, ubf%x_d, ubf%size(), &

--- a/examples/shear_convection_abl/shear_convection_abl.f90
+++ b/examples/shear_convection_abl/shear_convection_abl.f90
@@ -23,7 +23,7 @@ contains
     type(field_t), pointer :: p
     type(dofmap_t), pointer :: dof
     integer :: i
-    type(field_t), pointer :: fringe, ubf, vbf, wbf  
+    type(field_t), pointer :: fringe, ubf, vbf, wbf
     real(kind=rp) :: zmin_spng, delta_spng, lambda_max
     real(kind=rp) :: x, y, z
     real(kind=rp) :: eps, kx, ky, lx, ly, alpha, beta, gamma, delta, PI
@@ -59,7 +59,7 @@ contains
        v => fields%get("v")
        w => fields%get("w")
 
-       ! Implement top-mounted sponge l(z) = l*S( (z-z0)/delta ) 
+       ! Implement top-mounted sponge l(z) = l*S( (z-z0)/delta )
        call neko_registry%add_field(u%dof,"sponge_fringe")
        fringe => neko_registry%get_field("sponge_fringe")
        call neko_registry%add_field(u%dof,"sponge_bf_u")
@@ -71,33 +71,33 @@ contains
 
        zmin_spng = 1800.0_rp
        delta_spng = 150.0_rp
-       fringe%x(:,1,1,1) = 0.0_rp       
-       
-       do i = 1, fringe%size()
-         z = fringe%dof%z(i,1,1,1)
-   
-         if (z .gt. zmin_spng) then
-            fringe%x(i,1,1,1) = stp_fun( (z - zmin_spng)/delta_spng )
-         end if
+       fringe%x(:,1,1,1) = 0.0_rp
 
-         ubf%x(i,1,1,1) = u_geo
-         
+       do i = 1, fringe%size()
+          z = fringe%dof%z(i,1,1,1)
+
+          if (z .gt. zmin_spng) then
+             fringe%x(i,1,1,1) = stp_fun( (z - zmin_spng)/delta_spng )
+          end if
+
+          ubf%x(i,1,1,1) = u_geo
+
        end do
- 
+
        vbf%x(:,1,1,1) = 0.0_rp
        wbf%x(:,1,1,1) = 0.0_rp
 
        if (neko_bcknd_device .eq. 1) then
           call device_memcpy(ubf%x, ubf%x_d, ubf%size(), &
-                host_to_device, .false.)
+               host_to_device, .false.)
           call device_memcpy(vbf%x, vbf%x_d, vbf%size(), &
-                host_to_device, .false.)
+               host_to_device, .false.)
           call device_memcpy(wbf%x, wbf%x_d, wbf%size(), &
-                host_to_device, .false.)
+               host_to_device, .false.)
           call device_memcpy(fringe%x, fringe%x_d, fringe%size(), &
-                host_to_device, .false.)
+               host_to_device, .false.)
        end if
- 
+
        do i = 1, u%dof%size()
           u%x(i,1,1,1) = u_geo
           v%x(i,1,1,1) = 0.0_rp
@@ -143,8 +143,8 @@ contains
   ! Smooth step function, 0 if x <= 0, 1 if x >= 1, 1/erp(1/(x-1) + 1/x) between 0 and 1
   function stp_fun(x) result(y)
     real(kind=rp), intent(in) :: x
-    real(kind=rp)             :: y
- 
+    real(kind=rp) :: y
+
     if ( x.le.0._rp ) then
        y = 0._rp
     else if ( x.ge.1._rp ) then
@@ -152,7 +152,7 @@ contains
     else
        y = 1._rp / (1._rp + exp( 1._rp/(x-1._rp) + 1._rp/x))
     end if
- 
+
   end function stp_fun
 
 end module user

--- a/examples/shear_convection_abl/shear_convection_abl.f90
+++ b/examples/shear_convection_abl/shear_convection_abl.f90
@@ -23,7 +23,7 @@ contains
     type(field_t), pointer :: p
     type(dofmap_t), pointer :: dof
     integer :: i
-    type(field_t), pointer :: fringe, ubf, vbf, wbf
+    type(field_t), pointer :: fringe
     real(kind=rp) :: zmin_spng, delta_spng, lambda_max
     real(kind=rp) :: x, y, z
     real(kind=rp) :: eps, kx, ky, lx, ly, alpha, beta, gamma, delta, PI
@@ -49,7 +49,6 @@ contains
     ! parameters for TKE profile
     ze = 600.0_rp
 
-
     alpha = kx * PI / 1500.0_rp
     beta = ky * PI / 1500.0_rp
     gamma = lx * PI / 1500.0_rp
@@ -62,12 +61,6 @@ contains
        ! Implement top-mounted sponge l(z) = l*S( (z-z0)/delta )
        call neko_registry%add_field(u%dof,"sponge_fringe")
        fringe => neko_registry%get_field("sponge_fringe")
-       call neko_registry%add_field(u%dof,"sponge_bf_u")
-       ubf => neko_registry%get_field("sponge_bf_u")
-       call neko_registry%add_field(u%dof,"sponge_bf_v")
-       vbf => neko_registry%get_field("sponge_bf_v")
-       call neko_registry%add_field(u%dof,"sponge_bf_w")
-       wbf => neko_registry%get_field("sponge_bf_w")
 
        zmin_spng = 1800.0_rp
        delta_spng = 150.0_rp
@@ -80,23 +73,7 @@ contains
              fringe%x(i,1,1,1) = stp_fun( (z - zmin_spng)/delta_spng )
           end if
 
-          ubf%x(i,1,1,1) = u_geo
-
        end do
-
-       vbf%x(:,1,1,1) = 0.0_rp
-       wbf%x(:,1,1,1) = 0.0_rp
-
-       if (neko_bcknd_device .eq. 1) then
-          call device_memcpy(ubf%x, ubf%x_d, ubf%size(), &
-               host_to_device, .false.)
-          call device_memcpy(vbf%x, vbf%x_d, vbf%size(), &
-               host_to_device, .false.)
-          call device_memcpy(wbf%x, wbf%x_d, wbf%size(), &
-               host_to_device, .false.)
-          call device_memcpy(fringe%x, fringe%x_d, fringe%size(), &
-               host_to_device, .false.)
-       end if
 
        do i = 1, u%dof%size()
           u%x(i,1,1,1) = u_geo

--- a/examples/shear_convection_abl/shear_convection_abl.f90
+++ b/examples/shear_convection_abl/shear_convection_abl.f90
@@ -104,23 +104,23 @@ contains
     type(field_t), pointer :: fringe, u
     integer :: i
     real(kind=rp) :: zmin_spng, delta_spng, z
-      
+
     ! Implement top-mounted sponge l(z) = l*S( (z-z0)/delta )
     u => neko_registry%get_field("u")
     call neko_registry%add_field(u%dof,"sponge_fringe")
     fringe => neko_registry%get_field("sponge_fringe")
- 
+
     zmin_spng = 1800.0_rp
     delta_spng = 150.0_rp
     fringe%x(:,1,1,1) = 0.0_rp
- 
+
     do i = 1, fringe%size()
        z = fringe%dof%z(i,1,1,1)
- 
+
        if (z .gt. zmin_spng) then
           fringe%x(i,1,1,1) = stp_fun( (z - zmin_spng)/delta_spng )
        end if
- 
+
     end do
 
   end subroutine user_initialize

--- a/src/wall_models/rough_log_law.f90
+++ b/src/wall_models/rough_log_law.f90
@@ -41,7 +41,8 @@ module rough_log_law
   use wall_model, only : wall_model_t
   use utils, only : neko_error
   use registry, only : neko_registry
-  use json_utils, only : json_get_or_lookup
+  use json_utils, only : json_get_or_lookup, &
+       json_get_or_lookup_or_default
   use rough_log_law_device, only : rough_log_law_compute_device
   use rough_log_law_cpu, only : rough_log_law_compute_cpu
   use scratch_registry, only : neko_scratch_registry
@@ -97,8 +98,8 @@ contains
     type(json_file), intent(inout) :: json
     real(kind=rp) :: kappa, B, z0
 
-    call json_get_or_lookup(json, "kappa", kappa)
-    call json_get_or_lookup(json, "B", B)
+    call json_get_or_lookup_or_default(json, "kappa", kappa, 0.4_rp)
+    call json_get_or_lookup_or_default(json, "B", B, 0.0_rp)
     call json_get_or_lookup(json, "z0", z0)
 
     call this%init_from_components(scheme_name, coef, msk, facet, h_index, &
@@ -115,8 +116,8 @@ contains
     character(len=LOG_SIZE) :: log_buf
 
     call this%partial_init_base(coef, json)
-    call json_get_or_lookup(json, "kappa", this%kappa)
-    call json_get_or_lookup(json, "B", this%B)
+    call json_get_or_lookup_or_default(json, "kappa", this%kappa, 0.4_rp)
+    call json_get_or_lookup_or_default(json, "B", this%B, 0.0_rp)
     call json_get_or_lookup(json, "z0", this%z0)
 
     call neko_log%section('Wall model')


### PR DESCRIPTION
Quick PR to update the current ABL flow example.

- added sponge layer
- switch WM to MOST
- added a couple of references


-----

I also did two quick and small modifications to 
- the `rough_log_law` wall model: it now automatically assigns a default value to `B`and `kappa` if the user doesn't specify them (consistent with MOST)
- the `sponge` documentation: the way `wbf` was assigned in the coding example wasn't very safe (it actually lead to an `ALLOCATE` error when trying to run)


Both of these are quick modifications that I don't think were worth opening a separate PR for. I thought about them while modifying the case files for the example.