### PR TITLE
Add Valgrind regression testing to CI

### DIFF
--- a/.github/workflows/check_valgrind.yml
+++ b/.github/workflows/check_valgrind.yml
@@ -53,7 +53,6 @@ jobs:
 
       - name: Run valgrind regression test
         id: run-valgrind
-        continue-on-error: true
         run: |
           bash tests/regression/valgrind/run_valgrind_check.sh
 

--- a/.github/workflows/check_valgrind.yml
+++ b/.github/workflows/check_valgrind.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get install -y openmpi-bin libopenmpi-dev \
             autoconf automake autotools-dev libopenblas-dev make git m4 \
             python3 valgrind
-          echo "os-version=$(lsb_release -ds | tr \" \" -)" >> $GITHUB_OUTPUT
+          echo "os-version=$(lsb_release -ds | tr " " -)" >> $GITHUB_OUTPUT
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/check_valgrind.yml
+++ b/.github/workflows/check_valgrind.yml
@@ -1,0 +1,68 @@
+name: Valgrind Regression
+
+on:
+  workflow_call:
+    inputs:
+      json-fortran-version:
+        description: "The version of the JSON-Fortran library to use."
+        type: string
+        required: false
+        default: "8.4.0"
+
+jobs:
+  Valgrind:
+    runs-on: ubuntu-24.04
+    name: Valgrind Regression (gfortran-14)
+    env:
+      FC: gfortran-14
+
+    steps:
+      - name: Setup env.
+        id: setup-env
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y openmpi-bin libopenmpi-dev \
+            autoconf automake autotools-dev libopenblas-dev make git m4 \
+            python3 valgrind
+          echo "os-version=$(lsb_release -ds | tr \" \" -)" >> $GITHUB_OUTPUT
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Get JSON-Fortran
+        id: get-json-fortran
+        uses: ./.github/actions/setup_json-fortran
+        with:
+          version: ${{ inputs.json-fortran-version }}
+          os: ${{ steps.setup-env.outputs.os-version }}
+          compiler: ${{ env.FC }}
+
+      - name: Build Neko
+        env:
+          JSON_FORTRAN_DIR: ${{ steps.get-json-fortran.outputs.install-dir }}
+        run: |
+          mkdir ${{ github.workspace }}/install
+          echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:$JSON_FORTRAN_DIR/lib/pkgconfig:${{ github.workspace }}/install/lib/pkgconfig" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$JSON_FORTRAN_DIR/lib:${{ github.workspace }}/install/lib" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/install/bin" >> $GITHUB_PATH
+          ./regen.sh
+          ./configure FC=${FC} FCFLAGS="-g -O2 -pedantic -std=f2008 -w" --enable-real=dp --prefix=${{ github.workspace }}/install
+          make -j$(nproc) install
+
+      - name: Run valgrind regression test
+        id: run-valgrind
+        continue-on-error: true
+        run: |
+          bash tests/regression/valgrind/run_valgrind_check.sh
+
+      - name: Save valgrind logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: valgrind-regression-logs
+          path: |
+            tests/regression/valgrind/logs/*.log
+          overwrite: true
+          # if-no-files-found: ignore

--- a/.github/workflows/check_valgrind.yml
+++ b/.github/workflows/check_valgrind.yml
@@ -62,6 +62,6 @@ jobs:
         with:
           name: valgrind-regression-logs
           path: |
-            tests/regression/valgrind/logs/*.log
+            tests/regression/valgrind/workdir/*.log
           overwrite: true
-          # if-no-files-found: ignore
+          if-no-files-found: error

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -172,9 +172,9 @@ jobs:
             success=false
           fi
 
-          # Valgrind is informative-only for now and does not gate PR readiness.
+          # Valgrind check is informational only.
           if [ "$valgrind_status" != "success" ]; then
-            echo "Optional check did not pass: Valgrind check: $valgrind_status"
+            fail+=("\t- Valgrind check: $valgrind_status (informational only)")
           fi
 
           # NVidia check is skipped since the compiler is broken.
@@ -183,11 +183,14 @@ jobs:
           #   success=false
           # fi
 
-          if [ "$success" = false ]; then
+          if [ ${#fail[@]} -ne 0 ]; then
             >&2 echo "The following checks failed:"
             for i in "${fail[@]}"; do
               >&2 printf "$i\n"
             done
+          fi
+
+          if [ "$success" = false ]; then
             exit 1
           fi
           echo "All checks passed"

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -11,7 +11,7 @@ on:
       - ready_for_review
   workflow_dispatch:
 
-#merge queue trigger
+  #merge queue trigger
   merge_group:
     types:
       - checks_requested
@@ -51,6 +51,9 @@ jobs:
           echo "flint-changed-minimum=$FLINT_CHANGED_FILES_MINIMUM" >> $GITHUB_OUTPUT
           echo "pfunit-version=$PFUNIT_VERSION" >> $GITHUB_OUTPUT
           echo "json-fortran-version=$JSON_FORTRAN_VERSION" >> $GITHUB_OUTPUT
+
+  # ========================================================================== #
+  # Style and linting checks
 
   linting:
     name: Linting
@@ -102,6 +105,18 @@ jobs:
       json-fortran-version: ${{ needs.prepare.outputs.json-fortran-version }}
 
   # ========================================================================== #
+  # Regression checks
+
+  Valgrind:
+    name: Valgrind
+    needs:
+      - prepare
+      - depend
+    uses: ./.github/workflows/check_valgrind.yml
+    with:
+      json-fortran-version: ${{ needs.prepare.outputs.json-fortran-version }}
+
+      # ========================================================================== #
   # Determine if the PR is ready
 
   check_complete:
@@ -114,6 +129,7 @@ jobs:
       - depend
       - GNU
       - Intel
+      - Valgrind
       - Nvidia
 
     runs-on: ubuntu-latest
@@ -123,6 +139,7 @@ jobs:
       format_status: ${{ needs.formatting.result }}
       gnu_status: ${{ needs.GNU.result }}
       intel_status: ${{ needs.Intel.result }}
+      valgrind_status: ${{ needs.Valgrind.result }}
       nvidia_status: ${{ needs.Nvidia.result }}
 
     steps:
@@ -153,6 +170,11 @@ jobs:
           if [ "$intel_status" != "success" ]; then
             fail+=("\t- Intel check: $intel_status")
             success=false
+          fi
+
+          # Valgrind is informative-only for now and does not gate PR readiness.
+          if [ "$valgrind_status" != "success" ]; then
+            echo "Optional check did not pass: Valgrind check: $valgrind_status"
           fi
 
           # NVidia check is skipped since the compiler is broken.

--- a/tests/regression/valgrind/run_valgrind_check.sh
+++ b/tests/regression/valgrind/run_valgrind_check.sh
@@ -139,7 +139,11 @@ max_indirect="${NEKO_VALGRIND_MAX_INDIRECT:-$default_indirect}"
 max_possible="${NEKO_VALGRIND_MAX_POSSIBLE:-$default_possible}"
 max_reachable="${NEKO_VALGRIND_MAX_REACHABLE:-$default_reachable}"
 
-echo "Valgrind limits for backend '$backend_type': definite=$max_definite indirect=$max_indirect possible=$max_possible reachable=$max_reachable"
+echo "Valgrind limits for backend '$backend_type'"
+echo "  definitely lost: $max_definite bytes"
+echo "  indirectly lost: $max_indirect bytes"
+echo "  possibly lost:   $max_possible bytes"
+echo "  still reachable: $max_reachable bytes"
 
 python3 ./check_valgrind.py \
     --log valgrind_regression.log \

--- a/tests/regression/valgrind/run_valgrind_check.sh
+++ b/tests/regression/valgrind/run_valgrind_check.sh
@@ -61,9 +61,10 @@ makeneko valgrind_tgv.f90 || {
 export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
 export OPENBLAS_NUM_THREADS="${OPENBLAS_NUM_THREADS:-1}"
 
-valgrind -s \
+valgrind \
     --leak-check=full \
     --show-leak-kinds=all \
+    --show-error-list=no \
     --undef-value-errors=no \
     --num-callers=20 \
     --suppressions=valgrind_runtime.supp \

--- a/tests/regression/valgrind/valgrind_runtime.supp
+++ b/tests/regression/valgrind/valgrind_runtime.supp
@@ -275,3 +275,62 @@
    fun:call_init*
    fun:_dl_init
 }
+
+{
+   jsonfortran_all_leaks
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect,possible,reachable
+   fun:malloc
+   ...
+   obj:*/libjsonfortran.so*
+   ...
+}
+
+{
+   jsonfortran_all_leaks_any_allocator
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect,possible,reachable
+   ...
+   obj:*/libjsonfortran.so*
+   ...
+}
+
+{
+   jsonfortran_value_errors
+   Memcheck:Value8
+   ...
+   obj:*/libjsonfortran.so*
+   ...
+}
+
+{
+   jsonfortran_value_errors_4
+   Memcheck:Value4
+   ...
+   obj:*/libjsonfortran.so*
+   ...
+}
+
+{
+   jsonfortran_conditional_warnings
+   Memcheck:Cond
+   ...
+   obj:*/libjsonfortran.so*
+   ...
+}
+
+{
+   jsonfortran_invalid_read_8
+   Memcheck:Addr8
+   ...
+   obj:*/libjsonfortran.so*
+   ...
+}
+
+{
+   jsonfortran_invalid_read_4
+   Memcheck:Addr4
+   ...
+   obj:*/libjsonfortran.so*
+   ...
+}


### PR DESCRIPTION
Introduce a new workflow for Valgrind regression testing, enhancing the CI process by integrating checks for memory leaks and errors. This addition includes setup steps for the environment, building the necessary components, and running the Valgrind tests. Logs are saved for any failures to aid in debugging.

It should be noted, the Valgrind check is currently not mandatory to pass. It is used for information for now.