### PR TITLE
Enabling variable dt in mpmd

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -288,7 +288,7 @@ fluid/bcknd/device/euler_res_device.lo : fluid/bcknd/device/euler_res_device.F90
 fluid/bcknd/cpu/compressible_ops_cpu.lo : fluid/bcknd/cpu/compressible_ops_cpu.f90 config/num_types.lo 
 fluid/bcknd/device/compressible_ops_device.lo : fluid/bcknd/device/compressible_ops_device.F90 common/utils.lo field/field.lo config/num_types.lo 
 fluid/fluid_source_term.lo : fluid/fluid_source_term.f90 common/user_intf.lo sem/coef.lo field/field_list.lo field/field.lo source_terms/source_term_handler.lo source_terms/source_term.lo source_terms/user_source_term.lo 
-common/time_step_controller.lo : common/time_step_controller.f90 common/time_state.lo common/json_utils.lo common/log.lo config/num_types.lo 
+common/time_step_controller.lo : common/time_step_controller.f90 comm/comm.lo common/time_state.lo common/json_utils.lo common/log.lo config/num_types.lo 
 simulation.lo : simulation.f90 common/time_step_controller.lo common/time_state.lo common/json_utils.lo simulation_components/simcomp_executor.lo common/profiler.lo common/jobctrl.lo common/log.lo io/file.lo time_schemes/time_scheme_controller.lo config/num_types.lo common/checkpoint.lo case.lo 
 math/ax_helm_fctry.lo : math/ax_helm_fctry.f90 common/utils.lo math/bcknd/device/ax_helm_full_device.lo math/bcknd/cpu/ax_helm_full_cpu.lo math/bcknd/cpu/ax_helm_cpu.lo math/ax_helm.lo math/bcknd/sx/ax_helm_sx.lo math/bcknd/xsmm/ax_helm_xsmm.lo math/bcknd/device/ax_helm_device.lo config/neko_config.lo math/ax.lo 
 math/ax_helm.lo : math/ax_helm.f90 math/math.lo mesh/mesh.lo sem/space.lo sem/coef.lo config/num_types.lo math/ax.lo 

--- a/src/common/time_step_controller.f90
+++ b/src/common/time_step_controller.f90
@@ -37,6 +37,8 @@ module time_step_controller
   use json_module, only : json_file
   use json_utils, only : json_get_or_default, json_get_or_lookup_or_default
   use time_state, only : time_state_t
+  use comm, only : pe_size, global_pe_size, NEKO_GLOBAL_COMM, MPI_REAL_PRECISION
+  use mpi_f08, only : MPI_MIN, MPI_IN_PLACE
   implicit none
   private
 
@@ -109,6 +111,7 @@ contains
     real(kind=rp), intent(in) :: cfl
     real(kind=rp) :: dt_old, scaling_factor
     character(len=LOG_SIZE) :: log_buf
+    integer :: ierr
 
     ! Check if variable dt is requested
     if (.not. this%is_variable_dt) return
@@ -160,6 +163,12 @@ contains
        else
           this%dt_last_change = this%dt_last_change + 1
        end if
+    end if
+
+    ! If running in mpmd, the new dt is the minimun across simulations
+    if (pe_size .ne. global_pe_size) then
+       call MPI_Allreduce(MPI_IN_PLACE, time%dt, 1, MPI_REAL_PRECISION, &
+            MPI_MIN, NEKO_GLOBAL_COMM, ierr)
     end if
 
   end subroutine time_step_controller_set_dt

--- a/src/common/time_step_controller.f90
+++ b/src/common/time_step_controller.f90
@@ -167,15 +167,15 @@ contains
 
     ! If running in mpmd, the new dt is the minimum across simulations
     if (pe_size .ne. global_pe_size) then
-           global_min_dt = time%dt
+       global_min_dt = time%dt
        call MPI_Allreduce(MPI_IN_PLACE, global_min_dt, 1, MPI_REAL_PRECISION, &
             MPI_MIN, NEKO_GLOBAL_COMM, ierr)
 
-           ! If my dt is larger that the global min, mark a change
-           if (time%dt .gt. global_min_dt) then
-                time%dt = global_min_dt
-                this%dt_last_change = 0
-           end if
+       ! If my dt is larger that the global min, mark a change
+       if (time%dt .gt. global_min_dt) then
+          time%dt = global_min_dt
+          this%dt_last_change = 0
+       end if
     end if
 
   end subroutine time_step_controller_set_dt

--- a/src/common/time_step_controller.f90
+++ b/src/common/time_step_controller.f90
@@ -109,7 +109,7 @@ contains
     class(time_step_controller_t), intent(inout) :: this
     type(time_state_t), intent(inout) :: time
     real(kind=rp), intent(in) :: cfl
-    real(kind=rp) :: dt_old, scaling_factor
+    real(kind=rp) :: dt_old, scaling_factor, global_min_dt
     character(len=LOG_SIZE) :: log_buf
     integer :: ierr
 
@@ -167,8 +167,15 @@ contains
 
     ! If running in mpmd, the new dt is the minimum across simulations
     if (pe_size .ne. global_pe_size) then
-       call MPI_Allreduce(MPI_IN_PLACE, time%dt, 1, MPI_REAL_PRECISION, &
+           global_min_dt = time%dt
+       call MPI_Allreduce(MPI_IN_PLACE, global_min_dt, 1, MPI_REAL_PRECISION, &
             MPI_MIN, NEKO_GLOBAL_COMM, ierr)
+
+           ! If my dt is larger that the global min, mark a change
+           if (time%dt .gt. global_min_dt) then
+                time%dt = global_min_dt
+                this%dt_last_change = 0
+           end if
     end if
 
   end subroutine time_step_controller_set_dt

--- a/src/common/time_step_controller.f90
+++ b/src/common/time_step_controller.f90
@@ -165,7 +165,7 @@ contains
        end if
     end if
 
-    ! If running in mpmd, the new dt is the minimun across simulations
+    ! If running in mpmd, the new dt is the minimum across simulations
     if (pe_size .ne. global_pe_size) then
        call MPI_Allreduce(MPI_IN_PLACE, time%dt, 1, MPI_REAL_PRECISION, &
             MPI_MIN, NEKO_GLOBAL_COMM, ierr)


### PR DESCRIPTION
This PR sets the time step as the minimum across all Neko simulations run in MPMD.

This makes sense when we run multiple Neko sessions and they are coupled. However, this would break if simulations are actually supposed to be independent. Do you have any use case in mind where that would be needed? 

If not, then I think we can merge and if such workflow appears, we deal with it when it comes.