### PR TITLE
Add .gitignore for generated man pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ src/.libs/libneko.la
 src/.libs/libneko.lai
 src/api/neko.h
 src/python/pyneko/intf.py
+share/man/man1
 
 # Ignore temporary files
 *~


### PR DESCRIPTION
Add the `share/man/man1` installed man pages to the gitignore. This helps when neko is the root of the install.