### PR TITLE
Log: Always print job info.

### DIFF
--- a/src/neko.f90
+++ b/src/neko.f90
@@ -179,7 +179,11 @@ contains
     call neko_const_registry%init()
     call neko_scratch_registry%init()
 
+    !
+    ! Job information
+    !
     call neko_log%header(NEKO_VERSION, NEKO_BUILD_INFO)
+    call neko_job_info(date, time)
 
     if (present(C)) then
 
@@ -213,11 +217,6 @@ contains
              call neko_log%message(args, NEKO_LOG_QUIET)
           end do
        end if
-
-       !
-       ! Job information
-       !
-       call neko_job_info(date, time)
 
        !
        ! Create case


### PR DESCRIPTION
Enable visibility of job information for all users, even those without a case. This change enhances accessibility to job details.

It is the following block which is now printed even for library consumers of neko
```
 -------Job Information--------
 Start time: 14:15 / 2026-05-04
 Running on: 1 MPI rank, using 16 thrds each
 CPU type  : 11th Gen Intel(R) Core(TM) i9-11950H @ 2.60GHz
 Bcknd type: Accelerator (CUDA)
 Dev. name : NVIDIA RTX A3000 Laptop GPU
 Real type : double precision
```