### PR TITLE
Fix CCE OpenMP SEGV

### DIFF
--- a/src/bc/bc_list.f90
+++ b/src/bc/bc_list.f90
@@ -228,6 +228,7 @@ contains
     type(time_state_t), intent(in), optional :: time
     logical, intent(in), optional :: strong
     type(c_ptr), intent(inout), optional :: strm
+    logical :: strong_
     type(c_ptr) :: x_d
     integer :: i
 
@@ -238,12 +239,30 @@ contains
        call this%apply_scalar_device(x_d, time = time, &
             strong = strong, strm = strm)
     else
-       !$omp parallel
-       do i = 1, this%size_
-          call this%items(i)%ptr%apply_scalar(x, n, time = time, &
-               strong = strong)
-       end do
-       !$omp end parallel
+       ! Resolve strong into a concrete, always-present local before opening
+       ! the parallel region. CCE's outlined region prologue dereferences a
+       ! null descriptor for any absent optional dummy referenced inside the
+       ! region, and it does not treat an unallocated allocatable as not
+       ! present, so optionals must not be forwarded into the region. time
+       ! cannot be given a meaningful concrete default, so we branch on
+       ! present(time) outside the region instead.
+       strong_ = .true.
+       if (present(strong)) strong_ = strong
+
+       if (present(time)) then
+          !$omp parallel
+          do i = 1, this%size_
+             call this%items(i)%ptr%apply_scalar(x, n, time = time, &
+                  strong = strong_)
+          end do
+          !$omp end parallel
+       else
+          !$omp parallel
+          do i = 1, this%size_
+             call this%items(i)%ptr%apply_scalar(x, n, strong = strong_)
+          end do
+          !$omp end parallel
+       end if
     end if
   end subroutine bc_list_apply_scalar_array
 
@@ -265,6 +284,7 @@ contains
     type(time_state_t), intent(in), optional :: time
     logical, intent(in), optional :: strong
     type(c_ptr), intent(inout), optional :: strm
+    logical :: strong_
     type(c_ptr) :: x_d
     type(c_ptr) :: y_d
     type(c_ptr) :: z_d
@@ -279,12 +299,30 @@ contains
        call this%apply_vector_device(x_d, y_d, z_d, time = time, &
             strong = strong, strm = strm)
     else
-       !$omp parallel
-       do i = 1, this%size_
-          call this%items(i)%ptr%apply_vector(x, y, z, n, time = time, &
-               strong = strong)
-       end do
-       !$omp end parallel
+       ! Resolve strong into a concrete, always-present local before opening
+       ! the parallel region. CCE's outlined region prologue dereferences a
+       ! null descriptor for any absent optional dummy referenced inside the
+       ! region, and it does not treat an unallocated allocatable as not
+       ! present, so optionals must not be forwarded into the region. time
+       ! cannot be given a meaningful concrete default, so we branch on
+       ! present(time) outside the region instead.
+       strong_ = .true.
+       if (present(strong)) strong_ = strong
+
+       if (present(time)) then
+          !$omp parallel
+          do i = 1, this%size_
+             call this%items(i)%ptr%apply_vector(x, y, z, n, time = time, &
+                  strong = strong_)
+          end do
+          !$omp end parallel
+       else
+          !$omp parallel
+          do i = 1, this%size_
+             call this%items(i)%ptr%apply_vector(x, y, z, n, strong = strong_)
+          end do
+          !$omp end parallel
+       end if
     end if
 
   end subroutine bc_list_apply_vector_array
@@ -362,14 +400,37 @@ contains
     type(time_state_t), intent(in), optional :: time
     logical, intent(in), optional :: strong
     type(c_ptr), intent(inout), optional :: strm
+    logical :: strong_
+    type(c_ptr) :: strm_
     integer :: i
 
-    !$omp parallel if (.not. omp_in_parallel())
-    do i = 1, this%size_
-       call this%items(i)%ptr%apply_scalar_generic(x, time = time, &
-            strong = strong, strm = strm)
-    end do
-    !$omp end parallel
+    ! Resolve strong and strm into concrete, always-present locals before
+    ! opening the parallel region. CCE's outlined region prologue dereferences
+    ! a null descriptor for any absent optional dummy referenced inside the
+    ! region, and it does not treat an unallocated allocatable as not present,
+    ! so optionals must not be forwarded into the region. time cannot be given
+    ! a meaningful concrete default, so we branch on present(time) outside the
+    ! region instead.
+    strong_ = .true.
+    if (present(strong)) strong_ = strong
+    strm_ = glb_cmd_queue
+    if (present(strm)) strm_ = strm
+
+    if (present(time)) then
+       !$omp parallel if (.not. omp_in_parallel())
+       do i = 1, this%size_
+          call this%items(i)%ptr%apply_scalar_generic(x, time = time, &
+               strong = strong_, strm = strm_)
+       end do
+       !$omp end parallel
+    else
+       !$omp parallel if (.not. omp_in_parallel())
+       do i = 1, this%size_
+          call this%items(i)%ptr%apply_scalar_generic(x, &
+               strong = strong_, strm = strm_)
+       end do
+       !$omp end parallel
+    end if
 
   end subroutine bc_list_apply_scalar_field
 
@@ -389,14 +450,37 @@ contains
     type(time_state_t), intent(in), optional :: time
     logical, intent(in), optional :: strong
     type(c_ptr), intent(inout), optional :: strm
+    logical :: strong_
+    type(c_ptr) :: strm_
     integer :: i
 
-    !$omp parallel if (.not. omp_in_parallel())
-    do i = 1, this%size_
-       call this%items(i)%ptr%apply_vector_generic(x, y, z, time = time, &
-            strong = strong, strm = strm)
-    end do
-    !$omp end parallel
+    ! Resolve strong and strm into concrete, always-present locals before
+    ! opening the parallel region. CCE's outlined region prologue dereferences
+    ! a null descriptor for any absent optional dummy referenced inside the
+    ! region, and it does not treat an unallocated allocatable as not present,
+    ! so optionals must not be forwarded into the region. time cannot be given
+    ! a meaningful concrete default, so we branch on present(time) outside the
+    ! region instead.
+    strong_ = .true.
+    if (present(strong)) strong_ = strong
+    strm_ = glb_cmd_queue
+    if (present(strm)) strm_ = strm
+
+    if (present(time)) then
+       !$omp parallel if (.not. omp_in_parallel())
+       do i = 1, this%size_
+          call this%items(i)%ptr%apply_vector_generic(x, y, z, time = time, &
+               strong = strong_, strm = strm_)
+       end do
+       !$omp end parallel
+    else
+       !$omp parallel if (.not. omp_in_parallel())
+       do i = 1, this%size_
+          call this%items(i)%ptr%apply_vector_generic(x, y, z, &
+               strong = strong_, strm = strm_)
+       end do
+       !$omp end parallel
+    end if
 
   end subroutine bc_list_apply_vector_field
 

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -1443,6 +1443,7 @@ contains
     real(kind=rp), dimension(n), intent(inout) :: u
     type(c_ptr), optional, intent(inout) :: event
     integer :: m, l, op, lo, so, tid
+    type(c_ptr) :: scatter_event
 
     lo = gs%local_facet_offset
     so = -gs%shared_facet_offset
@@ -1454,6 +1455,13 @@ contains
     ! threads (device path) don't collide.
     tid = 0
     !$ tid = omp_get_thread_num()
+
+    ! Resolve the optional event into a non-optional local before opening
+    ! the parallel region. An absent optional dummy must not be captured by
+    ! the region's data-sharing, otherwise the outlined region prologue
+    ! dereferences a null descriptor (segfaults on CCE).
+    scatter_event = C_NULL_PTR
+    if (present(event)) scatter_event = event
 
     !$omp parallel if (NEKO_BCKND_DEVICE .eq. 0)
     call profiler_start_region("gather_scatter", 5)
@@ -1489,17 +1497,10 @@ contains
        call gs%comm%nbwait(gs%shared_gs, l, op, gs%bcknd%gs_stream)
        call profiler_end_region("gs_nbwait", 7)
        call profiler_start_region("gs_scatter_shared", 15)
-       if (present(event)) then
-          call gs%bcknd%scatter(gs%shared_gs, l,&
-               gs%shared_dof_gs, u, n, &
-               gs%shared_gs_dof, gs%nshared_blks, &
-               gs%shared_blk_len, gs%shared_blk_off, .true., event)
-       else
-          call gs%bcknd%scatter(gs%shared_gs, l,&
-               gs%shared_dof_gs, u, n, &
-               gs%shared_gs_dof, gs%nshared_blks, &
-               gs%shared_blk_len, gs%shared_blk_off, .true., C_NULL_PTR)
-       end if
+       call gs%bcknd%scatter(gs%shared_gs, l,&
+            gs%shared_dof_gs, u, n, &
+            gs%shared_gs_dof, gs%nshared_blks, &
+            gs%shared_blk_len, gs%shared_blk_off, .true., scatter_event)
        call profiler_end_region("gs_scatter_shared", 15)
     end if
 


### PR DESCRIPTION
Avoid passing absent optional arguments into OpenMP parallel regions in the bc_list apply routines and gs_op_vector, which crashes under CCE. Fixes #2565
