### PR TITLE
Fix device tests by correcting variable assignments

### DIFF
--- a/tests/unit/field/test_field_parallel.pf
+++ b/tests/unit/field/test_field_parallel.pf
@@ -273,7 +273,7 @@ contains
     call f%init(msh, Xh, 'test')
 
     n = f%size()
-    f = 1.0_rp
+    f%x = 1.0_rp
     f%x(1, 1, 1, 1) = -3.0_rp
     f%x(lx, lx, lx, msh%nelv) = 7.0_rp
 

--- a/tests/unit/matrix/test_matrix_parallel.pf
+++ b/tests/unit/matrix/test_matrix_parallel.pf
@@ -362,7 +362,7 @@ contains
     type(matrix_t) :: v
 
     call v%init(n, m)
-    v = 1.0_rp
+    v%x = 1.0_rp
     v%x(1, 1) = -3.0_rp
     v%x(n, m) = 7.0_rp
 

--- a/tests/unit/vector/test_vector_parallel.pf
+++ b/tests/unit/vector/test_vector_parallel.pf
@@ -264,7 +264,7 @@ contains
     type(vector_t) :: v
 
     call v%init(n)
-    v = 1.0_rp
+    v%x = 1.0_rp
     v%x(1) = -3.0_rp
     v%x(n) = 7.0_rp
 


### PR DESCRIPTION
Update variable assignments in device tests to ensure proper initialization of matrix and vector types. This change addresses issues with incorrect test results.