### PR TITLE
Compression for SEM mapping data

### DIFF
--- a/src/sem/coef.f90
+++ b/src/sem/coef.f90
@@ -74,6 +74,21 @@ module coefs
      !> Geometric factors \f$ G_{23} \f$
      real(kind=rp), allocatable :: G23(:,:,:,:)
 
+     !> Compressed geometric factors \f$ G_{11} \f$
+     real(kind=rp), allocatable :: G11_compressed(:,:,:,:)
+     !> Compressed geometric factors \f$ G_{22} \f$
+     real(kind=rp), allocatable :: G22_compressed(:,:,:,:)
+     !> Compressed geometric factors \f$ G_{33} \f$
+     real(kind=rp), allocatable :: G33_compressed(:,:,:,:)
+     !> Compressed geometric factors \f$ G_{12} \f$
+     real(kind=rp), allocatable :: G12_compressed(:,:,:,:)
+     !> Compressed geometric factors \f$ G_{13} \f$
+     real(kind=rp), allocatable :: G13_compressed(:,:,:,:)
+     !> Compressed geometric factors \f$ G_{23} \f$
+     real(kind=rp), allocatable :: G23_compressed(:,:,:,:)
+     !> Compressed geometric factors lookup indices
+     real(kind=rp), allocatable :: compression_inds(:)
+
      real(kind=rp), allocatable :: mult(:,:,:,:) !< Multiplicity
      !> generate mapping data between element and reference element
      !! \f$ dx/dr, dy/dr, dz/dr \f$
@@ -358,6 +373,8 @@ contains
 
     call coef_generate_geo(this)
 
+    call coef_generate_geo_compressed(this)
+
     call coef_generate_area_and_normal(this)
 
     call coef_generate_mass(this)
@@ -453,6 +470,30 @@ contains
 
     if (allocated(this%G23)) then
        deallocate(this%G23)
+    end if
+
+    if (allocated(this%G11_compressed)) then
+       deallocate(this%G11_compressed)
+    end if
+
+    if (allocated(this%G22_compressed)) then
+       deallocate(this%G22_compressed)
+    end if
+
+    if (allocated(this%G33_compressed)) then
+       deallocate(this%G33_compressed)
+    end if
+
+    if (allocated(this%G12_compressed)) then
+       deallocate(this%G12_compressed)
+    end if
+
+    if (allocated(this%G13_compressed)) then
+       deallocate(this%G13_compressed)
+    end if
+
+    if (allocated(this%G23_compressed)) then
+       deallocate(this%G23_compressed)
     end if
 
     if (allocated(this%mult)) then
@@ -1089,6 +1130,33 @@ contains
     end if
 
   end subroutine coef_generate_geo
+
+  !> Compute compressed versions of mappings Gij
+  !! @note This could be faster if it ran on device (among other algorithmic modifications)
+  subroutine coef_generate_geo_compressed(c)
+    type(coef_t), intent(inout) :: c
+    integer :: e, m, i, ntot, m_max
+
+    ! First step, allocate full-size lookup structure for entire mesh
+    allocate(c%compression_inds(this%msh%nelv))
+
+    ! Second step, loop over all elements, compute compression mapping
+    ! loop over e elements
+    !  loop over m compression mapping size
+    !   loop over i ntot
+    !    sum into difference
+    !   if difference <= tol
+    !    c%compression_inds(e) = m
+    !    break
+    !  mapping_size = mapping_size + 1
+    !  c%compression_inds(e) = mapping_size
+
+    ! Third step, allocate and fill Gij_compressed objects
+    ! loop over e elements
+    !  loop over i ntot
+    !   G11_compressed(i,1,1,e) = G11(i,1,1,c%compression_inds(e))
+
+  end subroutine coef_generate_geo_compressed
 
   !> Generate mass matrix B for the given mesh and space
   !! @note This is also a stapleholder, we need to go through the coef class properly.

--- a/src/sem/coef.f90
+++ b/src/sem/coef.f90
@@ -373,7 +373,7 @@ contains
 
     call coef_generate_geo(this)
 
-    call coef_generate_geo_compressed(this)
+    ! call coef_generate_geo_compressed(this)
 
     call coef_generate_area_and_normal(this)
 
@@ -1131,30 +1131,70 @@ contains
 
   end subroutine coef_generate_geo
 
-  !> Compute compressed versions of mappings Gij
+  !> Compute processor-local compressed versions of mappings Gij
   !! @note This could be faster if it ran on device (among other algorithmic modifications)
   subroutine coef_generate_geo_compressed(c)
     type(coef_t), intent(inout) :: c
     integer :: e, m, i, ntot, m_max
+    real(kind=rp) :: ctol = 1.0E-7_rp
+    real(kind=rp) :: diff = 0.0_rp
 
     ! First step, allocate full-size lookup structure for entire mesh
     allocate(c%compression_inds(this%msh%nelv))
 
     ! Second step, loop over all elements, compute compression mapping
-    ! loop over e elements
-    !  loop over m compression mapping size
-    !   loop over i ntot
-    !    sum into difference
-    !   if difference <= tol
-    !    c%compression_inds(e) = m
-    !    break
-    !  mapping_size = mapping_size + 1
-    !  c%compression_inds(e) = mapping_size
+    ! First entry must be itself to get started
+    m_max = 1
+    c%compression_inds(1) = 1
+
+    ! Loop over elements
+    ntot = c%dof%size()
+    do e = 1, c%msh%nelv
+       ! Loop over possible compression candidates
+       do m = 1, m_max
+          diff = 0.0_rp
+          ! Loop over quadrature points
+          do i = 1, ntot
+             ! diff += abs( \| G(i,:,:,e) - G(i,:,:,m) \|_fro )
+             diff = diff +     abs(G11(i,1,1,e) - G11(i,1,1,m))
+                         + 2.0*abs(G12(i,1,1,e) - G12(i,1,1,m))
+                         + 2.0*abs(G13(i,1,1,e) - G13(i,1,1,m))
+                         +     abs(G22(i,1,1,e) - G22(i,1,1,m))
+                         + 2.0*abs(G23(i,1,1,e) - G23(i,1,1,m))
+                         +     abs(G33(i,1,1,e) - G33(i,1,1,m))
+          end do
+
+          ! match is found
+          if ( diff <= ctol ) then
+             c%compression_inds(e) = m
+             exit
+          end if
+       end do
+
+       ! never found a match
+       if ( diff > ctol ) then
+          m_max = m_max + 1
+          c%compression_inds(e) = m_max
+       end if
+    end do
 
     ! Third step, allocate and fill Gij_compressed objects
-    ! loop over e elements
-    !  loop over i ntot
-    !   G11_compressed(i,1,1,e) = G11(i,1,1,c%compression_inds(e))
+    allocate(c%G11_compressed(this%Xh%lx, this%Xh%ly, this%Xh%lz, m_max))
+    allocate(c%G22_compressed(this%Xh%lx, this%Xh%ly, this%Xh%lz, m_max))
+    allocate(c%G33_compressed(this%Xh%lx, this%Xh%ly, this%Xh%lz, m_max))
+    allocate(c%G12_compressed(this%Xh%lx, this%Xh%ly, this%Xh%lz, m_max))
+    allocate(c%G13_compressed(this%Xh%lx, this%Xh%ly, this%Xh%lz, m_max))
+    allocate(c%G23_compressed(this%Xh%lx, this%Xh%ly, this%Xh%lz, m_max))
+    do e = 1, c%msh%nelv
+       do i = 1, ntot
+          c%G11_compressed(i,1,1,e) = c%G11(i,1,1,c%compression_inds(e))
+          c%G22_compressed(i,1,1,e) = c%G22(i,1,1,c%compression_inds(e))
+          c%G33_compressed(i,1,1,e) = c%G33(i,1,1,c%compression_inds(e))
+          c%G12_compressed(i,1,1,e) = c%G12(i,1,1,c%compression_inds(e))
+          c%G13_compressed(i,1,1,e) = c%G13(i,1,1,c%compression_inds(e))
+          c%G23_compressed(i,1,1,e) = c%G23(i,1,1,c%compression_inds(e))
+       end do
+    end do
 
   end subroutine coef_generate_geo_compressed
 

--- a/src/sem/coef.f90
+++ b/src/sem/coef.f90
@@ -1163,12 +1163,12 @@ contains
           ! Loop over quadrature points
           do i = 1, ntot
              ! diff += abs( \| G(i,:,:,e) - G(i,:,:,reverse(m)) \|_fro )
-             diff = diff +     abs(c%G11(i,1,1,e) - c%G11(i,1,1,c_inds_rev(m))) &
+             diff = diff + abs(c%G11(i,1,1,e) - c%G11(i,1,1,c_inds_rev(m))) &
                          + 2.0*abs(c%G12(i,1,1,e) - c%G12(i,1,1,c_inds_rev(m))) &
                          + 2.0*abs(c%G13(i,1,1,e) - c%G13(i,1,1,c_inds_rev(m))) &
-                         +     abs(c%G22(i,1,1,e) - c%G22(i,1,1,c_inds_rev(m))) &
+                         + abs(c%G22(i,1,1,e) - c%G22(i,1,1,c_inds_rev(m))) &
                          + 2.0*abs(c%G23(i,1,1,e) - c%G23(i,1,1,c_inds_rev(m))) &
-                         +     abs(c%G33(i,1,1,e) - c%G33(i,1,1,c_inds_rev(m)))
+                         + abs(c%G33(i,1,1,e) - c%G33(i,1,1,c_inds_rev(m)))
           end do
 
           ! match is found; mapping(e) is redundant

--- a/src/sem/coef.f90
+++ b/src/sem/coef.f90
@@ -476,6 +476,10 @@ contains
        deallocate(this%G11_compressed)
     end if
 
+    if (allocated(this%compression_inds)) then
+       deallocate(this%compression_inds)
+    end if
+
     if (allocated(this%G22_compressed)) then
        deallocate(this%G22_compressed)
     end if
@@ -1132,20 +1136,23 @@ contains
   end subroutine coef_generate_geo
 
   !> Compute processor-local compressed versions of mappings Gij
-  !! @note This could be faster if it ran on device (among other algorithmic modifications)
+  !! @note This could be faster with various tweaks
   subroutine coef_generate_geo_compressed(c)
     type(coef_t), intent(inout) :: c
     integer :: e, m, i, ntot, m_max
+    integer, allocatable :: c_inds_rev(:) ! reverse compression indices map
     real(kind=rp) :: ctol = 1.0E-7_rp
     real(kind=rp) :: diff = 0.0_rp
 
     ! First step, allocate full-size lookup structure for entire mesh
-    allocate(c%compression_inds(this%msh%nelv))
+    allocate(c%compression_inds(c%msh%nelv))
+    allocate(c_inds_rev(c%msh%nelv))
 
     ! Second step, loop over all elements, compute compression mapping
     ! First entry must be itself to get started
     m_max = 1
     c%compression_inds(1) = 1
+    c_inds_rev(1) = 1
 
     ! Loop over elements
     ntot = c%dof%size()
@@ -1155,16 +1162,16 @@ contains
           diff = 0.0_rp
           ! Loop over quadrature points
           do i = 1, ntot
-             ! diff += abs( \| G(i,:,:,e) - G(i,:,:,m) \|_fro )
-             diff = diff +     abs(G11(i,1,1,e) - G11(i,1,1,m))
-                         + 2.0*abs(G12(i,1,1,e) - G12(i,1,1,m))
-                         + 2.0*abs(G13(i,1,1,e) - G13(i,1,1,m))
-                         +     abs(G22(i,1,1,e) - G22(i,1,1,m))
-                         + 2.0*abs(G23(i,1,1,e) - G23(i,1,1,m))
-                         +     abs(G33(i,1,1,e) - G33(i,1,1,m))
+             ! diff += abs( \| G(i,:,:,e) - G(i,:,:,reverse(m)) \|_fro )
+             diff = diff +     abs(c%G11(i,1,1,e) - c%G11(i,1,1,c_inds_rev(m))) &
+                         + 2.0*abs(c%G12(i,1,1,e) - c%G12(i,1,1,c_inds_rev(m))) &
+                         + 2.0*abs(c%G13(i,1,1,e) - c%G13(i,1,1,c_inds_rev(m))) &
+                         +     abs(c%G22(i,1,1,e) - c%G22(i,1,1,c_inds_rev(m))) &
+                         + 2.0*abs(c%G23(i,1,1,e) - c%G23(i,1,1,c_inds_rev(m))) &
+                         +     abs(c%G33(i,1,1,e) - c%G33(i,1,1,c_inds_rev(m)))
           end do
 
-          ! match is found
+          ! match is found; mapping(e) is redundant
           if ( diff <= ctol ) then
              c%compression_inds(e) = m
              exit
@@ -1175,26 +1182,29 @@ contains
        if ( diff > ctol ) then
           m_max = m_max + 1
           c%compression_inds(e) = m_max
+          c_inds_rev(m_max) = e
        end if
     end do
 
     ! Third step, allocate and fill Gij_compressed objects
-    allocate(c%G11_compressed(this%Xh%lx, this%Xh%ly, this%Xh%lz, m_max))
-    allocate(c%G22_compressed(this%Xh%lx, this%Xh%ly, this%Xh%lz, m_max))
-    allocate(c%G33_compressed(this%Xh%lx, this%Xh%ly, this%Xh%lz, m_max))
-    allocate(c%G12_compressed(this%Xh%lx, this%Xh%ly, this%Xh%lz, m_max))
-    allocate(c%G13_compressed(this%Xh%lx, this%Xh%ly, this%Xh%lz, m_max))
-    allocate(c%G23_compressed(this%Xh%lx, this%Xh%ly, this%Xh%lz, m_max))
-    do e = 1, c%msh%nelv
+    allocate(c%G11_compressed(c%Xh%lx, c%Xh%ly, c%Xh%lz, m_max))
+    allocate(c%G22_compressed(c%Xh%lx, c%Xh%ly, c%Xh%lz, m_max))
+    allocate(c%G33_compressed(c%Xh%lx, c%Xh%ly, c%Xh%lz, m_max))
+    allocate(c%G12_compressed(c%Xh%lx, c%Xh%ly, c%Xh%lz, m_max))
+    allocate(c%G13_compressed(c%Xh%lx, c%Xh%ly, c%Xh%lz, m_max))
+    allocate(c%G23_compressed(c%Xh%lx, c%Xh%ly, c%Xh%lz, m_max))
+    do m = 1, m_max
        do i = 1, ntot
-          c%G11_compressed(i,1,1,e) = c%G11(i,1,1,c%compression_inds(e))
-          c%G22_compressed(i,1,1,e) = c%G22(i,1,1,c%compression_inds(e))
-          c%G33_compressed(i,1,1,e) = c%G33(i,1,1,c%compression_inds(e))
-          c%G12_compressed(i,1,1,e) = c%G12(i,1,1,c%compression_inds(e))
-          c%G13_compressed(i,1,1,e) = c%G13(i,1,1,c%compression_inds(e))
-          c%G23_compressed(i,1,1,e) = c%G23(i,1,1,c%compression_inds(e))
+          c%G11_compressed(i,1,1,m) = c%G11(i,1,1,c_inds_rev(m))
+          c%G22_compressed(i,1,1,m) = c%G22(i,1,1,c_inds_rev(m))
+          c%G33_compressed(i,1,1,m) = c%G33(i,1,1,c_inds_rev(m))
+          c%G12_compressed(i,1,1,m) = c%G12(i,1,1,c_inds_rev(m))
+          c%G13_compressed(i,1,1,m) = c%G13(i,1,1,c_inds_rev(m))
+          c%G23_compressed(i,1,1,m) = c%G23(i,1,1,c_inds_rev(m))
        end do
     end do
+
+    deallocate(c_inds_rev)
 
   end subroutine coef_generate_geo_compressed
 

--- a/src/sem/coef.f90
+++ b/src/sem/coef.f90
@@ -87,7 +87,7 @@ module coefs
      !> Compressed geometric factors \f$ G_{23} \f$
      real(kind=rp), allocatable :: G23_compressed(:,:,:,:)
      !> Compressed geometric factors lookup indices
-     real(kind=rp), allocatable :: compression_inds(:)
+     integer, allocatable :: compression_inds(:)
 
      real(kind=rp), allocatable :: mult(:,:,:,:) !< Multiplicity
      !> generate mapping data between element and reference element
@@ -1139,7 +1139,7 @@ contains
   !! @note This could be faster with various tweaks
   subroutine coef_generate_geo_compressed(c)
     type(coef_t), intent(inout) :: c
-    integer :: e, m, i, ntot, m_max
+    integer :: e, m, i, lxyz, m_max
     integer, allocatable :: c_inds_rev(:) ! reverse compression indices map
     real(kind=rp) :: ctol = 1.0E-7_rp
     real(kind=rp) :: diff = 0.0_rp
@@ -1152,17 +1152,18 @@ contains
     ! First entry must be itself to get started
     m_max = 1
     c%compression_inds(1) = 1
+    c_inds_rev = 0
     c_inds_rev(1) = 1
 
-    ! Loop over elements
-    ntot = c%dof%size()
-    do e = 1, c%msh%nelv
+    ! Loop over elements, but skip first
+    lxyz = c%Xh%lx * c%Xh%ly * c%Xh%lz
+    do e = 2, c%msh%nelv
        ! Loop over possible compression candidates
        do m = 1, m_max
           diff = 0.0_rp
           ! Loop over quadrature points
-          do i = 1, ntot
-             ! diff += abs( \| G(i,:,:,e) - G(i,:,:,reverse(m)) \|_fro )
+          do i = 1, lxyz
+             ! diff += abs( \| G(i,:,:,e) - G(i,:,:,reverse(m)) \|_l1 )
              diff = diff + abs(c%G11(i,1,1,e) - c%G11(i,1,1,c_inds_rev(m))) &
                          + 2.0*abs(c%G12(i,1,1,e) - c%G12(i,1,1,c_inds_rev(m))) &
                          + 2.0*abs(c%G13(i,1,1,e) - c%G13(i,1,1,c_inds_rev(m))) &
@@ -1186,6 +1187,10 @@ contains
        end if
     end do
 
+    write(*,*)
+    write(*,*) '------Mapping Compression-----'
+    write(*,*) 'Compressed from ', c%msh%nelv, ' to ', m_max
+
     ! Third step, allocate and fill Gij_compressed objects
     allocate(c%G11_compressed(c%Xh%lx, c%Xh%ly, c%Xh%lz, m_max))
     allocate(c%G22_compressed(c%Xh%lx, c%Xh%ly, c%Xh%lz, m_max))
@@ -1194,7 +1199,7 @@ contains
     allocate(c%G13_compressed(c%Xh%lx, c%Xh%ly, c%Xh%lz, m_max))
     allocate(c%G23_compressed(c%Xh%lx, c%Xh%ly, c%Xh%lz, m_max))
     do m = 1, m_max
-       do i = 1, ntot
+       do i = 1, lxyz
           c%G11_compressed(i,1,1,m) = c%G11(i,1,1,c_inds_rev(m))
           c%G22_compressed(i,1,1,m) = c%G22(i,1,1,c_inds_rev(m))
           c%G33_compressed(i,1,1,m) = c%G33(i,1,1,c_inds_rev(m))


### PR DESCRIPTION
This is not a final polished product, but this is a feature which is at the perfect stage for discussion. This PR implements an idea that I've put in a few software packages to great success (and tried to publish with great failure).

The main idea is as follows: the 4-dimensional SEM mapping tensors G11, G22, etc. (hereafter collectively Gij) store a lot of redundant information for certain classes of meshes. For example, on a perfectly structured mesh, the Gij array slices are identical along the slowest striding index e. Extruded meshes and many other meshes will also have some repeated structure where this would benefit. On very large meshes, these accesses into the full Gij arrays results in heavy memory paging and cache misses, producing significant memory overhead.

If you want an idea of how much this overhead costs in real simulations, take the poisson example and replace `G11(i,1,1,e)` with `G11(i,1,1,1)` and run it on a really large mesh. I see a **14% speedup** on a CPU-only run using the poisson example. Poisson example, tgv_16M.nmsh, 100 iterations, N=2, Neko v1.99.3 (only one run, so some noise is expected :) )
```
Tot MFlops =   4.6755E+02, MFlops      =   4.6755E+02
Setup Flop =   5.2345E+11, Solver Flop =   2.0334E+11
Start res  =   9.4389E+03, Final res   =   5.1621E+04
Solve Time =   0.1554E+04
```
Results with mappings "compressed" (all mapping data of the form G11(i,1,1,e) replaced with G11(i,1,1,1))
```
Tot MFlops =   5.4573E+02, MFlops      =   5.4573E+02
Setup Flop =   5.2345E+11, Solver Flop =   2.0334E+11
Start res  =   9.4389E+03, Final res   =   5.1621E+04
Solve Time =   0.1332E+04
```

How does this work? At the beginning of a simulation (before the main time-stepping loop), this computes a one-time "compression" of the Gij arrays, by identifying elements of the same shape. It then forms two objects:
1. Gij_compressed, which is the same as its corresponding Gij tensor, but all redundancies in the e dimension are removed
2. compression_inds, which is the random access lookup into Gij_compressed
In theory, you could throw away the original Gij arrays after this point if you want to free up application memory. This doesn't have any device syncing or backend kernels implemented, but I imagine a full feature would support that as well.

To use these in practice, the operator assembly loop is nearly identical, but instead of `c%G11(i,1,1,e)`, you use `c%G11_compressed(i,1,1,c%compression_inds(e))`. If you use `G11 => c%G11_compressed`, then it's even closer semantically. There's probably a smart Fortran-friendly way to do this in a way that's semantically the same without sacrificing performance, but I'm not a Fortran expert.

I'm tagging a few people blindly for feedback, ideas, etc., feel free to also tag others who are interested.