### PR TITLE
Rework (again) OpenMP directives for BC (cpu backend)

### DIFF
--- a/src/bc/bc_list.f90
+++ b/src/bc/bc_list.f90
@@ -40,6 +40,7 @@ module bc_list
   use, intrinsic :: iso_c_binding, only : c_ptr
   use bc, only : bc_t, bc_ptr_t
   use time_state, only : time_state_t
+  !$ use omp_lib
   implicit none
   private
 
@@ -237,10 +238,12 @@ contains
        call this%apply_scalar_device(x_d, time = time, &
             strong = strong, strm = strm)
     else
+       !$omp parallel
        do i = 1, this%size_
           call this%items(i)%ptr%apply_scalar(x, n, time = time, &
                strong = strong)
        end do
+       !$omp end parallel
     end if
   end subroutine bc_list_apply_scalar_array
 
@@ -276,10 +279,12 @@ contains
        call this%apply_vector_device(x_d, y_d, z_d, time = time, &
             strong = strong, strm = strm)
     else
+       !$omp parallel
        do i = 1, this%size_
           call this%items(i)%ptr%apply_vector(x, y, z, n, time = time, &
                strong = strong)
        end do
+       !$omp end parallel
     end if
 
   end subroutine bc_list_apply_vector_array
@@ -359,10 +364,12 @@ contains
     type(c_ptr), intent(inout), optional :: strm
     integer :: i
 
+    !$omp parallel if (.not. omp_in_parallel())
     do i = 1, this%size_
        call this%items(i)%ptr%apply_scalar_generic(x, time = time, &
             strong = strong, strm = strm)
     end do
+    !$omp end parallel
 
   end subroutine bc_list_apply_scalar_field
 
@@ -384,10 +391,12 @@ contains
     type(c_ptr), intent(inout), optional :: strm
     integer :: i
 
+    !$omp parallel if (.not. omp_in_parallel())
     do i = 1, this%size_
        call this%items(i)%ptr%apply_vector_generic(x, y, z, time = time, &
             strong = strong, strm = strm)
     end do
+    !$omp end parallel
 
   end subroutine bc_list_apply_vector_field
 

--- a/src/bc/blasius.f90
+++ b/src/bc/blasius.f90
@@ -201,7 +201,7 @@ contains
          nz => this%coef%nz, lx => this%coef%Xh%lx)
       m = this%msk(0)
       if (strong_) then
-         !$omp parallel do private(k, facet, idx)
+         !$omp do
          do i = 1, m
             k = this%msk(i)
             facet = this%facet(i)
@@ -224,7 +224,7 @@ contains
                     this%delta, this%uinf(3))
             end select
          end do
-         !$omp end parallel do
+         !$omp end do
       end if
     end associate
   end subroutine blasius_apply_vector

--- a/src/bc/dirichlet.f90
+++ b/src/bc/dirichlet.f90
@@ -113,10 +113,12 @@ contains
 
     if (strong_) then
        m = this%msk(0)
-       do concurrent (i = 1:m)
+       !$omp do
+       do i = 1, m
           k = this%msk(i)
           x(k) = this%g
        end do
+       !$omp end do
     end if
   end subroutine dirichlet_apply_scalar
 
@@ -141,12 +143,14 @@ contains
 
     if (strong_) then
        m = this%msk(0)
-       do concurrent (i = 1:m)
+       !$omp do
+       do i = 1, m
           k = this%msk(i)
           x(k) = this%g
           y(k) = this%g
           z(k) = this%g
        end do
+       !$omp end do
     end if
 
   end subroutine dirichlet_apply_vector

--- a/src/bc/dong_outflow.f90
+++ b/src/bc/dong_outflow.f90
@@ -116,7 +116,7 @@ contains
     !Im actually not sure what to do if one has two dong that share a corner.
     if (strong_) then
        m = this%msk(0)
-       !$omp parallel do private(k, facet, ux, uy, uz, idx, normal_xyz, vn, S0)
+       !$omp do
        do i = 1, m
           k = this%msk(i)
           facet = this%facet(i)
@@ -129,9 +129,9 @@ contains
           vn = ux*normal_xyz(1) + uy*normal_xyz(2) + uz*normal_xyz(3)
           S0 = 0.5_rp*(1.0_rp - tanh(vn / (this%uinf * this%delta)))
 
-          x(k) = -0.5*(ux*ux+uy*uy+uz*uz)*S0
+          x(k) = -0.5_rp * (ux*ux+uy*uy+uz*uz) * S0
        end do
-       !$omp end parallel do
+       !$omp end do
     end if
   end subroutine dong_outflow_apply_scalar
 

--- a/src/bc/facet_normal.f90
+++ b/src/bc/facet_normal.f90
@@ -154,13 +154,16 @@ contains
     real(kind=rp) :: normal(3), area
 
     m = this%unique_mask(0)
-
+    ! Since apply_surfvec is called outside of the parallel region, we
+    ! need to open a separate parallel region here
+    !$omp parallel do
     do i = 1, m
        k = this%unique_mask(i)
        x(k) = u(k) * this%nx%x(i)
        y(k) = v(k) * this%ny%x(i)
        z(k) = w(k) * this%nz%x(i)
     end do
+    !$omp end parallel do
 
   end subroutine facet_normal_apply_surfvec
 

--- a/src/bc/field_neumann.f90
+++ b/src/bc/field_neumann.f90
@@ -194,7 +194,7 @@ contains
        end if
 
        m = this%msk(0)
-       !$omp parallel do private(k, facet, idx)
+       !$omp do
        do i = 1, m
           k = this%msk(i)
           facet = this%facet(i)
@@ -215,7 +215,7 @@ contains
                   this%coef%area(idx(1), idx(2), facet, idx(4))
           end select
        end do
-       !$omp end parallel do
+       !$omp end do
     end if
 
   end subroutine field_neumann_apply_scalar

--- a/src/bc/inflow.f90
+++ b/src/bc/inflow.f90
@@ -114,12 +114,14 @@ contains
     m = this%msk(0)
 
     if (strong_) then
-       do concurrent (i = 1:m)
+       !$omp do
+       do i = 1, m
           k = this%msk(i)
           x(k) = this%x(1)
           y(k) = this%x(2)
           z(k) = this%x(3)
        end do
+       !$omp end do
     end if
   end subroutine inflow_apply_vector
 

--- a/src/bc/neumann.f90
+++ b/src/bc/neumann.f90
@@ -182,7 +182,7 @@ contains
 
     m = this%msk(0)
     if (.not. strong_) then
-       !$omp parallel do private(k, facet, idx)
+       !$omp do
        do i = 1,m
           k = this%msk(i)
           facet = this%facet(i)
@@ -203,7 +203,7 @@ contains
                   this%coef%area(idx(1), idx(2), facet, idx(4))
           end select
        end do
-       !$omp end parallel do
+       !$omp end do
     end if
   end subroutine neumann_apply_scalar
 

--- a/src/bc/zero_dirichlet.f90
+++ b/src/bc/zero_dirichlet.f90
@@ -107,10 +107,12 @@ contains
     m = this%msk(0)
 
     if (strong_) then
+       !$omp do
        do i = 1, m
           k = this%msk(i)
           x(k) = 0d0
        end do
+       !$omp end do
     end if
 
   end subroutine zero_dirichlet_apply_scalar
@@ -135,12 +137,14 @@ contains
 
     if (strong_) then
        m = this%msk(0)
-       do concurrent (i = 1:m)
+       !$omp do
+       do i = 1, m
           k = this%msk(i)
           x(k) = 0d0
           y(k) = 0d0
           z(k) = 0d0
        end do
+       !$omp end do
     end if
 
   end subroutine zero_dirichlet_apply_vector


### PR DESCRIPTION
This PR fixes the OpenMP-based parallelisation in several boundary condition routines, replacing previous `do concurrent` that relied on auto parallelisation to work, with OpenMP directives. Threads are spawn inside the `bc_list` apply routine to reduce synchronisation costs.

see #2335 
