### PR TITLE
Add read_duration utility and integrate with job control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Develop
 
+- Job control time limits can now be specified by a flexible string format, e.g.
+  "30:00" for 30 minutes, "1-00:00:00" for 24 hours, "3600" for 3600 seconds,
+  etc.  
 - Added `contrib/icem2re2`, a user-facing utility that converts ICEM/ANSYS
   Fluent `.msh` meshes to Neko `.re2` meshes. Requires Python 3 with `numpy`,
   `scipy`, and `pymech`. Supports translational periodic boundaries via

--- a/configure.ac
+++ b/configure.ac
@@ -439,6 +439,7 @@ AC_CONFIG_FILES([tests/unit/stack/Makefile\
         tests/unit/runge_kutta_scheme/Makefile\
         tests/unit/time_based_controller/Makefile\
         tests/unit/json_utils/Makefile\
+        tests/unit/utils/Makefile\
         tests/unit/point_interpolation/Makefile\
         tests/unit/templates/parallel/Makefile\
         tests/unit/boundary_operation/Makefile\

--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -88,7 +88,7 @@ but also defines several parameters that pertain to the simulation as a whole.
 | `restart_file`        | checkpoint to use for a restart from previous data                                                    | Strings ending with `.chkp`                     | -             |
 | `restart_mesh_file`   | If the restart file is on a different mesh, specify the .nmsh file used to generate it here           | Strings ending with `.nmsh`                     | -             |
 | `mesh2mesh_tolerance` | Tolerance for the restart when restarting from another mesh                                           | Positive reals                                  | 1e-6          |
-| `job_timelimit`       | The maximum wall clock duration of the simulation.                                                    | String formatted as HH:MM:SS                    | No limit      |
+| `job_timelimit`       | The maximum wall clock duration of the simulation.                                                    | String formatted as [[[DD-]HH:]MM:]SS           | No limit      |
 | `output_at_end`       | Whether to always write all enabled output at the end of the run.                                     | `true` or `false`                               | `true`        |
 
 Some additional practical comments are provided regarding the output triggered
@@ -116,7 +116,9 @@ checkpoint file, with the filename called `joblimit#####.chkp`. This is done so
 that the user is at least provided a restart file, and none of the computer time
 spent on the simulation is wasted. Generally, however, it is recommended to
 have `output_at_end` set to `true` in tandem with `job_timelimit`, so that what
-exactly gets written is controlled by the case file settings.
+exactly gets written is controlled by the case file settings. Note that the time
+format is flexible. For example, `1-01:00:00` and `25:00:00` are both valid ways
+to specify a 25-hour time limit.
 
 ### Constants
 The `constants` array allows the user to define parameters that are global to

--- a/src/.depends
+++ b/src/.depends
@@ -22,7 +22,7 @@ comm/mpi_types.lo : comm/mpi_types.f90 io/format/stl.lo io/format/nmsh.lo io/for
 comm/shmem.lo : comm/shmem.F90 
 common/datadist.lo : common/datadist.f90 
 common/distdata.lo : common/distdata.f90 adt/uset.lo adt/tuple.lo adt/stack.lo 
-common/utils.lo : common/utils.f90 
+common/utils.lo : common/utils.f90 config/num_types.lo 
 common/time_state.lo : common/time_state.f90 common/json_utils.lo common/log.lo config/num_types.lo 
 common/json_utils.lo : common/json_utils.f90 common/utils.lo config/num_types.lo 
 common/case_file_utils.lo : common/case_file_utils.f90 config/num_types.lo math/math.lo math/vector.lo registries/registry.lo common/json_utils.lo 

--- a/src/common/jobctrl.f90
+++ b/src/common/jobctrl.f90
@@ -35,7 +35,7 @@ module jobctrl
   use num_types, only : rp, dp
   use signal, only : signal_timeout, signal_usr, signal_trap_usr, &
        signal_set_timeout, signal_trap_cpulimit
-  use utils, onlY : neko_error
+  use utils, only : neko_error, read_duration
   use mpi_f08, only : MPI_Bcast, MPI_LOGICAL, MPI_WTIME
   use comm, only : NEKO_COMM
   use logger, only : neko_log, LOG_SIZE, NEKO_LOG_QUIET
@@ -66,28 +66,14 @@ contains
 
   end subroutine jobctrl_init
 
-  !> Set a job's time limit (in walltime 'HH:MM:SS')
+  !> Set a job's time limit from a duration string.
   subroutine jobctrl_set_time_limit_str(limit_str)
-    character(len=*) limit_str
-    integer :: str_len, sep_h, h, m, s
+    character(len=*), intent(in) :: limit_str
+    real(kind=rp) :: limit_sec
+    integer :: ierr
 
-    str_len = len_trim(limit_str)
-
-    if (str_len .lt. 8) then
-       call neko_error('Invalid job limit')
-    end if
-
-    ! hour
-    sep_h = scan(trim(limit_str), ':')
-    read(limit_str(1:sep_h-1), *) h
-
-    !min
-    read(limit_str(sep_h+1:sep_h+2), *) m
-
-    !sec
-    read(limit_str(sep_h+4:str_len), *) s
-
-    call jobctrl_set_time_limit_sec(h*3600 + m * 60 + s)
+    call read_duration(limit_str, limit_sec)
+    call jobctrl_set_time_limit_sec(int(limit_sec))
 
   end subroutine jobctrl_set_time_limit_str
 

--- a/src/common/jobctrl.f90
+++ b/src/common/jobctrl.f90
@@ -72,6 +72,7 @@ contains
     real(kind=rp) :: limit_sec
     integer :: ierr
 
+    limit_sec = 0.0_rp
     call read_duration(limit_str, limit_sec)
     call jobctrl_set_time_limit_sec(int(limit_sec))
 

--- a/src/common/utils.f90
+++ b/src/common/utils.f90
@@ -35,6 +35,7 @@
 module utils
   use, intrinsic :: iso_fortran_env, only : error_unit, output_unit
   use iso_c_binding
+  use num_types, only: rp, dp
   implicit none
   private
 
@@ -478,8 +479,8 @@ contains
     end if
 
     total_whole = int(parsed_seconds, kind=i64)
-    frac_seconds = parsed_seconds - real(total_whole, kind=rp)
-    if (frac_seconds .lt. 0.0_rp) frac_seconds = 0.0_rp
+    frac_seconds = parsed_seconds - real(total_whole, kind=dp)
+    if (frac_seconds .lt. 0.0_dp) frac_seconds = 0.0_dp
 
     days = total_whole / 86400_i64
     total_whole = total_whole - 86400_i64 * days
@@ -488,9 +489,9 @@ contains
     minutes = total_whole / 60_i64
     seconds_whole = total_whole - 60_i64 * minutes
 
-    second_value = real(seconds_whole, kind=rp) + frac_seconds
-    if (second_value .ge. 60.0_rp) then
-       second_value = second_value - 60.0_rp
+    second_value = real(seconds_whole, kind=dp) + frac_seconds
+    if (second_value .ge. 60.0_dp) then
+       second_value = second_value - 60.0_dp
        minutes = minutes + 1_i64
        if (minutes .ge. 60_i64) then
           minutes = minutes - 60_i64
@@ -507,17 +508,17 @@ contains
        runtime_values(1) = real(days, kind=rp)
        runtime_values(2) = real(hours, kind=rp)
        runtime_values(3) = real(minutes, kind=rp)
-       runtime_values(4) = second_value
+       runtime_values(4) = real(second_value, kind=rp)
     case (3)
        runtime_values(1) = real(days * 24_i64 + hours, kind=rp)
        runtime_values(2) = real(minutes, kind=rp)
-       runtime_values(3) = second_value
+       runtime_values(3) = real(second_value, kind=rp)
     case (2)
        runtime_values(1) = real((days * 24_i64 + hours) * 60_i64 + &
             minutes, kind=rp)
-       runtime_values(2) = second_value
+       runtime_values(2) = real(second_value, kind=rp)
     case (1)
-       runtime_values(1) = parsed_seconds
+       runtime_values(1) = real(parsed_seconds, kind=rp)
     end select
   end subroutine read_duration_components
 
@@ -564,7 +565,7 @@ contains
        end if
 
        time_string = time_string(sep + 1:)
-       parsed_seconds = parsed_seconds + real(86400 * read_int, kind=rp)
+       parsed_seconds = parsed_seconds + real(86400 * read_int, kind=dp)
     end if
 
     ! Read the hours.
@@ -579,7 +580,7 @@ contains
        end if
 
        time_string = time_string(sep + 1:)
-       parsed_seconds = parsed_seconds + real(3600 * read_int, kind=rp)
+       parsed_seconds = parsed_seconds + real(3600 * read_int, kind=dp)
     end if
 
     ! Read the minutes.
@@ -594,13 +595,13 @@ contains
        end if
 
        time_string = time_string(sep + 1:)
-       parsed_seconds = parsed_seconds + real(60 * read_int, kind=rp)
+       parsed_seconds = parsed_seconds + real(60 * read_int, kind=dp)
     end if
 
     ! Read the seconds.
     read(time_string, *, iostat=ios) read_real
-    if (ios .ne. 0 .or. read_real .lt. 0.0_rp .or. &
-         (has_minutes .and. read_real .ge. 60.0_rp)) then
+    if (ios .ne. 0 .or. read_real .lt. 0.0_dp .or. &
+         (has_minutes .and. read_real .ge. 60.0_dp)) then
        call set_error_or_throw( &
             'Error parsing duration: Invalid seconds value', ierr)
        return

--- a/src/common/utils.f90
+++ b/src/common/utils.f90
@@ -45,12 +45,17 @@ module utils
      module procedure neko_error_plain, neko_error_msg
   end interface neko_error
 
+  interface read_duration
+     module procedure read_duration_scalar
+     module procedure read_duration_components
+  end interface read_duration
+
   public :: neko_error, neko_warning, nonlinear_index, filename_chsuffix, &
        filename_path, filename_name, filename_suffix, &
        filename_suffix_pos, filename_tslash_pos, filename_split, &
        linear_index, split_string, NEKO_FNAME_LEN, index_is_on_facet, &
        concat_string_array, extract_fld_file_index, neko_type_error, &
-       neko_type_registration_error, NEKO_VARNAME_LEN, mkdir
+       neko_type_registration_error, NEKO_VARNAME_LEN, mkdir, read_duration
 
   interface
      function c_mkdir(path, mode) bind(C, name="mkdir")
@@ -416,4 +421,204 @@ contains
 
   end function concat_string_array
 
+  !> Parse runtime string to total seconds.
+  !! Supported formats are:
+  !! - seconds as an integer or real value (for example "5400" or "5400.0")
+  !! - mm:ss
+  !! - hh:mm:ss
+  !! - dd-hh:mm:ss
+  subroutine read_duration_scalar(runtime_string, runtime_seconds, &
+       ierr)
+    character(len=*), intent(in) :: runtime_string
+    real(kind=rp), intent(inout) :: runtime_seconds
+    integer, optional, intent(out) :: ierr
+    real(kind=dp) :: parsed_seconds
+
+    if (present(ierr)) ierr = 0
+    if (len_trim(runtime_string) .eq. 0) return
+
+    parsed_seconds = read_duration_internal(runtime_string, ierr)
+
+    if (present(ierr)) then
+       if (ierr .ne. 0) return
+    end if
+
+    runtime_seconds = parsed_seconds
+  end subroutine read_duration_scalar
+
+  !> Parse runtime string to components.
+  !! The output array maps to the largest unit available based on size:
+  !! - size 4: [dd, hh, mm, ss]
+  !! - size 3: [hh, mm, ss]
+  !! - size 2: [mm, ss]
+  !! - size 1: [ss]
+  subroutine read_duration_components(runtime_string, runtime_values, ierr)
+    character(len=*), intent(in) :: runtime_string
+    real(kind=rp), intent(inout) :: runtime_values(:)
+    integer, optional, intent(out) :: ierr
+    integer, parameter :: i64 = selected_int_kind(18)
+    integer :: n_values
+    integer(kind=i64) :: total_whole, days, hours, minutes, seconds_whole
+    real(kind=dp) :: parsed_seconds, second_value, frac_seconds
+
+    if (present(ierr)) ierr = 0
+    if (len_trim(runtime_string) .eq. 0) return
+
+    n_values = size(runtime_values)
+    if (n_values .lt. 1 .or. n_values .gt. 4) then
+       call set_error_or_throw( &
+            'Error parsing duration: output array size must be 1 to 4', ierr)
+       return
+    end if
+
+    parsed_seconds = read_duration_internal(runtime_string, ierr)
+
+    if (present(ierr)) then
+       if (ierr .ne. 0) return
+    end if
+
+    total_whole = int(parsed_seconds, kind=i64)
+    frac_seconds = parsed_seconds - real(total_whole, kind=rp)
+    if (frac_seconds .lt. 0.0_rp) frac_seconds = 0.0_rp
+
+    days = total_whole / 86400_i64
+    total_whole = total_whole - 86400_i64 * days
+    hours = total_whole / 3600_i64
+    total_whole = total_whole - 3600_i64 * hours
+    minutes = total_whole / 60_i64
+    seconds_whole = total_whole - 60_i64 * minutes
+
+    second_value = real(seconds_whole, kind=rp) + frac_seconds
+    if (second_value .ge. 60.0_rp) then
+       second_value = second_value - 60.0_rp
+       minutes = minutes + 1_i64
+       if (minutes .ge. 60_i64) then
+          minutes = minutes - 60_i64
+          hours = hours + 1_i64
+          if (hours .ge. 24_i64) then
+             hours = hours - 24_i64
+             days = days + 1_i64
+          end if
+       end if
+    end if
+
+    select case (n_values)
+    case (4)
+       runtime_values(1) = real(days, kind=rp)
+       runtime_values(2) = real(hours, kind=rp)
+       runtime_values(3) = real(minutes, kind=rp)
+       runtime_values(4) = second_value
+    case (3)
+       runtime_values(1) = real(days * 24_i64 + hours, kind=rp)
+       runtime_values(2) = real(minutes, kind=rp)
+       runtime_values(3) = second_value
+    case (2)
+       runtime_values(1) = real((days * 24_i64 + hours) * 60_i64 + &
+            minutes, kind=rp)
+       runtime_values(2) = second_value
+    case (1)
+       runtime_values(1) = parsed_seconds
+    end select
+  end subroutine read_duration_components
+
+  !> Parse runtime string to total seconds.
+  real(kind=dp) function read_duration_internal(runtime_string, ierr) &
+       result(runtime_seconds)
+    character(len=*), intent(in) :: runtime_string
+    integer, optional, intent(out) :: ierr
+    character(len=:), allocatable :: time_string
+    real(kind=dp) :: parsed_seconds, read_real
+    logical :: has_minutes, has_hours, has_days
+    integer :: read_int, ios, sep
+
+    if (present(ierr)) ierr = 0
+
+    runtime_seconds = 0.0_dp
+    time_string = trim(adjustl(runtime_string))
+
+    sep = index(time_string, ':')
+    has_minutes = sep .gt. 0
+    has_hours = .false.
+    if (has_minutes .and. sep .lt. len_trim(time_string)) then
+       has_hours = index(time_string(sep + 1:len_trim(time_string)), ':') &
+            .gt. 0
+    end if
+    has_days = index(time_string, '-') .gt. 0
+
+    if ((has_days .and. .not. has_hours) .or. &
+         (has_hours .and. .not. has_minutes)) then
+       call set_error_or_throw('Error parsing duration: Bad format', ierr)
+       return
+    end if
+
+    parsed_seconds = 0.0_dp
+
+    ! Read the days field.
+    if (has_days) then
+       sep = index(time_string, '-')
+       read(time_string(1:sep - 1), *, iostat=ios) read_int
+       if (ios .ne. 0 .or. read_int .lt. 0) then
+          call set_error_or_throw( &
+               'Error parsing duration: Invalid days value', ierr)
+          return
+       end if
+
+       time_string = time_string(sep + 1:)
+       parsed_seconds = parsed_seconds + real(86400 * read_int, kind=rp)
+    end if
+
+    ! Read the hours.
+    if (has_hours) then
+       sep = index(time_string, ':')
+       read(time_string(1:sep - 1), *, iostat=ios) read_int
+       if (ios .ne. 0 .or. read_int .lt. 0 .or. &
+            (has_days .and. read_int .gt. 23)) then
+          call set_error_or_throw( &
+               'Error parsing duration: Invalid hours value', ierr)
+          return
+       end if
+
+       time_string = time_string(sep + 1:)
+       parsed_seconds = parsed_seconds + real(3600 * read_int, kind=rp)
+    end if
+
+    ! Read the minutes.
+    if (has_minutes) then
+       sep = index(time_string, ':')
+       read(time_string(1:sep - 1), *, iostat=ios) read_int
+       if (ios .ne. 0 .or. read_int .lt. 0 .or. &
+            (has_hours .and. read_int .gt. 59)) then
+          call set_error_or_throw( &
+               'Error parsing duration: Invalid minutes value', ierr)
+          return
+       end if
+
+       time_string = time_string(sep + 1:)
+       parsed_seconds = parsed_seconds + real(60 * read_int, kind=rp)
+    end if
+
+    ! Read the seconds.
+    read(time_string, *, iostat=ios) read_real
+    if (ios .ne. 0 .or. read_real .lt. 0.0_rp .or. &
+         (has_minutes .and. read_real .ge. 60.0_rp)) then
+       call set_error_or_throw( &
+            'Error parsing duration: Invalid seconds value', ierr)
+       return
+    end if
+
+    parsed_seconds = parsed_seconds + read_real
+    runtime_seconds = parsed_seconds
+  end function read_duration_internal
+
+  !> Raise parser error or set ierr, depending on call mode.
+  subroutine set_error_or_throw(message, ierr)
+    character(len=*), intent(in) :: message
+    integer, optional, intent(out) :: ierr
+
+    if (present(ierr)) then
+       ierr = 1
+    else
+       call neko_error(trim(message))
+    end if
+  end subroutine set_error_or_throw
 end module utils

--- a/src/common/utils.f90
+++ b/src/common/utils.f90
@@ -609,6 +609,8 @@ contains
 
     parsed_seconds = parsed_seconds + read_real
     runtime_seconds = parsed_seconds
+
+    if (allocated(time_string)) deallocate(time_string)
   end function read_duration_internal
 
   !> Raise parser error or set ierr, depending on call mode.

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -36,6 +36,7 @@ SUBDIRS = tuple\
 	  runge_kutta_scheme\
 	  time_based_controller\
 	  json_utils\
+	  utils\
 	  point_interpolation\
 	  templates/parallel\
 	  boundary_operation\
@@ -79,6 +80,7 @@ TESTS = device/device_test\
 	runge_kutta_scheme/runge_kutta_scheme_test\
 	time_based_controller/time_based_controller_test\
 	json_utils/json_utils_test\
+	utils/read_duration_test\
 	point_interpolation/point_interpolation_test\
 	templates/parallel/parallel_test\
 	boundary_operation/boundary_operation_test\
@@ -160,6 +162,7 @@ EXTRA_DIST = \
 	time_scheme_controller/test_time_scheme_controller.pf\
 	runge_kutta_scheme/test_runge_kutta_scheme.pf\
 	json_utils/test_json_utils.pf\
+	utils/test_read_duration.pf\
 	time_based_controller/test_time_based_controller.pf\
 	point_interpolation/test_point_interpolation_parallel.pf\
 	point_interpolation/point_interpolation_test\

--- a/tests/unit/jobctrl/test_jobctrl_parallel.pf
+++ b/tests/unit/jobctrl/test_jobctrl_parallel.pf
@@ -21,33 +21,21 @@ contains
     pe_size = this%getNumProcesses()
 
     call jobctrl_init()
+
+    ! Test integer version of the time limit
     call jobctrl_set_time_limit(3)
     call sleep(1)
-    @assertFalse(signal_timeout())
+    @assertFalse(signal_timeout(), message = "Int early timeout")
     call sleep(3)
-    @assertTrue(signal_timeout())
+    @assertTrue(signal_timeout(), message = "Int late timeout")
+
+    ! Test string version of time limit, time is still running in the background
+    call jobctrl_set_time_limit('00:00:06')
+    call sleep(1)
+    @assertFalse(signal_timeout(), message = "Str early timeout")
+    call sleep(3)
+    @assertTrue(signal_timeout(), message = "Str late timeout")
 
   end subroutine test_jobctrl_set_time_limit
-
-  @test(npes=[1])
-  subroutine test_jobctrl_set_time_limit_str(this)
-    class (MpiTestMethod), intent(inout) :: this
-    type(mesh_t) :: m ! Dummy type to avoid link issues
-    integer :: ierr, limit_abs, hh, mm, ss
-    character(len=32) :: limit_str
-
-    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
-
-    pe_rank = this%getProcessRank()
-    pe_size = this%getNumProcesses()
-
-    call jobctrl_init()
-    call jobctrl_set_time_limit('00:00:03')
-    call sleep(1)
-    @assertFalse(signal_timeout())
-    call sleep(3)
-    @assertTrue(signal_timeout())
-
-  end subroutine test_jobctrl_set_time_limit_str
 
 end module test_jobctrl_parallel

--- a/tests/unit/jobctrl/test_jobctrl_parallel.pf
+++ b/tests/unit/jobctrl/test_jobctrl_parallel.pf
@@ -15,18 +15,39 @@ contains
     type(mesh_t) :: m ! Dummy type to avoid link issues
     integer :: ierr
 
-     call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
 
-     pe_rank = this%getProcessRank()
-     pe_size = this%getNumProcesses()
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
 
-     call jobctrl_init()
-     call jobctrl_set_time_limit(3)
-     call sleep(1)
-     @assertFalse(signal_timeout())
-     call sleep(3)
-     @assertTrue(signal_timeout())
+    call jobctrl_init()
+    call jobctrl_set_time_limit(3)
+    call sleep(1)
+    @assertFalse(signal_timeout())
+    call sleep(3)
+    @assertTrue(signal_timeout())
 
-   end subroutine test_jobctrl_set_time_limit
+  end subroutine test_jobctrl_set_time_limit
+
+  @test(npes=[1])
+  subroutine test_jobctrl_set_time_limit_str(this)
+    class (MpiTestMethod), intent(inout) :: this
+    type(mesh_t) :: m ! Dummy type to avoid link issues
+    integer :: ierr, limit_abs, hh, mm, ss
+    character(len=32) :: limit_str
+
+    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
+
+    call jobctrl_init()
+    call jobctrl_set_time_limit('00:00:03')
+    call sleep(1)
+    @assertFalse(signal_timeout())
+    call sleep(3)
+    @assertTrue(signal_timeout())
+
+  end subroutine test_jobctrl_set_time_limit_str
 
 end module test_jobctrl_parallel

--- a/tests/unit/utils/Makefile.in
+++ b/tests/unit/utils/Makefile.in
@@ -1,0 +1,28 @@
+ifneq ("$(wildcard @PFUNIT_DIR@/include/PFUNIT.mk)", "")
+include @PFUNIT_DIR@/include/PFUNIT.mk
+endif
+FFLAGS += $(PFUNIT_EXTRA_FFLAGS) @NEKO_PKG_FCFLAGS@ -I@top_builddir@/src
+FC = @FC@
+
+%.o : %.F90
+	$(FC) -c $(FFLAGS) $<
+
+
+check: read_duration_test
+
+read_duration_test_TESTS := test_read_duration.pf
+read_duration_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko
+$(eval $(call make_pfunit_test,read_duration_test))
+
+read_duration_test.inc: Makefile
+
+distclean:
+clean:
+	$(RM) *.o *.mod *.a  *.inc *.F90 read_duration_test
+
+
+
+all:
+html:
+install:
+distdir:

--- a/tests/unit/utils/test_read_duration.pf
+++ b/tests/unit/utils/test_read_duration.pf
@@ -1,0 +1,208 @@
+module test_read_duration
+  use pfunit
+  use math, only: NEKO_EPS
+  use num_types, only: rp
+  use utils, only: read_duration
+
+  implicit none
+
+contains
+
+  subroutine assert_invalid_runtime_string(input)
+    character(len=*), intent(in) :: input
+    real(kind=rp) :: runtime
+    integer :: ierr
+    character(len=256) :: msg
+
+    runtime = 42.0_rp
+    call read_duration(input, runtime, ierr)
+
+    write(msg, '(A,A)') 'Expected error for invalid time string: ', trim(input)
+    @assertNotEqual(0, ierr, message=trim(msg))
+
+    write(msg, '(A,A)') 'Runtime changed for invalid string: ', trim(input)
+    @assertEqual(42.0_rp, runtime, NEKO_EPS, message=trim(msg))
+  end subroutine assert_invalid_runtime_string
+
+  @test
+  subroutine parse_dd_hh_mm_ss()
+    real(kind=rp) :: runtime
+    integer :: ierr
+
+    runtime = -1.0_rp
+    call read_duration('1-02:03:04', runtime, ierr)
+
+    @assertEqual(0, ierr)
+    @assertEqual(93784.0_rp, runtime, NEKO_EPS)
+  end subroutine parse_dd_hh_mm_ss
+
+  @test
+  subroutine parse_dd_scalar()
+    real(kind=rp) :: runtime
+    integer :: ierr
+
+    runtime = -1.0_rp
+    call read_duration('1-00:00:00', runtime, ierr)
+
+    @assertEqual(0, ierr)
+    @assertEqual(86400.0_rp, runtime, NEKO_EPS)
+  end subroutine parse_dd_scalar
+
+  @test
+  subroutine parse_hh_mm_ss()
+    real(kind=rp) :: runtime
+    integer :: ierr
+
+    runtime = -1.0_rp
+    call read_duration('12:34:56', runtime, ierr)
+
+    @assertEqual(0, ierr)
+    @assertEqual(45296.0_rp, runtime, NEKO_EPS)
+  end subroutine parse_hh_mm_ss
+
+  @test
+  subroutine parse_mm_ss()
+    real(kind=rp) :: runtime
+    integer :: ierr
+
+    runtime = -1.0_rp
+    call read_duration('05:30', runtime, ierr)
+
+    @assertEqual(0, ierr)
+    @assertEqual(330.0_rp, runtime, NEKO_EPS)
+  end subroutine parse_mm_ss
+
+  @test
+  subroutine parse_numeric_seconds()
+    real(kind=rp) :: runtime
+    integer :: ierr
+
+    runtime = -1.0_rp
+    call read_duration('171900.0', runtime, ierr)
+
+    @assertEqual(0, ierr)
+    @assertEqual(171900.0_rp, runtime, NEKO_EPS)
+  end subroutine parse_numeric_seconds
+
+  @test
+  subroutine parse_components_dd_hh_mm_ss()
+    real(kind=rp) :: values(4)
+    integer :: ierr
+
+    values = -1.0_rp
+    call read_duration('1-02:03:04', values, ierr)
+
+    @assertEqual(0, ierr)
+    @assertEqual(1.0_rp, values(1), NEKO_EPS)
+    @assertEqual(2.0_rp, values(2), NEKO_EPS)
+    @assertEqual(3.0_rp, values(3), NEKO_EPS)
+    @assertEqual(4.0_rp, values(4), NEKO_EPS)
+  end subroutine parse_components_dd_hh_mm_ss
+
+  @test
+  subroutine parse_components_hh_mm_ss_short_array()
+    real(kind=rp) :: values(3)
+    integer :: ierr
+
+    values = -1.0_rp
+    call read_duration('1-00:00:00', values, ierr)
+
+    @assertEqual(0, ierr)
+    @assertEqual(24.0_rp, values(1), NEKO_EPS)
+    @assertEqual(0.0_rp, values(2), NEKO_EPS)
+    @assertEqual(0.0_rp, values(3), NEKO_EPS)
+  end subroutine parse_components_hh_mm_ss_short_array
+
+  @test
+  subroutine parse_components_mm_ss_short_array()
+    real(kind=rp) :: values(2)
+    integer :: ierr
+
+    values = -1.0_rp
+    call read_duration('1-00:00:00', values, ierr)
+
+    @assertEqual(0, ierr)
+    @assertEqual(1440.0_rp, values(1), NEKO_EPS)
+    @assertEqual(0.0_rp, values(2), NEKO_EPS)
+  end subroutine parse_components_mm_ss_short_array
+
+  @test
+  subroutine parse_components_ss_short_array()
+    real(kind=rp) :: values(1)
+    integer :: ierr
+
+    values = -1.0_rp
+    call read_duration('1-00:00:00', values, ierr)
+
+    @assertEqual(0, ierr)
+    @assertEqual(86400.0_rp, values(1), NEKO_EPS)
+  end subroutine parse_components_ss_short_array
+
+  @test
+  subroutine reject_invalid_time_string()
+    call assert_invalid_runtime_string('1-25:00:00')
+    call assert_invalid_runtime_string('12:60:00')
+    call assert_invalid_runtime_string('12:34:60')
+    call assert_invalid_runtime_string('1:2:3:4')
+    call assert_invalid_runtime_string('abc')
+    call assert_invalid_runtime_string('1d-00:00:00')
+
+    ! Missing or extra separator/fields.
+    call assert_invalid_runtime_string('1-')
+    call assert_invalid_runtime_string('-01:00:00')
+    call assert_invalid_runtime_string('1-02:03')
+    call assert_invalid_runtime_string('12::34')
+    call assert_invalid_runtime_string(':12')
+    call assert_invalid_runtime_string('12:')
+    call assert_invalid_runtime_string('1-02:03:04:05')
+
+    ! Sign and token corruption cases.
+    call assert_invalid_runtime_string('-10')
+    call assert_invalid_runtime_string('12:-3:00')
+    call assert_invalid_runtime_string('1--02:03:04')
+
+  end subroutine reject_invalid_time_string
+
+  @test
+  subroutine reject_invalid_component_array_size()
+    real(kind=rp) :: values(5)
+    integer :: ierr
+
+    values = 7.0_rp
+    call read_duration('1-00:00:00', values, ierr)
+
+    @assertNotEqual(0, ierr)
+    @assertEqual(7.0_rp, values(1), NEKO_EPS)
+    @assertEqual(7.0_rp, values(2), NEKO_EPS)
+    @assertEqual(7.0_rp, values(3), NEKO_EPS)
+    @assertEqual(7.0_rp, values(4), NEKO_EPS)
+    @assertEqual(7.0_rp, values(5), NEKO_EPS)
+  end subroutine reject_invalid_component_array_size
+
+  @test
+  subroutine parse_empty_string_keeps_value()
+    real(kind=rp) :: runtime
+    integer :: ierr
+
+    runtime = 314.0_rp
+    call read_duration('', runtime, ierr)
+
+    @assertEqual(0, ierr)
+    @assertEqual(314.0_rp, runtime, NEKO_EPS)
+  end subroutine parse_empty_string_keeps_value
+
+  @test
+  subroutine parse_empty_string_keeps_components()
+    real(kind=rp) :: values(3)
+    integer :: ierr
+
+    values = [11.0_rp, 22.0_rp, 33.0_rp]
+    call read_duration('', values, ierr)
+
+    @assertEqual(0, ierr)
+    @assertEqual(11.0_rp, values(1), NEKO_EPS)
+    @assertEqual(22.0_rp, values(2), NEKO_EPS)
+    @assertEqual(33.0_rp, values(3), NEKO_EPS)
+  end subroutine parse_empty_string_keeps_components
+
+end module test_read_duration

--- a/tests/unit/utils/test_read_duration.pf
+++ b/tests/unit/utils/test_read_duration.pf
@@ -58,6 +58,13 @@ contains
 
     @assertEqual(0, ierr)
     @assertEqual(45296.0_rp, runtime, NEKO_EPS)
+
+    runtime = -1.0_rp
+    call read_duration('25:00:00', runtime, ierr)
+
+    @assertEqual(0, ierr)
+    @assertEqual(90000.0_rp, runtime, NEKO_EPS)
+
   end subroutine parse_hh_mm_ss
 
   @test
@@ -70,6 +77,13 @@ contains
 
     @assertEqual(0, ierr)
     @assertEqual(330.0_rp, runtime, NEKO_EPS)
+
+    runtime = -1.0_rp
+    call read_duration('90:00', runtime, ierr)
+
+    @assertEqual(0, ierr)
+    @assertEqual(5400.0_rp, runtime, NEKO_EPS)
+
   end subroutine parse_mm_ss
 
   @test


### PR DESCRIPTION
Introduce a utility to parse duration strings and update job control to utilize this utility for setting time limits. Add corresponding tests to ensure functionality and error handling.

This is essentially a refactor, but allow others to use this more effectively.