### PR TITLE
Deprecate implicit device usage in tensor operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,3 +145,9 @@
 ### Deprecated features
 - `operator::ortho` calls with implicit device arrays are deprecated. Please use
   `device_ortho` instead.
+- `operator::tnsr3d` calls with implicit device arrays are deprecated. Please use
+  `device_tnsr3d` instead.
+- `operator::tnsr3d_el_list` calls with implicit device arrays are deprecated. Please use
+  `device_tnsr3d_el_list` instead.
+- `interpolator::map` calls with implicit device arrays are deprecated. Please use
+  device arrays directly.

--- a/src/.depends
+++ b/src/.depends
@@ -42,11 +42,12 @@ math/fast3d.lo : math/fast3d.f90 math/math.lo sem/speclib.lo config/num_types.lo
 sem/space.lo : sem/space.f90 math/math.lo math/mxm_wrapper.lo math/tensor.lo math/fast3d.lo common/utils.lo math/matrix.lo device/device.lo sem/speclib.lo config/num_types.lo config/neko_config.lo 
 sem/map_1d.lo : sem/map_1d.f90 math/math.lo common/utils.lo math/vector.lo math/matrix.lo field/field_list.lo sem/coef.lo comm/comm.lo device/device.lo mesh/mesh.lo gs/gather_scatter.lo sem/dofmap.lo sem/space.lo config/num_types.lo config/neko_config.lo 
 sem/map_2d.lo : sem/map_2d.f90 io/fld_file_data.lo comm/comm.lo device/device.lo field/field.lo math/math.lo common/utils.lo math/vector.lo sem/coef.lo field/field_list.lo mesh/mesh.lo gs/gather_scatter.lo sem/map_1d.lo sem/dofmap.lo config/num_types.lo config/neko_config.lo 
-sem/dofmap.lo : sem/dofmap.f90 sem/interpolation.lo mesh/hex.lo mesh/quad.lo mesh/element.lo math/bcknd/device/device_math.lo math/math.lo device/device.lo math/tensor.lo math/fast3d.lo common/utils.lo config/num_types.lo adt/tuple.lo sem/space.lo common/mask.lo mesh/mesh.lo config/neko_config.lo 
+sem/dofmap.lo : sem/dofmap.f90 mesh/hex.lo mesh/quad.lo mesh/element.lo math/bcknd/device/device_math.lo math/math.lo device/device.lo math/tensor.lo math/fast3d.lo common/utils.lo config/num_types.lo adt/tuple.lo sem/space.lo common/mask.lo mesh/mesh.lo config/neko_config.lo 
 sem/coef.lo : sem/coef.f90 comm/comm.lo common/utils.lo device/device.lo math/mxm_wrapper.lo sem/bcknd/device/device_coef.lo math/bcknd/device/device_math.lo mesh/mesh.lo math/math.lo sem/space.lo sem/dofmap.lo config/num_types.lo config/neko_config.lo gs/gs_ops.lo gs/gather_scatter.lo 
 sem/cpr.lo : sem/cpr.f90 math/mxm_wrapper.lo sem/dofmap.lo common/log.lo sem/coef.lo mesh/mesh.lo math/tensor.lo math/math.lo sem/space.lo field/field.lo config/num_types.lo 
 common/time_interpolator.lo : common/time_interpolator.f90 math/fast3d.lo common/utils.lo math/math.lo math/bcknd/device/device_math.lo config/neko_config.lo field/field_series.lo field/field.lo config/num_types.lo 
-sem/interpolation.lo : sem/interpolation.f90 common/utils.lo sem/space.lo math/bcknd/cpu/tensor_cpu.lo math/tensor.lo math/fast3d.lo device/device.lo config/num_types.lo config/neko_config.lo 
+sem/interpolation.lo : sem/interpolation.f90 common/log.lo common/utils.lo sem/space.lo math/bcknd/device/tensor_device.lo math/bcknd/cpu/tensor_cpu.lo math/tensor.lo field/field.lo math/fast3d.lo device/device.lo config/num_types.lo config/neko_config.lo 
+sem/bcknd/dofmap_init.lo : sem/bcknd/dofmap_init.f90 sem/interpolation.lo sem/dofmap.lo 
 sem/point_interpolator.lo : sem/point_interpolator.f90 config/neko_config.lo math/bcknd/device/device_math.lo device/device.lo common/utils.lo math/fast3d.lo math/math.lo mesh/point.lo config/num_types.lo sem/space.lo math/tensor.lo 
 sem/bcknd/device/device_coef.lo : sem/bcknd/device/device_coef.F90 common/utils.lo config/num_types.lo 
 sem/bcknd/device/device_local_interpolation.lo : sem/bcknd/device/device_local_interpolation.F90 common/utils.lo config/num_types.lo 
@@ -116,7 +117,7 @@ math/bcknd/cpu/opr_cpu.lo : math/bcknd/cpu/opr_cpu.f90 math/mathops.lo sem/inter
 math/bcknd/sx/opr_sx.lo : math/bcknd/sx/opr_sx.f90 math/mathops.lo math/math.lo sem/coef.lo sem/space.lo config/num_types.lo sem/interpolation.lo gs/gather_scatter.lo 
 math/bcknd/xsmm/opr_xsmm.lo : math/bcknd/xsmm/opr_xsmm.F90 math/mathops.lo gs/gather_scatter.lo sem/interpolation.lo mesh/mesh.lo math/math.lo sem/coef.lo sem/space.lo math/mxm_wrapper.lo config/num_types.lo 
 math/bcknd/device/opr_device.lo : math/bcknd/device/opr_device.F90 math/bcknd/device/device_mathops.lo math/bcknd/device/device_math.lo sem/interpolation.lo common/utils.lo field/field.lo sem/coef.lo sem/space.lo device/device.lo config/num_types.lo gs/gather_scatter.lo 
-math/tensor.lo : math/tensor.f90 device/device.lo config/neko_config.lo math/mxm_wrapper.lo config/num_types.lo math/bcknd/device/tensor_device.lo math/bcknd/sx/tensor_sx.lo math/bcknd/cpu/tensor_cpu.lo math/bcknd/xsmm/tensor_xsmm.lo 
+math/tensor.lo : math/tensor.f90 device/device.lo config/neko_config.lo math/mxm_wrapper.lo config/num_types.lo common/log.lo math/bcknd/device/tensor_device.lo math/bcknd/sx/tensor_sx.lo math/bcknd/cpu/tensor_cpu.lo math/bcknd/xsmm/tensor_xsmm.lo 
 math/bcknd/cpu/tensor_cpu.lo : math/bcknd/cpu/tensor_cpu.f90 math/mxm_wrapper.lo config/num_types.lo 
 math/bcknd/sx/tensor_sx.lo : math/bcknd/sx/tensor_sx.f90 math/mxm_wrapper.lo config/num_types.lo 
 math/bcknd/xsmm/tensor_xsmm.lo : math/bcknd/xsmm/tensor_xsmm.F90 math/mxm_wrapper.lo config/num_types.lo 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,6 +50,7 @@ neko_fortran_SOURCES = \
 	sem/cpr.f90\
 	common/time_interpolator.f90\
 	sem/interpolation.f90\
+	sem/bcknd/dofmap_init.f90\
 	sem/point_interpolator.f90\
 	sem/bcknd/device/device_coef.F90\
 	sem/bcknd/device/device_local_interpolation.F90\

--- a/src/fluid/bcknd/advection/adv_dealias.f90
+++ b/src/fluid/bcknd/advection/adv_dealias.f90
@@ -120,15 +120,29 @@ contains
     nel = coef%msh%nelv
     n_GL = nel*this%Xh_GL%lxyz
     n = nel*coef%Xh%lxyz
-    call this%GLL_to_GL%map(this%coef_GL%drdx, coef%drdx, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dsdx, coef%dsdx, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dtdx, coef%dtdx, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%drdy, coef%drdy, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dsdy, coef%dsdy, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dtdy, coef%dtdy, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%drdz, coef%drdz, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dsdz, coef%dsdz, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dtdz, coef%dtdz, nel, this%Xh_GL)
+
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call this%GLL_to_GL%map(this%coef_GL%drdx_d, coef%drdx_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdx_d, coef%dsdx_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdx_d, coef%dtdx_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%drdy_d, coef%drdy_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdy_d, coef%dsdy_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdy_d, coef%dtdy_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%drdz_d, coef%drdz_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdz_d, coef%dsdz_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdz_d, coef%dtdz_d, nel, this%Xh_GL)
+    else
+       call this%GLL_to_GL%map(this%coef_GL%drdx, coef%drdx, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdx, coef%dsdx, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdx, coef%dtdx, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%drdy, coef%drdy, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdy, coef%dsdy, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdy, coef%dtdy, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%drdz, coef%drdz, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdz, coef%dsdz, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdz, coef%dtdz, nel, this%Xh_GL)
+    end if
+
     if ((NEKO_BCKND_HIP .eq. 1) .or. (NEKO_BCKND_CUDA .eq. 1) .or. &
          (NEKO_BCKND_OPENCL .eq. 1) .or. (NEKO_BCKND_SX .eq. 1) .or. &
          (NEKO_BCKND_XSMM .eq. 1)) then
@@ -261,61 +275,61 @@ contains
     !This is extremely primitive and unoptimized  on the device //Karp
     associate(c_GL => this%coef_GL)
       if (NEKO_BCKND_DEVICE .eq. 1) then
-         call this%GLL_to_GL%map(this%tx, vx%x, nel, this%Xh_GL)
-         call this%GLL_to_GL%map(this%ty, vy%x, nel, this%Xh_GL)
-         call this%GLL_to_GL%map(this%tz, vz%x, nel, this%Xh_GL)
+         call this%GLL_to_GL%map(this%tx_d, vx%x_d, nel, this%Xh_GL)
+         call this%GLL_to_GL%map(this%ty_d, vy%x_d, nel, this%Xh_GL)
+         call this%GLL_to_GL%map(this%tz_d, vz%x_d, nel, this%Xh_GL)
 
          call opgrad(this%vr, this%vs, this%vt, this%tx, c_GL)
          call device_vdot3(this%tbf_d, this%vr_d, this%vs_d, this%vt_d, &
               this%tx_d, this%ty_d, this%tz_d, n_GL)
-         call this%GLL_to_GL%map(this%temp, this%tbf, nel, this%Xh_GLL)
+         call this%GLL_to_GL%map(this%temp_d, this%tbf_d, nel, this%Xh_GLL)
          call device_sub2(fx%x_d, this%temp_d, n)
 
 
          call opgrad(this%vr, this%vs, this%vt, this%ty, c_GL)
          call device_vdot3(this%tbf_d, this%vr_d, this%vs_d, this%vt_d, &
               this%tx_d, this%ty_d, this%tz_d, n_GL)
-         call this%GLL_to_GL%map(this%temp, this%tbf, nel, this%Xh_GLL)
+         call this%GLL_to_GL%map(this%temp_d, this%tbf_d, nel, this%Xh_GLL)
          call device_sub2(fy%x_d, this%temp_d, n)
 
          call opgrad(this%vr, this%vs, this%vt, this%tz, c_GL)
          call device_vdot3(this%tbf_d, this%vr_d, this%vs_d, this%vt_d, &
               this%tx_d, this%ty_d, this%tz_d, n_GL)
-         call this%GLL_to_GL%map(this%temp, this%tbf, nel, this%Xh_GLL)
+         call this%GLL_to_GL%map(this%temp_d, this%tbf_d, nel, this%Xh_GLL)
          call device_sub2(fz%x_d, this%temp_d, n)
 
       else if ((NEKO_BCKND_SX .eq. 1) .or. (NEKO_BCKND_XSMM .eq. 1)) then
 
-         call this%GLL_to_GL%map(this%tx, vx%x, nel, this%Xh_GL)
-         call this%GLL_to_GL%map(this%ty, vy%x, nel, this%Xh_GL)
-         call this%GLL_to_GL%map(this%tz, vz%x, nel, this%Xh_GL)
+         call this%GLL_to_GL%map_host(this%tx, vx%x, nel, this%Xh_GL)
+         call this%GLL_to_GL%map_host(this%ty, vy%x, nel, this%Xh_GL)
+         call this%GLL_to_GL%map_host(this%tz, vz%x, nel, this%Xh_GL)
 
          call opgrad(this%vr, this%vs, this%vt, this%tx, c_GL)
          call vdot3(this%tbf, this%vr, this%vs, this%vt, &
               this%tx, this%ty, this%tz, n_GL)
-         call this%GLL_to_GL%map(this%temp, this%tbf, nel, this%Xh_GLL)
+         call this%GLL_to_GL%map_host(this%temp, this%tbf, nel, this%Xh_GLL)
          call sub2(fx%x, this%temp, n)
 
 
          call opgrad(this%vr, this%vs, this%vt, this%ty, c_GL)
          call vdot3(this%tbf, this%vr, this%vs, this%vt, &
               this%tx, this%ty, this%tz, n_GL)
-         call this%GLL_to_GL%map(this%temp, this%tbf, nel, this%Xh_GLL)
+         call this%GLL_to_GL%map_host(this%temp, this%tbf, nel, this%Xh_GLL)
          call sub2(fy%x, this%temp, n)
 
          call opgrad(this%vr, this%vs, this%vt, this%tz, c_GL)
          call vdot3(this%tbf, this%vr, this%vs, this%vt, &
               this%tx, this%ty, this%tz, n_GL)
-         call this%GLL_to_GL%map(this%temp, this%tbf, nel, this%Xh_GLL)
+         call this%GLL_to_GL%map_host(this%temp, this%tbf, nel, this%Xh_GLL)
          call sub2(fz%x, this%temp, n)
 
       else
          !$omp parallel do private(e, i, idx, tempx, tempy, tempz), &
          !$omp& private(tx, ty, tz, vr, vs, vt, tfx, tfy, tfz)
          do e = 1, coef%msh%nelv
-            call this%GLL_to_GL%map(tx, vx%x(1,1,1,e), 1, this%Xh_GL)
-            call this%GLL_to_GL%map(ty, vy%x(1,1,1,e), 1, this%Xh_GL)
-            call this%GLL_to_GL%map(tz, vz%x(1,1,1,e), 1, this%Xh_GL)
+            call this%GLL_to_GL%map_host(tx, vx%x(1,1,1,e), 1, this%Xh_GL)
+            call this%GLL_to_GL%map_host(ty, vy%x(1,1,1,e), 1, this%Xh_GL)
+            call this%GLL_to_GL%map_host(tz, vz%x(1,1,1,e), 1, this%Xh_GL)
 
             call opgrad(vr, vs, vt, tx, c_GL, e, e)
             do i = 1, this%Xh_GL%lxyz
@@ -332,9 +346,9 @@ contains
                tfz(i) = tx(i)*vr(i) + ty(i)*vs(i) + tz(i)*vt(i)
             end do
 
-            call this%GLL_to_GL%map(tempx, tfx, 1, this%Xh_GLL)
-            call this%GLL_to_GL%map(tempy, tfy, 1, this%Xh_GLL)
-            call this%GLL_to_GL%map(tempz, tfz, 1, this%Xh_GLL)
+            call this%GLL_to_GL%map_host(tempx, tfx, 1, this%Xh_GLL)
+            call this%GLL_to_GL%map_host(tempy, tfy, 1, this%Xh_GLL)
+            call this%GLL_to_GL%map_host(tempz, tfz, 1, this%Xh_GLL)
 
             idx = (e-1)*this%Xh_GLL%lxyz+1
             do concurrent (i = 0:this%Xh_GLL%lxyz-1)
@@ -385,12 +399,12 @@ contains
       if (NEKO_BCKND_DEVICE .eq. 1) then
 
          ! Map advecting velocity onto the higher-order space
-         call this%GLL_to_GL%map(this%tx, vx%x, nel, this%Xh_GL)
-         call this%GLL_to_GL%map(this%ty, vy%x, nel, this%Xh_GL)
-         call this%GLL_to_GL%map(this%tz, vz%x, nel, this%Xh_GL)
+         call this%GLL_to_GL%map(this%tx_d, vx%x_d, nel, this%Xh_GL)
+         call this%GLL_to_GL%map(this%ty_d, vy%x_d, nel, this%Xh_GL)
+         call this%GLL_to_GL%map(this%tz_d, vz%x_d, nel, this%Xh_GL)
 
          ! Map the scalar onto the high-order space
-         call this%GLL_to_GL%map(this%temp, s%x, nel, this%Xh_GL)
+         call this%GLL_to_GL%map(this%temp_d, s%x_d, nel, this%Xh_GL)
 
          ! Compute the scalar gradient in the high-order space
          call opgrad(this%vr, this%vs, this%vt, this%temp, c_GL)
@@ -400,7 +414,7 @@ contains
               this%tx_d, this%ty_d, this%tz_d, n_GL)
 
          ! Map back to the original space (we reuse this%temp)
-         call this%GLL_to_GL%map(this%temp, this%tbf, nel, this%Xh_GLL)
+         call this%GLL_to_GL%map(this%temp_d, this%tbf_d, nel, this%Xh_GLL)
 
          ! Update the source term
          call device_sub2(fs%x_d, this%temp_d, n)
@@ -408,12 +422,12 @@ contains
       else if ((NEKO_BCKND_SX .eq. 1) .or. (NEKO_BCKND_XSMM .eq. 1)) then
 
          ! Map advecting velocity onto the higher-order space
-         call this%GLL_to_GL%map(this%tx, vx%x, nel, this%Xh_GL)
-         call this%GLL_to_GL%map(this%ty, vy%x, nel, this%Xh_GL)
-         call this%GLL_to_GL%map(this%tz, vz%x, nel, this%Xh_GL)
+         call this%GLL_to_GL%map_host(this%tx, vx%x, nel, this%Xh_GL)
+         call this%GLL_to_GL%map_host(this%ty, vy%x, nel, this%Xh_GL)
+         call this%GLL_to_GL%map_host(this%tz, vz%x, nel, this%Xh_GL)
 
          ! Map the scalar onto the high-order space
-         call this%GLL_to_GL%map(this%temp, s%x, nel, this%Xh_GL)
+         call this%GLL_to_GL%map_host(this%temp, s%x, nel, this%Xh_GL)
 
          ! Compute the scalar gradient in the high-order space
          call opgrad(this%vr, this%vs, this%vt, this%temp, c_GL)
@@ -423,7 +437,7 @@ contains
               this%tx, this%ty, this%tz, n_GL)
 
          ! Map back to the original space (we reuse this%temp)
-         call this%GLL_to_GL%map(this%temp, this%tbf, nel, this%Xh_GLL)
+         call this%GLL_to_GL%map_host(this%temp, this%tbf, nel, this%Xh_GLL)
 
          ! Update the source term
          call sub2(fs%x, this%temp, n)
@@ -432,12 +446,12 @@ contains
          !$omp parallel do private (e, i, idx, vx_GL, vy_GL, s_GL, f_GL, temp)
          do e = 1, coef%msh%nelv
             ! Map advecting velocity onto the higher-order space
-            call this%GLL_to_GL%map(vx_GL, vx%x(1,1,1,e), 1, this%Xh_GL)
-            call this%GLL_to_GL%map(vy_GL, vy%x(1,1,1,e), 1, this%Xh_GL)
-            call this%GLL_to_GL%map(vz_GL, vz%x(1,1,1,e), 1, this%Xh_GL)
+            call this%GLL_to_GL%map_host(vx_GL, vx%x(1,1,1,e), 1, this%Xh_GL)
+            call this%GLL_to_GL%map_host(vy_GL, vy%x(1,1,1,e), 1, this%Xh_GL)
+            call this%GLL_to_GL%map_host(vz_GL, vz%x(1,1,1,e), 1, this%Xh_GL)
 
             ! Map scalar onto the higher-order space
-            call this%GLL_to_GL%map(s_GL, s%x(1,1,1,e), 1, this%Xh_GL)
+            call this%GLL_to_GL%map_host(s_GL, s%x(1,1,1,e), 1, this%Xh_GL)
 
             ! Gradient of s in the higher-order space
             call opgrad(dsdx, dsdy, dsdz, s_GL, c_GL, e, e)
@@ -448,7 +462,7 @@ contains
             end do
 
             ! Map back the contructed operator to the original space
-            call this%GLL_to_GL%map(temp, f_GL, 1, this%Xh_GLL)
+            call this%GLL_to_GL%map_host(temp, f_GL, 1, this%Xh_GLL)
 
             idx = (e-1)*this%Xh_GLL%lxyz + 1
 
@@ -513,12 +527,12 @@ contains
          !$omp parallel do private(e, i, flux_GL, total_div_GL, idx)
          do e = 1, coef%msh%nelv
             ! Map advecting velocity and mesh velocity onto the higher-order space
-            call this%GLL_to_GL%map(vx_GL, vx%x(1,1,1,e), 1, this%Xh_GL)
-            call this%GLL_to_GL%map(vy_GL, vy%x(1,1,1,e), 1, this%Xh_GL)
-            call this%GLL_to_GL%map(vz_GL, vz%x(1,1,1,e), 1, this%Xh_GL)
-            call this%GLL_to_GL%map(wm_x_GL, wm_x%x(1,1,1,e), 1, this%Xh_GL)
-            call this%GLL_to_GL%map(wm_y_GL, wm_y%x(1,1,1,e), 1, this%Xh_GL)
-            call this%GLL_to_GL%map(wm_z_GL, wm_z%x(1,1,1,e), 1, this%Xh_GL)
+            call this%GLL_to_GL%map_host(vx_GL, vx%x(1,1,1,e), 1, this%Xh_GL)
+            call this%GLL_to_GL%map_host(vy_GL, vy%x(1,1,1,e), 1, this%Xh_GL)
+            call this%GLL_to_GL%map_host(vz_GL, vz%x(1,1,1,e), 1, this%Xh_GL)
+            call this%GLL_to_GL%map_host(wm_x_GL, wm_x%x(1,1,1,e), 1, this%Xh_GL)
+            call this%GLL_to_GL%map_host(wm_y_GL, wm_y%x(1,1,1,e), 1, this%Xh_GL)
+            call this%GLL_to_GL%map_host(wm_z_GL, wm_z%x(1,1,1,e), 1, this%Xh_GL)
 
             ! x-momentum
             total_div_GL = 0.0_rp
@@ -538,7 +552,7 @@ contains
             total_div_GL = total_div_GL + grad_z
 
             ! Map back the contructed operator to the original space
-            call this%GLL_to_GL%map(temp_x, total_div_GL, 1, this%Xh_GLL)
+            call this%GLL_to_GL%map_host(temp_x, total_div_GL, 1, this%Xh_GLL)
 
             ! y-momentum
             total_div_GL = 0.0_rp
@@ -555,7 +569,7 @@ contains
             total_div_GL = total_div_GL + grad_z
 
             ! Map back the contructed operator to the original space
-            call this%GLL_to_GL%map(temp_y, total_div_GL, 1, this%Xh_GLL)
+            call this%GLL_to_GL%map_host(temp_y, total_div_GL, 1, this%Xh_GLL)
 
             ! z-momentum
             total_div_GL = 0.0_rp
@@ -572,7 +586,7 @@ contains
             total_div_GL = total_div_GL + grad_z
 
             ! Map back the contructed operator to the original space
-            call this%GLL_to_GL%map(temp_z, total_div_GL, 1, this%Xh_GLL)
+            call this%GLL_to_GL%map_host(temp_z, total_div_GL, 1, this%Xh_GLL)
 
             ! Note we add (+) here since the ALE advection term is
             ! - div(u * wm) on the LHS. So on the RHS it will be + div(u * wm)
@@ -599,17 +613,29 @@ contains
     if (.not. moving_boundary) return
 
     nel = coef%msh%nelv
-    call this%GLL_to_GL%map(this%coef_GL%drdx, coef%drdx, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dsdx, coef%dsdx, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dtdx, coef%dtdx, nel, this%Xh_GL)
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call this%GLL_to_GL%map(this%coef_GL%drdx_d, coef%drdx_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdx_d, coef%dsdx_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdx_d, coef%dtdx_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%drdy_d, coef%drdy_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdy_d, coef%dsdy_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdy_d, coef%dtdy_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%drdz_d, coef%drdz_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdz_d, coef%dsdz_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdz_d, coef%dtdz_d, nel, this%Xh_GL)
+    else
+       call this%GLL_to_GL%map(this%coef_GL%drdx, coef%drdx, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdx, coef%dsdx, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdx, coef%dtdx, nel, this%Xh_GL)
 
-    call this%GLL_to_GL%map(this%coef_GL%drdy, coef%drdy, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dsdy, coef%dsdy, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dtdy, coef%dtdy, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%drdy, coef%drdy, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdy, coef%dsdy, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdy, coef%dtdy, nel, this%Xh_GL)
 
-    call this%GLL_to_GL%map(this%coef_GL%drdz, coef%drdz, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dsdz, coef%dsdz, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dtdz, coef%dtdz, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%drdz, coef%drdz, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdz, coef%dsdz, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdz, coef%dtdz, nel, this%Xh_GL)
+    end if
 
   end subroutine recompute_metrics_dealias
 

--- a/src/fluid/bcknd/advection/adv_oifs.f90
+++ b/src/fluid/bcknd/advection/adv_oifs.f90
@@ -162,15 +162,27 @@ contains
     n_GL = nel*this%Xh_GL%lxyz
     n = nel*coef%Xh%lxyz
 
-    call this%GLL_to_GL%map(this%coef_GL%drdx, coef%drdx, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dsdx, coef%dsdx, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dtdx, coef%dtdx, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%drdy, coef%drdy, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dsdy, coef%dsdy, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dtdy, coef%dtdy, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%drdz, coef%drdz, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dsdz, coef%dsdz, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%coef_GL%dtdz, coef%dtdz, nel, this%Xh_GL)
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call this%GLL_to_GL%map(this%coef_GL%drdx_d, coef%drdx_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdx_d, coef%dsdx_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdx_d, coef%dtdx_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%drdy_d, coef%drdy_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdy_d, coef%dsdy_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdy_d, coef%dtdy_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%drdz_d, coef%drdz_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdz_d, coef%dsdz_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdz_d, coef%dtdz_d, nel, this%Xh_GL)
+    else
+       call this%GLL_to_GL%map(this%coef_GL%drdx, coef%drdx, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdx, coef%dsdx, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdx, coef%dtdx, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%drdy, coef%drdy, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdy, coef%dsdy, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdy, coef%dtdy, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%drdz, coef%drdz, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dsdz, coef%dsdz, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%coef_GL%dtdz, coef%dtdz, nel, this%Xh_GL)
+    end if
 
 
     allocate(this%cx(n_GL))
@@ -232,9 +244,15 @@ contains
 
     ! Initializing the convecting fields
     ! Map the velocity fields from GLL space to GL space
-    call this%GLL_to_GL%map(this%cx, this%ulag%f%x, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%cy, this%vlag%f%x, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%cz, this%wlag%f%x, nel, this%Xh_GL)
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call this%GLL_to_GL%map(this%cx_d, this%ulag%f%x_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%cy_d, this%vlag%f%x_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%cz_d, this%wlag%f%x_d, nel, this%Xh_GL)
+    else
+       call this%GLL_to_GL%map_host(this%cx, this%ulag%f%x, nel, this%Xh_GL)
+       call this%GLL_to_GL%map_host(this%cy, this%vlag%f%x, nel, this%Xh_GL)
+       call this%GLL_to_GL%map_host(this%cz, this%wlag%f%x, nel, this%Xh_GL)
+    end if
 
     ! Set the convecting field in the rst format
     call set_convect_rst(this%cr_GL, this%cs_GL, this%ct_GL, &
@@ -246,9 +264,15 @@ contains
     call this%convt_GL%init(this%ct_GL, 3)
 
     ! Repeat for previous time-steps
-    call this%GLL_to_GL%map(this%cx, this%ulag%lf(1)%x, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%cy, this%vlag%lf(1)%x, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%cz, this%wlag%lf(1)%x, nel, this%Xh_GL)
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call this%GLL_to_GL%map(this%cx_d, this%ulag%lf(1)%x_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%cy_d, this%vlag%lf(1)%x_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%cz_d, this%wlag%lf(1)%x_d, nel, this%Xh_GL)
+    else
+       call this%GLL_to_GL%map_host(this%cx, this%ulag%lf(1)%x, nel, this%Xh_GL)
+       call this%GLL_to_GL%map_host(this%cy, this%vlag%lf(1)%x, nel, this%Xh_GL)
+       call this%GLL_to_GL%map_host(this%cz, this%wlag%lf(1)%x, nel, this%Xh_GL)
+    end if
 
     call set_convect_rst(this%cr_GL, this%cs_GL, this%ct_GL, &
          this%cx, this%cy, this%cz, this%Xh_GL, this%coef_GL)
@@ -257,9 +281,15 @@ contains
     this%convs_GL%lf(1) = this%cs_GL
     this%convt_GL%lf(1) = this%ct_GL
 
-    call this%GLL_to_GL%map(this%cx, this%ulag%lf(2)%x, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%cy, this%vlag%lf(2)%x, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%cz, this%wlag%lf(2)%x, nel, this%Xh_GL)
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call this%GLL_to_GL%map(this%cx_d, this%ulag%lf(2)%x_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%cy_d, this%vlag%lf(2)%x_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%cz_d, this%wlag%lf(2)%x_d, nel, this%Xh_GL)
+    else
+       call this%GLL_to_GL%map_host(this%cx, this%ulag%lf(2)%x, nel, this%Xh_GL)
+       call this%GLL_to_GL%map_host(this%cy, this%vlag%lf(2)%x, nel, this%Xh_GL)
+       call this%GLL_to_GL%map_host(this%cz, this%wlag%lf(2)%x, nel, this%Xh_GL)
+    end if
 
     call set_convect_rst(this%cr_GL, this%cs_GL, this%ct_GL, &
          this%cx, this%cy, this%cz, this%Xh_GL, this%coef_GL)
@@ -387,9 +417,15 @@ contains
     call this%convs_GL%update()
     call this%convt_GL%update()
 
-    call this%GLL_to_GL%map(this%cx, u%x, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%cy, v%x, nel, this%Xh_GL)
-    call this%GLL_to_GL%map(this%cz, w%x, nel, this%Xh_GL)
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call this%GLL_to_GL%map(this%cx_d, u%x_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%cy_d, v%x_d, nel, this%Xh_GL)
+       call this%GLL_to_GL%map(this%cz_d, w%x_d, nel, this%Xh_GL)
+    else
+       call this%GLL_to_GL%map_host(this%cx, u%x, nel, this%Xh_GL)
+       call this%GLL_to_GL%map_host(this%cy, v%x, nel, this%Xh_GL)
+       call this%GLL_to_GL%map_host(this%cz, w%x, nel, this%Xh_GL)
+    end if
 
     call set_convect_rst(this%cr_GL, this%cs_GL, this%ct_GL, &
          this%cx, this%cy, this%cz, this%Xh_GL, this%coef_GL)
@@ -637,7 +673,7 @@ contains
 
 
   subroutine adv_oifs_compute_ale(this, vx, vy, vz, wm_x, wm_y, wm_z, &
-                                           fx, fy, fz, Xh, coef, n, dt)
+       fx, fy, fz, Xh, coef, n, dt)
     class(adv_oifs_t), intent(inout) :: this
     type(field_t), intent(inout) :: vx, vy, vz
     type(field_t), intent(inout) :: wm_x, wm_y, wm_z

--- a/src/io/fld_file_data.f90
+++ b/src/io/fld_file_data.f90
@@ -252,11 +252,11 @@ contains
        call space_interp%init(Xh, prev_Xh)
 
        ! Do the space-to-space interpolation
-       if (present(u)) call space_interp%map(u%x, this%u%x, this%nelv, Xh)
-       if (present(v)) call space_interp%map(v%x, this%v%x, this%nelv, Xh)
-       if (present(w)) call space_interp%map(w%x, this%w%x, this%nelv, Xh)
-       if (present(p)) call space_interp%map(p%x, this%p%x, this%nelv, Xh)
-       if (present(t)) call space_interp%map(t%x, this%t%x, this%nelv, Xh)
+       if (present(u)) call space_interp%map_old(u%x, this%u%x, this%nelv, Xh)
+       if (present(v)) call space_interp%map_old(v%x, this%v%x, this%nelv, Xh)
+       if (present(w)) call space_interp%map_old(w%x, this%w%x, this%nelv, Xh)
+       if (present(p)) call space_interp%map_old(p%x, this%p%x, this%nelv, Xh)
+       if (present(t)) call space_interp%map_old(t%x, this%t%x, this%nelv, Xh)
        if (present(s_target_list)) then
 
           ! If the index list exists, use it as a "mask"
@@ -265,11 +265,11 @@ contains
 
                 ! 0 means we want temperature
                 if (s_index_list(i) .eq. 0) then
-                   call space_interp%map(s_target_list%x(i), &
+                   call space_interp%map_old(s_target_list%x(i), &
                         this%t%x, this%nelv, Xh)
                 else if (s_index_list(i) .ge. 1 .and. &
                      s_index_list(i) .le. this%n_scalars) then
-                   call space_interp%map(s_target_list%x(i), &
+                   call space_interp%map_old(s_target_list%x(i), &
                         this%s(s_index_list(i))%x, this%nelv, Xh)
                 else
                    call neko_error("s_index_list entry out of bounds")
@@ -279,7 +279,7 @@ contains
              ! otherwise, just copy element-to-element
           else
              do i = 1, s_target_list%size()
-                call space_interp%map(s_target_list%x(i), this%s(i)%x, &
+                call space_interp%map_old(s_target_list%x(i), this%s(i)%x, &
                      this%nelv, Xh)
              end do
           end if ! present s_index_list

--- a/src/krylov/pc_hsmg.f90
+++ b/src/krylov/pc_hsmg.f90
@@ -494,7 +494,7 @@ contains
        call device_col2(this%r_d, this%grids(3)%coef%mult_d, &
             this%grids(3)%dof%size())
        !Restrict to middle level
-       call this%interp_fine_mid%map(this%e%x, this%r, &
+       call this%interp_fine_mid%map(this%e%x_d, this%r_d, &
             this%msh%nelv, this%grids(2)%Xh)
        call this%grids(2)%gs_h%op(this%e%x, &
             this%grids(2)%dof%size(), GS_OP_ADD, this%gs_event)
@@ -508,7 +508,7 @@ contains
        call device_col2(this%w_d, this%grids(2)%coef%mult_d, &
             this%grids(2)%dof%size())
        !restrict residual to crs
-       call this%interp_mid_crs%map(this%wf%x, this%w, this%msh%nelv, &
+       call this%interp_mid_crs%map(this%wf%x_d, this%w_d, this%msh%nelv, &
             this%grids(1)%Xh)
        !Crs solve
        call device_copy(this%w_d, this%e%x_d, this%grids(2)%dof%size())
@@ -553,11 +553,11 @@ contains
        end if
        !$omp end parallel
 
-       call this%interp_mid_crs%map(this%w, this%grids(1)%e%x, &
+       call this%interp_mid_crs%map(this%w_d, this%grids(1)%e%x_d, &
             this%msh%nelv, this%grids(2)%Xh)
        call device_add2(this%grids(2)%e%x_d, this%w_d, this%grids(2)%dof%size())
 
-       call this%interp_fine_mid%map(this%w, this%grids(2)%e%x, &
+       call this%interp_fine_mid%map(this%w_d, this%grids(2)%e%x_d, &
             this%msh%nelv, this%grids(3)%Xh)
        call device_add2(z_d, this%w_d, this%grids(3)%dof%size())
        call this%grids(3)%gs_h%op(z, this%grids(3)%dof%size(), &
@@ -575,14 +575,14 @@ contains
        call col2(this%r, this%grids(3)%coef%mult, &
             this%grids(3)%dof%size())
        !Restrict to middle level
-       call this%interp_fine_mid%map(this%w, this%r, &
+       call this%interp_fine_mid%map_host(this%w, this%r, &
             this%msh%nelv, this%grids(2)%Xh)
        call this%grids(2)%gs_h%op(this%w, this%grids(2)%dof%size(), GS_OP_ADD)
        !OVERLAPPING Schwarz exchange and solve
        call this%grids(2)%schwarz%compute(this%grids(2)%e%x, this%w)
        call col2(this%w, this%grids(2)%coef%mult, this%grids(2)%dof%size())
        !restrict residual to crs
-       call this%interp_mid_crs%map(this%r, this%w, &
+       call this%interp_mid_crs%map_host(this%r, this%w, &
             this%msh%nelv, this%grids(1)%Xh)
        !Crs solve
 
@@ -606,11 +606,11 @@ contains
             this%grids(1)%dof%size())
 
 
-       call this%interp_mid_crs%map(this%w, this%grids(1)%e%x, &
+       call this%interp_mid_crs%map_host(this%w, this%grids(1)%e%x, &
             this%msh%nelv, this%grids(2)%Xh)
        call add2(this%grids(2)%e%x, this%w, this%grids(2)%dof%size())
 
-       call this%interp_fine_mid%map(this%w, this%grids(2)%e%x, &
+       call this%interp_fine_mid%map_host(this%w, this%grids(2)%e%x, &
             this%msh%nelv, this%grids(3)%Xh)
        call add2(z, this%w, this%grids(3)%dof%size())
        call this%grids(3)%gs_h%op(z, this%grids(3)%dof%size(), GS_OP_ADD)

--- a/src/math/bcknd/cpu/convect_scalar.f90
+++ b/src/math/bcknd/cpu/convect_scalar.f90
@@ -171,7 +171,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -236,7 +236,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -301,7 +301,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -366,7 +366,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -431,7 +431,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -496,7 +496,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -561,7 +561,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -626,7 +626,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -691,7 +691,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -756,7 +756,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -821,7 +821,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -886,7 +886,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -951,7 +951,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -1016,7 +1016,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -1081,7 +1081,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -1146,7 +1146,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -1211,7 +1211,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
@@ -1276,7 +1276,7 @@ contains
                + ct(i,e) * ut(i,1,1)
        end do
        idx = (e-1) * Xh_GLL%lxyz+1
-       call GLL_to_GL%map(du(idx,1,1,1), ud, 1, Xh_GLL)
+       call GLL_to_GL%map_host(du(idx,1,1,1), ud, 1, Xh_GLL)
     end do
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)

--- a/src/math/bcknd/device/opr_device.F90
+++ b/src/math/bcknd/device/opr_device.F90
@@ -644,7 +644,7 @@ contains
       call neko_error('No device backend configured')
 #endif
 
-      call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+      call GLL_to_GL%map_device(du_d, ud_d, nelv, Xh_GLL)
       call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
       call device_col2(du_d, coef_GLL%Binv_d, n_GLL)
 

--- a/src/math/bcknd/device/tensor_device.F90
+++ b/src/math/bcknd/device/tensor_device.F90
@@ -98,6 +98,8 @@ contains
   subroutine tnsr3d_device(v_d, nv, u_d, nu, A_d, Bt_d, Ct_d, nelv)
     type(c_ptr) :: v_d, u_d, A_d, Bt_d, Ct_d
     integer(c_int) :: nu, nv, nelv
+    if (nelv .eq. 0) return
+
 #ifdef HAVE_HIP
     call hip_tnsr3d(v_d, nv, u_d, nu, A_d, Bt_d, Ct_d, nelv)
 #elif HAVE_CUDA
@@ -113,6 +115,8 @@ contains
        elements, n_points)
     type(c_ptr) :: v_d, u_d, A_d, Bt_d, Ct_d, elements
     integer(c_int) :: nu, nv, n_points
+    if (n_points .eq. 0) return
+
 #ifdef HAVE_HIP
     call hip_tnsr3d_el_list(v_d, nv, u_d, nu, A_d, Bt_d, Ct_d, elements, &
          n_points)

--- a/src/math/bcknd/sx/sx_convect_scalar.f90
+++ b/src/math/bcknd/sx/sx_convect_scalar.f90
@@ -38,16 +38,16 @@ submodule (opr_sx) sx_convect_scalar
 contains
 
   module subroutine opr_sx_convect_scalar(du, u, cr, cs, ct, Xh_GLL, Xh_GL, &
-                                          coef_GLL, coef_GL, GLL_to_GL)
+       coef_GLL, coef_GL, GLL_to_GL)
     type(space_t), intent(in) :: Xh_GL
     type(space_t), intent(in) :: Xh_GLL
     type(coef_t), intent(in) :: coef_GLL
     type(coef_t), intent(in) :: coef_GL
     type(interpolator_t), intent(inout) :: GLL_to_GL
     real(kind=rp), intent(inout) :: &
-                   du(Xh_GLL%lx, Xh_GLL%ly, Xh_GLL%lz, coef_GL%msh%nelv)
+         du(Xh_GLL%lx, Xh_GLL%ly, Xh_GLL%lz, coef_GL%msh%nelv)
     real(kind=rp), intent(inout) :: &
-                   u(Xh_GL%lx, Xh_GL%lx, Xh_GL%lx, coef_GL%msh%nelv)
+         u(Xh_GL%lx, Xh_GL%lx, Xh_GL%lx, coef_GL%msh%nelv)
     real(kind=rp), intent(inout) :: cr(Xh_GL%lxyz, coef_GL%msh%nelv)
     real(kind=rp), intent(inout) :: cs(Xh_GL%lxyz, coef_GL%msh%nelv)
     real(kind=rp), intent(inout) :: ct(Xh_GL%lxyz, coef_GL%msh%nelv)
@@ -115,7 +115,7 @@ contains
   end subroutine opr_sx_convect_scalar
 
   subroutine sx_convect_scalar_lx(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                  coef_GLL, GLL_to_GL, nelv, lx)
+       coef_GLL, GLL_to_GL, nelv, lx)
     integer, intent(in) :: nelv, lx
     type(space_t), intent(in) :: Xh_GLL
     type(coef_t), intent(in) :: coef_GLL
@@ -176,18 +176,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_host(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx
 
   subroutine sx_convect_scalar_lx18(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                    coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 18
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -249,18 +249,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx18
 
   subroutine sx_convect_scalar_lx17(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                    coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 17
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -322,18 +322,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx17
 
   subroutine sx_convect_scalar_lx16(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                    coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 16
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -395,18 +395,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx16
 
   subroutine sx_convect_scalar_lx15(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                    coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 15
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -468,18 +468,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx15
 
   subroutine sx_convect_scalar_lx14(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                    coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 14
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -541,18 +541,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx14
 
   subroutine sx_convect_scalar_lx13(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                    coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 13
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -614,18 +614,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx13
 
   subroutine sx_convect_scalar_lx12(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                    coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 12
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -687,18 +687,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx12
 
   subroutine sx_convect_scalar_lx11(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                    coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 11
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -760,18 +760,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx11
 
   subroutine sx_convect_scalar_lx10(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                    coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 10
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -833,18 +833,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx10
 
   subroutine sx_convect_scalar_lx9(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                   coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 9
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -906,18 +906,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx9
 
   subroutine sx_convect_scalar_lx8(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                   coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 8
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -979,18 +979,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx8
 
   subroutine sx_convect_scalar_lx7(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                   coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 7
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -1052,18 +1052,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx7
 
   subroutine sx_convect_scalar_lx6(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                   coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 6
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -1125,18 +1125,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx6
 
   subroutine sx_convect_scalar_lx5(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                   coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 5
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -1198,18 +1198,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx5
 
   subroutine sx_convect_scalar_lx4(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                   coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 4
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -1271,18 +1271,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx4
 
   subroutine sx_convect_scalar_lx3(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                   coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 3
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -1344,18 +1344,18 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 
   end subroutine sx_convect_scalar_lx3
 
   subroutine sx_convect_scalar_lx2(du, u, cr, cs, ct, dx, dy, dz, Xh_GLL, &
-                                   coef_GLL, GLL_to_GL, nelv)
+       coef_GLL, GLL_to_GL, nelv)
     integer, parameter :: lx = 2
     integer, intent(in) :: nelv
     type(space_t), intent(in) :: Xh_GLL
@@ -1417,11 +1417,11 @@ contains
     do i = 1, lx * lx * lx
        do e = 1, nelv
           ud(i,1,1,e) = ( cr(i,e) * ur(i,1,1,e) &
-                      + cs(i,e) * us(i,1,1,e) &
-                      + ct(i,e) * ut(i,1,1,e) )
+               + cs(i,e) * us(i,1,1,e) &
+               + ct(i,e) * ut(i,1,1,e) )
        end do
     end do
-    call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+    call GLL_to_GL%map_old(du, ud, nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
 

--- a/src/math/bcknd/xsmm/opr_xsmm.F90
+++ b/src/math/bcknd/xsmm/opr_xsmm.F90
@@ -408,7 +408,7 @@ contains
        end do
     end do
 #endif
-    call GLL_to_GL%map(du, ud, coef_GL%msh%nelv, Xh_GLL)
+    call GLL_to_GL%map_host(du, ud, coef_GL%msh%nelv, Xh_GLL)
     call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
     call col2(du, coef_GLL%Binv, n_GLL)
   end subroutine opr_xsmm_convect_scalar

--- a/src/math/operators.f90
+++ b/src/math/operators.f90
@@ -990,7 +990,7 @@ contains
 
        ! Stage 1:
        call device_invcol3(u1%x_d, phi%x_d, coef%B_d, n)
-       call GLL_to_GL%map(u1_GL%x, u1%x, nel, Xh_GL)
+       call GLL_to_GL%map(u1_GL%x_d, u1%x_d, nel, Xh_GL)
        call convect_scalar(k1%x, u1_GL%x, conv_k1%items(1)%ptr, &
             conv_k1%items(2)%ptr, conv_k1%items(3)%ptr, &
             Xh_GLL, Xh_GL, coef, coef_GL, GLL_to_GL)
@@ -999,7 +999,7 @@ contains
        ! Stage 2:
        call device_add3s2(u1%x_d, phi%x_d, k1%x_d, c1, c2, n)
        call device_invcol2(u1%x_d, coef%B_d, n)
-       call GLL_to_GL%map(u1_GL%x, u1%x, nel, Xh_GL)
+       call GLL_to_GL%map(u1_GL%x_d, u1%x_d, nel, Xh_GL)
        call convect_scalar(k2%x, u1_GL%x, conv_k23%items(1)%ptr, &
             conv_k23%items(2)%ptr, conv_k23%items(3)%ptr, &
             Xh_GLL, Xh_GL, coef, coef_GL, GLL_to_GL)
@@ -1008,7 +1008,7 @@ contains
        ! Stage 3:
        call device_add3s2(u1%x_d, phi%x_d, k2%x_d, c1, c2, n)
        call device_invcol2(u1%x_d, coef%B_d, n)
-       call GLL_to_GL%map(u1_GL%x, u1%x, nel, Xh_GL)
+       call GLL_to_GL%map(u1_GL%x_d, u1%x_d, nel, Xh_GL)
        call convect_scalar(k3%x, u1_GL%x, conv_k23%items(1)%ptr, &
             conv_k23%items(2)%ptr, conv_k23%items(3)%ptr, &
             Xh_GLL, Xh_GL, coef, coef_GL, GLL_to_GL)
@@ -1017,7 +1017,7 @@ contains
        ! Stage 4:
        call device_add3s2(u1%x_d, phi%x_d, k3%x_d, c1, c3, n)
        call device_invcol2(u1%x_d, coef%B_d, n)
-       call GLL_to_GL%map(u1_GL%x, u1%x, nel, Xh_GL)
+       call GLL_to_GL%map(u1_GL%x_d, u1%x_d, nel, Xh_GL)
        call convect_scalar(k4%x, u1_GL%x, conv_k4%items(1)%ptr, &
             conv_k4%items(2)%ptr, conv_k4%items(3)%ptr, &
             Xh_GLL, Xh_GL, coef, coef_GL, GLL_to_GL)
@@ -1033,7 +1033,7 @@ contains
 
        ! Stage 1:
        call invcol3(u1%x, phi%x, coef%B, n)
-       call GLL_to_GL%map(u1_GL%x, u1%x, nel, Xh_GL)
+       call GLL_to_GL%map_host(u1_GL%x, u1%x, nel, Xh_GL)
        call convect_scalar(k1%x, u1_GL%x, conv_k1%items(1)%ptr, &
             conv_k1%items(2)%ptr, conv_k1%items(3)%ptr, &
             Xh_GLL, Xh_GL, coef, coef_GL, GLL_to_GL)
@@ -1042,7 +1042,7 @@ contains
        ! Stage 2:
        call add3s2(u1%x, phi%x, k1%x, c1, c2, n)
        call invcol2(u1%x, coef%B, n)
-       call GLL_to_GL%map(u1_GL%x, u1%x, nel, Xh_GL)
+       call GLL_to_GL%map_host(u1_GL%x, u1%x, nel, Xh_GL)
        call convect_scalar(k2%x, u1_GL%x, conv_k23%items(1)%ptr, &
             conv_k23%items(2)%ptr, conv_k23%items(3)%ptr, &
             Xh_GLL, Xh_GL, coef, coef_GL, GLL_to_GL)
@@ -1051,7 +1051,7 @@ contains
        ! Stage 3:
        call add3s2(u1%x, phi%x, k2%x, c1, c2, n)
        call invcol2(u1%x, coef%B, n)
-       call GLL_to_GL%map(u1_GL%x, u1%x, nel, Xh_GL)
+       call GLL_to_GL%map_host(u1_GL%x, u1%x, nel, Xh_GL)
        call convect_scalar(k3%x, u1_GL%x, conv_k23%items(1)%ptr, &
             conv_k23%items(2)%ptr, conv_k23%items(3)%ptr, &
             Xh_GLL, Xh_GL, coef, coef_GL, GLL_to_GL)
@@ -1060,7 +1060,7 @@ contains
        ! Stage 4:
        call add3s2(u1%x, phi%x, k3%x, c1, c3, n)
        call invcol2(u1%x, coef%B, n)
-       call GLL_to_GL%map(u1_GL%x, u1%x, nel, Xh_GL)
+       call GLL_to_GL%map_host(u1_GL%x, u1%x, nel, Xh_GL)
        call convect_scalar(k4%x, u1_GL%x, conv_k4%items(1)%ptr, &
             conv_k4%items(2)%ptr, conv_k4%items(3)%ptr, &
             Xh_GLL, Xh_GL, coef, coef_GL, GLL_to_GL)

--- a/src/math/tensor.f90
+++ b/src/math/tensor.f90
@@ -66,6 +66,7 @@ module tensor
   use tensor_sx, only : tnsr3d_sx, tnsr1_3d_sx, &
        tnsr2d_el_sx, tnsr3d_el_sx
   use tensor_device, only : tnsr3d_device, tnsr3d_el_list_device
+  use logger, only : neko_log
   use num_types, only : rp
   use mxm_wrapper, only : mxm
   use neko_config, only : NEKO_BCKND_SX, NEKO_BCKND_XSMM, NEKO_BCKND_DEVICE
@@ -210,6 +211,9 @@ contains
                nu, A(1, 1, i), Bt(1, 1, i), Ct(1, 1, i))
        end do
     else if (NEKO_BCKND_DEVICE .eq. 1 .and. .not. on_host) then
+       call neko_log%deprecated('Tensor: tnsr3d_el_list, implicit device', &
+            '2.0.0', 'Please call tnsr3d_el_list_device instead.')
+
        v_d = device_get_ptr(v)
        u_d = device_get_ptr(u)
        A_d = device_get_ptr(A)
@@ -244,6 +248,9 @@ contains
     else if (NEKO_BCKND_XSMM .eq. 1) then
        call tnsr3d_xsmm(v, nv, u, nu, A, Bt, Ct, nelv)
     else if (NEKO_BCKND_DEVICE .eq. 1) then
+       call neko_log%deprecated('Tensor: tnsr3d, implicit device', &
+            '2.0.0', 'Please call tnsr3d_device instead.')
+
        v_d = device_get_ptr(v)
        u_d = device_get_ptr(u)
        A_d = device_get_ptr(A)

--- a/src/multigrid/phmg.f90
+++ b/src/multigrid/phmg.f90
@@ -353,7 +353,7 @@ contains
     integer :: lvl
 
     associate(mg => this%phmg_hrchy%lvl, intrp => this%intrp, &
-        msh => this%msh, Ax => this%Ax)
+         msh => this%msh, Ax => this%Ax)
       do lvl = 0, this%nlvls-2
          write(lvl_name, '(I0)') lvl
          call profiler_start_region( "PHMG_level_" // trim(lvl_name))
@@ -398,7 +398,7 @@ contains
               call col2(w%x, mg(lvl)%coef%mult, mg(lvl)%dm_Xh%size())
            end if
 
-           call intrp(lvl+1)%map(mg(lvl+1)%r%x, w%x, msh%nelv, mg(lvl+1)%Xh)
+           call intrp(lvl+1)%map(mg(lvl+1)%r, w, msh%nelv, mg(lvl+1)%Xh)
 
            call mg(lvl+1)%gs_h%op(mg(lvl+1)%r%x, mg(lvl+1)%dm_Xh%size(), &
                 GS_OP_ADD, glb_cmd_event)
@@ -433,7 +433,7 @@ contains
            !------------!
            !  Project   !
            !------------!
-           call intrp(lvl+1)%map(w%x, mg(lvl+1)%z%x, msh%nelv, mg(lvl)%Xh)
+           call intrp(lvl+1)%map(w, mg(lvl+1)%z, msh%nelv, mg(lvl)%Xh)
 
            call mg(lvl)%gs_h%op(w%x, mg(lvl)%dm_Xh%size(), GS_OP_ADD, glb_cmd_event)
            call device_stream_wait_event(glb_cmd_queue, glb_cmd_event, 0)

--- a/src/sem/bcknd/dofmap_init.f90
+++ b/src/sem/bcknd/dofmap_init.f90
@@ -31,7 +31,7 @@
 ! POSSIBILITY OF SUCH DAMAGE.
 !
 !> Submodule containing the mapping based initialization of dofmaps
-submodule (dofmap) dofmap_init
+submodule (dofmap) dofmap_init_m
   use interpolation, only : interpolator_t
 
 contains
@@ -79,4 +79,4 @@ contains
 
   end subroutine dofmap_init_and_map
 
-end submodule dofmap_init
+end submodule dofmap_init_m

--- a/src/sem/bcknd/dofmap_init.f90
+++ b/src/sem/bcknd/dofmap_init.f90
@@ -52,15 +52,15 @@ contains
     if (dof%Xh%lxyz .ne. this%Xh%lxyz) then
        call interpolator%init(this%Xh, dof%Xh)
 
-       call interpolator%map(this%x, &
-            dof%x, &
-            this%msh%nelv, this%Xh)
-       call interpolator%map(this%y, &
-            dof%y, &
-            this%msh%nelv, this%Xh)
-       call interpolator%map(this%z, &
-            dof%z, &
-            this%msh%nelv, this%Xh)
+       if (NEKO_BCKND_DEVICE .eq. 1) then
+          call interpolator%map(this%x_d, dof%x_d, this%msh%nelv, this%Xh)
+          call interpolator%map(this%y_d, dof%y_d, this%msh%nelv, this%Xh)
+          call interpolator%map(this%z_d, dof%z_d, this%msh%nelv, this%Xh)
+       else
+          call interpolator%map_host(this%x, dof%x, this%msh%nelv, this%Xh)
+          call interpolator%map_host(this%y, dof%y, this%msh%nelv, this%Xh)
+          call interpolator%map_host(this%z, dof%z, this%msh%nelv, this%Xh)
+       end if
 
        call interpolator%free()
 

--- a/src/sem/bcknd/dofmap_init.f90
+++ b/src/sem/bcknd/dofmap_init.f90
@@ -1,0 +1,82 @@
+! Copyright (c) 2020-2026, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Submodule containing the mapping based initialization of dofmaps
+submodule (dofmap) dofmap_init
+  use interpolation, only : interpolator_t
+
+contains
+
+  !> Constructor.
+  !! @param dof The existing dofmap to initialize from.
+  !! @param Xh The SEM function space.
+  subroutine dofmap_init_and_map(this, dof, Xh)
+    class(dofmap_t), intent(inout) :: this
+    type(dofmap_t), intent(in) :: dof
+    type(space_t), intent(in) :: Xh
+    type(interpolator_t) :: interpolator
+
+    ! Initialize as usual
+    call this%init_from_mesh(dof%msh, Xh)
+
+    ! Interpolate if needed
+    if (dof%Xh%lxyz .ne. this%Xh%lxyz) then
+       call interpolator%init(this%Xh, dof%Xh)
+
+       call interpolator%map(this%x, &
+            dof%x, &
+            this%msh%nelv, this%Xh)
+       call interpolator%map(this%y, &
+            dof%y, &
+            this%msh%nelv, this%Xh)
+       call interpolator%map(this%z, &
+            dof%z, &
+            this%msh%nelv, this%Xh)
+
+       call interpolator%free()
+
+    else
+       if (NEKO_BCKND_DEVICE .eq. 1) then
+          call device_copy(this%x_d, dof%x_d, this%ntot)
+          call device_copy(this%y_d, dof%y_d, this%ntot)
+          call device_copy(this%z_d, dof%z_d, this%ntot)
+       else
+          call copy(this%x, dof%x, this%ntot)
+          call copy(this%y, dof%y, this%ntot)
+          call copy(this%z, dof%z, this%ntot)
+       end if
+
+    end if
+
+  end subroutine dofmap_init_and_map
+
+end submodule dofmap_init

--- a/src/sem/bcknd/dofmap_init.f90
+++ b/src/sem/bcknd/dofmap_init.f90
@@ -39,7 +39,7 @@ contains
   !> Constructor.
   !! @param dof The existing dofmap to initialize from.
   !! @param Xh The SEM function space.
-  subroutine dofmap_init_and_map(this, dof, Xh)
+  module subroutine dofmap_init_and_map(this, dof, Xh)
     class(dofmap_t), intent(inout) :: this
     type(dofmap_t), intent(in) :: dof
     type(space_t), intent(in) :: Xh

--- a/src/sem/dofmap.f90
+++ b/src/sem/dofmap.f90
@@ -42,13 +42,12 @@ module dofmap
   use utils, only : neko_error, neko_warning
   use fast3d, only : fd_weights_full
   use tensor, only : tensr3, tnsr2d_el, trsp, addtnsr
-  use device
+  use device, only : device_map, device_unmap, device_memcpy, HOST_TO_DEVICE, DEVICE_TO_HOST
   use math, only : add3, copy, rone, rzero, masked_gather_copy
   use device_math, only : device_masked_gather_copy_aligned, device_copy
   use element, only : element_t
   use quad, only : quad_t
   use hex, only : hex_t
-  use interpolation, only : interpolator_t
   use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR, c_associated
   implicit none
   private
@@ -87,6 +86,14 @@ module dofmap
      procedure, pass(this) :: global_size => dofmap_global_size
   end type dofmap_t
 
+  interface
+     module subroutine dofmap_init_and_map(this, dof, Xh)
+       class(dofmap_t), intent(inout) :: this
+       type(dofmap_t), intent(in) :: dof
+       type(space_t), intent(in) :: Xh
+     end subroutine dofmap_init_and_map
+  end interface
+
 contains
 
   !> Constructor.
@@ -94,8 +101,8 @@ contains
   !! @param Xh The SEM function space.
   subroutine dofmap_init(this, msh, Xh)
     class(dofmap_t) :: this
-    type(mesh_t), target, intent(inout) :: msh
-    type(space_t), target, intent(inout) :: Xh
+    type(mesh_t), target, intent(in) :: msh
+    type(space_t), target, intent(in) :: Xh
 
     if ((msh%gdim .eq. 3 .and. Xh%lz .eq. 1) .or. &
          (msh%gdim .eq. 2 .and. Xh%lz .gt. 1)) then
@@ -159,52 +166,24 @@ contains
 
   end subroutine dofmap_init
 
-  !> Constructor.
-  !! @param dof The existing dofmap to initialize from.
-  !! @param Xh The SEM function space.
-  subroutine dofmap_init_and_map(this, dof, Xh)
-    class(dofmap_t) :: this
-    type(dofmap_t), target, intent(inout) :: dof
-    type(space_t), target, intent(inout) :: Xh
-    type(interpolator_t) :: interpolator
-
-    ! Initialize as usual
-    call this%init_from_mesh(dof%msh, Xh)
-
-    ! Interpolate if needed
-    if (dof%Xh%lxyz .ne. this%Xh%lxyz) then
-       call interpolator%init(this%Xh, dof%Xh)
-
-       call interpolator%map(this%x, &
-            dof%x, &
-            this%msh%nelv, this%Xh)
-       call interpolator%map(this%y, &
-            dof%y, &
-            this%msh%nelv, this%Xh)
-       call interpolator%map(this%z, &
-            dof%z, &
-            this%msh%nelv, this%Xh)
-
-       call interpolator%free()
-
-    else
-       if (NEKO_BCKND_DEVICE .eq. 1) then
-          call device_copy(this%x_d, dof%x_d, this%ntot)
-          call device_copy(this%y_d, dof%y_d, this%ntot)
-          call device_copy(this%z_d, dof%z_d, this%ntot)
-       else
-          call copy(this%x, dof%x, this%ntot)
-          call copy(this%y, dof%y, this%ntot)
-          call copy(this%z, dof%z, this%ntot)
-       end if
-
-    end if
-
-  end subroutine dofmap_init_and_map
-
   !> Destructor.
   subroutine dofmap_free(this)
     class(dofmap_t), intent(inout) :: this
+
+    !
+    ! Cleanup the device (if present)
+    !
+    if (c_associated(this%x_d)) then
+       call device_unmap(this%x, this%x_d)
+    end if
+
+    if (c_associated(this%y_d)) then
+       call device_unmap(this%y, this%y_d)
+    end if
+
+    if (c_associated(this%z_d)) then
+       call device_unmap(this%z, this%z_d)
+    end if
 
     if (allocated(this%dof)) then
        deallocate(this%dof)
@@ -234,20 +213,6 @@ contains
        deallocate(this%msh_subset)
     end if
 
-    !
-    ! Cleanup the device (if present)
-    !
-    if (c_associated(this%x_d)) then
-       call device_free(this%x_d)
-    end if
-
-    if (c_associated(this%y_d)) then
-       call device_free(this%y_d)
-    end if
-
-    if (c_associated(this%z_d)) then
-       call device_free(this%z_d)
-    end if
 
   end subroutine dofmap_free
 

--- a/src/sem/interpolation.f90
+++ b/src/sem/interpolation.f90
@@ -32,14 +32,17 @@
 !
 !> Routines to interpolate between different spaces
 module interpolation
-  use neko_config
+  use neko_config, only : NEKO_BCKND_DEVICE
   use num_types, only : rp
-  use device
-  use fast3d
+  use device, only : device_map, device_unmap, device_memcpy, HOST_TO_DEVICE
+  use fast3d, only : setup_intp
+  use field, only : field_t
   use tensor, only : tnsr3d
   use tensor_cpu, only : tnsr3d_cpu
+  use tensor_device, only : tnsr3d_device
   use space, only : space_t, operator(.eq.), GL, GLL
   use utils, only : neko_error
+  use logger, only : neko_log
   use, intrinsic :: iso_c_binding
   implicit none
   private
@@ -60,23 +63,33 @@ module interpolation
      !> Interpolation weights from Yh to Xh.
      real(kind=rp), allocatable :: Yh_to_Xh(:,:), Yh_to_XhT(:,:)
      !> Device pointer for Xh_to_Yh.
-     type(c_ptr) :: Xh_Yh_d = C_NULL_PTR
+     type(c_ptr) :: Xh_to_Yh_d = C_NULL_PTR
      !> Device pointer for Xh_to_YhT.
-     type(c_ptr) :: Xh_YhT_d = C_NULL_PTR
+     type(c_ptr) :: Xh_to_YhT_d = C_NULL_PTR
      !> Device pointer for Yh_to_Xh.
-     type(c_ptr) :: Yh_Xh_d = C_NULL_PTR
+     type(c_ptr) :: Yh_to_Xh_d = C_NULL_PTR
      !> Device pointer for Yh_to_XhT.
-     type(c_ptr) :: Yh_XhT_d = C_NULL_PTR
+     type(c_ptr) :: Yh_to_XhT_d = C_NULL_PTR
    contains
 
      !> Constructor.
      procedure, pass(this) :: init => interpolator_init
      !> Destructor.
      procedure, pass(this) :: free => interpolator_free
-     !> Interpolate an array to one of Xh or Yh.
-     procedure, pass(this) :: map => interpolator_map
+
+     !> Generic interface to map an array to one of Xh or Yh.
+     generic :: map => map_old, map_device, map_field
      !> Interpolate an array to one of Xh or Yh on the host.
      procedure, pass(this) :: map_host => interpolator_map_host
+     !> Interpolate an array to one of Xh or Yh.
+     procedure, pass(this) :: map_device => interpolator_map_device
+     !> Interpolate an array to one of Xh or Yh.
+     procedure, pass(this) :: map_field => interpolator_map_field
+
+     !> Interpolate an array to one of Xh or Yh.
+     !! @deprecated This is an older version of the interpolation routine, still
+     !! relying on the implicit device mapping.
+     procedure, pass(this) :: map_old => interpolator_map_old
 
   end type interpolator_t
 
@@ -113,17 +126,18 @@ contains
     this%Xh => Xh
     this%Yh => Yh
     if (NEKO_BCKND_DEVICE .eq. 1) then
-       call device_map(this%Xh_to_Yh, this%Xh_Yh_d, Yh%lx*Xh%lx)
-       call device_map(this%Xh_to_YhT, this%Xh_YhT_d, Yh%lx*Xh%lx)
-       call device_map(this%Yh_to_Xh, this%Yh_Xh_d, Yh%lx*Xh%lx)
-       call device_map(this%Yh_to_XhT, this%Yh_XhT_d, Yh%lx*Xh%lx)
-       call device_memcpy(this%Xh_to_Yh, this%Xh_Yh_d, Yh%lx*Xh%lx, &
+       call device_map(this%Xh_to_Yh, this%Xh_to_Yh_d, Yh%lx*Xh%lx)
+       call device_map(this%Xh_to_YhT, this%Xh_to_YhT_d, Yh%lx*Xh%lx)
+       call device_map(this%Yh_to_Xh, this%Yh_to_Xh_d, Yh%lx*Xh%lx)
+       call device_map(this%Yh_to_XhT, this%Yh_to_XhT_d, Yh%lx*Xh%lx)
+
+       call device_memcpy(this%Xh_to_Yh, this%Xh_to_Yh_d, Yh%lx*Xh%lx, &
             HOST_TO_DEVICE, sync=.false.)
-       call device_memcpy(this%Xh_to_YhT, this%Xh_YhT_d, Yh%lx*Xh%lx, &
+       call device_memcpy(this%Xh_to_YhT, this%Xh_to_YhT_d, Yh%lx*Xh%lx, &
             HOST_TO_DEVICE, sync=.false.)
-       call device_memcpy(this%Yh_to_Xh, this%Yh_Xh_d, Yh%lx*Xh%lx, &
+       call device_memcpy(this%Yh_to_Xh, this%Yh_to_Xh_d, Yh%lx*Xh%lx, &
             HOST_TO_DEVICE, sync=.false.)
-       call device_memcpy(this%Yh_to_XhT, this%Yh_XhT_d, Yh%lx*Xh%lx, &
+       call device_memcpy(this%Yh_to_XhT, this%Yh_to_XhT_d, Yh%lx*Xh%lx, &
             HOST_TO_DEVICE, sync=.true.)
     end if
 
@@ -131,6 +145,19 @@ contains
 
   subroutine interpolator_free(this)
     class(interpolator_t), intent(inout) :: this
+
+    if (c_associated(this%Yh_to_Xh_d)) then
+       call device_unmap(this%Xh_to_Yh, this%Xh_to_Yh_d)
+    end if
+    if (c_associated(this%Yh_to_XhT_d)) then
+       call device_unmap(this%Xh_to_YhT, this%Xh_to_YhT_d)
+    end if
+    if (c_associated(this%Xh_to_Yh_d)) then
+       call device_unmap(this%Yh_to_Xh, this%Yh_to_Xh_d)
+    end if
+    if (c_associated(this%Xh_to_YhT_d)) then
+       call device_unmap(this%Yh_to_XhT, this%Yh_to_XhT_d)
+    end if
 
     if (allocated(this%Xh_to_Yh)) then
        deallocate(this%Xh_to_Yh)
@@ -144,18 +171,6 @@ contains
     if (allocated(this%Yh_to_XhT)) then
        deallocate(this%Yh_to_XhT)
     end if
-    if (c_associated(this%Yh_Xh_d)) then
-       call device_free(this%Yh_Xh_d)
-    end if
-    if (c_associated(this%Yh_XhT_d)) then
-       call device_free(this%Yh_XhT_d)
-    end if
-    if (c_associated(this%Xh_Yh_d)) then
-       call device_free(this%Xh_Yh_d)
-    end if
-    if (c_associated(this%Xh_YhT_d)) then
-       call device_free(this%Xh_YhT_d)
-    end if
 
     nullify(this%Xh)
     nullify(this%Yh)
@@ -167,12 +182,18 @@ contains
   !! @param y Interpolated array.
   !! @param nel Number of elements in the mesh.
   !! @param to_space The space to interpolate to, must be either Xh or Yh.
-  subroutine interpolator_map(this, y, x, nel, to_space)
-    class(interpolator_t), intent(inout) :: this
-    integer :: nel
-    type(space_t) :: to_space
-    real(kind=rp), intent(in) :: x(this%Xh%lx, this%Xh%lx, this%Xh%lx, nel)
-    real(kind=rp), intent(inout) :: y(this%Yh%lx, this%Yh%lx, this%Yh%lx, nel)
+  subroutine interpolator_map_old(this, y, x, nel, to_space)
+    class(interpolator_t), intent(in) :: this
+    integer, intent(in) :: nel
+    type(space_t), intent(in) :: to_space
+    real(kind=rp), intent(in) :: x(this%Xh%lx, this%Xh%ly, this%Xh%lz, nel)
+    real(kind=rp), intent(inout) :: y(this%Yh%lx, this%Yh%ly, this%Yh%lz, nel)
+
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call neko_log%deprecated('Interpolator: map implicit device', '2.0.0', &
+            'Please call the generic map or direct interfaces instead.')
+    end if
+
     if (to_space .eq. this%Yh) then
        call tnsr3d(y, this%Yh%lx, x, &
             this%Xh%lx,this%Yh_to_XhT, &
@@ -184,8 +205,7 @@ contains
     else
        call neko_error('Invalid interpolation')
     end if
-  end subroutine interpolator_map
-
+  end subroutine interpolator_map_old
 
   !> Interpolates an array to one of Xh or Yh on host.
   !! @param x Original array.
@@ -194,23 +214,74 @@ contains
   !! @param to_space The space to interpolate to, must be either Xh or Yh.
   !! @note Not optimized for performance, should only be used during init.
   subroutine interpolator_map_host(this, y, x, nel, to_space)
-    class(interpolator_t), intent(inout) :: this
-    integer :: nel
-    type(space_t) :: to_space
-    real(kind=rp), intent(inout) :: x(this%Xh%lx, this%Xh%lx, this%Xh%lx, nel)
-    real(kind=rp), intent(inout) :: y(this%Yh%lx, this%Yh%lx, this%Yh%lx, nel)
+    class(interpolator_t), intent(in) :: this
+    integer, intent(in) :: nel
+    type(space_t), intent(in) :: to_space
+    real(kind=rp), intent(in) :: x(this%Xh%lx, this%Xh%ly, this%Xh%lz, nel)
+    real(kind=rp), intent(inout) :: y(this%Yh%lx, this%Yh%ly, this%Yh%lz, nel)
     if (to_space .eq. this%Yh) then
-       call tnsr3d_cpu(y, this%Yh%lx, x, &
-            this%Xh%lx,this%Yh_to_XhT, &
-            this%Yh_to_Xh, this%Yh_to_Xh, nel)
+       call tnsr3d_cpu(y, this%Yh%lx, x, this%Xh%lx, &
+            this%Yh_to_XhT, this%Yh_to_Xh, this%Yh_to_Xh, nel)
     else if (to_space .eq. this%Xh) then
-       call tnsr3d_cpu(y, this%Xh%lx, x, &
-            this%Yh%lx,this%Yh_to_Xh, &
-            this%Yh_to_XhT, this%Yh_to_XhT, nel)
+       call tnsr3d_cpu(y, this%Xh%lx, x, this%Yh%lx, &
+            this%Yh_to_Xh, this%Yh_to_XhT, this%Yh_to_XhT, nel)
     else
        call neko_error('Invalid interpolation')
     end if
   end subroutine interpolator_map_host
 
+  !> Interpolates an array to one of Xh or Yh.
+  !! @param x Original array.
+  !! @param y Interpolated array.
+  !! @param nel Number of elements in the mesh.
+  !! @param to_space The space to interpolate to, must be either Xh or Yh.
+  subroutine interpolator_map_field(this, y, x, nel, to_space)
+    class(interpolator_t), intent(in) :: this
+    integer, intent(in) :: nel
+    type(space_t), intent(in) :: to_space
+    type(field_t), intent(in) :: x
+    type(field_t), intent(inout) :: y
+    if (to_space .eq. this%Yh) then
+       if (NEKO_BCKND_DEVICE .eq. 1) then
+          call tnsr3d_device(y%x_d, this%Yh%lx, x%x_d, this%Xh%lx, &
+               this%Yh_to_XhT_d, this%Yh_to_Xh_d, this%Yh_to_Xh_d, nel)
+       else
+          call tnsr3d_cpu(y%x, this%Yh%lx, x%x, this%Xh%lx, &
+               this%Yh_to_XhT, this%Yh_to_Xh, this%Yh_to_Xh, nel)
+       end if
+    else if (to_space .eq. this%Xh) then
+       if (NEKO_BCKND_DEVICE .eq. 1) then
+          call tnsr3d_device(y%x_d, this%Xh%lx, x%x_d, this%Yh%lx, &
+               this%Yh_to_Xh_d, this%Yh_to_XhT_d, this%Yh_to_XhT_d, nel)
+       else
+          call tnsr3d_cpu(y%x, this%Xh%lx, x%x, this%Yh%lx, &
+               this%Yh_to_Xh, this%Yh_to_XhT, this%Yh_to_XhT, nel)
+       end if
+    else
+       call neko_error('Invalid interpolation')
+    end if
+  end subroutine interpolator_map_field
+
+  !> Interpolates an array to one of Xh or Yh on device.
+  !! @param x Original array.
+  !! @param y Interpolated array.
+  !! @param nel Number of elements in the mesh.
+  !! @param to_space The space to interpolate to, must be either Xh or Yh.
+  subroutine interpolator_map_device(this, y_d, x_d, nel, to_space)
+    class(interpolator_t), intent(in) :: this
+    integer, intent(in) :: nel
+    type(space_t), intent(in) :: to_space
+    type(c_ptr), intent(in) :: x_d
+    type(c_ptr), intent(inout) :: y_d
+    if (to_space .eq. this%Yh) then
+       call tnsr3d_device(y_d, this%Yh%lx, x_d, this%Xh%lx, &
+            this%Yh_to_XhT_d, this%Yh_to_Xh_d, this%Yh_to_Xh_d, nel)
+    else if (to_space .eq. this%Xh) then
+       call tnsr3d_device(y_d, this%Xh%lx, x_d, this%Yh%lx, &
+            this%Yh_to_Xh_d, this%Yh_to_XhT_d, this%Yh_to_XhT_d, nel)
+    else
+       call neko_error('Invalid interpolation')
+    end if
+  end subroutine interpolator_map_device
 
 end module interpolation

--- a/src/sem/interpolation.f90
+++ b/src/sem/interpolation.f90
@@ -147,16 +147,16 @@ contains
     class(interpolator_t), intent(inout) :: this
 
     if (c_associated(this%Yh_to_Xh_d)) then
-       call device_unmap(this%Xh_to_Yh, this%Xh_to_Yh_d)
-    end if
-    if (c_associated(this%Yh_to_XhT_d)) then
-       call device_unmap(this%Xh_to_YhT, this%Xh_to_YhT_d)
-    end if
-    if (c_associated(this%Xh_to_Yh_d)) then
        call device_unmap(this%Yh_to_Xh, this%Yh_to_Xh_d)
     end if
-    if (c_associated(this%Xh_to_YhT_d)) then
+    if (c_associated(this%Yh_to_XhT_d)) then
        call device_unmap(this%Yh_to_XhT, this%Yh_to_XhT_d)
+    end if
+    if (c_associated(this%Xh_to_Yh_d)) then
+       call device_unmap(this%Xh_to_Yh, this%Xh_to_Yh_d)
+    end if
+    if (c_associated(this%Xh_to_YhT_d)) then
+       call device_unmap(this%Xh_to_YhT, this%Xh_to_YhT_d)
     end if
 
     if (allocated(this%Xh_to_Yh)) then

--- a/src/sem/interpolation.f90
+++ b/src/sem/interpolation.f90
@@ -230,9 +230,9 @@ contains
     end if
   end subroutine interpolator_map_host
 
-  !> Interpolates an array to one of Xh or Yh.
-  !! @param x Original array.
-  !! @param y Interpolated array.
+  !> Interpolates a field to one of Xh or Yh.
+  !! @param x Original field.
+  !! @param y Interpolated field.
   !! @param nel Number of elements in the mesh.
   !! @param to_space The space to interpolate to, must be either Xh or Yh.
   subroutine interpolator_map_field(this, y, x, nel, to_space)

--- a/src/simulation_components/field_subsampler.f90
+++ b/src/simulation_components/field_subsampler.f90
@@ -525,8 +525,8 @@ contains
     integer :: i
 
     do i = 1, this%n_fields
-       call this%interpolator%map(this%fields%x(i), &
-            this%source_fields%x(i), &
+       call this%interpolator%map(this%fields%get(i), &
+            this%source_fields%get(i), &
             this%msh%nelv, this%Xh)
     end do
 
@@ -541,10 +541,11 @@ contains
     type(time_state_t), intent(in) :: time
 
     type(field_t), pointer :: wk
-    integer :: i, n, n_mask, tmp_index
+    integer :: i, n, n_mask, nelv, tmp_index
 
-    n = this%source_fields%items(1)%ptr%dof%size()
+    n = this%source_fields%item_size(1)
     n_mask = this%point_zone%mask%size()
+    nelv = this%msh%nelv
 
     call neko_scratch_registry%request_field(wk, tmp_index, .false.)
 
@@ -563,8 +564,7 @@ contains
        end if
 
        ! Then, map the two different spaces
-       call this%interpolator%map(this%fields%x(i), wk%x, &
-            this%msh%nelv, this%Xh)
+       call this%interpolator%map(this%fields%get(i), wk, nelv, this%Xh)
 
     end do
 


### PR DESCRIPTION
Deprecate implicit device usage in tensor operations and protect against zero-sized device tensors. Update the dofmap interface to eliminate dependency on interpolation, ensuring a more robust and clear implementation. Adjust related calls to reflect these changes.