### PR TITLE
Reduce stack size to 1 in mesh_init allocation

### DIFF
--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -297,7 +297,7 @@ contains
        end if
        allocate(this%point_neigh(this%gdim*this%npts*this%nelv))
        do i = 1, this%gdim*this%npts*this%nelv
-          call this%point_neigh(i)%init()
+          call this%point_neigh(i)%init(size=1)
        end do
     end if
 

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -297,7 +297,7 @@ contains
        end if
        allocate(this%point_neigh(this%gdim*this%npts*this%nelv))
        do i = 1, this%gdim*this%npts*this%nelv
-          call this%point_neigh(i)%init(size=1)
+          call this%point_neigh(i)%init(size=4)
        end do
     end if
 


### PR DESCRIPTION
Reduces memory footprint of mesh construction by 25%.