### PR TITLE
Fix json in docs and simcomp names in the factory

### DIFF
--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -128,17 +128,19 @@ represented as a subobject inside the `constants` object and should containt two
 entries: `name` and `value`. Here is an example:
 
 ```json
-"constants":
-[
-  {
-    "name": "const1",
-    "value": 3.5
-  },
-  {
-    "name": "vector1",
-    "value": [1, 0, 1]
-  }
-]
+{
+  "constants":
+  [
+    {
+      "name": "const1",
+      "value": 3.5
+    },
+    {
+      "name": "vector1",
+      "value": [1, 0, 1]
+    }
+  ]
+}
 ```
 
 Other parameters in the case file that require a scalar or array entry, can
@@ -150,20 +152,22 @@ a simulation with both [fluid](@ref case-file_fluid) and [scalar](@ref
 case-file_scalar) solvers active, the following could be used.
 
 ```json
-"constants":
-[
+{
+  "constants":
+  [
+    {
+      "name": "common_output_value",
+      "value": 10
+    }
+  ],
+  "fluid":
   {
-    "name": "common_output_value",
-    "value": 10
+    "output_value": "common_output_value"
+  },
+  "scalar":
+  {
+    "output_value": "common_output_value"
   }
-],
-"fluid":
-{
-  "output_value": "common_output_value"
-},
-"scalar":
-{
-  "output_value": "common_output_value"
 }
 ```
 The advantage is that this guarantees that the fluid and scalar output will be
@@ -1112,16 +1116,18 @@ The reference velocity field, or `baseflow` can be set from three methods:
    <details>
    <summary><b><u>Example code snippet</u></b></summary>
    ```json
-   "source_terms": [
-      {
-         "type": "sponge",
-         "amplitudes": [1.0, 1.0, 1.0],
-         "baseflow": {
-             "method": "constant",
-             "value": [2.0, 0.0, 0.0]
+   {
+      "source_terms": [
+         {
+            "type": "sponge",
+            "amplitudes": [1.0, 1.0, 1.0],
+            "baseflow": {
+                "method": "constant",
+                "value": [2.0, 0.0, 0.0]
+            }
          }
-      }
-   ]
+      ]
+   }
    ```
    </details>
 
@@ -1132,18 +1138,20 @@ The reference velocity field, or `baseflow` can be set from three methods:
    <details>
    <summary><b><u>Example code snippet</u></b></summary>
    ```json
-   "source_terms": [
-      {
-         "type": "sponge",
-         "amplitudes": [1.0, 1.0, 1.0],
-         "baseflow": {
-             "method": "field",
-             "file_name": "my_field0.f00016",
-             "mesh_file_name": "my_field0.f00000",
-             "interpolate": true
+   {
+      "source_terms": [
+         {
+            "type": "sponge",
+            "amplitudes": [1.0, 1.0, 1.0],
+            "baseflow": {
+                "method": "field",
+                "file_name": "my_field0.f00016",
+                "mesh_file_name": "my_field0.f00000",
+                "interpolate": true
+            }
          }
-      }
-   ]
+      ]
+   }
    ```
    </details>
 
@@ -1155,15 +1163,17 @@ The reference velocity field, or `baseflow` can be set from three methods:
    <details>
    <summary><b><u>Example code snippet</u></b></summary>
    ```json
-   "source_terms": [
-      {
-         "type": "sponge",
-         "amplitudes": [1.0, 1.0, 1.0],
-         "baseflow": {
-             "method": "user"
+   {
+      "source_terms": [
+         {
+            "type": "sponge",
+            "amplitudes": [1.0, 1.0, 1.0],
+            "baseflow": {
+                "method": "user"
+            }
          }
-      }
-   ]
+      ]
+   }
    ```
    </details>
 
@@ -1842,11 +1852,13 @@ If the eddy diffusivity field is associated to the eddy viscosity field by a coe
 And the corresponding setting could be done by the following:
 
 ```json
-"alphat":{
+{
+  "alphat": {
     "nut_dependency": true,
     "nut_field": "nut",
     "Pr_t": 0.7
-},
+  }
+}
 ```
 
 Otherwise one could have some SGS models providing an eddy diffusivity field, and the
@@ -1854,10 +1866,12 @@ user could set it up by the following manner to include an eddy diffusivity fiel
 `temperature_alphat`:
 
 ```json
-"alphat":{
+{
+  "alphat": {
     "nut_dependency": false,
     "alphat_field": "temperature_alphat"
-},
+  }
+}
 ```
 
 ### Boundary conditions

--- a/doc/pages/user-guide/simcomps.md
+++ b/doc/pages/user-guide/simcomps.md
@@ -134,8 +134,8 @@ the curl.  By default, registers the result in `curl_x`, `curl_y` and `curl_z`.
 
  ~~~~~~~~~~~~~~~{.json}
  {
-   "type": "curl"
-   "name": "curl"
+   "type": "curl",
+   "name": "curl",
    "fields": ["u", "v", "w"],
    "computed_field": "vorticity"
  }
@@ -147,14 +147,14 @@ the divergence.  By default, registers the result in `div`.
 
  ~~~~~~~~~~~~~~~{.json}
  {
-   "type": "divergence"
-   "name": "divergence"
+   "type": "divergence",
+   "name": "divergence",
    "fields": ["u", "v", "w"],
    "computed_field": "continuity"
  }
  ~~~~~~~~~~~~~~~
 
-### gradient {#simcomp_gradient}
+### grad {#simcomp_gradient}
 Computes the gradient of a field.
 The field to derivate is controlled by the `field` keyword. The simcomp will, by
 default, register the computed components of the gradients in the registry as
@@ -163,8 +163,8 @@ value in the brackets corresponds to the choice of the user keyword.
 
  ~~~~~~~~~~~~~~~{.json}
  {
-   "type": "gradient"
-   "name": "gradient"
+   "type": "gradient",
+   "name": "gradient",
    "field": "u",
  }
  ~~~~~~~~~~~~~~~
@@ -180,8 +180,8 @@ value in the brackets corresponds to the choice of the user keyword.
 
  ~~~~~~~~~~~~~~~{.json}
  {
-   "type": "weak_gradient"
-   "name": "weak_gradient"
+   "type": "weak_gradient",
+   "name": "weak_gradient",
    "field": "u",
  }
  ~~~~~~~~~~~~~~~
@@ -195,7 +195,7 @@ the `"output_filename"` parameter.
 
  ~~~~~~~~~~~~~~~{.json}
  {
-   "type": "lambda2"
+   "type": "lambda2",
    "name": "lambda2"
  }
  ~~~~~~~~~~~~~~~
@@ -500,8 +500,8 @@ Subroutines used in the simcomp can be found in src/qoi/drag_torque.f90
    "center_type": "fixed",
    "center": [0.0, 0.0, 0.0],
    "zone_name": "some chosen name, optional",
-   "scale": 1.0
-   "long_print" : false
+   "scale": 1.0,
+   "long_print" : false,
    "compute_control" : "tsteps",
    "compute_value" : 10
  }
@@ -594,8 +594,8 @@ keywords:
 
  ~~~~~~~~~~~~~~~{.json}
  {
-   "type": "les_model"
-   "name": "les_model"
+   "type": "les_model",
+   "name": "les_model",
    "model": "smagorinsky",
    "delta_type": "pointwise",
    "output_control" : "never"
@@ -607,7 +607,7 @@ keywords:
  (one could also use "nonBoyd" as the option):
  ~~~~~~~~~~~~~~~{.json}
  {
-   "type": "les_model"
+   "type": "les_model",
    "model": "dynamic_smagorinsky",
    "test_filter": {
       "filter": {
@@ -670,7 +670,7 @@ in 3 additional fields appended to the field files.
 
 ~~~~~~~~~~~~~~~{.json}
  {
-   "type": "spectral_error"
+   "type": "spectral_error",
    "name": "spectral_error"
  }
  ~~~~~~~~~~~~~~~

--- a/doc/pages/user-guide/user-file.md
+++ b/doc/pages/user-guide/user-file.md
@@ -294,14 +294,15 @@ Enabling user defined initial conditions for the fluid and/or scalar is done by
 setting the `initial_condition.type` to `"user"` in the relevant sections of the
 case file, `case.fluid` and/or `case.scalar`.
 
-```.json
-
-"case": {
+```json
+{
+  "case": {
     "fluid": {
-        "initial_condition": {
-            "type": "user"
-        }
+      "initial_condition": {
+        "type": "user"
+      }
     }
+  }
 }
 ```
 
@@ -369,17 +370,18 @@ Enabling user defined source terms for the fluid and/or scalar is done by adding
 JSON Objects to the `case.fluid.source_terms` and/or `case.scalar.source_terms`
 lists.
 
-```.json
-
-"case": {
+```json
+{
+  "case": {
     "fluid": {
-        "source_terms":
-        [
-            {
-                "type": "user"
-            }
-        ]
+      "source_terms":
+      [
+        {
+          "type": "user"
+        }
+      ]
     }
+  }
 }
 ```
 

--- a/src/simulation_components/gradient_simcomp.f90
+++ b/src/simulation_components/gradient_simcomp.f90
@@ -106,7 +106,6 @@ contains
     fields(1) = computed_field // "_x"
     fields(2) = computed_field // "_y"
     fields(3) = computed_field // "_z"
-    write(*,*) fields(1), fields(2), fields(3)
 
     call json%add("fields", fields)
 

--- a/src/simulation_components/simulation_component_fctry.f90
+++ b/src/simulation_components/simulation_component_fctry.f90
@@ -69,11 +69,11 @@ submodule (simulation_component) simulation_component_fctry
        "fluid_sgs_stats", &
        "scalar_stats", &
        "scalar_sgs_stats", &
-       "grad", &
-       "div", &
+       "gradient", &
+       "divergence", &
        "curl", &
        "derivative", &
-       "weak_grad", &
+       "weak_gradient", &
        "force_torque", &
        "user_stats", &
        "spectral_error", &


### PR DESCRIPTION
Aligns the names of several simcomps with what is documented (divergence, gradient, weak_gradient). Fixes some formatting and missing commas in JSON snippets in the docs.