### PR TITLE
Import allreduce in timestep controller

### DIFF
--- a/src/common/time_step_controller.f90
+++ b/src/common/time_step_controller.f90
@@ -38,7 +38,7 @@ module time_step_controller
   use json_utils, only : json_get_or_default, json_get_or_lookup_or_default
   use time_state, only : time_state_t
   use comm, only : pe_size, global_pe_size, NEKO_GLOBAL_COMM, MPI_REAL_PRECISION
-  use mpi_f08, only : MPI_MIN, MPI_IN_PLACE
+  use mpi_f08, only : MPI_MIN, MPI_IN_PLACE, MPI_Allreduce
   implicit none
   private
 


### PR DESCRIPTION
Added MPI_Allreduce at the import stage. Interestingly, it compiled everywhere, but whichever implementation was being picked up, ended up giving wrong results in LUMI.