### PR TITLE
Some changes to the integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,6 +50,7 @@ def pytest_addoption(parser):
         "--real_precision",
         action="store",
         default="dp",
+        choices=["dp", "sp"],
         help="Precisions of reals for Neko (dp [default], sp)."
     )
 

--- a/tests/integration/testlib.py
+++ b/tests/integration/testlib.py
@@ -26,7 +26,9 @@ def which_command(command):
 
 def get_genmeshbox():
     """
-    Returns the path to genmeshbox
+    Returns the path to the genmeshbox executable, via the environmental 
+    variable GENMESHBOX_EXEC, or returns the path to the first genmeshbox
+    executable in the PATH environment variable.
     """
     if os.getenv("GENMESHBOX_EXEC"):
         return os.getenv("GENMESHBOX_EXEC")
@@ -39,9 +41,9 @@ def get_genmeshbox():
 def get_neko():
     """
     Returns the path to the turboneko executable via the environmental variable
-    NEKO_EXEC, or just returns "neko", assuming it is in the PATH.
+    NEKO_EXEC, or just returns the path to the first "neko" executable in the 
+    PATH environmental variable.
     """
-
     if os.getenv("NEKO_EXEC"):
         return os.getenv("NEKO_EXEC")
     else:
@@ -51,6 +53,11 @@ def get_neko():
         return cmd
 
 def get_makeneko():
+    """
+    Returns the path to the makeneko executable via the environmental variable
+    NEKO_EXEC, or just returns the path to the first "makeneko" executable in the 
+    PATH environmental variable.
+    """
     if os.getenv("MAKENEKO_EXEC"):
         return os.getenv("MAKENEKO_EXEC")
     else:
@@ -60,7 +67,7 @@ def get_makeneko():
         return cmd
 
 def get_neko_dir():
-    """Returns the root of the neko dirctory structure relative to the directory
+    """Returns the root of the neko directory structure relative to the directory
     with the integration tests
 
     """

--- a/tests/integration/testlib.py
+++ b/tests/integration/testlib.py
@@ -6,7 +6,35 @@ from os.path import join
 import subprocess
 from conftest import logger, MAX_NPROCS
 
+def which_command(command):
+    """
+    Mimics the behavior of the bash command "which [cmd]".
+    Returns the absolute path of the executable, based on the PATH env.
+    variable. If not found, returns None
+    """
 
+    path_env = os.getenv("PATH")
+    if not path_env:
+        return None
+
+    for path in path_env.split(":"):
+        test_path = os.path.join(path, command)
+        if os.path.isfile(test_path):
+            return test_path
+
+    return None
+
+def get_genmeshbox():
+    """
+    Returns the path to the /bin directory where all executables are located
+    """
+    if os.getenv("GENMESHBOX_EXEC"):
+        return os.getenv("GENMESHBOX_EXEC")
+    else:
+        cmd = which_command("genmeshbox")
+        if cmd is None:
+            raise FileNotFoundError("The genmeshbox executable could not be found")
+        return cmd
 
 def get_neko():
     """
@@ -17,13 +45,19 @@ def get_neko():
     if os.getenv("NEKO_EXEC"):
         return os.getenv("NEKO_EXEC")
     else:
-        return "neko"
+        cmd = which_command("neko")
+        if cmd is None:
+            raise FileNotFoundError("The neko executable could not be found")
+        return cmd
 
 def get_makeneko():
     if os.getenv("MAKENEKO_EXEC"):
         return os.getenv("MAKENEKO_EXEC")
     else:
-        return "makeneko"
+        cmd = which_command("makeneko")
+        if cmd is None:
+            raise FileNotFoundError("The makeneko executable could not be found")
+        return cmd
 
 def get_neko_dir():
     """Returns the root of the neko dirctory structure relative to the directory

--- a/tests/integration/testlib.py
+++ b/tests/integration/testlib.py
@@ -26,7 +26,7 @@ def which_command(command):
 
 def get_genmeshbox():
     """
-    Returns the path to the /bin directory where all executables are located
+    Returns the path to genmeshbox
     """
     if os.getenv("GENMESHBOX_EXEC"):
         return os.getenv("GENMESHBOX_EXEC")

--- a/tests/integration/tests/test_fluid_stats/test_fluid_stats.py
+++ b/tests/integration/tests/test_fluid_stats/test_fluid_stats.py
@@ -1,5 +1,5 @@
 from os.path import join
-from testlib import get_neko, run_neko, configure_nprocs, get_makeneko
+from testlib import get_neko, run_neko, configure_nprocs, get_makeneko, get_genmeshbox
 import subprocess
 import numpy as np
 #from pysemtools.datatypes.field import FieldRegistry
@@ -69,8 +69,9 @@ def test_fluid_stats(launcher_script, request, log_file, tmp_path):
         result.returncode == 0
     ), f"makeneko process failed with exit code {result.returncode}"
 
+    genmeshbox = get_genmeshbox()
     result = subprocess.run(
-        ["genmeshbox", "0", "1", "0", "1", "0", "1", "3", "3", "3",
+        [genmeshbox, "0", "1", "0", "1", "0", "1", "3", "3", "3",
          ".true.", ".true.", ".true."],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/tests/integration/tests/test_scalar_stats/test_scalar_stats.py
+++ b/tests/integration/tests/test_scalar_stats/test_scalar_stats.py
@@ -1,5 +1,5 @@
 from os.path import join
-from testlib import get_neko, run_neko, configure_nprocs, get_makeneko
+from testlib import get_neko, run_neko, configure_nprocs, get_makeneko, get_genmeshbox
 import subprocess
 import numpy as np
 #from pysemtools.datatypes.field import FieldRegistry
@@ -61,8 +61,9 @@ def test_scalar_stats(launcher_script, request, log_file, tmp_path):
         result.returncode == 0
     ), f"makeneko process failed with exit code {result.returncode}"
 
+    genmeshbox = get_genmeshbox()
     result = subprocess.run(
-        ["genmeshbox", "0", "1", "0", "1", "0", "1", "3", "3", "3",
+        [genmeshbox, "0", "1", "0", "1", "0", "1", "3", "3", "3",
          ".true.", ".true.", ".true."],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/tests/integration/tests/test_user_stats/test_user_stats.py
+++ b/tests/integration/tests/test_user_stats/test_user_stats.py
@@ -1,5 +1,5 @@
 from os.path import join
-from testlib import get_neko, run_neko, configure_nprocs, get_makeneko
+from testlib import get_neko, run_neko, configure_nprocs, get_makeneko, get_genmeshbox
 import subprocess
 import numpy as np
 
@@ -26,8 +26,9 @@ def test_user_stats(launcher_script, request, log_file, tmp_path):
         result.returncode == 0
     ), f"makeneko process failed with exit code {result.returncode}"
 
+    genmeshbox = get_genmeshbox()
     result = subprocess.run(
-        ["genmeshbox", "0", "1", "0", "1", "0", "1", "3", "3", "3",
+        [genmeshbox, "0", "1", "0", "1", "0", "1", "3", "3", "3",
          ".true.", ".true.", ".true."],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,


### PR DESCRIPTION
Just some suggestions for the integration tests, these are just suggested improvements but I don't feel strongly about them :)

- Allows the user to specify a genmeshbox executable through the `GENMESHBOX_EXEC` env. variable. I've been experimenting with the integration tests with GPUs on LUMI but my contrib scripts are compiled in a separate installation folder, so I thought perhaps that could come in handy for other people.
- Instead of assuming the existence of the "neko", "makeneko", "genmeshbox" executables if they aren't specified as envirionment variables, we check their presence in `PATH` and throws an error if they aren't found. 