### PR TITLE
Use case timestep as initial time for variable timestep

### DIFF
--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -177,7 +177,9 @@ Under the hood, Neko stores the constants in an object called
 ### Time control
 The `time` object is used to define the time-stepping of the simulation,
 including the time-step size, the start and end time, and the variables related
-to the variable time-stepping algorithm.
+to the variable time-stepping algorithm. For the variable timestep, one can
+specify a `timestep`, such that the first timestep will be assigned to the
+smallest of `timestep` and the value calculated from the target CFL number.
 
 | Name                       | Description                                                                                 | Admissible values                 | Default value |
 | -------------------------- | ------------------------------------------------------------------------------------------- | --------------------------------- | ------------- |

--- a/src/common/time_step_controller.f90
+++ b/src/common/time_step_controller.f90
@@ -47,6 +47,7 @@ module time_step_controller
      logical :: is_variable_dt
      real(kind=rp) :: cfl_trg = 0.0_rp
      real(kind=rp) :: cfl_avg = 0.0_rp
+     real(kind=rp) :: init_dt = huge(0.0_rp)
      real(kind=rp) :: max_dt = 0.0_rp
      real(kind=rp) :: min_dt = 0.0_rp
      integer :: max_update_frequency = 0
@@ -78,6 +79,8 @@ contains
     if (this%is_variable_dt) then
        call json_get_or_lookup_or_default(params, 'target_cfl', &
             this%cfl_trg, 0.4_rp)
+       call json_get_or_lookup_or_default(params, 'timestep', &
+            this%init_dt, huge(0.0_rp))
        call json_get_or_lookup_or_default(params, 'max_timestep', &
             this%max_dt, huge(0.0_rp))
        call json_get_or_lookup_or_default(params, 'min_timestep', &
@@ -123,9 +126,10 @@ contains
 
     if (this%dt_last_change .eq. -1) then
 
-       ! set the first dt for desired cfl
-       time%dt = max(min(this%cfl_trg / cfl * time%dt, &
-            this%max_dt), this%min_dt)
+       ! Set the first dt for desired cfl, or use the provided initial dt if it
+       ! is smaller. Then clamp between max and min dt if provided.
+       time%dt = min(this%cfl_trg / cfl * time%dt, this%init_dt)
+       time%dt = max(min(time%dt, this%max_dt), this%min_dt)
        this%dt_last_change = 0
        this%cfl_avg = cfl
 


### PR DESCRIPTION
The fluid initial condition is not always a great first step for detemining the timestep based on CFL. This allows a user to manually specify an initial timestep.