### PR TITLE
Changing the way time_state is set at restart stage

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -22,7 +22,7 @@ comm/mpi_types.lo : comm/mpi_types.f90 io/format/stl.lo io/format/nmsh.lo io/for
 common/datadist.lo : common/datadist.f90 
 common/distdata.lo : common/distdata.f90 adt/uset.lo adt/tuple.lo adt/stack.lo 
 common/utils.lo : common/utils.f90 
-common/time_state.lo : common/time_state.f90 common/json_utils.lo common/checkpoint.lo common/log.lo config/num_types.lo 
+common/time_state.lo : common/time_state.f90 common/json_utils.lo common/log.lo config/num_types.lo 
 common/json_utils.lo : common/json_utils.f90 common/utils.lo config/num_types.lo 
 common/case_file_utils.lo : common/case_file_utils.f90 config/num_types.lo math/math.lo math/vector.lo registries/registry.lo common/json_utils.lo 
 common/mask.lo : common/mask.f90 common/utils.lo math/bcknd/device/device_math.lo device/device.lo config/neko_config.lo 
@@ -136,7 +136,7 @@ multigrid/tree_amg_multigrid.lo : multigrid/tree_amg_multigrid.f90 config/neko_c
 multigrid/tree_amg_smoother.lo : multigrid/tree_amg_smoother.f90 config/neko_config.lo multigrid/bcknd/device/device_tree_amg_smoother.lo device/device.lo common/log.lo gs/gather_scatter.lo bc/bc_list.lo krylov/krylov.lo math/bcknd/device/device_math.lo math/math.lo config/num_types.lo multigrid/tree_amg_utils.lo multigrid/tree_amg.lo 
 multigrid/bcknd/device/device_tree_amg_smoother.lo : multigrid/bcknd/device/device_tree_amg_smoother.F90 common/utils.lo device/device.lo config/num_types.lo 
 multigrid/phmg.lo : multigrid/phmg.f90 common/log.lo common/profiler.lo krylov/krylov.lo config/neko_config.lo math/bcknd/device/device_math.lo device/device.lo math/math.lo common/json_utils.lo sem/interpolation.lo multigrid/tree_amg_multigrid.lo math/ax.lo math/schwarz.lo krylov/bcknd/device/pc_jacobi_device.lo krylov/bcknd/cpu/pc_jacobi.lo krylov/bcknd/device/cheby_device.lo krylov/bcknd/cpu/cheby.lo common/utils.lo bc/dirichlet.lo bc/bc_list.lo bc/bc.lo mesh/mesh.lo sem/coef.lo field/field.lo sem/dofmap.lo sem/space.lo gs/gather_scatter.lo krylov/precon.lo config/num_types.lo 
-common/checkpoint.lo : common/checkpoint.f90 global_interpolation/global_interpolation.lo math/math.lo mesh/mesh.lo common/utils.lo field/field.lo device/device.lo sem/space.lo field/field_series_list.lo field/field_series.lo config/num_types.lo config/neko_config.lo 
+common/checkpoint.lo : common/checkpoint.f90 common/time_state.lo global_interpolation/global_interpolation.lo math/math.lo mesh/mesh.lo common/utils.lo field/field.lo device/device.lo sem/space.lo field/field_series_list.lo field/field_series.lo config/num_types.lo config/neko_config.lo 
 io/generic_file.lo : io/generic_file.f90 comm/comm.lo common/utils.lo config/num_types.lo 
 io/map_file.lo : io/map_file.f90 io/format/map.lo comm/comm.lo common/utils.lo io/generic_file.lo config/num_types.lo 
 io/re2_file.lo : io/re2_file.f90 comm/comm.lo adt/htable.lo io/format/re2.lo common/utils.lo common/log.lo io/format/map.lo common/datadist.lo comm/mpi_types.lo mesh/point.lo mesh/mesh.lo io/map_file.lo config/num_types.lo io/generic_file.lo 

--- a/src/common/checkpoint.f90
+++ b/src/common/checkpoint.f90
@@ -44,6 +44,7 @@ module checkpoint
   use mesh, only : mesh_t
   use math, only : NEKO_EPS
   use global_interpolation, only : GLOB_INTERP_TOL
+  use time_state, only : time_state_t
   implicit none
   private
 
@@ -113,6 +114,7 @@ module checkpoint
      procedure, pass(this) :: add_scalar => chkp_add_scalar
      procedure, pass(this) :: add_ale => chkp_add_ale
      procedure, pass(this) :: restart_time => chkp_restart_time
+     procedure, pass(this) :: set_time_state => chkp_set_time_state
      procedure, pass(this) :: free => chkp_free
   end type chkp_t
 
@@ -477,5 +479,15 @@ contains
 
     rtime = this%t
   end function chkp_restart_time
+
+  !> Set time state
+  subroutine chkp_set_time_state(this, time_state)
+    class(chkp_t), intent(in) :: this
+    type(time_state_t), intent(inout) :: time_state
+
+    time_state%t = this%t
+    time_state%dtlag = this%dtlag
+    time_state%tlag = this%tlag
+  end subroutine chkp_set_time_state
 
 end module checkpoint

--- a/src/common/time_state.f90
+++ b/src/common/time_state.f90
@@ -34,7 +34,6 @@
 module time_state
   use num_types, only : rp
   use logger, only : neko_log, LOG_SIZE, NEKO_LOG_QUIET
-  use checkpoint, only : chkp_t
   use json_module, only : json_file
   use json_utils, only : json_get_or_lookup, json_get_or_default, &
        json_get_or_lookup_or_default
@@ -57,7 +56,6 @@ module time_state
           time_state_init_from_components
      procedure, pass(this) :: init_from_json => time_state_init_from_json
      procedure, pass(this) :: reset => time_state_reset
-     procedure, pass(this) :: restart => time_state_restart
      procedure, pass(this) :: status => time_state_status
      procedure, pass(this) :: is_done => time_state_is_done
   end type time_state_t
@@ -121,16 +119,6 @@ contains
     this%dtlag = this%dt
 
   end subroutine time_state_reset
-
-  !> Restart time state
-  subroutine time_state_restart(this, chkp)
-    class(time_state_t), intent(inout) :: this
-    type(chkp_t), intent(in) :: chkp
-
-    this%t = chkp%t
-    this%dtlag = chkp%dtlag
-    this%tlag = chkp%tlag
-  end subroutine time_state_restart
 
   !> Write status banner
   subroutine time_state_status(this)

--- a/src/simulation.f90
+++ b/src/simulation.f90
@@ -279,7 +279,7 @@ contains
     integer :: i
 
     ! Restart the time state and BDF coefficients
-    call C%time%restart(chkp)
+    call chkp%set_time_state(C%time)
     do i = 1, size(C%time%dtlag)
        call C%fluid%ext_bdf%set_coeffs(C%time%dtlag)
     end do


### PR DESCRIPTION
To simplify usage of time_state and avoid possible module circular dependencies restart is removed from time_state and time_state setting routine is added to checkpoint. This removes dependency of time_state on e.g. field_t.