### PR TITLE
Improve folder creation safety and functionality

### DIFF
--- a/src/case.f90
+++ b/src/case.f90
@@ -454,7 +454,7 @@ contains
        if (this%output_directory(output_dir_len:output_dir_len) .ne. "/") then
           this%output_directory = trim(this%output_directory)//"/"
           if (pe_rank .eq. 0) then
-             call execute_command_line('mkdir -p '//this%output_directory)
+            call mkdir(trim(this%output_directory))
           end if
        end if
     end if

--- a/src/case.f90
+++ b/src/case.f90
@@ -45,7 +45,7 @@ module case
   use flow_ic, only : set_flow_ic
   use scalar_ic, only : set_scalar_ic
   use file, only : file_t
-  use utils, only : neko_error
+  use utils, only : neko_error, mkdir
   use mesh, only : mesh_t
   use math, only : NEKO_EPS
   use checkpoint, only: chkp_t
@@ -453,9 +453,9 @@ contains
     if (output_dir_len .gt. 0) then
        if (this%output_directory(output_dir_len:output_dir_len) .ne. "/") then
           this%output_directory = trim(this%output_directory)//"/"
-          if (pe_rank .eq. 0) then
-            call mkdir(trim(this%output_directory))
-          end if
+       end if
+       if (pe_rank .eq. 0) then
+          call mkdir(trim(this%output_directory))
        end if
     end if
 

--- a/src/common/utils.f90
+++ b/src/common/utils.f90
@@ -34,6 +34,7 @@
 !! @details Various utility functions
 module utils
   use, intrinsic :: iso_fortran_env, only : error_unit, output_unit
+  use iso_c_binding
   implicit none
   private
 
@@ -49,8 +50,16 @@ module utils
        filename_suffix_pos, filename_tslash_pos, filename_split, &
        linear_index, split_string, NEKO_FNAME_LEN, index_is_on_facet, &
        concat_string_array, extract_fld_file_index, neko_type_error, &
-       neko_type_registration_error, NEKO_VARNAME_LEN
+       neko_type_registration_error, NEKO_VARNAME_LEN, mkdir
 
+  interface
+     function c_mkdir(path, mode) bind(C, name="mkdir")
+       import :: c_char, c_int
+       character(kind=c_char), dimension(*) :: path
+       integer(c_int), value :: mode
+       integer(c_int) :: c_mkdir
+     end function c_mkdir
+  end interface
 
 contains
 
@@ -147,6 +156,42 @@ contains
     new_fname = trim(fname(1:suffix_pos))//new_suffix
 
   end subroutine filename_chsuffix
+
+  !> Recursively create a directory and all parent directories if they do not
+  !! exist. This should be safer than the
+  !! `execute_command_line('mkdir -p ' // path)` approach, which can be used to
+  !! execute arbitrary code if `path` is not properly sanitized.
+  !! @param path The path of the directory to create.
+  !! @param mode The octal mode to create the directory with, will adjust by
+  !! umask.
+  recursive subroutine mkdir(path, mode)
+    character(len=*), intent(in) :: path
+    integer, intent(in), optional :: mode
+    integer :: slash_pos, i, path_len
+    character(kind=c_char), allocatable :: c_path(:)
+    integer(c_int) :: dir_mode, ierr
+
+    if (present(mode)) then
+       dir_mode = int(mode, kind=c_int)
+    else
+       dir_mode = int(o'777', kind=c_int)
+    end if
+
+    slash_pos = scan(path, '/', back = .true.)
+    if (slash_pos .gt. 0) then
+       call mkdir(trim(path(1:slash_pos-1)), dir_mode)
+    end if
+
+    path_len = len_trim(path)
+    allocate(c_path(path_len + 1))
+    do i = 1, path_len
+       c_path(i) = path(i:i)
+    end do
+    c_path(path_len + 1) = c_null_char
+
+    ierr = c_mkdir(c_path, dir_mode)
+    deallocate(c_path)
+  end subroutine mkdir
 
   !> Extracts the index of a field file. For example, "myfield.f00045"
   !! will return `45`. If the suffix of the file name is invalid, returns

--- a/src/io/vtkhdf_file.F90
+++ b/src/io/vtkhdf_file.F90
@@ -36,7 +36,7 @@ module vtkhdf_file
   use generic_file, only : generic_file_t
   use checkpoint, only : chkp_t
   use utils, only : neko_error, neko_warning, filename_split, &
-       nonlinear_index, linear_index
+       nonlinear_index, linear_index, mkdir
   use mesh, only : mesh_t
   use field, only : field_t
   use field_list, only : field_list_t
@@ -806,14 +806,10 @@ contains
        write(ext_fname, '(A,I0,".h5")') trim(ext_path), counter
        write(src_pattern, '(A,".data/%b.h5")') trim(main_name)
 
-       if (pe_rank .eq. 0) inquire(file = trim(ext_path), exist = exists)
-       call MPI_Bcast(exists, 1, MPI_LOGICAL, 0, NEKO_COMM, ierr)
-       if (.not. exists) then
-          if (pe_rank .eq. 0) then
-             call execute_command_line("mkdir -p '" // trim(ext_path) // "'")
-          end if
-          call MPI_Barrier(NEKO_COMM, ierr)
+       if (pe_rank .eq. 0) then
+          call mkdir(trim(ext_path))
        end if
+       call MPI_Barrier(NEKO_COMM, ierr)
 
        call h5pcreate_f(H5P_FILE_ACCESS_F, ext_plist_id, ierr)
        call h5pset_fapl_mpio_f(ext_plist_id, mpi_comm, mpi_info, ierr)


### PR DESCRIPTION
Enhance folder creation by implementing a safer `mkdir` subroutine, addressing a bug that prevented output folders from being created if the path ended with a `/`, and ensuring consistent usage of the new function across relevant modules.