### PR TITLE
Setup_normals_vector_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Develop
 
+- Changed the normal vectors argument type in `setup_normals` to `vector_t` and added copy to device in the routine.
 - Job control time limits can now be specified by a flexible string format, e.g.
   "30:00" for 30 minutes, "1-00:00:00" for 24 hours, "3600" for 3600 seconds,
   etc.  

--- a/src/.depends
+++ b/src/.depends
@@ -34,7 +34,7 @@ data_types/host_array.lo : data_types/host_array.f90 math/math.lo config/num_typ
 data_types/device_array.lo : data_types/device_array.f90 common/utils.lo math/bcknd/device/device_math.lo device/device.lo config/neko_config.lo config/num_types.lo 
 math/mxm_wrapper.lo : math/mxm_wrapper.F90 common/utils.lo config/num_types.lo 
 sem/speclib.lo : sem/speclib.f90 common/utils.lo math/math.lo config/num_types.lo 
-qoi/drag_torque.lo : qoi/drag_torque.f90 comm/comm.lo math/bcknd/device/device_math.lo config/neko_config.lo common/utils.lo config/num_types.lo sem/space.lo math/math.lo mesh/facet_zone.lo sem/coef.lo field/field.lo 
+qoi/drag_torque.lo : qoi/drag_torque.f90 comm/comm.lo math/bcknd/device/device_math.lo device/device.lo config/neko_config.lo common/utils.lo config/num_types.lo sem/space.lo math/math.lo mesh/facet_zone.lo math/vector.lo sem/coef.lo field/field.lo 
 sem/local_interpolation.lo : sem/local_interpolation.f90 config/neko_config.lo math/bcknd/device/device_math.lo device/device.lo field/field_list.lo field/field.lo common/utils.lo math/fast3d.lo math/math.lo mesh/point.lo config/num_types.lo sem/space.lo math/tensor.lo 
 math/math.lo : math/math.f90 common/utils.lo comm/comm.lo config/num_types.lo 
 math/mathops.lo : math/mathops.f90 config/num_types.lo 

--- a/src/qoi/drag_torque.f90
+++ b/src/qoi/drag_torque.f90
@@ -62,6 +62,7 @@
 module drag_torque
   use field, only : field_t
   use coefs, only : coef_t
+  use vector, only : vector_t
   use facet_zone, only : facet_zone_t
   use math, only : rzero, col3, vdot3, col2
   use space, only : space_t
@@ -69,6 +70,7 @@ module drag_torque
   use utils, only : nonlinear_index
   use iso_c_binding, only : c_ptr
   use neko_config, only : NEKO_BCKND_DEVICE
+  use device, only : HOST_TO_DEVICE
   use device_math, only : device_cmult, device_col2, &
        device_col3, device_vdot3, device_rzero
   use comm, only : NEKO_COMM, MPI_REAL_PRECISION
@@ -79,8 +81,8 @@ module drag_torque
   !> Some functions to calculate the lift/drag and torque
   !! Calculation can be done on a zone, a facet, or a point
   !! Currently everything is CPU only
-  public :: drag_torque_zone, drag_torque_facet, drag_torque_pt, setup_normals,&
-       calc_force_array, device_calc_force_array
+  public :: drag_torque_zone, drag_torque_facet, drag_torque_pt, &
+       setup_normals, calc_force_array, device_calc_force_array
 
 contains
   !> Calculate drag and torque over a zone.
@@ -467,7 +469,7 @@ contains
   subroutine setup_normals(coef, mask, facets, n1, n2, n3, n_pts)
     type(coef_t) :: coef
     integer :: n_pts
-    real(kind=rp), dimension(n_pts) :: n1, n2, n3
+    type(vector_t), intent(inout) :: n1, n2, n3
     integer :: mask(0:n_pts), facets(0:n_pts), fid, idx(4)
     real(kind=rp) :: normal(3), area(3)
     integer :: i
@@ -477,10 +479,16 @@ contains
        idx = nonlinear_index(mask(i), coef%Xh%lx, coef%Xh%lx, coef%Xh%lx)
        normal = coef%get_normal(idx(1), idx(2), idx(3), idx(4), fid)
        area = coef%get_area(idx(1), idx(2), idx(3), idx(4), fid)
-       n1(i) = normal(1)*area(1)
-       n2(i) = normal(2)*area(2)
-       n3(i) = normal(3)*area(3)
+       n1%x(i) = normal(1)*area(1)
+       n2%x(i) = normal(2)*area(2)
+       n3%x(i) = normal(3)*area(3)
     end do
+
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call n1%copy_from(HOST_TO_DEVICE, .false.)
+       call n2%copy_from(HOST_TO_DEVICE, .false.)
+       call n3%copy_from(HOST_TO_DEVICE, .true.)
+    end if
   end subroutine setup_normals
 
 end module drag_torque

--- a/src/simulation_components/boundary_flux.f90
+++ b/src/simulation_components/boundary_flux.f90
@@ -209,18 +209,10 @@ contains
        call this%surface_v%init(n_pts)
        call this%surface_w%init(n_pts)
        call setup_normals(this%coef, this%bc%msk, this%bc%facet, &
-            this%n1%x, this%n2%x, this%n3%x, n_pts)
+            this%n1, this%n2, this%n3, n_pts)
        call vector_cmult(this%n1, -1.0_rp, n_pts)
        call vector_cmult(this%n2, -1.0_rp, n_pts)
        call vector_cmult(this%n3, -1.0_rp, n_pts)
-       if (NEKO_BCKND_DEVICE .eq. 1) then
-          call device_memcpy(this%n1%x, this%n1%x_d, n_pts, &
-               HOST_TO_DEVICE, .false.)
-          call device_memcpy(this%n2%x, this%n2%x_d, n_pts, &
-               HOST_TO_DEVICE, .false.)
-          call device_memcpy(this%n3%x, this%n3%x_d, n_pts, &
-               HOST_TO_DEVICE, .true.)
-       end if
     end if
 
     if (present(output_filename)) then

--- a/src/simulation_components/force_torque.f90
+++ b/src/simulation_components/force_torque.f90
@@ -346,7 +346,7 @@ contains
     end if
 
     call setup_normals(this%coef, this%bc%msk, this%bc%facet, &
-         this%n1%x, this%n2%x, this%n3%x, n_pts)
+         this%n1, this%n2, this%n3, n_pts)
     call masked_gather_copy_0(this%r1%x, this%coef%dof%x, this%bc%msk, &
          this%u%size(), n_pts)
     call masked_gather_copy_0(this%r2%x, this%coef%dof%y, this%bc%msk, &
@@ -399,12 +399,6 @@ contains
     call cadd(this%r2%x, -this%center(2), n_pts)
     call cadd(this%r3%x, -this%center(3), n_pts)
     if (NEKO_BCKND_DEVICE .eq. 1 .and. n_pts .gt. 0) then
-       call device_memcpy(this%n1%x, this%n1%x_d, n_pts, HOST_TO_DEVICE, &
-            .false.)
-       call device_memcpy(this%n2%x, this%n2%x_d, n_pts, HOST_TO_DEVICE, &
-            .false.)
-       call device_memcpy(this%n3%x, this%n3%x_d, n_pts, HOST_TO_DEVICE, &
-            .true.)
        call device_memcpy(this%r1%x, this%r1%x_d, n_pts, HOST_TO_DEVICE, &
             .false.)
        call device_memcpy(this%r2%x, this%r2%x_d, n_pts, HOST_TO_DEVICE, &
@@ -489,7 +483,7 @@ contains
     if (this%update_normals) then
 
        call setup_normals(this%coef, this%bc%msk, this%bc%facet, &
-            this%n1%x, this%n2%x, this%n3%x, n_pts)
+            this%n1, this%n2, this%n3, n_pts)
 
        call masked_gather_copy_0(this%r1%x, this%coef%dof%x, this%bc%msk, &
             this%u%size(), n_pts)
@@ -503,12 +497,6 @@ contains
        call cadd(this%r3%x, -this%center(3), n_pts)
 
        if (NEKO_BCKND_DEVICE .eq. 1 .and. n_pts .gt. 0) then
-          call device_memcpy(this%n1%x, this%n1%x_d, n_pts, &
-               HOST_TO_DEVICE, .false.)
-          call device_memcpy(this%n2%x, this%n2%x_d, n_pts, &
-               HOST_TO_DEVICE, .false.)
-          call device_memcpy(this%n3%x, this%n3%x_d, n_pts, &
-               HOST_TO_DEVICE, .true.)
           call device_memcpy(this%r1%x, this%r1%x_d, n_pts, &
                HOST_TO_DEVICE, .false.)
           call device_memcpy(this%r2%x, this%r2%x_d, n_pts, &


### PR DESCRIPTION
Changed the type of normal vectors inside `setup_normals` subroutine to `vector_t`. Also added the copy to device in the routine itself, so we don't need to do it seperatley.