### PR TITLE
Remove binv residual scaling in coupled_cg

### DIFF
--- a/src/krylov/bcknd/cpu/cg_coupled.f90
+++ b/src/krylov/bcknd/cpu/cg_coupled.f90
@@ -254,7 +254,7 @@ contains
          tmp(i) = r1(i)**2 + r2(i)**2 + r3(i)**2
       end do
 
-      rtr = glsc3(tmp, coef%mult, coef%binv, n)
+      rtr = glsc2(tmp, coef%mult, n)
       rnorm = sqrt(rtr)*norm_fac
       ksp_results%res_start = rnorm
       ksp_results%res_final = rnorm
@@ -319,7 +319,7 @@ contains
             tmp(i) = r1(i)**2 + r2(i)**2 + r3(i)**2
          end do
 
-         rtr = glsc3(tmp, coef%mult, coef%binv, n)
+         rtr = glsc2(tmp, coef%mult, n)
          if (iter .eq. 1) rtr0 = rtr
          rnorm = sqrt(rtr) * norm_fac
          call this%monitor_iter(iter, rnorm)

--- a/src/krylov/bcknd/cpu/cg_coupled.f90
+++ b/src/krylov/bcknd/cpu/cg_coupled.f90
@@ -40,7 +40,7 @@ module cg_cpld
   use coefs, only : coef_t
   use gather_scatter, only : gs_t, GS_OP_ADD
   use bc_list, only : bc_list_t
-  use math, only : glsc3, glsc2, abscmp
+  use math, only : glsc2, abscmp
   use utils, only : neko_error
   use operators, only : rotate_cyc
   implicit none

--- a/src/krylov/bcknd/cpu/cg_coupled.f90
+++ b/src/krylov/bcknd/cpu/cg_coupled.f90
@@ -230,7 +230,7 @@ contains
     else
        max_iter = this%max_iter
     end if
-    norm_fac = 1.0_rp / coef%volume
+    norm_fac = 1.0_rp / sqrt(coef%volume)
 
     associate (p1 => this%p1, p2 => this%p2, p3 => this%p3, z1 => this%z1, &
          z2 => this%z2, z3 => this%z3, r1 => this%r1, r2 => this%r2, &

--- a/src/krylov/bcknd/device/cg_cpld_device.f90
+++ b/src/krylov/bcknd/device/cg_cpld_device.f90
@@ -42,7 +42,7 @@ module cg_cpld_device
   use bc_list, only : bc_list_t
   use math, only : abscmp
   use device
-  use device_math, only : device_rzero, device_copy, device_glsc3, &
+  use device_math, only : device_rzero, device_copy, &
        device_add2s1, device_vdot3, device_glsc2
   use device_mathops, only : device_opadd2cm
   use utils, only : neko_error

--- a/src/krylov/bcknd/device/cg_cpld_device.f90
+++ b/src/krylov/bcknd/device/cg_cpld_device.f90
@@ -358,7 +358,7 @@ contains
       call device_vdot3(tmp_d, r1_d, r2_d, r3_d, r1_d, r2_d, r3_d, n)
 
 
-      rtr = device_glsc3(tmp_d, coef%mult_d, coef%binv_d, n)
+      rtr = device_glsc2(tmp_d, coef%mult_d, n)
       rnorm = sqrt(rtr)*norm_fac
       ksp_results%res_start = rnorm
       ksp_results%res_final = rnorm
@@ -413,7 +413,7 @@ contains
               w1_d, w2_d, w3_d, alphm, n, gdim)
          call device_vdot3(tmp_d, r1_d, r2_d, r3_d, r1_d, r2_d, r3_d, n)
 
-         rtr = device_glsc3(tmp_d, coef%mult_d, coef%binv_d, n)
+         rtr = device_glsc2(tmp_d, coef%mult_d, n)
          if (iter .eq. 1) rtr0 = rtr
          rnorm = sqrt(rtr) * norm_fac
          call this%monitor_iter(iter, rnorm)

--- a/src/krylov/bcknd/device/cg_cpld_device.f90
+++ b/src/krylov/bcknd/device/cg_cpld_device.f90
@@ -334,7 +334,7 @@ contains
     else
        max_iter = this%max_iter
     end if
-    norm_fac = 1.0_rp / coef%volume
+    norm_fac = 1.0_rp / sqrt(coef%volume)
 
     associate (p1_d => this%p1_d, p2_d => this%p2_d, p3_d => this%p3_d, &
          z1_d => this%z1_d, z2_d => this%z2_d, z3_d => this%z3_d, &

--- a/src/krylov/bcknd/device/fusedcg_cpld_device.F90
+++ b/src/krylov/bcknd/device/fusedcg_cpld_device.F90
@@ -41,7 +41,7 @@ module fusedcg_cpld_device
   use gather_scatter, only : gs_t, GS_OP_ADD
   use bc_list, only : bc_list_t
   use math, only : glsc3, rzero, copy, abscmp
-  use device_math, only : device_rzero, device_copy, device_glsc3, device_glsc2
+  use device_math, only : device_rzero, device_copy, device_glsc2
   use device
   use utils, only : neko_error
   use comm, only : NEKO_COMM, pe_size, MPI_REAL_PRECISION

--- a/src/krylov/bcknd/device/fusedcg_cpld_device.F90
+++ b/src/krylov/bcknd/device/fusedcg_cpld_device.F90
@@ -592,7 +592,7 @@ contains
       call device_fusedcg_cpld_part1(r1_d, r2_d, r3_d, r1_d, &
            r2_d, r3_d, tmp_d, n)
 
-      rtr = device_glsc3(tmp_d, coef%mult_d, coef%binv_d, n)
+      rtr = device_glsc2(tmp_d, coef%mult_d, n)
 
       rnorm = sqrt(rtr)*norm_fac
       ksp_results%res_start = rnorm


### PR DESCRIPTION
coupled_cg appears to be the only one to scale the residual with the local Binv.

fused_coupled_cg seems to be inconsistent because on line 595 binv is used, but later on line 643

         rtr = device_fusedcg_cpld_part2(r1_d, r2_d, r3_d, coef%mult_d, &
              w1_d, w2_d, w3_d, alpha_d, alpha(p_cur), p_cur, n)

where the 4th argument to the kernel is the scaling, which is just mult.

Here, I remove the binv scaling.