### PR TITLE
Rework Krylov solvers and Jacobi preconditioner for CPU

### DIFF
--- a/src/krylov/bcknd/cpu/cg.f90
+++ b/src/krylov/bcknd/cpu/cg.f90
@@ -41,8 +41,8 @@ module cg
   use coefs, only : coef_t
   use gather_scatter, only : gs_t, GS_OP_ADD
   use bc_list, only : bc_list_t
-  use math, only : glsc3, rzero, copy, abscmp
-  use comm, only : MPI_EXTRA_PRECISION, NEKO_COMM
+  use math, only : glsc3, abscmp
+  use comm, only : MPI_EXTRA_PRECISION, MPI_REAL_PRECISION, NEKO_COMM
   use mpi_f08, only : MPI_Allreduce, MPI_IN_PLACE, MPI_SUM
   implicit none
   private
@@ -148,9 +148,9 @@ contains
     type(gs_t), intent(inout) :: gs_h
     type(ksp_monitor_t) :: ksp_results
     integer, optional, intent(in) :: niter
-    integer :: iter, max_iter, i, j, k, p_cur, p_prev, blk_size
+    integer :: iter, max_iter, i, j, k, p_cur, p_prev, ierr
     real(kind=rp) :: rnorm, rtr, rtz2, rtz1, x_plus(NEKO_BLK_SIZE)
-    real(kind=rp) :: beta, pap, norm_fac
+    real(kind=rp) :: beta, pap, norm_fac, tmp
 
     if (present(niter)) then
        max_iter = niter
@@ -163,11 +163,19 @@ contains
          z => this%z, alpha => this%alpha)
 
       rtz1 = 1.0_rp
-      call rzero(x%x, n)
-      call rzero(p(1,CG_P_SPACE), n)
-      call copy(r, f, n)
+      rtr = 0.0_rp
+      !$omp parallel do reduction(+:rtr)
+      do i = 1, n
+         x%x(i,1,1,1) = 0.0_rp
+         p(i, CG_P_SPACE) = 0.0_rp
+         r(i) = f(i)
+         rtr = rtr + (r(i) * coef%mult(i,1,1,1) * r(i))
+      end do
+      !$omp end parallel do
 
-      rtr = glsc3(r, coef%mult, r, n)
+      call MPI_Allreduce(MPI_IN_PLACE, rtr, 1, &
+           MPI_REAL_PRECISION, MPI_SUM, NEKO_COMM, ierr)
+
       rnorm = sqrt(rtr) * norm_fac
       ksp_results%res_start = rnorm
       ksp_results%res_final = rnorm
@@ -187,9 +195,11 @@ contains
 
          beta = rtz1 / rtz2
          if (iter .eq. 1) beta = 0.0_rp
+         !$omp parallel do
          do i = 1, n
             p(i,p_cur) = z(i) + beta * p(i,p_prev)
          end do
+         !$omp end parallel do
 
          call Ax%compute(w, p(1,p_cur), coef, x%msh, x%Xh)
          call gs_h%op(w, n, GS_OP_ADD)
@@ -204,22 +214,32 @@ contains
 
          if ((p_cur .eq. CG_P_SPACE) .or. &
               (rnorm .lt. this%abs_tol) .or. iter .eq. max_iter) then
-            !$omp parallel do private(blk_size, j, k, x_plus)
-            do i = 0, n, NEKO_BLK_SIZE
-               blk_size = min(NEKO_BLK_SIZE, n - i)
-               do concurrent (k = 1:blk_size)
-                  x_plus(k) = 0.0_rp
-               end do
-
-               do j = 1, p_cur
-                  do concurrent (k = 1:blk_size)
-                     x_plus(k) = x_plus(k) + alpha(j) * p(i+k,j)
+            !$omp parallel do private(j, k, x_plus, tmp)
+            do i = 0, n-1, NEKO_BLK_SIZE
+               if (i + NEKO_BLK_SIZE .le. n) then
+                  !$omp simd
+                  do k = 1, NEKO_BLK_SIZE
+                     x_plus(k) = 0.0_rp
                   end do
-               end do
-
-               do concurrent (k = 1:blk_size)
-                  x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
-               end do
+                  do j = 1, p_cur
+                     !$omp simd
+                     do k = 1, NEKO_BLK_SIZE
+                        x_plus(k) = x_plus(k) + alpha(j) * p(i+k,j)
+                     end do
+                  end do
+                  !$omp simd
+                  do k = 1, NEKO_BLK_SIZE
+                     x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
+                  end do
+               else
+                  do k = 1, n - i
+                     tmp = 0.0_rp
+                     do j = 1, p_cur
+                        tmp = tmp + alpha(j) * p(i+k,j)
+                     end do
+                     x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + tmp
+                  end do
+               end if
             end do
             !$omp end parallel do
             p_prev = p_cur

--- a/src/krylov/bcknd/cpu/gmres.f90
+++ b/src/krylov/bcknd/cpu/gmres.f90
@@ -60,7 +60,7 @@ module gmres
      real(kind=xp), allocatable :: s(:)
      real(kind=xp), allocatable :: gam(:)
      real(kind=xp), allocatable :: c(:)
-     !> Per-thread partial-sum buffer for orthogonalization + fused norm.
+     !> Per-thread partial-sum buffer
      real(kind=xp), allocatable :: hp(:,:)
    contains
      procedure, pass(this) :: init => gmres_init
@@ -102,7 +102,7 @@ contains
 
     nthrds = 1
     !$ nthrds = omp_get_max_threads()
-    allocate(this%hp(this%lgmres + 1, nthrds))
+    allocate(this%hp(this%lgmres, nthrds))
 
     if (present(rel_tol) .and. present(abs_tol) .and. present(monitor)) then
        call this%ksp_init(max_iter, rel_tol, abs_tol, monitor = monitor)
@@ -187,7 +187,7 @@ contains
     integer :: iter, max_iter
     integer :: i, j, k, l, ierr, tid, nthrds
     real(kind=xp) :: w_plus(NEKO_BLK_SIZE), x_plus(NEKO_BLK_SIZE)
-    real(kind=xp) :: alpha, lr, alpha2, norm_fac, tmp, ww
+    real(kind=xp) :: alpha, lr, alpha2, norm_fac, tmp, acc
     real(kind=rp) :: temp, rnorm
     logical :: conv
 
@@ -245,32 +245,26 @@ contains
             call gs_h%op(w, n, GS_OP_ADD)
             call blst%apply(w, n)
 
-            ! Fused orthogonalization + post-projection norm with
-            ! constant-trip-count inner loops. Rows 1..j of hp accumulate
-            ! <w, v_l>_mult and row j+1 accumulates <w,w>_mult, so a
-            ! single MPI_Allreduce of length j+1 covers both reductions.
-            ! alpha2 then follows by Pythagoras since {v_l} are mult-
-            ! orthonormal: ||w - sum h_l v_l||^2 = <w,w> - sum h_l^2.
-            !$omp parallel private(i, k, l, tid)
+            ! Classical Gram-Schmidt orthogonalization: accumulate
+            ! <w, v_l>_mult for l=1..j into per-thread columns of hp,
+            ! merge across threads, then one MPI_Allreduce of length j.
+            !$omp parallel private(i, k, l, tid, acc)
             tid = 1
             !$ tid = omp_get_thread_num() + 1
-            do l = 1, j+1
+            do l = 1, j
                hp(l,tid) = 0.0_xp
             end do
             !$omp do
             do i = 0, n-1, NEKO_BLK_SIZE
                if (i + NEKO_BLK_SIZE .le. n) then
                   do l = 1, j
-                     !$omp simd
+                     acc = hp(l,tid)
+                     !$omp simd reduction(+:acc)
                      do k = 1, NEKO_BLK_SIZE
-                        hp(l,tid) = hp(l,tid) + &
+                        acc = acc + &
                              w(i+k) * v(i+k,l) * coef%mult(i+k,1,1,1)
                      end do
-                  end do
-                  !$omp simd
-                  do k = 1, NEKO_BLK_SIZE
-                     hp(j+1,tid) = hp(j+1,tid) + &
-                          w(i+k)**2 * coef%mult(i+k,1,1,1)
+                     hp(l,tid) = acc
                   end do
                else
                   do l = 1, j
@@ -279,36 +273,30 @@ contains
                              w(i+k) * v(i+k,l) * coef%mult(i+k,1,1,1)
                      end do
                   end do
-                  do k = 1, n - i
-                     hp(j+1,tid) = hp(j+1,tid) + &
-                          w(i+k)**2 * coef%mult(i+k,1,1,1)
-                  end do
                end if
             end do
             !$omp end do
             !$omp end parallel
 
-            ! Cross-thread merge into hp(:, 1), then one Allreduce of j+1.
+            ! Cross-thread merge into hp(:, 1), then one Allreduce of j.
             do k = 2, nthrds
-               do l = 1, j+1
+               do l = 1, j
                   hp(l,1) = hp(l,1) + hp(l,k)
                end do
             end do
-            call MPI_Allreduce(MPI_IN_PLACE, hp(1,1), j+1, &
+            call MPI_Allreduce(MPI_IN_PLACE, hp(1,1), j, &
                  MPI_EXTRA_PRECISION, MPI_SUM, NEKO_COMM, ierr)
 
             do l = 1, j
                h(l,j) = hp(l,1)
             end do
-            ww = hp(j+1,1)
-            alpha2 = ww
-            do l = 1, j
-               alpha2 = alpha2 - h(l,j) * h(l,j)
-            end do
-            if (alpha2 .lt. 0.0_xp) alpha2 = 0.0_xp
 
-            ! Pure AXPY: w = w - sum h(l,j) * v(:,l). No reduction.
-            !$omp parallel do private(k, l, w_plus, tmp)
+            ! Projection w = w - sum h(l,j) v_l, with fused <w,w>_mult
+            ! reduction for the post-projection norm. alpha2 is computed
+            ! directly (not by Pythagoras) so accuracy is preserved when
+            ! the Krylov subspace is becoming invariant.
+            alpha2 = 0.0_xp
+            !$omp parallel do private(k, l, w_plus, tmp) reduction(+:alpha2)
             do i = 0, n-1, NEKO_BLK_SIZE
                if (i + NEKO_BLK_SIZE .le. n) then
                   !$omp simd
@@ -321,9 +309,9 @@ contains
                         w_plus(k) = w_plus(k) - h(l,j) * v(i+k,l)
                      end do
                   end do
-                  !$omp simd
                   do k = 1, NEKO_BLK_SIZE
                      w(i+k) = w(i+k) + w_plus(k)
+                     alpha2 = alpha2 + w(i+k)**2 * coef%mult(i+k,1,1,1)
                   end do
                else
                   do k = 1, n - i
@@ -332,10 +320,13 @@ contains
                         tmp = tmp - h(l,j) * v(i+k,l)
                      end do
                      w(i+k) = w(i+k) + tmp
+                     alpha2 = alpha2 + w(i+k)**2 * coef%mult(i+k,1,1,1)
                   end do
                end if
             end do
             !$omp end parallel do
+            call MPI_Allreduce(MPI_IN_PLACE, alpha2, 1, &
+                 MPI_EXTRA_PRECISION, MPI_SUM, NEKO_COMM, ierr)
             alpha = sqrt(alpha2)
             do i = 1, j-1
                temp = h(i,j)

--- a/src/krylov/bcknd/cpu/gmres.f90
+++ b/src/krylov/bcknd/cpu/gmres.f90
@@ -32,6 +32,7 @@
 !
 !> Defines various GMRES methods
 module gmres
+  !$ use omp_lib
   use krylov, only : ksp_t, ksp_monitor_t
   use precon, only : pc_t
   use ax_product, only : ax_t
@@ -59,6 +60,8 @@ module gmres
      real(kind=xp), allocatable :: s(:)
      real(kind=xp), allocatable :: gam(:)
      real(kind=xp), allocatable :: c(:)
+     !> Per-thread partial-sum buffer for orthogonalization + fused norm.
+     real(kind=xp), allocatable :: hp(:,:)
    contains
      procedure, pass(this) :: init => gmres_init
      procedure, pass(this) :: free => gmres_free
@@ -77,6 +80,7 @@ contains
     real(kind=rp), optional, intent(in) :: rel_tol
     real(kind=rp), optional, intent(in) :: abs_tol
     logical, optional, intent(in) :: monitor
+    integer :: nthrds
 
     call this%free()
 
@@ -95,6 +99,10 @@ contains
     allocate(this%v(n, this%lgmres))
 
     allocate(this%h(this%lgmres, this%lgmres))
+
+    nthrds = 1
+    !$ nthrds = omp_get_max_threads()
+    allocate(this%hp(this%lgmres + 1, nthrds))
 
     if (present(rel_tol) .and. present(abs_tol) .and. present(monitor)) then
        call this%ksp_init(max_iter, rel_tol, abs_tol, monitor = monitor)
@@ -155,6 +163,10 @@ contains
        deallocate(this%gam)
     end if
 
+    if (allocated(this%hp)) then
+       deallocate(this%hp)
+    end if
+
     nullify(this%M)
 
   end subroutine gmres_free
@@ -173,10 +185,9 @@ contains
     type(ksp_monitor_t) :: ksp_results
     integer, optional, intent(in) :: niter
     integer :: iter, max_iter
-    integer :: i, j, k, l, ierr, blk_size
+    integer :: i, j, k, l, ierr, tid, nthrds
     real(kind=xp) :: w_plus(NEKO_BLK_SIZE), x_plus(NEKO_BLK_SIZE)
-    real(kind=xp) :: alpha, lr, alpha2, norm_fac
-    real(kind=xp) :: hl_priv(this%lgmres)
+    real(kind=xp) :: alpha, lr, alpha2, norm_fac, tmp, ww
     real(kind=rp) :: temp, rnorm
     logical :: conv
 
@@ -190,8 +201,11 @@ contains
        max_iter = this%max_iter
     end if
 
+    nthrds = 1
+    !$ nthrds = omp_get_max_threads()
+
     associate(w => this%w, c => this%c, r => this%r, z => this%z, h => this%h, &
-         v => this%v, s => this%s, gam => this%gam)
+         v => this%v, s => this%s, gam => this%gam, hp => this%hp)
 
       norm_fac = 1.0_rp / sqrt(coef%volume)
       call rzero(x%x, n)
@@ -231,55 +245,97 @@ contains
             call gs_h%op(w, n, GS_OP_ADD)
             call blst%apply(w, n)
 
-            do l = 1, j
-               h(l,j) = 0.0_xp
-            end do
-
-            !$omp parallel private(k, l, hl_priv, blk_size)
-            do l = 1, j
-               hl_priv(l) = 0.0_xp
+            ! Fused orthogonalization + post-projection norm with
+            ! constant-trip-count inner loops. Rows 1..j of hp accumulate
+            ! <w, v_l>_mult and row j+1 accumulates <w,w>_mult, so a
+            ! single MPI_Allreduce of length j+1 covers both reductions.
+            ! alpha2 then follows by Pythagoras since {v_l} are mult-
+            ! orthonormal: ||w - sum h_l v_l||^2 = <w,w> - sum h_l^2.
+            !$omp parallel private(i, k, l, tid)
+            tid = 1
+            !$ tid = omp_get_thread_num() + 1
+            do l = 1, j+1
+               hp(l,tid) = 0.0_xp
             end do
             !$omp do
-            do i = 0, n, NEKO_BLK_SIZE
-               blk_size = min(NEKO_BLK_SIZE, n - i)
-               do l = 1, j
-                  do concurrent (k = 1:blk_size)
-                     hl_priv(l) = hl_priv(l) + &
-                          w(i+k) * v(i+k,l) * coef%mult(i+k,1,1,1)
+            do i = 0, n-1, NEKO_BLK_SIZE
+               if (i + NEKO_BLK_SIZE .le. n) then
+                  do l = 1, j
+                     !$omp simd
+                     do k = 1, NEKO_BLK_SIZE
+                        hp(l,tid) = hp(l,tid) + &
+                             w(i+k) * v(i+k,l) * coef%mult(i+k,1,1,1)
+                     end do
                   end do
-               end do
+                  !$omp simd
+                  do k = 1, NEKO_BLK_SIZE
+                     hp(j+1,tid) = hp(j+1,tid) + &
+                          w(i+k)**2 * coef%mult(i+k,1,1,1)
+                  end do
+               else
+                  do l = 1, j
+                     do k = 1, n - i
+                        hp(l,tid) = hp(l,tid) + &
+                             w(i+k) * v(i+k,l) * coef%mult(i+k,1,1,1)
+                     end do
+                  end do
+                  do k = 1, n - i
+                     hp(j+1,tid) = hp(j+1,tid) + &
+                          w(i+k)**2 * coef%mult(i+k,1,1,1)
+                  end do
+               end if
             end do
             !$omp end do
+            !$omp end parallel
+
+            ! Cross-thread merge into hp(:, 1), then one Allreduce of j+1.
+            do k = 2, nthrds
+               do l = 1, j+1
+                  hp(l,1) = hp(l,1) + hp(l,k)
+               end do
+            end do
+            call MPI_Allreduce(MPI_IN_PLACE, hp(1,1), j+1, &
+                 MPI_EXTRA_PRECISION, MPI_SUM, NEKO_COMM, ierr)
 
             do l = 1, j
-               !$omp atomic
-               h(l,j) = h(l,j) + hl_priv(l)
+               h(l,j) = hp(l,1)
             end do
+            ww = hp(j+1,1)
+            alpha2 = ww
+            do l = 1, j
+               alpha2 = alpha2 - h(l,j) * h(l,j)
+            end do
+            if (alpha2 .lt. 0.0_xp) alpha2 = 0.0_xp
 
-            !$omp end parallel
-            call MPI_Allreduce(MPI_IN_PLACE, h(1,j), j, &
-                 MPI_EXTRA_PRECISION, MPI_SUM, NEKO_COMM, ierr)
-
-            alpha2 = 0.0_rp
-            !$omp parallel do private(k, l, w_plus, blk_size) reduction(+:alpha2)
-            do i = 0, n, NEKO_BLK_SIZE
-               blk_size = min(NEKO_BLK_SIZE, n - i)
-               do concurrent (k = 1:blk_size)
-                  w_plus(k) = 0.0_rp
-               end do
-               do l = 1, j
-                  do concurrent (k = 1:blk_size)
-                     w_plus(k) = w_plus(k) - h(l,j) * v(i+k,l)
+            ! Pure AXPY: w = w - sum h(l,j) * v(:,l). No reduction.
+            !$omp parallel do private(k, l, w_plus, tmp)
+            do i = 0, n-1, NEKO_BLK_SIZE
+               if (i + NEKO_BLK_SIZE .le. n) then
+                  !$omp simd
+                  do k = 1, NEKO_BLK_SIZE
+                     w_plus(k) = 0.0_xp
                   end do
-               end do
-               do k = 1, blk_size
-                  w(i+k) = w(i+k) + w_plus(k)
-                  alpha2 = alpha2 + w(i+k)**2 * coef%mult(i+k,1,1,1)
-               end do
+                  do l = 1, j
+                     !$omp simd
+                     do k = 1, NEKO_BLK_SIZE
+                        w_plus(k) = w_plus(k) - h(l,j) * v(i+k,l)
+                     end do
+                  end do
+                  !$omp simd
+                  do k = 1, NEKO_BLK_SIZE
+                     w(i+k) = w(i+k) + w_plus(k)
+                  end do
+               else
+                  do k = 1, n - i
+                     tmp = 0.0_xp
+                     do l = 1, j
+                        tmp = tmp - h(l,j) * v(i+k,l)
+                     end do
+                     w(i+k) = w(i+k) + tmp
+                  end do
+               end if
             end do
             !$omp end parallel do
-            call MPI_Allreduce(MPI_IN_PLACE,alpha2, 1, &
-                 MPI_EXTRA_PRECISION, MPI_SUM, NEKO_COMM, ierr)
             alpha = sqrt(alpha2)
             do i = 1, j-1
                temp = h(i,j)
@@ -325,20 +381,32 @@ contains
             c(k) = temp / h(k,k)
          end do
 
-         !$omp parallel do private(k, l, x_plus, blk_size)
-         do i = 0, n, NEKO_BLK_SIZE
-            blk_size = min(NEKO_BLK_SIZE, n - i)
-            do concurrent (k = 1:blk_size)
-               x_plus(k) = 0.0_rp
-            end do
-            do l = 1,j
-               do concurrent (k = 1:blk_size)
-                  x_plus(k) = x_plus(k) + c(l) * z(i+k,l)
+         !$omp parallel do private(k, l, x_plus, tmp)
+         do i = 0, n-1, NEKO_BLK_SIZE
+            if (i + NEKO_BLK_SIZE .le. n) then
+               !$omp simd
+               do k = 1, NEKO_BLK_SIZE
+                  x_plus(k) = 0.0_xp
                end do
-            end do
-            do concurrent (k = 1:blk_size)
-               x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
-            end do
+               do l = 1, j
+                  !$omp simd
+                  do k = 1, NEKO_BLK_SIZE
+                     x_plus(k) = x_plus(k) + c(l) * z(i+k,l)
+                  end do
+               end do
+               !$omp simd
+               do k = 1, NEKO_BLK_SIZE
+                  x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
+               end do
+            else
+               do k = 1, n - i
+                  tmp = 0.0_xp
+                  do l = 1, j
+                     tmp = tmp + c(l) * z(i+k,l)
+                  end do
+                  x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + tmp
+               end do
+            end if
          end do
          !$omp end parallel do
       end do

--- a/src/krylov/bcknd/cpu/pc_jacobi.f90
+++ b/src/krylov/bcknd/cpu/pc_jacobi.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2020-2021, The Neko Authors
+! Copyright (c) 2020-2026, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -96,7 +96,7 @@ contains
     class(jacobi_t), intent(inout) :: this
     associate(dof => this%dof, coef => this%coef, gs_h => this%gs_h)
 
-
+      !$omp parallel
       select case (dof%Xh%lx)
       case (14)
          call jacobi_update_lx14(this%d, dof%Xh%dxt, dof%Xh%dyt, dof%Xh%dzt, &
@@ -155,6 +155,7 @@ contains
               coef%G11, coef%G22, coef%G33, coef%G12, coef%G13, coef%G23, &
               dof%msh%dfrmd_el, dof%msh%nelv, dof%Xh%lx)
       end select
+      !$omp end parallel
 
       call col2(this%d, coef%h1, coef%dof%size())
       if (coef%ifh2) call addcol3(this%d, coef%h2, coef%B, coef%dof%size())
@@ -180,12 +181,21 @@ contains
     logical, intent(in) :: dfrmd_el(n)
     integer :: i, j, k, l, e
 
-    d = 0d0
-
+    !$omp do
     do e = 1, n
+       do k = 1, lx
+          do j = 1, lx
+             !$omp simd
+             do i = 1, lx*lx*lx
+                d(i,j,k,e) = 0.0_rp
+             end do
+          end do
+       end do
+
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G11(l,j,k,e) * dxt(i,l)**2
@@ -196,6 +206,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G22(i,l,k,e) * dyt(j,l)**2
@@ -206,6 +217,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G33(i,j,l,e) * dzt(k,l)**2
@@ -248,6 +260,7 @@ contains
           end do
        end if
     end do
+    !$omp end do
   end subroutine jacobi_update_lx
 
   subroutine jacobi_update_lx14(d, dxt, dyt, dzt, G11, G22, G33, &
@@ -267,12 +280,21 @@ contains
     logical, intent(in) :: dfrmd_el(n)
     integer :: i, j, k, l, e
 
-    d = 0d0
-
+    !$omp do
     do e = 1, n
+       do k = 1, lx
+          do j = 1, lx
+             !$omp simd
+             do i = 1, lx
+                d(i,j,k,e) = 0.0_rp
+             end do
+          end do
+       end do
+
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G11(l,j,k,e) * dxt(i,l)**2
@@ -283,6 +305,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G22(i,l,k,e) * dyt(j,l)**2
@@ -293,6 +316,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G33(i,j,l,e) * dzt(k,l)**2
@@ -335,6 +359,7 @@ contains
           end do
        end if
     end do
+    !$omp end do
   end subroutine jacobi_update_lx14
 
   subroutine jacobi_update_lx13(d, dxt, dyt, dzt, G11, G22, G33, &
@@ -354,12 +379,21 @@ contains
     logical, intent(in) :: dfrmd_el(n)
     integer :: i, j, k, l, e
 
-    d = 0d0
-
+    !$omp do
     do e = 1, n
+       do k = 1, lx
+          do j = 1, lx
+             !$omp simd
+             do i = 1, lx
+                d(i,j,k,e) = 0.0_rp
+             end do
+          end do
+       end do
+
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G11(l,j,k,e) * dxt(i,l)**2
@@ -370,6 +404,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G22(i,l,k,e) * dyt(j,l)**2
@@ -380,6 +415,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G33(i,j,l,e) * dzt(k,l)**2
@@ -422,6 +458,7 @@ contains
           end do
        end if
     end do
+    !$omp end do
   end subroutine jacobi_update_lx13
 
   subroutine jacobi_update_lx12(d, dxt, dyt, dzt, G11, G22, G33, &
@@ -441,12 +478,21 @@ contains
     logical, intent(in) :: dfrmd_el(n)
     integer :: i, j, k, l, e
 
-    d = 0d0
-
+    !$omp do
     do e = 1, n
+       do k = 1, lx
+          do j = 1, lx
+             !$omp simd
+             do i = 1, lx
+                d(i,j,k,e) = 0.0_rp
+             end do
+          end do
+       end do
+
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G11(l,j,k,e) * dxt(i,l)**2
@@ -457,6 +503,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G22(i,l,k,e) * dyt(j,l)**2
@@ -467,6 +514,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G33(i,j,l,e) * dzt(k,l)**2
@@ -509,6 +557,7 @@ contains
           end do
        end if
     end do
+    !$omp end do
   end subroutine jacobi_update_lx12
 
   subroutine jacobi_update_lx11(d, dxt, dyt, dzt, G11, G22, G33, &
@@ -528,12 +577,21 @@ contains
     logical, intent(in) :: dfrmd_el(n)
     integer :: i, j, k, l, e
 
-    d = 0d0
-
+    !$omp do
     do e = 1, n
+       do k = 1, lx
+          do j = 1, lx
+             !$omp simd
+             do i = 1, lx
+                d(i,j,k,e) = 0.0_rp
+             end do
+          end do
+       end do
+
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G11(l,j,k,e) * dxt(i,l)**2
@@ -544,6 +602,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G22(i,l,k,e) * dyt(j,l)**2
@@ -554,6 +613,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G33(i,j,l,e) * dzt(k,l)**2
@@ -596,6 +656,7 @@ contains
           end do
        end if
     end do
+    !$omp end do
   end subroutine jacobi_update_lx11
 
   subroutine jacobi_update_lx10(d, dxt, dyt, dzt, G11, G22, G33, &
@@ -615,12 +676,21 @@ contains
     logical, intent(in) :: dfrmd_el(n)
     integer :: i, j, k, l, e
 
-    d = 0d0
-
+    !$omp do
     do e = 1, n
+       do k = 1, lx
+          do j = 1, lx
+             !$omp simd
+             do i = 1, lx
+                d(i,j,k,e) = 0.0_rp
+             end do
+          end do
+       end do
+
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G11(l,j,k,e) * dxt(i,l)**2
@@ -631,6 +701,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G22(i,l,k,e) * dyt(j,l)**2
@@ -641,6 +712,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G33(i,j,l,e) * dzt(k,l)**2
@@ -683,6 +755,7 @@ contains
           end do
        end if
     end do
+    !$omp end do
   end subroutine jacobi_update_lx10
 
   subroutine jacobi_update_lx9(d, dxt, dyt, dzt, G11, G22, G33, &
@@ -702,12 +775,21 @@ contains
     logical, intent(in) :: dfrmd_el(n)
     integer :: i, j, k, l, e
 
-    d = 0d0
-
+    !$omp do
     do e = 1, n
+       do k = 1, lx
+          do j = 1, lx
+             !$omp simd
+             do i = 1, lx
+                d(i,j,k,e) = 0.0_rp
+             end do
+          end do
+       end do
+
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G11(l,j,k,e) * dxt(i,l)**2
@@ -718,6 +800,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G22(i,l,k,e) * dyt(j,l)**2
@@ -728,6 +811,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G33(i,j,l,e) * dzt(k,l)**2
@@ -770,6 +854,7 @@ contains
           end do
        end if
     end do
+    !$omp end do
   end subroutine jacobi_update_lx9
 
   subroutine jacobi_update_lx8(d, dxt, dyt, dzt, G11, G22, G33, &
@@ -789,12 +874,21 @@ contains
     logical, intent(in) :: dfrmd_el(n)
     integer :: i, j, k, l, e
 
-    d = 0d0
-
+    !$omp do
     do e = 1, n
+       do k = 1, lx
+          do j = 1, lx
+             !$omp simd
+             do i = 1, lx
+                d(i,j,k,e) = 0.0_rp
+             end do
+          end do
+       end do
+
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G11(l,j,k,e) * dxt(i,l)**2
@@ -805,6 +899,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G22(i,l,k,e) * dyt(j,l)**2
@@ -815,6 +910,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G33(i,j,l,e) * dzt(k,l)**2
@@ -857,6 +953,7 @@ contains
           end do
        end if
     end do
+    !$omp end do
   end subroutine jacobi_update_lx8
 
   subroutine jacobi_update_lx7(d, dxt, dyt, dzt, G11, G22, G33, &
@@ -876,12 +973,21 @@ contains
     logical, intent(in) :: dfrmd_el(n)
     integer :: i, j, k, l, e
 
-    d = 0d0
-
+    !$omp do
     do e = 1, n
+       do k = 1, lx
+          do j = 1, lx
+             !$omp simd
+             do i = 1, lx
+                d(i,j,k,e) = 0.0_rp
+             end do
+          end do
+       end do
+
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G11(l,j,k,e) * dxt(i,l)**2
@@ -892,6 +998,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G22(i,l,k,e) * dyt(j,l)**2
@@ -902,6 +1009,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G33(i,j,l,e) * dzt(k,l)**2
@@ -944,6 +1052,7 @@ contains
           end do
        end if
     end do
+    !$omp end do
   end subroutine jacobi_update_lx7
 
   subroutine jacobi_update_lx6(d, dxt, dyt, dzt, G11, G22, G33, &
@@ -963,12 +1072,21 @@ contains
     logical, intent(in) :: dfrmd_el(n)
     integer :: i, j, k, l, e
 
-    d = 0d0
-
+    !$omp do
     do e = 1, n
+       do k = 1, lx
+          do j = 1, lx
+             !$omp simd
+             do i = 1, lx
+                d(i,j,k,e) = 0.0_rp
+             end do
+          end do
+       end do
+
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G11(l,j,k,e) * dxt(i,l)**2
@@ -979,6 +1097,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G22(i,l,k,e) * dyt(j,l)**2
@@ -989,6 +1108,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G33(i,j,l,e) * dzt(k,l)**2
@@ -1031,6 +1151,7 @@ contains
           end do
        end if
     end do
+    !$omp end do
   end subroutine jacobi_update_lx6
 
   subroutine jacobi_update_lx5(d, dxt, dyt, dzt, G11, G22, G33, &
@@ -1050,12 +1171,21 @@ contains
     logical, intent(in) :: dfrmd_el(n)
     integer :: i, j, k, l, e
 
-    d = 0d0
-
+    !$omp do
     do e = 1, n
+       do k = 1, lx
+          do j = 1, lx
+             !$omp simd
+             do i = 1, lx
+                d(i,j,k,e) = 0.0_rp
+             end do
+          end do
+       end do
+
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G11(l,j,k,e) * dxt(i,l)**2
@@ -1066,6 +1196,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G22(i,l,k,e) * dyt(j,l)**2
@@ -1076,6 +1207,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G33(i,j,l,e) * dzt(k,l)**2
@@ -1118,6 +1250,7 @@ contains
           end do
        end if
     end do
+    !$omp end do
   end subroutine jacobi_update_lx5
 
   subroutine jacobi_update_lx4(d, dxt, dyt, dzt, G11, G22, G33, &
@@ -1137,12 +1270,21 @@ contains
     logical, intent(in) :: dfrmd_el(n)
     integer :: i, j, k, l, e
 
-    d = 0d0
-
+    !$omp do
     do e = 1, n
+       do k = 1, lx
+          do j = 1, lx
+             !$omp simd
+             do i = 1, lx
+                d(i,j,k,e) = 0.0_rp
+             end do
+          end do
+       end do
+
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G11(l,j,k,e) * dxt(i,l)**2
@@ -1153,6 +1295,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G22(i,l,k,e) * dyt(j,l)**2
@@ -1163,6 +1306,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G33(i,j,l,e) * dzt(k,l)**2
@@ -1205,6 +1349,7 @@ contains
           end do
        end if
     end do
+    !$omp end do
   end subroutine jacobi_update_lx4
 
   subroutine jacobi_update_lx3(d, dxt, dyt, dzt, G11, G22, G33, &
@@ -1224,12 +1369,21 @@ contains
     logical, intent(in) :: dfrmd_el(n)
     integer :: i, j, k, l, e
 
-    d = 0d0
-
+    !$omp do
     do e = 1, n
+       do k = 1, lx
+          do j = 1, lx
+             !$omp simd
+             do i = 1, lx
+                d(i,j,k,e) = 0.0_rp
+             end do
+          end do
+       end do
+
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G11(l,j,k,e) * dxt(i,l)**2
@@ -1240,6 +1394,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G22(i,l,k,e) * dyt(j,l)**2
@@ -1250,6 +1405,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G33(i,j,l,e) * dzt(k,l)**2
@@ -1292,6 +1448,7 @@ contains
           end do
        end if
     end do
+    !$omp end do
   end subroutine jacobi_update_lx3
 
   subroutine jacobi_update_lx2(d, dxt, dyt, dzt, G11, G22, G33, &
@@ -1311,12 +1468,21 @@ contains
     logical, intent(in) :: dfrmd_el(n)
     integer :: i, j, k, l, e
 
-    d = 0d0
-
+    !$omp do
     do e = 1, n
+       do k = 1, lx
+          do j = 1, lx
+             !$omp simd
+             do i = 1, lx
+                d(i,j,k,e) = 0.0_rp
+             end do
+          end do
+       end do
+
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G11(l,j,k,e) * dxt(i,l)**2
@@ -1327,6 +1493,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G22(i,l,k,e) * dyt(j,l)**2
@@ -1337,6 +1504,7 @@ contains
        do l = 1, lx
           do k = 1, lx
              do j = 1, lx
+                !$omp simd
                 do i = 1, lx
                    d(i,j,k,e) = d(i,j,k,e) + &
                         G33(i,j,l,e) * dzt(k,l)**2
@@ -1379,6 +1547,7 @@ contains
           end do
        end if
     end do
+    !$omp end do
   end subroutine jacobi_update_lx2
 
 end module jacobi

--- a/src/krylov/bcknd/cpu/pipecg.f90
+++ b/src/krylov/bcknd/cpu/pipecg.f90
@@ -41,7 +41,7 @@ module pipecg
   use coefs, only : coef_t
   use gather_scatter, only : gs_t, GS_OP_ADD
   use bc_list, only : bc_list_t
-  use math, only : glsc3, rzero, copy, abscmp
+  use math, only : glsc3, abscmp
   use comm, only : MPI_REAL_PRECISION, NEKO_COMM
   use mpi_f08, only : MPI_Iallreduce, MPI_IN_PLACE, MPI_SUM, MPI_Wait, &
        MPI_Request, MPI_Status
@@ -191,12 +191,16 @@ contains
       p_prev = PIPECG_P_SPACE
       u_prev = PIPECG_P_SPACE+1
       p_cur = 1
-      call rzero(x%x, n)
-      call rzero(z, n)
-      call rzero(q, n)
-      call rzero(p, n)
-      call rzero(s, n)
-      call copy(r, f, n)
+      !$omp parallel do
+      do i = 1, n
+         x%x(i,1,1,1) = 0.0_rp
+         z(i) = 0.0_rp
+         q(i) = 0.0_rp
+         p(i) = 0.0_rp
+         s(i) = 0.0_rp
+         r(i) = f(i)
+      end do
+      !$omp end parallel do
       call this%M%solve(u(1,u_prev), r, n)
       call Ax%compute(w, u(1,u_prev), coef, x%msh, x%Xh)
       call gs_h%op(w, n, GS_OP_ADD)
@@ -260,18 +264,33 @@ contains
          tmp2 = 0.0_rp
          tmp3 = 0.0_rp
          !$omp parallel do private(k) reduction(+:tmp1,tmp2,tmp3)
-         do i = 0, n, NEKO_BLK_SIZE
-            do k = 1, min(NEKO_BLK_SIZE, n - i)
-               z(i+k) = beta(p_cur) * z(i+k) + ni(i+k)
-               q(i+k) = beta(p_cur) * q(i+k) + mi(i+k)
-               s(i+k) = beta(p_cur) * s(i+k) + w(i+k)
-               r(i+k) = r(i+k) - alpha(p_cur) * s(i+k)
-               u(i+k,p_cur) = u(i+k,u_prev) - alpha(p_cur) * q(i+k)
-               w(i+k) = w(i+k) - alpha(p_cur) * z(i+k)
-               tmp1 = tmp1 + r(i+k) * coef%mult(i+k,1,1,1) * u(i+k,p_cur)
-               tmp2 = tmp2 + w(i+k) * coef%mult(i+k,1,1,1) * u(i+k,p_cur)
-               tmp3 = tmp3 + r(i+k) * coef%mult(i+k,1,1,1) * r(i+k)
-            end do
+         do i = 0, n-1, NEKO_BLK_SIZE
+            if (i + NEKO_BLK_SIZE .le. n) then
+               !$omp simd reduction(+:tmp1,tmp2,tmp3)
+               do k = 1, NEKO_BLK_SIZE
+                  z(i+k) = beta(p_cur) * z(i+k) + ni(i+k)
+                  q(i+k) = beta(p_cur) * q(i+k) + mi(i+k)
+                  s(i+k) = beta(p_cur) * s(i+k) + w(i+k)
+                  r(i+k) = r(i+k) - alpha(p_cur) * s(i+k)
+                  u(i+k,p_cur) = u(i+k,u_prev) - alpha(p_cur) * q(i+k)
+                  w(i+k) = w(i+k) - alpha(p_cur) * z(i+k)
+                  tmp1 = tmp1 + r(i+k) * coef%mult(i+k,1,1,1) * u(i+k,p_cur)
+                  tmp2 = tmp2 + w(i+k) * coef%mult(i+k,1,1,1) * u(i+k,p_cur)
+                  tmp3 = tmp3 + r(i+k) * coef%mult(i+k,1,1,1) * r(i+k)
+               end do
+            else
+               do k = 1, n - i
+                  z(i+k) = beta(p_cur) * z(i+k) + ni(i+k)
+                  q(i+k) = beta(p_cur) * q(i+k) + mi(i+k)
+                  s(i+k) = beta(p_cur) * s(i+k) + w(i+k)
+                  r(i+k) = r(i+k) - alpha(p_cur) * s(i+k)
+                  u(i+k,p_cur) = u(i+k,u_prev) - alpha(p_cur) * q(i+k)
+                  w(i+k) = w(i+k) - alpha(p_cur) * z(i+k)
+                  tmp1 = tmp1 + r(i+k) * coef%mult(i+k,1,1,1) * u(i+k,p_cur)
+                  tmp2 = tmp2 + w(i+k) * coef%mult(i+k,1,1,1) * u(i+k,p_cur)
+                  tmp3 = tmp3 + r(i+k) * coef%mult(i+k,1,1,1) * r(i+k)
+               end do
+            end if
          end do
          !$omp end parallel do
          reduction(1) = tmp1
@@ -280,22 +299,43 @@ contains
 
          if (p_cur .eq. PIPECG_P_SPACE) then
             !$omp parallel do private(k, j, p_prev, x_plus)
-            do i = 0, n, NEKO_BLK_SIZE
-               do k = 1, min(NEKO_BLK_SIZE, n - i)
-                  x_plus(k) = 0.0_rp
-               end do
-               p_prev = PIPECG_P_SPACE+1
-               do j = 1, p_cur
-                  do k = 1, min(NEKO_BLK_SIZE, n - i)
-                     p(i+k) = beta(j) * p(i+k) + u(i+k,p_prev)
-                     x_plus(k) = x_plus(k) + alpha(j) * p(i+k)
+            do i = 0, n-1, NEKO_BLK_SIZE
+               if (i + NEKO_BLK_SIZE .le. n) then
+                  !$omp simd
+                  do k = 1, NEKO_BLK_SIZE
+                     x_plus(k) = 0.0_rp
                   end do
-                  p_prev = j
-               end do
-               do k = 1, min(NEKO_BLK_SIZE, n - i)
-                  x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
-                  u(i+k,PIPECG_P_SPACE+1) = u(i+k,PIPECG_P_SPACE)
-               end do
+                  p_prev = PIPECG_P_SPACE+1
+                  do j = 1, p_cur
+                     !$omp simd
+                     do k = 1, NEKO_BLK_SIZE
+                        p(i+k) = beta(j) * p(i+k) + u(i+k,p_prev)
+                        x_plus(k) = x_plus(k) + alpha(j) * p(i+k)
+                     end do
+                     p_prev = j
+                  end do
+                  !$omp simd
+                  do k = 1, NEKO_BLK_SIZE
+                     x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
+                     u(i+k,PIPECG_P_SPACE+1) = u(i+k,PIPECG_P_SPACE)
+                  end do
+               else
+                  do k = 1, n - i
+                     x_plus(k) = 0.0_rp
+                  end do
+                  p_prev = PIPECG_P_SPACE+1
+                  do j = 1, p_cur
+                     do k = 1, n - i
+                        p(i+k) = beta(j) * p(i+k) + u(i+k,p_prev)
+                        x_plus(k) = x_plus(k) + alpha(j) * p(i+k)
+                     end do
+                     p_prev = j
+                  end do
+                  do k = 1, n - i
+                     x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
+                     u(i+k,PIPECG_P_SPACE+1) = u(i+k,PIPECG_P_SPACE)
+                  end do
+               end if
             end do
             !$omp end parallel do
             p_prev = p_cur
@@ -312,22 +352,43 @@ contains
 
       if ( p_cur .ne. 1) then
          !$omp parallel do private(k, j, p_prev, x_plus)
-         do i = 0, n, NEKO_BLK_SIZE
-            do k = 1, min(NEKO_BLK_SIZE, n - i)
-               x_plus(k) = 0.0_rp
-            end do
-            p_prev = PIPECG_P_SPACE+1
-            do j = 1, p_cur
-               do k = 1, min(NEKO_BLK_SIZE, n - i)
-                  p(i+k) = beta(j) * p(i+k) + u(i+k,p_prev)
-                  x_plus(k) = x_plus(k) + alpha(j) * p(i+k)
+         do i = 0, n-1, NEKO_BLK_SIZE
+            if (i + NEKO_BLK_SIZE .le. n) then
+               !$omp simd
+               do k = 1, NEKO_BLK_SIZE
+                  x_plus(k) = 0.0_rp
                end do
-               p_prev = j
-            end do
-            do k = 1, min(NEKO_BLK_SIZE, n - i)
-               x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
-               u(i+k,PIPECG_P_SPACE+1) = u(i+k,PIPECG_P_SPACE)
-            end do
+               p_prev = PIPECG_P_SPACE+1
+               do j = 1, p_cur
+                  !$omp simd
+                  do k = 1, NEKO_BLK_SIZE
+                     p(i+k) = beta(j) * p(i+k) + u(i+k,p_prev)
+                     x_plus(k) = x_plus(k) + alpha(j) * p(i+k)
+                  end do
+                  p_prev = j
+               end do
+               !$omp simd
+               do k = 1, NEKO_BLK_SIZE
+                  x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
+                  u(i+k,PIPECG_P_SPACE+1) = u(i+k,PIPECG_P_SPACE)
+               end do
+            else
+               do k = 1, n - i
+                  x_plus(k) = 0.0_rp
+               end do
+               p_prev = PIPECG_P_SPACE+1
+               do j = 1, p_cur
+                  do k = 1, n - i
+                     p(i+k) = beta(j) * p(i+k) + u(i+k,p_prev)
+                     x_plus(k) = x_plus(k) + alpha(j) * p(i+k)
+                  end do
+                  p_prev = j
+               end do
+               do k = 1, n - i
+                  x%x(i+k,1,1,1) = x%x(i+k,1,1,1) + x_plus(k)
+                  u(i+k,PIPECG_P_SPACE+1) = u(i+k,PIPECG_P_SPACE)
+               end do
+            end if
          end do
          !$omp end parallel do
       end if


### PR DESCRIPTION
This PR introduces performance improvements and parallelisation enhancements to the Krylov solvers (CPU backend) and the Jacobi preconditioner. The main focus is on optimising key computational kernels with OpenMP parallelism and SIMD vectorisation, as well as improving the efficiency of reductions and orthogonalisation in GMRES.

(_yes this does revert some of the blocked loop to an earlier verbose version for better SIMD vectorisation_) 

see #2335 

