### PR TITLE
Fix normlization in coupled_cg

### DIFF
--- a/src/krylov/bcknd/cpu/cg_coupled.f90
+++ b/src/krylov/bcknd/cpu/cg_coupled.f90
@@ -230,7 +230,7 @@ contains
     else
        max_iter = this%max_iter
     end if
-    norm_fac = 1.0_rp / coef%volume
+    norm_fac = 1.0_rp / sqrt(coef%volume)
 
     associate (p1 => this%p1, p2 => this%p2, p3 => this%p3, z1 => this%z1, &
          z2 => this%z2, z3 => this%z3, r1 => this%r1, r2 => this%r2, &

--- a/src/krylov/bcknd/device/cg_cpld_device.f90
+++ b/src/krylov/bcknd/device/cg_cpld_device.f90
@@ -334,7 +334,7 @@ contains
     else
        max_iter = this%max_iter
     end if
-    norm_fac = 1.0_rp / coef%volume
+    norm_fac = 1.0_rp / sqrt(coef%volume)
 
     associate (p1_d => this%p1_d, p2_d => this%p2_d, p3_d => this%p3_d, &
          z1_d => this%z1_d, z2_d => this%z2_d, z3_d => this%z3_d, &


### PR DESCRIPTION
Standard CPU CG uses 1.0_rp / sqrt(coef%volume) (src/krylov/bcknd/cpu/cg.f90:160), and fused_coupled_cg does the same
 (src/krylov/bcknd/device/fusedcg_cpld_device.F90:565).

So looks like a bug in coupled_cg, or?
