### PR TITLE
Fix configuration logic and bug in sx detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,11 +4,13 @@ AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_MAINTAINER_MODE
 AC_CONFIG_MACRO_DIR([m4])
 AC_CANONICAL_HOST
-AC_LANG(Fortran)
+AC_LANG([Fortran])
 AC_PROG_INSTALL
 AC_PROG_SED
 AC_PROG_MAKE_SET
+AC_LANG_PUSH([C])
 LT_INIT([disable-shared])
+AC_LANG_POP([C])
 LT_LANG([Fortran])
 
 AC_ARG_ENABLE(contrib,
@@ -39,7 +41,7 @@ AC_ARG_ENABLE(python, AC_HELP_STRING([--enable-python],
               [enable_python=${enableval}],[enable_python=no])
 
 # Test for a sane fortran environment (^-^)
-AC_LANG(Fortran)
+AC_LANG([Fortran])
 AC_PROG_FC(,90)
 AX_COARRAY
 AX_DTYPE_IO
@@ -50,19 +52,20 @@ AX_MPI([have_mpi=yes], [have_mpi=no])
 if test "x${have_mpi}" != xno; then
    FC="$MPIFC"
    LIBS="$MPILIBS $LIBS"
-   AC_LANG(C)
+   AC_LANG_PUSH([C])
    AX_MPI([have_mpi=yes],[have_mpi=no])
    if  test "x${have_mpi}" != xno; then
        CC="$MPICC"
    else
        AC_MSG_ERROR([Can't find a suitable C MPI compiler])
    fi
-   AC_LANG(C++)
+   AC_LANG_POP([C])
+   AC_LANG_PUSH([C++])
    AX_MPI([have_mpi=yes],[have_mpi=no])
    if  test "x${have_mpi}" != xno; then
        CXX="$MPICXX"
    fi
-   AC_LANG(Fortran)
+   AC_LANG_POP([C++])
 else
    AC_MSG_ERROR([Can't find a suitable MPI compiler])
 fi
@@ -74,12 +77,12 @@ if test "x${enable_openmp}" != xno; then
    AX_OPENMP([have_openmp=yes], [have_openmp=no])
    if test "x${have_openmp}" != xno; then
       NEKO_PKG_FCFLAGS="$NEKO_PKG_FCFLAGS $OPENMP_FCFLAGS"
-      AC_LANG(C)
+      AC_LANG_PUSH([C])
       AX_OPENMP([have_openmp=yes], [have_openmp=no])
       if test "x${have_openmp}" != xno; then
          CFLAGS="$CFLAGS $OPENMP_CFLAGS"
       fi
-      AC_LANG(Fortran)
+      AC_LANG_POP([C])
    fi
 fi
 

--- a/m4/ax_sx.m4
+++ b/m4/ax_sx.m4
@@ -1,7 +1,7 @@
 #
 # ----------------------------------------------------------------------------
 # "THE BEER-WARE LICENSE" (Revision 42):
-# <njansson@kth.se> wrote this file. As long as you retain this notice you 
+# <njansson@kth.se> wrote this file. As long as you retain this notice you
 # can do whatever you want with this stuff. If we meet some day, and you think
 # this stuff is worth it, you can buy me a beer in return Niclas Jansson
 # ----------------------------------------------------------------------------
@@ -11,7 +11,7 @@ AC_DEFUN([AX_SX],[
 	AC_MSG_CHECKING([for a NEC SX-Aurora system])
 	AC_LANG_PUSH([C])
 	AC_EGREP_CPP(yes,
-	[#if defined(__ve__))
+	[#if defined(__ve__)
 	  yes
 	 #endif
 	],


### PR DESCRIPTION
Improve language switching logic in the configuration to enhance error reporting and clean up failed confidence tests. Fix a bug in the sx detection macro to ensure proper functionality.