### PR TITLE
Refactor host MPI gs backend to allow for OpenMP worksharing

### DIFF
--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -23,6 +23,7 @@ of the code. But can be useful for users and developers alike.
 | `NEKO_GS_COMM`           | Gather-scatter communication backend                                  | Unset         |
 | `NEKO_GS_CAF_SIGNALING`  | Coarray Fortran gather-scatter signaling mode                         | Unset         |
 | `NEKO_COMM_ID`           | Communicator id for this process (non-negative integer)               | 0             |
+| `NEKO_MPI_THREAD_LEVEL`  | Requested MPI (and SHMEM) thread support level                        | Unset         |
 | `NEKO_DEPRECATION_ERROR` | Whether to treat deprecated features as errors (boolean)              | Unset         |
 
 ### Logging level details
@@ -46,6 +47,23 @@ A number of gather-scatter backends are supported.
   OpenSHMEM based on CPU builds (requires a native OpenSHMEM library,
   e.g. Cray OpenSHMEMX, enabled at configure time with `--with-openshmem`)
 - `NEKO_GS_COMM=CAF`    : Coarray Fortran (requires a coarray-capable compiler)
+
+### MPI thread level details
+
+`NEKO_MPI_THREAD_LEVEL` overrides the default thread support requested
+from the MPI runtime (and, when built with `--with-openshmem`, from
+the SHMEM runtime as well). When unset, the level is chosen
+automatically: `MPI_THREAD_MULTIPLE` when running with more than one
+OpenMP thread per rank, falling back to `MPI_THREAD_FUNNELED` on
+host-only backends, and `MPI_Init` otherwise. Device backends require
+`MPI_THREAD_MULTIPLE` under the automatic policy. Setting the variable
+bypasses these heuristics; if the runtime cannot honor the requested
+level, initialisation aborts.
+
+- `NEKO_MPI_THREAD_LEVEL=single`     : `MPI_THREAD_SINGLE` (calls `MPI_Init`).
+- `NEKO_MPI_THREAD_LEVEL=funneled`   : `MPI_THREAD_FUNNELED`.
+- `NEKO_MPI_THREAD_LEVEL=serialized` : `MPI_THREAD_SERIALIZED`.
+- `NEKO_MPI_THREAD_LEVEL=multiple`   : `MPI_THREAD_MULTIPLE`.
 
 ### Coarray Fortran signaling mode details
 

--- a/src/comm/comm.F90.in
+++ b/src/comm/comm.F90.in
@@ -1,6 +1,7 @@
 module comm
   use mpi_f08, only : MPI_COMM, MPI_Datatype, MPI_Initialized, MPI_init_thread, &
-       MPI_Init, MPI_THREAD_MULTIPLE, MPI_THREAD_SERIALIZED, MPI_Comm_rank, &
+       MPI_Init, MPI_THREAD_SINGLE, MPI_THREAD_FUNNELED, &
+       MPI_THREAD_SERIALIZED, MPI_THREAD_MULTIPLE, MPI_Comm_rank, &
        MPI_Comm_split, MPI_Comm_dup, MPI_Barrier, MPI_Comm_free, MPI_FInalize, &
        MPI_COMM_WORLD, MPI_DOUBLE_PRECISION, MPI_REAL, MPI_Comm_size
   use utils, only : neko_error
@@ -68,6 +69,9 @@ module comm
   !> Global MPI size of communicator
   integer, public :: global_pe_size
 
+  !> Thread support provided by the MPI library
+  integer, public :: NEKO_MPI_THREAD_PROVIDED
+
   public :: comm_init, comm_free
 
 contains
@@ -78,8 +82,13 @@ contains
     integer :: color = 0
     integer :: envvar_len
     character(len=255) :: color_str
+    character(len=32) :: thread_str
+    integer :: thread_envvar_len
+    integer :: requested_thread_level
+    logical :: user_thread_level
 #ifdef HAVE_OPENSHMEM
     integer :: shmem_ierr
+    integer :: shmem_requested
 #endif
 
     pe_rank = -1
@@ -102,16 +111,45 @@ contains
     !$omp end master
     !$omp end parallel
 
+    call get_environment_variable("NEKO_MPI_THREAD_LEVEL", thread_str, &
+         thread_envvar_len)
+    user_thread_level = thread_envvar_len .gt. 0
+    if (user_thread_level) then
+       select case (trim(adjustl(thread_str(1:thread_envvar_len))))
+       case ("single", "SINGLE")
+          requested_thread_level = MPI_THREAD_SINGLE
+       case ("funneled", "FUNNELED")
+          requested_thread_level = MPI_THREAD_FUNNELED
+       case ("serialized", "SERIALIZED")
+          requested_thread_level = MPI_THREAD_SERIALIZED
+       case ("multiple", "MULTIPLE")
+          requested_thread_level = MPI_THREAD_MULTIPLE
+       case default
+          call neko_error('Unknown NEKO_MPI_THREAD_LEVEL: '// &
+               trim(thread_str(1:thread_envvar_len)))
+       end select
+    end if
+
     if (.not.initialized) then
-       if (nthrds .gt. 1) then
+       if (user_thread_level) then
+          if (requested_thread_level .eq. MPI_THREAD_SINGLE) then
+             call MPI_Init(ierr)
+             provided = MPI_THREAD_SINGLE
+          else
+             call MPI_Init_thread(requested_thread_level, provided, ierr)
+             if (provided .lt. requested_thread_level) then
+                call neko_error('Requested MPI thread level not provided')
+             end if
+          end if
+       else if (nthrds .gt. 1) then
           call MPI_Init_thread(MPI_THREAD_MULTIPLE, provided, ierr)
           if (provided .ne. MPI_THREAD_MULTIPLE) then
              ! MPI_THREAD_MULTIPLE is required for mt. device backends
              if (NEKO_BCKND_DEVICE .eq. 1) then
                 call neko_error('Invalid thread support provided by MPI')
              else
-                call MPI_Init_thread(MPI_THREAD_SERIALIZED, provided, ierr)
-                if (provided .ne. MPI_THREAD_SERIALIZED) then
+                call MPI_Init_thread(MPI_THREAD_FUNNELED, provided, ierr)
+                if (provided .ne. MPI_THREAD_FUNNELED) then
                    call neko_error('Invalid thread support provided by MPI')
                 end if
              end if
@@ -121,6 +159,8 @@ contains
        end if
     end if
 
+    NEKO_MPI_THREAD_PROVIDED = provided
+    
 #ifndef HAVE_MPI_PARAM_DTYPE
     MPI_REAL_PRECISION = @NEKO_MPI_REAL_TYPE@
     MPI_EXTRA_PRECISION = @NEKO_MPI_XREAL_TYPE@
@@ -163,7 +203,26 @@ contains
 
 #ifdef HAVE_OPENSHMEM
     ! Setup OpenSHMEM (if requested)
-    if (nthrds .gt. 1) then
+    if (user_thread_level) then
+       select case (requested_thread_level)
+       case (MPI_THREAD_SINGLE)
+          shmem_requested = SHMEM_THREAD_SINGLE
+       case (MPI_THREAD_FUNNELED)
+          shmem_requested = SHMEM_THREAD_FUNNELED
+       case (MPI_THREAD_SERIALIZED)
+          shmem_requested = SHMEM_THREAD_SERIALIZED
+       case (MPI_THREAD_MULTIPLE)
+          shmem_requested = SHMEM_THREAD_MULTIPLE
+       end select
+       if (shmem_requested .eq. SHMEM_THREAD_SINGLE) then
+          call shmem_init()
+       else
+          shmem_ierr = shmem_init_thread(shmem_requested, provided)
+          if (provided .lt. shmem_requested) then
+             call neko_error('Requested SHMEM thread level not provided')
+          end if
+       end if
+    else if (nthrds .gt. 1) then
        shmem_ierr = shmem_init_thread(SHMEM_THREAD_MULTIPLE, provided)
        if (provided .ne. SHMEM_THREAD_MULTIPLE) then
           if (NEKO_BCKND_DEVICE .eq. 1) then

--- a/src/gs/bcknd/cpu/gs_cpu.f90
+++ b/src/gs/bcknd/cpu/gs_cpu.f90
@@ -109,7 +109,8 @@ contains
     integer :: i, j, k, blk_len
     real(kind=rp) :: tmp
 
-    do concurrent (i = 1:nb)
+    !$omp do
+    do i = 1, nb
        k = bo(i)
        blk_len = b(i)
        tmp = u(gd(k + 1))
@@ -118,15 +119,20 @@ contains
        end do
        v(dg(k + 1)) = tmp
     end do
+    !$omp end do nowait
 
     if (o .lt. 0) then
-       do concurrent (i = abs(o):m)
+       !$omp do
+       do i = abs(o), m
           v(dg(i)) = u(gd(i))
        end do
+       !$omp end do
     else
-       do concurrent (i = o:m:2)
+       !$omp do
+       do i = o, m, 2
           v(dg(i)) = u(gd(i)) + u(gd(i+1))
        end do
+       !$omp end do
     end if
 
   end subroutine gs_gather_kernel_add
@@ -147,7 +153,8 @@ contains
     integer :: i, j, k, blk_len
     real(kind=rp) :: tmp
 
-    do concurrent (i = 1:nb)
+    !$omp do
+    do i = 1, nb
        k = bo(i)
        blk_len = b(i)
        tmp = u(gd(k + 1))
@@ -156,15 +163,20 @@ contains
        end do
        v(dg(k + 1)) = tmp
     end do
+    !$omp end do nowait
 
     if (o .lt. 0) then
-       do concurrent (i = abs(o):m)
+       !$omp do
+       do i = abs(o), m
           v(dg(i)) = u(gd(i))
        end do
+       !$omp end do nowait
     else
-       do concurrent (i = o:m:2)
+       !$omp do
+       do i = o, m, 2
           v(dg(i)) = u(gd(i)) * u(gd(i+1))
        end do
+       !$omp end do nowait
     end if
 
   end subroutine gs_gather_kernel_mul
@@ -185,7 +197,8 @@ contains
     integer :: i, j, k, blk_len
     real(kind=rp) :: tmp
 
-    do concurrent (i = 1:nb)
+    !$omp do
+    do i = 1, nb
        k = bo(i)
        blk_len = b(i)
        tmp = u(gd(k + 1))
@@ -194,15 +207,20 @@ contains
        end do
        v(dg(k + 1)) = tmp
     end do
+    !$omp end do nowait
 
     if (o .lt. 0) then
-       do concurrent (i = abs(o):m)
+       !$omp do
+       do i = abs(o), m
           v(dg(i)) = u(gd(i))
        end do
+       !$omp end do
     else
-       do concurrent (i = o:m:2)
+       !$omp do
+       do i = o, m, 2
           v(dg(i)) = min(u(gd(i)), u(gd(i+1)))
        end do
+       !$omp end do
     end if
 
   end subroutine gs_gather_kernel_min
@@ -223,7 +241,8 @@ contains
     integer :: i, j, k, blk_len
     real(kind=rp) :: tmp
 
-    do concurrent (i = 1:nb)
+    !$omp do
+    do i = 1, nb
        k = bo(i)
        blk_len = b(i)
        tmp = u(gd(k + 1))
@@ -232,15 +251,20 @@ contains
        end do
        v(dg(k + 1)) = tmp
     end do
+    !$omp end do nowait
 
     if (o .lt. 0) then
-       do concurrent (i = abs(o):m)
+       !$omp do
+       do i = abs(o), m
           v(dg(i)) = u(gd(i))
        end do
+       !$omp end do
     else
-       do concurrent (i = o:m:2)
+       !$omp do
+       do i = o, m, 2
           v(dg(i)) = max(u(gd(i)), u(gd(i+1)))
        end do
+       !$omp end do
     end if
 
   end subroutine gs_gather_kernel_max
@@ -278,7 +302,8 @@ contains
     integer :: i, j, k, blk_len
     real(kind=rp) :: tmp
 
-    do concurrent (i = 1:nb)
+    !$omp do
+    do i = 1, nb
        k = bo(i)
        blk_len = b(i)
        tmp = v(dg(k + 1))
@@ -286,10 +311,13 @@ contains
           u(gd(k + j)) = tmp
        end do
     end do
+    !$omp end do nowait
 
-    do concurrent (i = (bo(nb) + b(nb) + 1):m)
+    !$omp do
+    do i = (bo(nb) + b(nb) + 1), m
        u(gd(i)) = v(dg(i))
     end do
+    !$omp end do
 
   end subroutine gs_scatter_kernel
 

--- a/src/gs/bcknd/device/device_mpi.c
+++ b/src/gs/bcknd/device/device_mpi.c
@@ -39,9 +39,6 @@
 
 #include <stdlib.h>
 #include <mpi.h>
-#ifdef _OPENMP
-#include <omp.h>
-#endif
 
 #include <comm/comm.h>
 
@@ -56,27 +53,17 @@ void device_mpi_free_reqs(void **reqs) {
 }
 
 void device_mpi_isend(void *buf_d, int offset, int nbytes, int rank,
-		      void *vreqs, int i) {
+		      int tag, void *vreqs, int i) {
   MPI_Request *reqs = vreqs;
-#ifdef _OPENMP
-  int tid = omp_get_thread_num();
-#else
-  int tid = 0;
-#endif
   void *buf = (char *)buf_d + offset; // Adjust pointer to the correct offset
-  MPI_Isend(buf, nbytes, MPI_BYTE, rank, tid, NEKO_COMM, &reqs[i-1]);
+  MPI_Isend(buf, nbytes, MPI_BYTE, rank, tag, NEKO_COMM, &reqs[i-1]);
 }
 
 void device_mpi_irecv(void *buf_d, int offset, int nbytes, int rank,
-		      void *vreqs, int i) {
+		      int tag, void *vreqs, int i) {
   MPI_Request *reqs = vreqs;
-#ifdef _OPENMP
-  int tid = omp_get_thread_num();
-#else
-  int tid = 0;
-#endif
   void *buf = (char *)buf_d + offset; // Adjust pointer to the correct offset
-  MPI_Irecv(buf, nbytes, MPI_BYTE, rank, tid, NEKO_COMM, &reqs[i-1]);
+  MPI_Irecv(buf, nbytes, MPI_BYTE, rank, tag, NEKO_COMM, &reqs[i-1]);
 }
 
 int device_mpi_test(void *vreqs, int i) {

--- a/src/gs/bcknd/device/gs_device_mpi.F90
+++ b/src/gs/bcknd/device/gs_device_mpi.F90
@@ -140,21 +140,21 @@ module gs_device_mpi
   end interface
 
   interface
-     subroutine device_mpi_isend(buf_d, offset, nbytes, rank, reqs, i) &
+     subroutine device_mpi_isend(buf_d, offset, nbytes, rank, tag, reqs, i) &
           bind(c, name = 'device_mpi_isend')
        use, intrinsic :: iso_c_binding
        implicit none
-       integer(c_int), value :: offset, nbytes, rank, i
+       integer(c_int), value :: offset, nbytes, rank, tag, i
        type(c_ptr), value :: buf_d, reqs
      end subroutine device_mpi_isend
   end interface
 
   interface
-     subroutine device_mpi_irecv(buf_d, offset, nbytes, rank, reqs, i) &
+     subroutine device_mpi_irecv(buf_d, offset, nbytes, rank, tag, reqs, i) &
           bind(c, name = 'device_mpi_irecv')
        use, intrinsic :: iso_c_binding
        implicit none
-       integer(c_int), value :: offset, nbytes, rank, i
+       integer(c_int), value :: offset, nbytes, rank, tag, i
        type(c_ptr), value :: buf_d, reqs
      end subroutine device_mpi_irecv
   end interface
@@ -332,10 +332,11 @@ contains
   end subroutine gs_device_mpi_free
 
   !> Post non-blocking send operations
-  subroutine gs_device_mpi_nbsend(this, u, n, deps, strm)
+  subroutine gs_device_mpi_nbsend(this, u, n, tag, deps, strm)
     class(gs_device_mpi_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
+    integer, intent(in) :: tag
     type(c_ptr), intent(inout) :: deps
     type(c_ptr), intent(inout) :: strm
     integer :: i
@@ -366,7 +367,7 @@ contains
        do i = 1, size(this%send_pe)
           call device_mpi_isend(this%send_buf%buf_d, &
                rp*this%send_buf%offset(i), &
-               rp*this%send_buf%ndofs(i), this%send_pe(i), &
+               rp*this%send_buf%ndofs(i), this%send_pe(i), tag, &
                this%send_buf%reqs, i)
        end do
 
@@ -398,7 +399,7 @@ contains
           call device_sync(this%stream(i))
           call device_mpi_isend(this%send_buf%buf_d, &
                rp*this%send_buf%offset(i), &
-               rp*this%send_buf%ndofs(i), this%send_pe(i), &
+               rp*this%send_buf%ndofs(i), this%send_pe(i), tag, &
                this%send_buf%reqs, i)
        end do
     end if
@@ -406,13 +407,14 @@ contains
   end subroutine gs_device_mpi_nbsend
 
   !> Post non-blocking receive operations
-  subroutine gs_device_mpi_nbrecv(this)
+  subroutine gs_device_mpi_nbrecv(this, tag)
     class(gs_device_mpi_t), intent(inout) :: this
+    integer, intent(in) :: tag
     integer :: i
 
     do i = 1, size(this%recv_pe)
        call device_mpi_irecv(this%recv_buf%buf_d, rp*this%recv_buf%offset(i), &
-            rp*this%recv_buf%ndofs(i), this%recv_pe(i), &
+            rp*this%recv_buf%ndofs(i), this%recv_pe(i), tag, &
             this%recv_buf%reqs, i)
     end do
 

--- a/src/gs/bcknd/device/gs_device_nccl.F90
+++ b/src/gs/bcknd/device/gs_device_nccl.F90
@@ -259,10 +259,11 @@ contains
   end subroutine gs_device_nccl_free
 
   !> Post non-blocking send operations
-  subroutine gs_device_nccl_nbsend(this, u, n, deps, strm)
+  subroutine gs_device_nccl_nbsend(this, u, n, tag, deps, strm)
     class(gs_device_nccl_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
+    integer, intent(in) :: tag
     type(c_ptr), intent(inout) :: deps
     type(c_ptr), intent(inout) :: strm
     integer :: i
@@ -297,8 +298,9 @@ contains
   end subroutine gs_device_nccl_nbsend
 
   !> Post non-blocking receive operations
-  subroutine gs_device_nccl_nbrecv(this)
+  subroutine gs_device_nccl_nbrecv(this, tag)
     class(gs_device_nccl_t), intent(inout) :: this
+    integer, intent(in) :: tag
     integer :: i
 
     ! Everything is done in the wait routine

--- a/src/gs/bcknd/device/gs_device_shmem.F90
+++ b/src/gs/bcknd/device/gs_device_shmem.F90
@@ -289,10 +289,11 @@ contains
   end subroutine gs_device_shmem_free
 
   !> Post non-blocking send operations
-  subroutine gs_device_shmem_nbsend(this, u, n, deps, strm)
+  subroutine gs_device_shmem_nbsend(this, u, n, tag, deps, strm)
     class(gs_device_shmem_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
+    integer, intent(in) :: tag
     type(c_ptr), intent(inout) :: deps
     type(c_ptr), intent(inout) :: strm
     integer :: i
@@ -312,8 +313,9 @@ contains
   end subroutine gs_device_shmem_nbsend
 
   !> Post non-blocking receive operations
-  subroutine gs_device_shmem_nbrecv(this)
+  subroutine gs_device_shmem_nbrecv(this, tag)
     class(gs_device_shmem_t), intent(inout) :: this
+    integer, intent(in) :: tag
     integer :: i
 
     ! We do everything in the "wait" routine below

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -64,6 +64,7 @@ module gather_scatter
   use device, only : device_memcpy, HOST_TO_DEVICE, device_sync, device_free, &
        device_map, device_deassociate
   use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR
+  !$ use omp_lib, only : omp_get_thread_num
   implicit none
   private
 
@@ -1441,18 +1442,25 @@ contains
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
     type(c_ptr), optional, intent(inout) :: event
-    integer :: m, l, op, lo, so
+    integer :: m, l, op, lo, so, tid
 
     lo = gs%local_facet_offset
     so = -gs%shared_facet_offset
     m = gs%nlocal
     l = gs%nshared
 
+    ! Capture the calling thread id before opening any parallel region; it
+    ! is used as the MPI tag so concurrent gs ops driven from different
+    ! threads (device path) don't collide.
+    tid = 0
+    !$ tid = omp_get_thread_num()
+
+    !$omp parallel if (NEKO_BCKND_DEVICE .eq. 0)
     call profiler_start_region("gather_scatter", 5)
     ! Gather shared dofs
     if (pe_size .gt. 1 .and. n .gt. 0) then
        call profiler_start_region("gs_nbrecv", 13)
-       call gs%comm%nbrecv()
+       call gs%comm%nbrecv(tid)
        call profiler_end_region("gs_nbrecv", 13)
        call profiler_start_region("gs_gather_shared", 14)
        call gs%bcknd%gather(gs%shared_gs, l, so, gs%shared_dof_gs, u, n, &
@@ -1460,7 +1468,7 @@ contains
             gs%shared_blk_off, op, .true.)
        call profiler_end_region("gs_gather_shared", 14)
        call profiler_start_region("gs_nbsend", 6)
-       call gs%comm%nbsend(gs%shared_gs, l, &
+       call gs%comm%nbsend(gs%shared_gs, l, tid, &
             gs%bcknd%gather_event, gs%bcknd%gs_stream)
        call profiler_end_region("gs_nbsend", 6)
 
@@ -1496,7 +1504,7 @@ contains
     end if
 
     call profiler_end_region("gather_scatter", 5)
-
+    !$omp end parallel
   end subroutine gs_op_vector
 
 end module gather_scatter

--- a/src/gs/gs_caf.F90
+++ b/src/gs/gs_caf.F90
@@ -331,10 +331,11 @@ contains
   !! half of the recv coarray, so no back-pressure synchronisation is
   !! needed in sync mode -- the visibility synchronisation in nbwait
   !! suffices. Atomic and event modes still use their per-pair signalling.
-  subroutine gs_nbsend_caf(this, u, n, deps, strm)
+  subroutine gs_nbsend_caf(this, u, n, tag, deps, strm)
     class(gs_caf_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
+    integer, intent(in) :: tag
     type(c_ptr), intent(inout) :: deps
     type(c_ptr), intent(inout) :: strm
 #ifdef HAVE_COARRAY
@@ -449,8 +450,9 @@ contains
 
   !> No-op for coarrays: senders push into the receiver's buffer, so
   !! the receive side does not need to post anything.
-  subroutine gs_nbrecv_caf(this)
+  subroutine gs_nbrecv_caf(this, tag)
     class(gs_caf_t), intent(inout) :: this
+    integer, intent(in) :: tag
   end subroutine gs_nbrecv_caf
 
   !> Wait for all incoming puts and reduce them into u. In sync mode a

--- a/src/gs/gs_comm.f90
+++ b/src/gs/gs_comm.f90
@@ -96,7 +96,7 @@ module gs_comm
   !! @param deps, gather_event (for device aware mpi)
   !! @param strm, device stream to execute operation on
   abstract interface
-     subroutine gs_nbsend(this, u, n, deps, strm)
+     subroutine gs_nbsend(this, u, n, tag, deps, strm)
        import gs_comm_t
        import stack_i4_t
        import c_ptr
@@ -104,6 +104,7 @@ module gs_comm
        class(gs_comm_t), intent(inout) :: this
        integer, intent(in) :: n
        real(kind=rp), dimension(n), intent(inout) :: u
+       integer, intent(in) :: tag
        type(c_ptr), intent(inout) :: deps
        type(c_ptr), intent(inout) :: strm
      end subroutine gs_nbsend
@@ -113,9 +114,10 @@ module gs_comm
   !> Abstract interface for initiating non-blocking recieve operations
   !! Posts non-blocking recieve of values and puts the values into buffers
   abstract interface
-     subroutine gs_nbrecv(this)
+     subroutine gs_nbrecv(this, tag)
        import gs_comm_t
        class(gs_comm_t), intent(inout) :: this
+       integer, intent(in) :: tag
      end subroutine gs_nbrecv
   end interface
 

--- a/src/gs/gs_mpi.f90
+++ b/src/gs/gs_mpi.f90
@@ -231,8 +231,8 @@ contains
 
     ! Issue recv requests, we will later check that these have finished
     ! in nbwait
-    
-    
+
+
     ! If the MPI library doesn't support MULTIPLE, the master thread
     ! will issue all Irecv's. Otherwise, threads will issue Irecv's
     ! concurrently.

--- a/src/gs/gs_mpi.f90
+++ b/src/gs/gs_mpi.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2020-2022, The Neko Authors
+! Copyright (c) 2020-2026, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -36,34 +36,32 @@ module gs_mpi
   use gs_comm, only : gs_comm_t, GS_COMM_MPI, GS_COMM_MPIGPU
   use gs_ops, only : GS_OP_ADD, GS_OP_MAX, GS_OP_MIN, GS_OP_MUL
   use stack, only : stack_i4_t
-  use mpi_f08, only : MPI_Test, MPI_STATUS_IGNORE, MPI_Status, &
-       MPI_Request, MPI_Isend, MPI_IRecv
-  use comm, only : NEKO_COMM, MPI_REAL_PRECISION
+  use mpi_f08, only : MPI_STATUSES_IGNORE, MPI_Status, &
+       MPI_Request, MPI_Isend, MPI_IRecv, MPI_Testsome, MPI_Testall, &
+       MPI_THREAD_MULTIPLE
+  use comm, only : NEKO_COMM, MPI_REAL_PRECISION, NEKO_MPI_THREAD_PROVIDED
   use, intrinsic :: iso_c_binding
   use utils, only : neko_error
-  !$ use omp_lib
   implicit none
   private
 
-  !> MPI buffer for non-blocking operations
-  type, private :: gs_comm_mpi_t
-     !> status of this operation
-     type(MPI_Status) :: status
-     !> unique request for this buffer
-     type(MPI_Request) :: request
-     !> flag = false when operation is in process
-     !! Set to true when operation has succeeded
-     logical :: flag
-     !> Buffer with data to send/recieve
-     real(kind=rp), allocatable :: data(:)
-  end type gs_comm_mpi_t
-
-  !> Gather-scatter communication using MPI
+  !> Gather-scatter communication using MPI.
   type, public, extends(gs_comm_t) :: gs_mpi_t
-     !> Comm. buffers for send operations
-     type(gs_comm_mpi_t), allocatable :: send_buf(:)
-     !> Comm. buffers for recv operations
-     type(gs_comm_mpi_t), allocatable :: recv_buf(:)
+     !> Concatenated send slabs, one per peer.
+     real(kind=rp), allocatable :: send_buf(:)
+     !> Concatenated recv slabs, one per peer.
+     real(kind=rp), allocatable :: recv_buf(:)
+     !> Number of dofs to send to / receive from each peer.
+     integer, allocatable :: send_len(:), recv_len(:)
+     !> 0-based offsets into send_buf / recv_buf for each peer.
+     integer, allocatable :: send_offset(:), recv_offset(:)
+     !> Per-peer non-blocking MPI requests.
+     type(MPI_Request), allocatable :: send_request(:), recv_request(:)
+     !> Scratch arrays for MPI_Testsome on the recv side: indices of the
+     !! requests completed by the call and their statuses.
+     integer, allocatable :: recv_indices(:)
+     type(MPI_Status), allocatable :: recv_statuses(:)
+     integer :: ncompleted
    contains
      procedure, pass(this) :: init => gs_mpi_init
      procedure, pass(this) :: free => gs_mpi_free
@@ -81,48 +79,80 @@ contains
     class(gs_mpi_t), intent(inout) :: this
     type(stack_i4_t), intent(inout) :: send_pe
     type(stack_i4_t), intent(inout) :: recv_pe
-    integer, pointer :: sp(:), rp(:)
-    integer :: i
+    integer :: i, nsend, nrecv, send_total, recv_total
 
     call this%init_order(send_pe, recv_pe)
 
-    allocate(this%send_buf(send_pe%size()))
+    nsend = size(this%send_pe)
+    nrecv = size(this%recv_pe)
 
-    sp => send_pe%array()
-    do i = 1, send_pe%size()
-       allocate(this%send_buf(i)%data(this%send_dof(sp(i))%size()))
+    allocate(this%send_len(nsend), this%send_offset(nsend))
+    allocate(this%send_request(nsend))
+
+    allocate(this%recv_len(nrecv), this%recv_offset(nrecv))
+    allocate(this%recv_request(nrecv))
+    allocate(this%recv_indices(nrecv), this%recv_statuses(nrecv))
+
+    send_total = 0
+    do i = 1, nsend
+       this%send_len(i) = this%send_dof(this%send_pe(i))%size()
+       this%send_offset(i) = send_total
+       send_total = send_total + this%send_len(i)
     end do
+    allocate(this%send_buf(max(1, send_total)))
 
-    allocate(this%recv_buf(recv_pe%size()))
-
-    rp => recv_pe%array()
-    do i = 1, recv_pe%size()
-       allocate(this%recv_buf(i)%data(this%recv_dof(rp(i))%size()))
+    recv_total = 0
+    do i = 1, nrecv
+       this%recv_len(i) = this%recv_dof(this%recv_pe(i))%size()
+       this%recv_offset(i) = recv_total
+       recv_total = recv_total + this%recv_len(i)
     end do
+    allocate(this%recv_buf(max(1, recv_total)))
 
   end subroutine gs_mpi_init
 
   !> Deallocate MPI based communication method
   subroutine gs_mpi_free(this)
     class(gs_mpi_t), intent(inout) :: this
-    integer :: i
 
     if (allocated(this%send_buf)) then
-       do i = 1, size(this%send_buf)
-          if (allocated(this%send_buf(i)%data)) then
-             deallocate(this%send_buf(i)%data)
-          end if
-       end do
        deallocate(this%send_buf)
     end if
 
     if (allocated(this%recv_buf)) then
-       do i = 1, size(this%recv_buf)
-          if (allocated(this%recv_buf(i)%data)) then
-             deallocate(this%recv_buf(i)%data)
-          end if
-       end do
        deallocate(this%recv_buf)
+    end if
+
+    if (allocated(this%send_len)) then
+       deallocate(this%send_len)
+    end if
+
+    if (allocated(this%recv_len)) then
+       deallocate(this%recv_len)
+    end if
+
+    if (allocated(this%send_offset)) then
+       deallocate(this%send_offset)
+    end if
+
+    if (allocated(this%recv_offset)) then
+       deallocate(this%recv_offset)
+    end if
+
+    if (allocated(this%send_request)) then
+       deallocate(this%send_request)
+    end if
+
+    if (allocated(this%recv_request)) then
+       deallocate(this%recv_request)
+    end if
+
+    if (allocated(this%recv_indices)) then
+       deallocate(this%recv_indices)
+    end if
+
+    if (allocated(this%recv_statuses)) then
+       deallocate(this%recv_statuses)
     end if
 
     call this%free_order()
@@ -131,60 +161,107 @@ contains
   end subroutine gs_mpi_free
 
   !> Post non-blocking send operations
-  subroutine gs_nbsend_mpi(this, u, n, deps, strm)
+  subroutine gs_nbsend_mpi(this, u, n, tag, deps, strm)
     class(gs_mpi_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
+    integer, intent(in) :: tag
     type(c_ptr), intent(inout) :: deps
     type(c_ptr), intent(inout) :: strm
-    integer :: i, j, ierr, dst, thrdid
-    integer , pointer :: sp(:)
+    integer :: i, j, ierr, dst, off, ndst
 
-    thrdid = 0
-    !$ thrdid = omp_get_thread_num()
+    ! Gather data from u into the per-peer slab of send_buf according
+    ! to indices in send_dof. Slabs are contiguous so each MPI_Isend
+    ! sends a single contiguous block.
 
-    do i = 1, size(this%send_pe)
-       dst = this%send_pe(i)
-       ! Gather data from u into buffers according to indices in send_dof
-       ! We want to send contigous data to each process in send_pe
-       sp => this%send_dof(dst)%array()
-       do concurrent (j = 1:this%send_dof(dst)%size())
-          this%send_buf(i)%data(j) = u(sp(j))
+    ! If the MPI library doesn't support MULTIPLE, use all threads to
+    ! pack the send buffer. Otherwise, let each thread pack and send
+    ! to a different neighbour
+    if (NEKO_MPI_THREAD_PROVIDED .lt. MPI_THREAD_MULTIPLE) then
+       do i = 1, size(this%send_pe)
+          dst = this%send_pe(i)
+          off = this%send_offset(i)
+          ndst = this%send_len(i)
+          select type (sp => this%send_dof(dst)%data)
+          type is (integer)
+             !$omp do
+             do j = 1, ndst
+                this%send_buf(off + j) = u(sp(j))
+             end do
+             !$omp end do
+          end select
+          !$omp master
+          associate(send_data => this%send_buf(off + 1 : off + ndst))
+            call MPI_Isend(send_data, ndst, &
+                 MPI_REAL_PRECISION, dst, tag, &
+                 NEKO_COMM, this%send_request(i), ierr)
+          end associate
+          !$omp end master
        end do
-       ! We should not need this extra associate block, ant it works
-       ! great without it for GNU, Intel, NEC and Cray, but throws an
-       ! ICE with NAG.
-       associate(send_data => this%send_buf(i)%data)
-         call MPI_Isend(send_data, size(send_data), &
-              MPI_REAL_PRECISION, this%send_pe(i), thrdid, &
-              NEKO_COMM, this%send_buf(i)%request, ierr)
-       end associate
-       this%send_buf(i)%flag = .false.
-    end do
+       !$omp barrier
+    else
+       !$omp do
+       do i = 1, size(this%send_pe)
+          dst = this%send_pe(i)
+          off = this%send_offset(i)
+          ndst = this%send_len(i)
+          select type (sp => this%send_dof(dst)%data)
+          type is (integer)
+             !$omp simd
+             do j = 1, ndst
+                this%send_buf(off + j) = u(sp(j))
+             end do
+          end select
+          associate(send_data => this%send_buf(off + 1 : off + ndst))
+            call MPI_Isend(send_data, ndst, &
+                 MPI_REAL_PRECISION, dst, tag, &
+                 NEKO_COMM, this%send_request(i), ierr)
+          end associate
+       end do
+       !$omp end do
+    end if
+
   end subroutine gs_nbsend_mpi
 
   !> Post non-blocking receive operations
-  subroutine gs_nbrecv_mpi(this)
+  subroutine gs_nbrecv_mpi(this, tag)
     class(gs_mpi_t), intent(inout) :: this
-    integer :: i, ierr, thrdid
+    integer, intent(in) :: tag
+    integer :: i, ierr, off, nsrc
 
-    thrdid = 0
-    !$ thrdid = omp_get_thread_num()
-
-    do i = 1, size(this%recv_pe)
-       ! We should not need this extra associate block, ant it works
-       ! great without it for GNU, Intel, NEC and Cray, but throws an
-       ! ICE with NAG.
-       ! Issue recv requests, we will later check that these have finished
-       ! in nbwait
-       associate(recv_data => this%recv_buf(i)%data)
-         call MPI_IRecv(recv_data, size(recv_data), &
-              MPI_REAL_PRECISION, this%recv_pe(i), thrdid, &
-              NEKO_COMM, this%recv_buf(i)%request, ierr)
-       end associate
-       this%recv_buf(i)%flag = .false.
-    end do
-
+    ! Issue recv requests, we will later check that these have finished
+    ! in nbwait
+    
+    
+    ! If the MPI library doesn't support MULTIPLE, the master thread
+    ! will issue all Irecv's. Otherwise, threads will issue Irecv's
+    ! concurrently.
+    if (NEKO_MPI_THREAD_PROVIDED .lt. MPI_THREAD_MULTIPLE) then
+       !$omp master
+       do i = 1, size(this%recv_pe)
+          off = this%recv_offset(i)
+          nsrc = this%recv_len(i)
+          associate(recv_data => this%recv_buf(off + 1 : off + nsrc))
+            call MPI_IRecv(recv_data, nsrc, &
+                 MPI_REAL_PRECISION, this%recv_pe(i), tag, &
+                 NEKO_COMM, this%recv_request(i), ierr)
+          end associate
+       end do
+       !$omp end master
+       !$omp barrier
+    else
+       !$omp do
+       do i = 1, size(this%recv_pe)
+          off = this%recv_offset(i)
+          nsrc = this%recv_len(i)
+          associate(recv_data => this%recv_buf(off + 1 : off + nsrc))
+            call MPI_IRecv(recv_data, nsrc, &
+                 MPI_REAL_PRECISION, this%recv_pe(i), tag, &
+                 NEKO_COMM, this%recv_request(i), ierr)
+          end associate
+       end do
+       !$omp end do
+    end if
   end subroutine gs_nbrecv_mpi
 
   !> Wait for non-blocking operations
@@ -193,67 +270,93 @@ contains
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
     type(c_ptr), intent(inout) :: strm
-    integer :: i, j, src, ierr
+    integer :: i, j, k, src, off, nsrc, ierr
     integer :: op
-    integer , pointer :: sp(:)
+    integer, pointer :: sp(:)
     integer :: nreqs
+    logical :: sends_done
 
+    ! Poll for any subset of the outstanding recv requests to complete,
+    ! reduce each completed slab into u, and repeat until all are done.
     nreqs = size(this%recv_pe)
-
     do while (nreqs .gt. 0)
-       do i = 1, size(this%recv_pe)
-          if (.not. this%recv_buf(i)%flag) then
-             ! Check if we have recieved the data we want
-             call MPI_Test(this%recv_buf(i)%request, this%recv_buf(i)%flag, &
-                  this%recv_buf(i)%status, ierr)
-             ! If it has been received
-             if (this%recv_buf(i)%flag) then
-                ! One more request has been succesful
-                nreqs = nreqs - 1
-                !> @todo Check size etc against status
-                src = this%recv_pe(i)
-                sp => this%recv_dof(src)%array()
-                !Do operation with data in buffer on dof specified by recv_dof
-                select case (op)
-                case (GS_OP_ADD)
-                   !NEC$ IVDEP
-                   do concurrent (j = 1:this%recv_dof(src)%size())
-                      u(sp(j)) = u(sp(j)) + this%recv_buf(i)%data(j)
-                   end do
-                case (GS_OP_MUL)
-                   !NEC$ IVDEP
-                   do concurrent (j = 1:this%recv_dof(src)%size())
-                      u(sp(j)) = u(sp(j)) * this%recv_buf(i)%data(j)
-                   end do
-                case (GS_OP_MIN)
-                   !NEC$ IVDEP
-                   do concurrent (j = 1:this%recv_dof(src)%size())
-                      u(sp(j)) = min(u(sp(j)), this%recv_buf(i)%data(j))
-                   end do
-                case (GS_OP_MAX)
-                   !NEC$ IVDEP
-                   do concurrent (j = 1:this%recv_dof(src)%size())
-                      u(sp(j)) = max(u(sp(j)), this%recv_buf(i)%data(j))
-                   end do
-                case default
-                   call neko_error("Unknown operation in gs_nbwait_mpi")
-                end select
-             end if
-          end if
+       !$omp master
+       call MPI_Testsome(size(this%recv_request), this%recv_request, &
+            this%ncompleted, this%recv_indices, this%recv_statuses, ierr)
+       !$omp end master
+       !$omp barrier
+       do k = 1, this%ncompleted
+          i = this%recv_indices(k)
+          !> @todo Check size etc against status
+          src = this%recv_pe(i)
+          off = this%recv_offset(i)
+          nsrc = this%recv_len(i)
+          select type (sp => this%recv_dof(src)%data)
+          type is (integer)
+             ! Do operation with data in buffer on dof specified by recv_dof
+             select case (op)
+             case (GS_OP_ADD)
+                !OCL NORECURRENCE, NOVREC, NOALIAS
+                !DIR$ CONCURRENT
+                !GCC$ ivdep
+                !NEC$ IVDEP
+                !$omp do
+                do j = 1, nsrc
+                   u(sp(j)) = u(sp(j)) + this%recv_buf(off + j)
+                end do
+                !$omp end do
+             case (GS_OP_MUL)
+                !OCL NORECURRENCE, NOVREC, NOALIAS
+                !DIR$ CONCURRENT
+                !GCC$ ivdep
+                !NEC$ IVDEP
+                !$omp do
+                do j = 1, nsrc
+                   u(sp(j)) = u(sp(j)) * this%recv_buf(off + j)
+                end do
+                !$omp end do
+             case (GS_OP_MIN)
+                !OCL NORECURRENCE, NOVREC, NOALIAS
+                !DIR$ CONCURRENT
+                !GCC$ ivdep
+                !NEC$ IVDEP
+                !$omp do
+                do j = 1, nsrc
+                   u(sp(j)) = min(u(sp(j)), this%recv_buf(off + j))
+                end do
+                !$omp end do
+             case (GS_OP_MAX)
+                !OCL NORECURRENCE, NOVREC, NOALIAS
+                !DIR$ CONCURRENT
+                !GCC$ ivdep
+                !NEC$ IVDEP
+                !$omp do
+                do j = 1, nsrc
+                   u(sp(j)) = max(u(sp(j)), this%recv_buf(off + j))
+                end do
+                !$omp end do
+             case default
+                call neko_error("Unknown operation in gs_nbwait_mpi")
+             end select
+          end select
        end do
+       nreqs = nreqs - this%ncompleted
+       ! Synchronise before master can re-enter MPI_Testsome and overwrite
+       ! this%ncompleted / this%recv_indices, which non-master threads are
+       ! still reading in the unpack above.
+       !$omp barrier
     end do
-    ! Finally, check that the non-blocking sends this rank have issued have also
-    ! completed successfully
-    nreqs = size(this%send_pe)
-    do while (nreqs .gt. 0)
-       do i = 1, size(this%send_pe)
-          if (.not. this%send_buf(i)%flag) then
-             call MPI_Test(this%send_buf(i)%request, this%send_buf(i)%flag, &
-                  MPI_STATUS_IGNORE, ierr)
-             if (this%send_buf(i)%flag) nreqs = nreqs - 1
-          end if
+    !$omp master
+    ! Finally, poll until all outstanding non-blocking sends have drained.
+    if (size(this%send_request) .gt. 0) then
+       sends_done = .false.
+       do while (.not. sends_done)
+          call MPI_Testall(size(this%send_request), this%send_request, &
+               sends_done, MPI_STATUSES_IGNORE, ierr)
        end do
-    end do
+    end if
+    !$omp end master
+    !$omp barrier
 
   end subroutine gs_nbwait_mpi
 

--- a/src/gs/gs_shmem.F90
+++ b/src/gs/gs_shmem.F90
@@ -272,10 +272,11 @@ contains
   !! buffer. Before each put, wait for the receiver's ack of our
   !! previous round so we never overwrite a buffer the receiver hasn't
   !! consumed yet.
-  subroutine gs_shmem_nbsend(this, u, n, deps, strm)
+  subroutine gs_shmem_nbsend(this, u, n, tag, deps, strm)
     class(gs_shmem_t), intent(inout) :: this
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
+    integer, intent(in) :: tag
     type(c_ptr), intent(inout) :: deps
     type(c_ptr), intent(inout) :: strm
     integer :: i, j, dst, base
@@ -326,8 +327,9 @@ contains
   end subroutine gs_shmem_nbsend
 
   !> No-op: receives are completed via remote put-with-signal.
-  subroutine gs_shmem_nbrecv(this)
+  subroutine gs_shmem_nbrecv(this, tag)
     class(gs_shmem_t), intent(inout) :: this
+    integer, intent(in) :: tag
 
   end subroutine gs_shmem_nbrecv
 


### PR DESCRIPTION
This PR introduces OpenMP for gather-scatter CPU kernels. The host based MPI communication backend has been refactored to use linear buffers, similar to device MPI and the PGAS backends. This allows for more performant multithreading, and reduced amount of MPI_Test polling per gs operation.

Furthermore, the PR also introduces the possibility to set the MPI thread level via the environment variable `NEKO_MPI_THREAD_LEVEL` (see appendix). If `MULTIPLE` is supported, the host based MPI backend will issue `Isend/Irecv` calls concurrently from each thread. 

**Note**  For CPU builds using OpenMP, `gs_op` will create an own parallel region, thus calling `gs_op` from within a parallel region on CPUs is currently not supported. On devices, it is supported with the assumption that each threads has its own gather-scatter operation (as used in the task-parallel hsmg implementation).

ref #2335, #2542, #2555, #2556 
