### PR TITLE
Add remaning OpenMP directives on the critical path for the incompressible solver

### DIFF
--- a/src/les/bcknd/cpu/deardorff_cpu.f90
+++ b/src/les/bcknd/cpu/deardorff_cpu.f90
@@ -145,7 +145,12 @@ contains
     call col2(a33%x, coef%mult, nut%dof%size())
 
     ! Determine static stability and length scale
-    do concurrent (i = 1:coef%dof%size())
+    !OCL NORECURRENCE, NOVREC, NOALIAS
+    !DIR$ CONCURRENT
+    !GCC$ ivdep
+    !$omp parallel do private(i, N2, l, s11, s22, s33, s12, s13, s23, &
+    !$omp& shear, buoyancy, dissipation)
+    do i = 1, coef%dof%size()
        ! correct TKE if negative or nearly zero
        if (TKE%x(i,1,1,1) .lt. NEKO_EPS) then
           TKE%x(i,1,1,1) = NEKO_EPS
@@ -199,6 +204,7 @@ contains
        ! Add three source terms together
        TKE_source%x(i,1,1,1) = shear + buoyancy + dissipation
     end do
+    !$omp end parallel do
 
     call neko_scratch_registry%relinquish_field(temp_indices)
   end subroutine deardorff_compute_cpu

--- a/src/les/bcknd/cpu/dynamic_smagorinsky_cpu.f90
+++ b/src/les/bcknd/cpu/dynamic_smagorinsky_cpu.f90
@@ -119,7 +119,11 @@ contains
     call coef%gs_h%op(s13%x, s11%dof%size(), GS_OP_ADD)
     call coef%gs_h%op(s23%x, s11%dof%size(), GS_OP_ADD)
 
-    do concurrent (i = 1:u%dof%size())
+    !OCL NORECURRENCE, NOVREC, NOALIAS
+    !DIR$ CONCURRENT
+    !GCC$ ivdep
+    !$omp parallel do
+    do i = 1, u%dof%size()
        s11%x(i,1,1,1) = s11%x(i,1,1,1) * coef%mult(i,1,1,1)
        s22%x(i,1,1,1) = s22%x(i,1,1,1) * coef%mult(i,1,1,1)
        s33%x(i,1,1,1) = s33%x(i,1,1,1) * coef%mult(i,1,1,1)
@@ -127,8 +131,13 @@ contains
        s13%x(i,1,1,1) = s13%x(i,1,1,1) * coef%mult(i,1,1,1)
        s23%x(i,1,1,1) = s23%x(i,1,1,1) * coef%mult(i,1,1,1)
     end do
+    !$omp end parallel do
 
-    do concurrent (i = 1:u%dof%size())
+    !OCL NORECURRENCE, NOVREC, NOALIAS
+    !DIR$ CONCURRENT
+    !GCC$ ivdep
+    !$omp parallel do
+    do i = 1, u%dof%size()
        s_abs%x(i,1,1,1) = sqrt(2.0_rp * (s11%x(i,1,1,1)*s11%x(i,1,1,1) + &
             s22%x(i,1,1,1)*s22%x(i,1,1,1) + &
             s33%x(i,1,1,1)*s33%x(i,1,1,1)) + &
@@ -136,13 +145,18 @@ contains
             s13%x(i,1,1,1)*s13%x(i,1,1,1) + &
             s23%x(i,1,1,1)*s23%x(i,1,1,1)))
     end do
+    !$omp end parallel do
 
     call compute_lij_cpu(lij, u, v, w, test_filter, u%dof%size())
     call compute_mij_cpu(mij, s11, s22, s33, s12, s13, s23, &
          s_abs, test_filter, delta, u%dof%size())
     call compute_num_den_cpu(num, den, lij, mij, alpha, u%dof%size())
 
-    do concurrent (i =1:u%dof%size())
+    !OCL NORECURRENCE, NOVREC, NOALIAS
+    !DIR$ CONCURRENT
+    !GCC$ ivdep
+    !$omp parallel do
+    do i = 1, u%dof%size()
        if (den%x(i,1,1,1) .gt. 0.0_rp) then
           c_dyn%x(i,1,1,1) = 0.5_rp * (num%x(i,1,1,1)/den%x(i,1,1,1))
        else
@@ -152,6 +166,7 @@ contains
        nut%x(i,1,1,1) = c_dyn%x(i,1,1,1) * delta%x(i,1,1,1)**2 &
             * s_abs%x(i,1,1,1)
     end do
+    !$omp end parallel do
 
     call coef%gs_h%op(nut, GS_OP_ADD)
     call col2(nut%x, coef%mult, nut%dof%size())
@@ -187,7 +202,11 @@ contains
     call test_filter%apply(fw, w)
 
     !! The first term
-    do concurrent (i = 1:n)
+    !OCL NORECURRENCE, NOVREC, NOALIAS
+    !DIR$ CONCURRENT
+    !GCC$ ivdep
+    !$omp parallel do
+    do i = 1, n
        lij(1)%x(i,1,1,1) = fu%x(i,1,1,1) * fu%x(i,1,1,1)
        lij(2)%x(i,1,1,1) = fv%x(i,1,1,1) * fv%x(i,1,1,1)
        lij(3)%x(i,1,1,1) = fw%x(i,1,1,1) * fw%x(i,1,1,1)
@@ -195,6 +214,7 @@ contains
        lij(5)%x(i,1,1,1) = fu%x(i,1,1,1) * fw%x(i,1,1,1)
        lij(6)%x(i,1,1,1) = fv%x(i,1,1,1) * fw%x(i,1,1,1)
     end do
+    !$omp end parallel do
 
     !! Subtract the second term:
     !! use test filter for the cross terms
@@ -319,7 +339,11 @@ contains
     call sub2(mij(6)%x, fs22%x, n)
 
     !! Lastly multiplied by delta^2
-    do concurrent (i = 1:n)
+    !OCL NORECURRENCE, NOVREC, NOALIAS
+    !DIR$ CONCURRENT
+    !GCC$ ivdep
+    !$omp parallel do private(i, delta2)
+    do i = 1, n
        delta2 = delta%x(i,1,1,1)**2
        mij(1)%x(i,1,1,1) = mij(1)%x(i,1,1,1) * delta2
        mij(2)%x(i,1,1,1) = mij(2)%x(i,1,1,1) * delta2
@@ -328,6 +352,7 @@ contains
        mij(5)%x(i,1,1,1) = mij(5)%x(i,1,1,1) * delta2
        mij(6)%x(i,1,1,1) = mij(6)%x(i,1,1,1) * delta2
     end do
+    !$omp end parallel do
 
   end subroutine compute_mij_cpu
 
@@ -347,7 +372,11 @@ contains
     real(kind=rp), dimension(n) :: num_curr, den_curr
     integer :: i
 
-    do concurrent (i = 1:n)
+    !OCL NORECURRENCE, NOVREC, NOALIAS
+    !DIR$ CONCURRENT
+    !GCC$ ivdep
+    !$omp parallel do
+    do i = 1, n
        num_curr(i) = mij(1)%x(i,1,1,1)*lij(1)%x(i,1,1,1) + &
             mij(2)%x(i,1,1,1)*lij(2)%x(i,1,1,1) + &
             mij(3)%x(i,1,1,1)*lij(3)%x(i,1,1,1) + &
@@ -361,12 +390,18 @@ contains
             mij(5)%x(i,1,1,1)*mij(5)%x(i,1,1,1) + &
             mij(6)%x(i,1,1,1)*mij(6)%x(i,1,1,1))
     end do
+    !$omp end parallel do
 
     ! running average over time
-    do concurrent (i = 1:n)
+    !OCL NORECURRENCE, NOVREC, NOALIAS
+    !DIR$ CONCURRENT
+    !GCC$ ivdep
+    !$omp parallel do
+    do i = 1, n
        num%x(i,1,1,1) = alpha * num%x(i,1,1,1) + (1.0_rp - alpha) * num_curr(i)
        den%x(i,1,1,1) = alpha * den%x(i,1,1,1) + (1.0_rp - alpha) * den_curr(i)
     end do
+    !$omp end parallel do
 
   end subroutine compute_num_den_cpu
 

--- a/src/les/bcknd/cpu/sigma_cpu.f90
+++ b/src/les/bcknd/cpu/sigma_cpu.f90
@@ -133,8 +133,14 @@ contains
     call coef%gs_h%op(g32, GS_OP_ADD)
     call coef%gs_h%op(g33, GS_OP_ADD)
 
-    do concurrent (e = 1:coef%msh%nelv)
-       do concurrent (i = 1:coef%Xh%lxyz)
+    !$omp parallel do private(e, i, sigG11, sigG12, sigG13, sigG22, sigG23, &
+    !$omp& sigG33, sigma1, sigma2, sigma3, Invariant1, Invariant2, Invariant3, &
+    !$omp& alpha1, alpha2, alpha3, Dsigma, tmp1)
+    do e = 1, coef%msh%nelv
+       !OCL NORECURRENCE, NOVREC, NOALIAS
+       !DIR$ CONCURRENT
+       !GCC$ ivdep
+       do i = 1, coef%Xh%lxyz
           ! G_ij = g^t g = g_mi g_mj
           sigG11 = g11%x(i,1,1,e)**2 + g21%x(i,1,1,e)**2 + g31%x(i,1,1,e)**2
           sigG22 = g12%x(i,1,1,e)**2 + g22%x(i,1,1,e)**2 + g32%x(i,1,1,e)**2
@@ -268,6 +274,7 @@ contains
 
        end do
     end do
+    !$omp end parallel do
 
     call coef%gs_h%op(nut, GS_OP_ADD)
     call col2(nut%x, coef%mult, nut%dof%size())

--- a/src/les/bcknd/cpu/smagorinsky_cpu.f90
+++ b/src/les/bcknd/cpu/smagorinsky_cpu.f90
@@ -99,8 +99,12 @@ contains
     call coef%gs_h%op(s13, GS_OP_ADD)
     call coef%gs_h%op(s23, GS_OP_ADD)
 
-    do concurrent (e = 1:coef%msh%nelv)
-       do concurrent (i = 1:coef%Xh%lxyz)
+    !$omp parallel do private(e, i, s_abs)
+    do e = 1, coef%msh%nelv
+       !OCL NORECURRENCE, NOVREC, NOALIAS
+       !DIR$ CONCURRENT
+       !GCC$ ivdep
+       do i = 1, coef%Xh%lxyz
           s_abs = sqrt(2.0_rp * (s11%x(i,1,1,e)*s11%x(i,1,1,e) + &
                s22%x(i,1,1,e)*s22%x(i,1,1,e) + &
                s33%x(i,1,1,e)*s33%x(i,1,1,e)) + &
@@ -112,6 +116,7 @@ contains
                * coef%mult(i,1,1,e)
        end do
     end do
+    !$omp end parallel do
 
     call coef%gs_h%op(nut, GS_OP_ADD)
     call col2(nut%x, coef%mult, nut%dof%size())

--- a/src/les/bcknd/cpu/vreman_cpu.f90
+++ b/src/les/bcknd/cpu/vreman_cpu.f90
@@ -137,8 +137,13 @@ contains
     call coef%gs_h%op(a32, GS_OP_ADD)
     call coef%gs_h%op(a33, GS_OP_ADD)
 
-    do concurrent (e = 1:coef%msh%nelv)
-       do concurrent (i = 1:coef%Xh%lxyz)
+    !$omp parallel do private(e, i, beta11, beta12, beta13, beta22, beta23, &
+    !$omp& beta33, b_beta, aijaij)
+    do e = 1, coef%msh%nelv
+       !OCL NORECURRENCE, NOVREC, NOALIAS
+       !DIR$ CONCURRENT
+       !GCC$ ivdep
+       do i = 1, coef%Xh%lxyz
           ! beta_ij = alpha_mi alpha_mj
           beta11 = a11%x(i,1,1,e)**2 + a21%x(i,1,1,e)**2 + a31%x(i,1,1,e)**2
           beta22 = a12%x(i,1,1,e)**2 + a22%x(i,1,1,e)**2 + a32%x(i,1,1,e)**2
@@ -166,6 +171,7 @@ contains
                * coef%mult(i,1,1,e)
        end do
     end do
+    !$omp end parallel do
     if (if_corr) then
        temperature => neko_registry%get_field_by_name(scalar_name)
        call neko_scratch_registry%request_field(dTdx, temp_indices_buoy(1), .false.)
@@ -180,8 +186,13 @@ contains
           call neko_error("The gravity vector must have at least one nonzero component")
        endif
        call grad(dTdx%x, dTdy%x, dTdz%x, temperature%x, coef)
-       do concurrent (e = 1:coef%msh%nelv)
-          do concurrent (i = 1:coef%Xh%lxyz)
+       !$omp parallel do private(e, i, j, buoyancy, du_n, du_parallel, &
+       !$omp& sh, shear_sq, ri, correction)
+       do e = 1, coef%msh%nelv
+          !OCL NORECURRENCE, NOVREC, NOALIAS
+          !DIR$ CONCURRENT
+          !GCC$ ivdep
+          do i = 1, coef%Xh%lxyz
 
              ! Buoyancy component (numerator in Ri definition)
              buoyancy = (-g(1) * dTdx%x(i,1,1,e) - &
@@ -201,7 +212,7 @@ contains
              du_parallel = du_n(1)*n(1) + du_n(2)*n(2) + du_n(3)*n(3)
 
              ! Perpendicular (shear) components
-             do concurrent (j = 1:3)
+             do j = 1, 3
                 sh(j) = du_n(j) - du_parallel*n(j)
              end do
 
@@ -219,6 +230,7 @@ contains
              end if
           end do
        end do
+       !$omp end parallel do
        call neko_scratch_registry%relinquish_field(temp_indices_buoy)
     end if
 

--- a/src/les/bcknd/cpu/wale_cpu.f90
+++ b/src/les/bcknd/cpu/wale_cpu.f90
@@ -142,8 +142,14 @@ contains
     call coef%gs_h%op(s23, GS_OP_ADD)
 
 
-    do concurrent(e = 1:coef%msh%nelv)
-       do concurrent(i = 1:coef%Xh%lxyz)
+    !$omp parallel do private(e, i, gsqr_11, gsqr_12, gsqr_13, gsqr_21, &
+    !$omp& gsqr_22, gsqr_23, gsqr_31, gsqr_32, gsqr_33, sd11, sd22, sd33, &
+    !$omp& sd12, sd13, sd23, Sdij_Sdij, Sij_Sij, OP_wale)
+    do e = 1, coef%msh%nelv
+       !OCL NORECURRENCE, NOVREC, NOALIAS
+       !DIR$ CONCURRENT
+       !GCC$ ivdep
+       do i = 1, coef%Xh%lxyz
           ! gij^2 = g_ik * g_kj
           gsqr_11 = g11%x(i,1,1,e)*g11%x(i,1,1,e) + &
                g12%x(i,1,1,e)*g21%x(i,1,1,e) + &
@@ -197,6 +203,7 @@ contains
           nut%x(i,1,1,e) = c_w**2 * delta%x(i,1,1,e)**2 * OP_wale * coef%mult(i,1,1,e)
        end do
     end do
+    !$omp end parallel do
 
     call neko_scratch_registry%relinquish_field(temp_indices)
   end subroutine wale_compute_cpu

--- a/src/math/bcknd/cpu/opr_cpu.f90
+++ b/src/math/bcknd/cpu/opr_cpu.f90
@@ -193,6 +193,8 @@ contains
     integer :: i, j, k, e
     cfl = 0d0
     if (gdim .eq. 3) then
+       !$omp parallel do reduction(max:cfl) private(e, k, j, i, ur, us, ut, &
+       !$omp& cflr, cfls, cflt, cflm)
        do e = 1, nelv
           do k = 1, Xh%lz
              do j = 1, Xh%ly
@@ -220,7 +222,10 @@ contains
              end do
           end do
        end do
+       !$omp end parallel do
     else
+       !$omp parallel do reduction(max:cfl) private(e, j, i, ur, us, &
+       !$omp& cflr, cfls, cflm)
        do e = 1, nelv
           do j = 1, Xh%ly
              do i = 1, Xh%lx
@@ -238,6 +243,7 @@ contains
              end do
           end do
        end do
+       !$omp end parallel do
     end if
   end function opr_cpu_cfl
 


### PR DESCRIPTION
This PR adds the remaning OpenMP directives on the critical path for the incompressible solver (CPU backend), fixes #2555, and provides a baseline multithreaded version of the solver. The stress-formulation path is still not OpenMP enabled (will be fixed in a separate PR).