### PR TITLE
Use fixed random seed for phmg

### DIFF
--- a/src/krylov/bcknd/cpu/cheby.f90
+++ b/src/krylov/bcknd/cpu/cheby.f90
@@ -133,14 +133,26 @@ contains
     real(kind=rp) :: boost = 1.1_rp
     real(kind=rp) :: lam_factor = 30.0_rp
     real(kind=rp) :: wtw, dtw, dtd
-    integer :: i
+    integer, allocatable :: fixed_seed(:), saved_seed(:)
+    integer :: i, rnd_n
     associate(w => this%w, d => this%d, r => this%r)
 
+      ! Save current random seed and set a fixed seed
+      call random_seed( size=rnd_n )
+      allocate(saved_seed(rnd_n))
+      allocate(fixed_seed(rnd_n))
+      fixed_seed = 3901
+      call random_seed( get=saved_seed )
+      call random_seed( put=fixed_seed )
+
       do i = 1, n
-         !TODO: replace with a better way to initialize power method
          call random_number(rn)
          d(i) = rn + 10.0_rp
       end do
+
+      ! Restore saved random seed
+      call random_seed( put=saved_seed )
+
       call gs_h%op(d, n, GS_OP_ADD)
       call blst%apply(d, n)
 

--- a/src/krylov/bcknd/device/cheby_device.F90
+++ b/src/krylov/bcknd/device/cheby_device.F90
@@ -274,16 +274,27 @@ contains
     real(kind=rp) :: boost = 1.1_rp
     real(kind=rp) :: lam_factor = 30.0_rp
     real(kind=rp) :: wtw, dtw, dtd
-    integer :: i
+    integer, allocatable :: fixed_seed(:), saved_seed(:)
+    integer :: i, rnd_n
 
     associate(w => this%w, w_d => this%w_d, d => this%d, d_d => this%d_d)
 
+      ! Save current random seed and set a fixed seed
+      call random_seed( size=rnd_n )
+      allocate(saved_seed(rnd_n))
+      allocate(fixed_seed(rnd_n))
+      fixed_seed = 3901
+      call random_seed( get=saved_seed )
+      call random_seed( put=fixed_seed )
+
       do i = 1, n
-         !TODO: replace with a better way to initialize power method
          call random_number(rn)
          d(i) = rn + 10.0_rp
       end do
       call device_memcpy(d, d_d, n, HOST_TO_DEVICE, sync = .true.)
+
+      ! Restore saved random seed
+      call random_seed( put=saved_seed )
 
       call gs_h%op(d, n, GS_OP_ADD, this%gs_event)
       call blst%apply(d, n)

--- a/src/multigrid/tree_amg_aggregate.f90
+++ b/src/multigrid/tree_amg_aggregate.f90
@@ -119,10 +119,18 @@ contains
     integer, intent(inout) :: is_aggregated(:)
     integer, allocatable, intent(inout) :: aggregate_size(:)
     integer, allocatable :: as_tmp(:)
-    integer, allocatable :: rand_order(:)
+    integer, allocatable :: rand_order(:), fixed_seed(:), saved_seed(:)
     real(kind=dp) :: random_value, r
-    integer :: i, side, nhbr, j, tmp
+    integer :: i, side, nhbr, j, tmp, rnd_n
     logical :: no_nhbr_agg
+
+    ! Save current random seed and set a fixed seed
+    call random_seed( size=rnd_n )
+    allocate(saved_seed(rnd_n))
+    allocate(fixed_seed(rnd_n))
+    fixed_seed = 3901
+    call random_seed( get=saved_seed )
+    call random_seed( put=fixed_seed )
 
     ! Initialize a random permutation
     allocate( rand_order( n_elements ) )
@@ -138,10 +146,9 @@ contains
        rand_order(j) = tmp
     end do
 
-!-----!    do while (naggs .le. max_aggs)
-!-----!      call random_number(random_value)
-!-----!      i = floor(random_value * n_elements + 1)
-    !do i = 1, n_elements! THE NON-RANDOM VERSION...
+    ! Restore saved random seed
+    call random_seed( put=saved_seed )
+
     do tmp = 1, n_elements
        i = rand_order(tmp)
        if (is_aggregated(i) .eq. -1) then
@@ -602,10 +609,10 @@ contains
     integer, intent(inout), allocatable :: agg_nhbr(:, :)
     integer, allocatable :: is_aggregated(:)
     integer, allocatable :: aggregate_size(:)
-    integer, allocatable :: rand_order(:)
+    integer, allocatable :: rand_order(:), fixed_seed(:), saved_seed(:)
     integer :: n_elements, naggs, n_facet, offset_el
     integer :: i, j, l, ntot, n_agg_facet, gid_ptr, n_agg_nhbr
-    integer :: n_pairs, tmp
+    integer :: n_pairs, tmp, rnd_n
     integer :: side, nhbr, nhbr_id
     real(kind=rp) :: nhbr_msr, nhbr_tst, r
 
@@ -629,6 +636,14 @@ contains
     ! fill with large number
     aggregate_size = huge(i)
 
+    ! Save current random seed and set a fixed seed
+    call random_seed( size=rnd_n )
+    allocate(saved_seed(rnd_n))
+    allocate(fixed_seed(rnd_n))
+    fixed_seed = 3901
+    call random_seed( get=saved_seed )
+    call random_seed( put=fixed_seed )
+
     ! Initialize a random permutation
     allocate( rand_order( n_elements ) )
     do i = 1, n_elements
@@ -642,6 +657,9 @@ contains
        rand_order(i) = rand_order(j)
        rand_order(j) = tmp
     end do
+
+    ! Restore saved random seed
+    call random_seed( put=saved_seed )
 
     naggs = 0
     ! first pass of pair agg

--- a/src/multigrid/tree_amg_smoother.f90
+++ b/src/multigrid/tree_amg_smoother.f90
@@ -157,15 +157,27 @@ contains
     real(kind=rp), parameter :: boost = 1.1_rp
     real(kind=rp), parameter :: lam_factor = 30.0_rp
     real(kind=rp) :: wtw, dtw, dtd
-    integer :: i
+    integer, allocatable :: fixed_seed(:), saved_seed(:)
+    integer :: i, rnd_n
     associate(w => this%w, d => this%d, coef => amg%coef, gs_h => amg%gs_h, &
          msh => amg%msh, Xh => amg%Xh, blst => amg%blst)
 
+      ! Save current random seed and set a fixed seed
+      call random_seed( size=rnd_n )
+      allocate(saved_seed(rnd_n))
+      allocate(fixed_seed(rnd_n))
+      fixed_seed = 3901
+      call random_seed( get=saved_seed )
+      call random_seed( put=fixed_seed )
+
       do i = 1, n
-         !call random_number(rn)
-         !d(i) = rn + 10.0_rp
-         d(i) = sin(real(i))
+         call random_number(rn)
+         d(i) = rn + 10.0_rp
       end do
+
+      ! Restore saved random seed
+      call random_seed( put=saved_seed )
+
       if (this%lvl .eq. 0) then
          call gs_h%op(d, n, GS_OP_ADD)!TODO
          call blst%apply(d, n)
@@ -291,14 +303,28 @@ contains
     real(kind=rp), parameter :: boost = 1.1_rp
     real(kind=rp), parameter :: lam_factor = 30.0_rp
     real(kind=rp) :: wtw, dtw, dtd
-    integer :: i
+    integer, allocatable :: fixed_seed(:), saved_seed(:)
+    integer :: i, rnd_n
     associate(w => this%w, d => this%d, coef => amg%coef, gs_h => amg%gs_h, &
          msh => amg%msh, Xh => amg%Xh, blst => amg%blst)
+
+      ! Save current random seed and set a fixed seed
+      call random_seed( size=rnd_n )
+      allocate(saved_seed(rnd_n))
+      allocate(fixed_seed(rnd_n))
+      fixed_seed = 3901
+      call random_seed( get=saved_seed )
+      call random_seed( put=fixed_seed )
+
       do i = 1, n
-         !TODO: replace with a better way to initialize power method
-         d(i) = sin(real(i))
+         call random_number(rn)
+         d(i) = rn + 10.0_rp
       end do
       call device_memcpy(this%d, this%d_d, n, HOST_TO_DEVICE, .true.)
+
+      ! Restore saved random seed
+      call random_seed( put=saved_seed )
+
       if (this%lvl .eq. 0) then
          call gs_h%op(d, n, GS_OP_ADD)!TODO
          call blst%apply(d, n)


### PR DESCRIPTION
Set functions used for phmg (tamg aggregation, Chebyshev's power method) to use a fixed random number seed.