### PR TITLE
Add environmental variable reference to documentation

### DIFF
--- a/doc/pages/index.md
+++ b/doc/pages/index.md
@@ -59,5 +59,6 @@ information that is not directly related to the usage of the code.
   - [Run-time selectable types](@ref rts_types) presents the standard
     programming pattern used to select object types at run time.
 - \subpage appendices
+  - [Environmental variable reference](@ref appendices_env-var)
   - [Governing Equations](@ref governing-equations) used in our solvers.
   - [Publications](@ref publications)


### PR DESCRIPTION
Include a reference to environmental variables in the appendices section of the documentation.