### PR TITLE
MPI and gs fixes

### DIFF
--- a/src/comm/comm.F90.in
+++ b/src/comm/comm.F90.in
@@ -143,15 +143,15 @@ contains
           end if
        else if (nthrds .gt. 1) then
           call MPI_Init_thread(MPI_THREAD_MULTIPLE, provided, ierr)
-          if (provided .ne. MPI_THREAD_MULTIPLE) then
-             ! MPI_THREAD_MULTIPLE is required for mt. device backends
+          if (provided .lt. MPI_THREAD_MULTIPLE) then
+             ! MPI_THREAD_MULTIPLE is required for mt. device backends. For
+             ! host backends the gather-scatter MPI calls are issued from the
+             ! OpenMP master thread, so MPI_THREAD_SERIALIZED (or FUNNELED) is
+             ! sufficient as a last resort.
              if (NEKO_BCKND_DEVICE .eq. 1) then
                 call neko_error('Invalid thread support provided by MPI')
-             else
-                call MPI_Init_thread(MPI_THREAD_FUNNELED, provided, ierr)
-                if (provided .ne. MPI_THREAD_FUNNELED) then
-                   call neko_error('Invalid thread support provided by MPI')
-                end if
+             else if (provided .lt. MPI_THREAD_FUNNELED) then
+                call neko_error('Invalid thread support provided by MPI')
              end if
           end if
        else

--- a/src/gs/gs_mpi.f90
+++ b/src/gs/gs_mpi.f90
@@ -191,11 +191,9 @@ contains
              !$omp end do
           end select
           !$omp master
-          associate(send_data => this%send_buf(off + 1 : off + ndst))
-            call MPI_Isend(send_data, ndst, &
-                 MPI_REAL_PRECISION, dst, tag, &
-                 NEKO_COMM, this%send_request(i), ierr)
-          end associate
+          call MPI_Isend(this%send_buf(off + 1), ndst, &
+               MPI_REAL_PRECISION, dst, tag, &
+               NEKO_COMM, this%send_request(i), ierr)
           !$omp end master
        end do
        !$omp barrier
@@ -212,11 +210,9 @@ contains
                 this%send_buf(off + j) = u(sp(j))
              end do
           end select
-          associate(send_data => this%send_buf(off + 1 : off + ndst))
-            call MPI_Isend(send_data, ndst, &
-                 MPI_REAL_PRECISION, dst, tag, &
-                 NEKO_COMM, this%send_request(i), ierr)
-          end associate
+          call MPI_Isend(this%send_buf(off + 1), ndst, &
+               MPI_REAL_PRECISION, dst, tag, &
+               NEKO_COMM, this%send_request(i), ierr)
        end do
        !$omp end do
     end if
@@ -241,11 +237,9 @@ contains
        do i = 1, size(this%recv_pe)
           off = this%recv_offset(i)
           nsrc = this%recv_len(i)
-          associate(recv_data => this%recv_buf(off + 1 : off + nsrc))
-            call MPI_IRecv(recv_data, nsrc, &
-                 MPI_REAL_PRECISION, this%recv_pe(i), tag, &
-                 NEKO_COMM, this%recv_request(i), ierr)
-          end associate
+          call MPI_IRecv(this%recv_buf(off + 1), nsrc, &
+               MPI_REAL_PRECISION, this%recv_pe(i), tag, &
+               NEKO_COMM, this%recv_request(i), ierr)
        end do
        !$omp end master
        !$omp barrier
@@ -254,11 +248,9 @@ contains
        do i = 1, size(this%recv_pe)
           off = this%recv_offset(i)
           nsrc = this%recv_len(i)
-          associate(recv_data => this%recv_buf(off + 1 : off + nsrc))
-            call MPI_IRecv(recv_data, nsrc, &
-                 MPI_REAL_PRECISION, this%recv_pe(i), tag, &
-                 NEKO_COMM, this%recv_request(i), ierr)
-          end associate
+          call MPI_IRecv(this%recv_buf(off + 1), nsrc, &
+               MPI_REAL_PRECISION, this%recv_pe(i), tag, &
+               NEKO_COMM, this%recv_request(i), ierr)
        end do
        !$omp end do
     end if


### PR DESCRIPTION
This PR addresses two issues with MPI threading and the new multithreaded `gs_mpi`. 

During MPI init, `serialized` thread level was added to the default/auto options since `funneled` isn't supported on Fugaku. 

`gs_mpi` used some potentially hazardous associated blocks that has now been removed.
