### PR TITLE
Add native Tofu (uTofu) gather-scatter backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Develop
 
+- Added a native Tofu (uTofu) gather-scatter backend for Fugaku and other
+  Tofu-D systems (`NEKO_GS_COMM=UTOFU`, `--with-utofu`), using one-sided
+  RDMA puts with fused arrival signalling and thread-parallel injection;
+  tunable via the `NEKO_GS_UTOFU_*` environment variables.
+- Added a gather-scatter backend using MPI-3 neighbourhood collectives
+  (`NEKO_GS_COMM=NEIGHBOUR`), one `MPI_Ineighbor_alltoallv` per operation
+  instead of per-peer point-to-point messages.
+- Added a Coarray Fortran gather-scatter backend (`NEKO_GS_COMM=CAF`) using
+  one-sided coarray puts, with the signalling mechanism selectable at
+  runtime via `NEKO_GS_CAF_SIGNALING` (`sync`, `atomic`, or F2018 `event`).
+- Added an OpenSHMEM gather-scatter backend for CPU builds
+  (`NEKO_GS_COMM=SHMEM`, `--with-openshmem`) using put-with-signal, for
+  systems with a native OpenSHMEM such as Cray OpenSHMEMX.
+- Added a fused multi-component gather-scatter, `gs%op(u1, u2, u3, n, op)`,
+  exchanging three-component halos in one communication round instead of
+  three; used by curl, the fluid residuals, and the coupled Krylov solvers.
+- Changed the gather-scatter setup and the mesh's external point
+  connectivity to an owner-rendezvous scheme via a new crystal router,
+  enabling initialisation beyond ~100k MPI ranks.
+- Added OpenMP threading of the CPU backend's critical path (math and
+  solver kernels, Krylov solvers and preconditioners, boundary conditions,
+  dealiasing, and the host gather-scatter), making hybrid MPI+OpenMP a
+  supported execution mode on CPUs rather than accelerator-only.
 - Added HIP and CUDA support for ALE.
 - Added `spatial_average` simcomp for spatially averaging a list of registered
   fields.

--- a/configure.ac
+++ b/configure.ac
@@ -325,6 +325,9 @@ AX_RCCL
 # Checks for NVSHMEM backend
 AX_NVSHMEM
 
+# Checks for uTofu (native Tofu) gather-scatter backend
+AX_UTOFU
+
 # Checks for NVTX profiling
 AX_NVTX
 
@@ -359,6 +362,7 @@ AM_CONDITIONAL([ENABLE_OPENCL], [test "x${have_opencl}" = xyes])
 AM_CONDITIONAL([ENABLE_METAL], [test "x${have_metal}" = xyes])
 AM_CONDITIONAL([ENABLE_CONTRIB], [test "x${enable_contrib}" = xyes])
 AM_CONDITIONAL([ENABLE_NVSHMEM], [test "x${have_nvshmem}" = xyes])
+AM_CONDITIONAL([ENABLE_UTOFU], [test "x${have_utofu}" = xyes])
 AM_CONDITIONAL([ENABLE_HDF5], [test "x${have_hdf5}" = xyes])
 
 # Set device dependent flags

--- a/doc/man/neko.1
+++ b/doc/man/neko.1
@@ -125,6 +125,13 @@ Caps the number of injection VCQs created by the uTofu gather\-scatter
 backend (default: one per OpenMP thread). Useful when the hardware VCQ
 budget, which is shared with the per\-instance receive VCQs, is tight.
 .TP
+.B NEKO_GS_UTOFU_NRVCQ
+Number of receive VCQs per gather\-scatter instance path in the uTofu
+backend (default: one per TNI). Each receive peer is bound to one, so
+incoming halo traffic is spread over the TNIs;
+.B 1
+restores a single receive queue.
+.TP
 .B NEKO_GS_UTOFU_MASTER_INJECT
 When set to a non\-zero value, the uTofu gather\-scatter backend issues
 all puts from the master thread instead of thread\-parallel injection

--- a/doc/man/neko.1
+++ b/doc/man/neko.1
@@ -120,10 +120,21 @@ are dealt over.
 Defaults to
 .BR 1 .
 .TP
+.B NEKO_GS_UTOFU_NVCQ
+Caps the number of injection VCQs created by the uTofu gather\-scatter
+backend (default: one per OpenMP thread). Useful when the hardware VCQ
+budget, which is shared with the per\-instance receive VCQs, is tight.
+.TP
 .B NEKO_GS_UTOFU_MASTER_INJECT
 When set to a non\-zero value, the uTofu gather\-scatter backend issues
 all puts from the master thread instead of thread\-parallel injection
 (an A/B reference).
+.TP
+.B NEKO_GS_UTOFU_VEC
+When set to
+.BR 0 ,
+disables the uTofu backend's fused vector (multi\-component) exchange;
+multi\-component gather\-scatter falls back to independent scalar rounds.
 .TP
 .B NEKO_GLOBAL_INTERP_EL_FINDER
 Selects the element search algorithm used by the global interpolation

--- a/doc/man/neko.1
+++ b/doc/man/neko.1
@@ -112,6 +112,19 @@ on accelerator builds and host MPI otherwise.
 .B NEKO_GS_STRTGY
 Selects the gather\-scatter strategy.
 .TP
+.B NEKO_GS_UTOFU_NTNI
+Number of Tofu network interfaces (TNIs) that the per\-thread injection
+VCQs of the native Tofu (uTofu) gather\-scatter backend
+.RB ( NEKO_GS_COMM=UTOFU )
+are dealt over.
+Defaults to
+.BR 1 .
+.TP
+.B NEKO_GS_UTOFU_MASTER_INJECT
+When set to a non\-zero value, the uTofu gather\-scatter backend issues
+all puts from the master thread instead of thread\-parallel injection
+(an A/B reference).
+.TP
 .B NEKO_GLOBAL_INTERP_EL_FINDER
 Selects the element search algorithm used by the global interpolation
 routines.

--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -107,6 +107,11 @@ granted VCQ count do not inject).
   The VCQ budget (roughly 8 per TNI per rank on Fugaku) is shared with
   the per-instance receive VCQs, so on tight budgets the pool must
   leave room.
+- `NEKO_GS_UTOFU_NRVCQ=N`          : Receive VCQs per instance path
+  (default: one per TNI; `1` restores a single receive queue). Each
+  receive peer is bound to one of them, so an instance's incoming halo
+  traffic is processed by several TNIs instead of funnelling through
+  one.
 - `NEKO_GS_UTOFU_MASTER_INJECT=1`  : Serialise all injection onto the
   master thread (still spread over every VCQ), as an A/B reference for
   the thread-parallel default.
@@ -115,7 +120,8 @@ The per-instance receive VCQs are placed round-robin over *all*
 one-sided TNIs (not only the `NEKO_GS_UTOFU_NTNI` injection set),
 sweeping past TNIs whose VCQ budget is exhausted; incoming puts are
 routed by the advertised VCQ id, so this costs nothing and balances
-receive processing across the interfaces.
+receive processing across the interfaces. When the budget runs dry an
+instance is granted fewer receive VCQs (at least one).
 
 The startup log prints the granted counts, e.g.
 `uTofu inj.   : 12 VCQs (12 threads) over 4 TNIs (6 requested)`.

--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -103,9 +103,19 @@ granted VCQ count do not inject).
 - `NEKO_GS_UTOFU_NTNI=1` (default) : All injection VCQs sit on one TNI.
 - `NEKO_GS_UTOFU_NTNI=N`           : Deal the per-thread VCQs across `N`
   TNIs (benefits large messages and high neighbour counts).
+- `NEKO_GS_UTOFU_NVCQ=N`           : Cap the injection pool at `N` VCQs.
+  The VCQ budget (roughly 8 per TNI per rank on Fugaku) is shared with
+  the per-instance receive VCQs, so on tight budgets the pool must
+  leave room.
 - `NEKO_GS_UTOFU_MASTER_INJECT=1`  : Serialise all injection onto the
   master thread (still spread over every VCQ), as an A/B reference for
   the thread-parallel default.
+
+The per-instance receive VCQs are placed round-robin over *all*
+one-sided TNIs (not only the `NEKO_GS_UTOFU_NTNI` injection set),
+sweeping past TNIs whose VCQ budget is exhausted; incoming puts are
+routed by the advertised VCQ id, so this costs nothing and balances
+receive processing across the interfaces.
 
 The startup log prints the granted counts, e.g.
 `uTofu inj.   : 12 VCQs (12 threads) over 4 TNIs (6 requested)`.
@@ -117,3 +127,7 @@ be disabled for A/B testing:
 
 - `NEKO_GS_UTOFU_CACHE_INJECT=1` (default, or unset) : cache injection on.
 - `NEKO_GS_UTOFU_CACHE_INJECT=0`                     : cache injection off.
+
+The fused vector (multi-component) exchange can be disabled with
+`NEKO_GS_UTOFU_VEC=0`, in which case multi-component gather-scatter
+falls back to independent scalar rounds (a validation/bisection aid).

--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -49,6 +49,8 @@ A number of gather-scatter backends are supported.
 - `NEKO_GS_COMM=CAF`    : Coarray Fortran (requires a coarray-capable compiler)
 - `NEKO_GS_COMM=NEIGHBOUR` : Host MPI using an `MPI_Ineighbor_alltoallv`
   neighbourhood collective (`NEIGHBOR` is also accepted; MPI-3, host only)
+- `NEKO_GS_COMM=UTOFU`  : Native Tofu interconnect (uTofu) one-sided RDMA
+  (Fugaku and other Tofu-D systems; requires building with `--with-utofu`)
 
 ### MPI thread level details
 
@@ -81,3 +83,37 @@ default (when unset) is `sync`.
 - `NEKO_GS_CAF_SIGNALING=event`  : F2018 events (`event post` /
   `event wait`); requires a runtime that implements F2018 event
   semantics.
+
+### uTofu injection details
+
+When `NEKO_GS_COMM=UTOFU`, one injection virtual control queue (VCQ) is
+created per OpenMP thread, dealt round-robin over the Tofu network
+interfaces (TNIs) selected by `NEKO_GS_UTOFU_NTNI` (default `1`). Every
+VCQ is created with `UTOFU_VCQ_FLAG_THREAD_SAFE`, and both the packing
+of the send buffer and the `utofu_put` calls are parallelised over the
+OpenMP team: each thread fires the puts for its share of the peers on
+its own VCQ. This is the uTofu substitute for the per-thread
+`MPI_Isend` that Fujitsu MPI's missing `MPI_THREAD_MULTIPLE` support
+rules out. The counts are bound on the first gather-scatter
+initialisation and cannot change thereafter; the TNI count is silently
+clamped to the number of one-sided TNIs the hardware exposes, and the
+VCQ count to whatever the TNIs' VCQ budget allows (threads beyond the
+granted VCQ count do not inject).
+
+- `NEKO_GS_UTOFU_NTNI=1` (default) : All injection VCQs sit on one TNI.
+- `NEKO_GS_UTOFU_NTNI=N`           : Deal the per-thread VCQs across `N`
+  TNIs (benefits large messages and high neighbour counts).
+- `NEKO_GS_UTOFU_MASTER_INJECT=1`  : Serialise all injection onto the
+  master thread (still spread over every VCQ), as an A/B reference for
+  the thread-parallel default.
+
+The startup log prints the granted counts, e.g.
+`uTofu inj.   : 12 VCQs (12 threads) over 4 TNIs (6 requested)`.
+
+The puts also request Tofu cache injection by default, which writes each
+arriving slab straight into the receiver's cache. This helps when the
+slab is consumed immediately but can pollute cache otherwise, so it can
+be disabled for A/B testing:
+
+- `NEKO_GS_UTOFU_CACHE_INJECT=1` (default, or unset) : cache injection on.
+- `NEKO_GS_UTOFU_CACHE_INJECT=0`                     : cache injection off.

--- a/doc/pages/user-guide/installation.md
+++ b/doc/pages/user-guide/installation.md
@@ -147,6 +147,7 @@ Optional packages are controlled by passing either `--with-PACKAGE[=ARG]` or `--
 | `--with-roctx=DIR`              | Compile with support for ROCTX                |
 | `--with-nccl=DIR`               | Compiler with support for NCCL                |
 | `--with-rccl=DIR`               | Compiler with support for RCCL                |
+| `--with-utofu=DIR`              | Compile with support for the native Tofu interconnect (uTofu) |
 | `--with-hdf5`                   | Compile with support for HDF5                 |
 | `--with-pfunit=DIR`             | Directory for pFUnit (see \subpage testing)   |
 
@@ -198,6 +199,7 @@ supported backends are listed below.
 | NVSHMEM          | NVIDIA OpenSHMEM, one-sided on device buffers   | CUDA             | `--with-nvshmem`              | `SHMEM`        |
 | OpenSHMEM        | Host OpenSHMEM, one-sided                        | CPU              | `--with-openshmem`           | `SHMEM`        |
 | Co-Array Fortran | Fortran coarrays                                | CPU              | coarray-capable compiler      | `CAF`          |
+| uTofu            | Native Tofu interconnect, one-sided RDMA        | CPU              | `--with-utofu`                | `UTOFU`        |
 
 @note Every device backend (CUDA, HIP, OpenCL, Metal) can use host `MPI`, which
 stages data through host memory before the exchange. The device-resident
@@ -207,6 +209,11 @@ host `MPI`.
 
 @note `NEKO_GS_COMM=SHMEM` selects NVSHMEM on a device (GPU) build and host
 OpenSHMEM otherwise.
+
+@note `UTOFU` targets the native Tofu interconnect (Tofu-D, e.g. Fugaku) and
+requires the `libtofucom` library; it is a host (CPU) backend. The number of
+Tofu network interfaces used for injection is set with `NEKO_GS_UTOFU_NTNI`
+(default `1`).
 
 #### Compiling Neko for CPU or SX-Aurora
 

--- a/doc/pages/user-guide/performance.md
+++ b/doc/pages/user-guide/performance.md
@@ -316,6 +316,19 @@ stash holds notices that arrive from a neighbour running one round ahead
 and replays them on the next round, so the unpack-as-ready path stays
 correct without a global barrier or a back-pressure channel.
 
+The backend also implements the fused vector (multi-component) halo
+exchange used by `gs_op_r3`, so a three-component gather-scatter costs
+one halo round instead of three. The vector path is a second, fully
+independent instance of the same transport: its own registered
+double-buffered slabs (sized for `GS_VEC_NC` components, each peer slab
+holding `nc` consecutive component blocks), its own receive VCQ (and
+thus private MRQ), and its own parity. The separation is what keeps the
+skew handling sound -- a neighbour racing from a vector round into a
+scalar round (or vice versa) lands its notice in the right queue. The
+scalar per-peer layout is reused scaled by `nc`, with the destination
+offsets recomputed each round from the receiver's advertised unscaled
+layout.
+
 The backend is gated on the autoconf macro `HAVE_UTOFU` and enabled at
 configure time with `--with-utofu[=DIR]` (linking `-ltofucom`); builds
 without uTofu are unaffected. Neighbour metadata (remote VCQ id,
@@ -325,9 +338,9 @@ thereafter is pure uTofu.
 
 @note The uTofu backend uses per-instance (not symmetric) send and
 receive buffers, so it carries no global-maximum sizing constraint.
-Each `gs_t` instance also gets its own receive VCQ (and therefore its
-own MRQ), so an arrival notice for one instance can never be consumed
-by another instance's poll -- multiple `gs_t` objects can be used back
-to back safely. The injection VCQs (one per OpenMP thread) are
+Each `gs_t` instance also gets its own receive VCQs (one scalar, one
+vector, each with its own MRQ), so an arrival notice for one instance
+or path can never be consumed by another's poll -- multiple `gs_t`
+objects can be used back to back safely. The injection VCQs (one per OpenMP thread) are
 process-global and shared across instances; send-completion accounting
 is per instance, per VCQ, and per buffer-half.

--- a/doc/pages/user-guide/performance.md
+++ b/doc/pages/user-guide/performance.md
@@ -143,6 +143,7 @@ MPI is available, host MPI otherwise). The supported values are:
 | `SHMEM` | NVSHMEM (`gs_device_shmem`) on GPU builds, OpenSHMEM (`gs_shmem`) on CPU builds | `--with-nvshmem=...` (GPU) or `--with-openshmem` (CPU, Cray) | NVIDIA GPUs with NVSHMEM-capable interconnect; CPU systems with a native OpenSHMEM (e.g. Cray OpenSHMEMX) |
 | `CAF` | Coarray Fortran (`gs_caf`) | Coarray-capable Fortran compiler | Systems with a tuned coarray runtime |
 | `NEIGHBOUR` | MPI neighbourhood collective (`gs_neighbour`) | None (MPI-3) | CPU runs where one collective per gs beats many point-to-point messages (e.g. Fugaku / Tofu) |
+| `UTOFU` | Native Tofu RDMA (`gs_utofu`) | `--with-utofu` (Tofu-D, e.g. Fugaku) | CPU runs on Fugaku/Tofu; native RDMA, a faster successor to CAF |
 
 @note `MPIGPU` and `NCCL` require Neko to be built with GPU support
 and the corresponding optional dependency. `SHMEM` picks the device
@@ -152,9 +153,9 @@ which of NVSHMEM / OpenSHMEM is present at configure time.
 The backend can also be selected programmatically by passing the
 `comm_bcknd` argument to `gs%init`, using the constants `GS_COMM_MPI`,
 `GS_COMM_MPIGPU`, `GS_COMM_NCCL`, `GS_COMM_NVSHMEM`,
-`GS_COMM_OPENSHMEM`, `GS_COMM_CAF`, or `GS_COMM_NEIGHBOUR` exposed by
-the `gather_scatter` module. The environment variable wins when both
-are present.
+`GS_COMM_OPENSHMEM`, `GS_COMM_CAF`, `GS_COMM_NEIGHBOUR` or `GS_COMM_UTOFU`
+exposed by the `gather_scatter` module. The environment variable wins when
+both are present.
 
 #### MPI neighbourhood collective backend {#performance-neighbour-backend}
 
@@ -268,3 +269,65 @@ parity), shared by all gs instances. The buffer is grown on demand and
 retained for the program lifetime. Multiple `gs_t` objects can coexist
 provided they are used strictly sequentially -- no overlapping
 nbsend/nbwait windows across instances.
+
+#### uTofu backend {#performance-utofu-backend}
+
+The uTofu backend (`NEKO_GS_COMM=UTOFU`) talks to the Tofu-D
+interconnect directly through the native uTofu (`libtofucom`) API,
+bypassing both MPI and the coarray runtime. It is the
+performance-oriented successor to the CAF backend on Fugaku and other
+Tofu systems, where coarray puts are roughly an order of magnitude
+slower than MPI because every put is followed by a separate, serial
+master-thread synchronisation step.
+
+Each neighbour's contribution is packed into a per-instance send buffer
+and delivered with a one-sided `utofu_put` straight into the remote
+receive buffer. The slab tag is fused into the put's `edata` field, so
+the put's arrival *is* the completion signal -- there is one network
+operation per peer, with no separate atomic, credit message, or back
+channel. This single-op-per-peer pattern is the main win over CAF.
+
+Injection is non-blocking and thread-parallel. Packing each neighbour's
+contribution into the send buffer is parallelised over the OpenMP team
+in a single work-shared loop, and the `utofu_put` calls are as well:
+one injection VCQ is created per OpenMP thread (with
+`UTOFU_VCQ_FLAG_THREAD_SAFE`, which is what makes multithreaded uTofu
+operation defined), dealt round-robin over the `NEKO_GS_UTOFU_NTNI`
+TNIs (default `1`), and each thread fires the puts for its share of the
+peers on its own VCQ. Since Fujitsu MPI does not provide a usable
+`MPI_THREAD_MULTIPLE`, this is the only per-thread injection path
+available on Fugaku; `NEKO_GS_UTOFU_MASTER_INJECT=1` restores serial
+master-thread injection as an A/B reference. On the receive side each
+slab is reduced into `u` as soon as its remote-put notice is observed
+in the MRQ, mirroring the `Testsome`-style unpack-as-ready loop of the
+MPI backend.
+
+The send buffer is double-buffered (selected by the parity bit): each
+put's completion is charged, via its `cbdata`, to a per-(VCQ, half)
+counter, and the next `nbsend` drains only the half it is about to
+reuse -- which was last used two rounds earlier, so the drain is a
+non-blocking reap rather than a wait on the critical path. Each VCQ is
+drained by exactly one thread per round, so the counters need no
+atomics.
+
+Correctness under skew is handled by a double-buffered receive region
+selected by a parity bit (`edata = slab_tag*2 + parity`); a per-instance
+stash holds notices that arrive from a neighbour running one round ahead
+and replays them on the next round, so the unpack-as-ready path stays
+correct without a global barrier or a back-pressure channel.
+
+The backend is gated on the autoconf macro `HAVE_UTOFU` and enabled at
+configure time with `--with-utofu[=DIR]` (linking `-ltofucom`); builds
+without uTofu are unaffected. Neighbour metadata (remote VCQ id,
+receive STADD, the two parity offsets, and the slab tag) is exchanged
+once at initialisation over `NEKO_COMM` via MPI; the data path
+thereafter is pure uTofu.
+
+@note The uTofu backend uses per-instance (not symmetric) send and
+receive buffers, so it carries no global-maximum sizing constraint.
+Each `gs_t` instance also gets its own receive VCQ (and therefore its
+own MRQ), so an arrival notice for one instance can never be consumed
+by another instance's poll -- multiple `gs_t` objects can be used back
+to back safely. The injection VCQs (one per OpenMP thread) are
+process-global and shared across instances; send-completion accounting
+is per instance, per VCQ, and per buffer-half.

--- a/doc/pages/user-guide/performance.md
+++ b/doc/pages/user-guide/performance.md
@@ -338,9 +338,11 @@ thereafter is pure uTofu.
 
 @note The uTofu backend uses per-instance (not symmetric) send and
 receive buffers, so it carries no global-maximum sizing constraint.
-Each `gs_t` instance also gets its own receive VCQs (one scalar, one
-vector, each with its own MRQ), so an arrival notice for one instance
-or path can never be consumed by another's poll -- multiple `gs_t`
-objects can be used back to back safely. The injection VCQs (one per OpenMP thread) are
-process-global and shared across instances; send-completion accounting
-is per instance, per VCQ, and per buffer-half.
+Each `gs_t` instance also gets its own receive VCQs (a set per path,
+scalar and vector, spread over the TNIs with each receive peer bound
+to one -- see `NEKO_GS_UTOFU_NRVCQ`), so an arrival notice for one
+instance or path can never be consumed by another's poll -- multiple
+`gs_t` objects can be used back to back safely. The injection VCQs
+(one per OpenMP thread) are process-global and shared across
+instances; send-completion accounting is per instance, per VCQ, and
+per buffer-half.

--- a/doc/pages/user-guide/performance.md
+++ b/doc/pages/user-guide/performance.md
@@ -29,9 +29,19 @@ it could be beneficial to configure Neko to use OpenMP
 `--enable-openmp`, and launch the simulation with two threads. This
 would enable the task-parallel preconditioners inside Neko.
 
-@note In the current release, OpenMP is only used to launch jobs
-concurrently into different accelerator streams. Thus, no gains should
-be expected from OpenMP when using a CPU backend.
+### CPU specific options
+
+On CPU backends, the performance-critical path (math and solver
+kernels, Krylov solvers and preconditioners, boundary conditions,
+dealiasing, and the host gather-scatter) is threaded with OpenMP when
+Neko is configured with `--enable-openmp`, making hybrid MPI+OpenMP a
+supported execution mode: launch one rank per NUMA domain (e.g. one
+per CMG on A64FX) and set `OMP_NUM_THREADS` to the number of cores in
+it. Flat MPI (one rank per core, single-threaded) generally remains
+the fastest configuration per node, but the hybrid mode reduces the
+number of ranks -- and with it the memory footprint, initialisation
+time, and communication metadata -- which pays off at very large
+scale or under tight memory constraints.
 
 ## Simulation setup
 

--- a/m4/ax_utofu.m4
+++ b/m4/ax_utofu.m4
@@ -1,0 +1,46 @@
+#
+# ----------------------------------------------------------------------------
+# "THE BEER-WARE LICENSE" (Revision 42):
+# <njansson@kth.se> wrote this file. As long as you retain this notice you
+# can do whatever you want with this stuff. If we meet some day, and you think
+# this stuff is worth it, you can buy me a beer in return Niclas Jansson
+# ----------------------------------------------------------------------------
+#
+AC_DEFUN([AX_UTOFU],[
+        AC_ARG_WITH([utofu],
+                    AS_HELP_STRING([--with-utofu=DIR],
+                    [Compile with support for the native Tofu interconnect (uTofu)]),
+                    [
+                    if test -d "$withval"; then
+                       ac_utofu_path="$withval";
+                       UTOFU_LDFLAGS="-L$ac_utofu_path/lib"
+                       UTOFU_CFLAGS="-I$ac_utofu_path/include"
+                    fi
+                    ], [with_utofu=no])
+        have_utofu=no
+        if test "x${with_utofu}" != xno; then
+           CPPFLAGS_SAVED="$CPPFLAGS"
+           LDFLAGS_SAVED="$LDFLAGS"
+           CPPFLAGS="$UTOFU_CFLAGS $CPPFLAGS"
+           LDFLAGS="$UTOFU_LDFLAGS $LDFLAGS"
+           export CPPFLAGS
+           export LDFLAGS
+
+           AC_LANG_PUSH([C])
+           AC_CHECK_HEADER([utofu.h],
+                           [have_utofu_hdr=yes], [have_utofu_hdr=no])
+           AC_CHECK_LIB([tofucom], [utofu_get_onesided_tnis],
+                        [have_utofu=yes; UTOFU_LIBS="-ltofucom"],
+                        [have_utofu=no], [])
+           AC_LANG_POP([C])
+
+           if test x"${have_utofu}" = xyes -a x"${have_utofu_hdr}" = xyes; then
+              AC_DEFINE(HAVE_UTOFU, 1, [Define if you have uTofu.])
+              LIBS="$UTOFU_LIBS $LIBS"
+              CFLAGS="$CFLAGS $UTOFU_CFLAGS"
+           else
+              AC_MSG_ERROR([uTofu requested but utofu.h / libtofucom not found])
+           fi
+        fi
+        AC_SUBST(have_utofu)
+])

--- a/src/.depends
+++ b/src/.depends
@@ -61,10 +61,11 @@ gs/gs_mpi.lo : gs/gs_mpi.f90 common/utils.lo comm/comm.lo adt/stack.lo gs/gs_ops
 gs/gs_shmem.lo : gs/gs_shmem.F90 common/utils.lo comm/comm.lo adt/stack.lo gs/gs_ops.lo gs/gs_comm.lo config/num_types.lo 
 gs/gs_caf.lo : gs/gs_caf.F90 common/utils.lo comm/comm.lo adt/stack.lo gs/gs_ops.lo gs/gs_comm.lo config/num_types.lo 
 gs/gs_neighbour.lo : gs/gs_neighbour.f90 common/utils.lo comm/comm.lo adt/stack.lo gs/gs_ops.lo gs/gs_comm.lo config/num_types.lo 
+gs/gs_utofu.lo : gs/gs_utofu.F90 common/utils.lo common/log.lo comm/comm.lo adt/stack.lo gs/gs_ops.lo gs/gs_comm.lo config/num_types.lo 
 gs/bcknd/device/gs_device_mpi.lo : gs/bcknd/device/gs_device_mpi.F90 common/utils.lo device/device.lo adt/htable.lo comm/comm.lo adt/stack.lo gs/gs_comm.lo config/num_types.lo 
 gs/bcknd/device/gs_device_nccl.lo : gs/bcknd/device/gs_device_nccl.F90 common/utils.lo device/device.lo adt/htable.lo comm/comm.lo adt/stack.lo gs/gs_comm.lo config/num_types.lo 
 gs/bcknd/device/gs_device_shmem.lo : gs/bcknd/device/gs_device_shmem.F90 common/utils.lo comm/comm.lo device/device.lo adt/htable.lo adt/stack.lo gs/gs_comm.lo config/num_types.lo 
-gs/gather_scatter.lo : gs/gather_scatter.f90 device/device.lo common/profiler.lo common/log.lo common/utils.lo math/math.lo comm/crystal_router.lo adt/stack.lo adt/htable.lo config/num_types.lo field/field.lo sem/dofmap.lo comm/comm.lo mesh/mesh.lo gs/bcknd/device/gs_device_shmem.lo gs/bcknd/device/gs_device_nccl.lo gs/bcknd/device/gs_device_mpi.lo gs/gs_caf.lo gs/gs_shmem.lo gs/gs_neighbour.lo gs/gs_mpi.lo gs/gs_comm.lo gs/gs_ops.lo gs/bcknd/cpu/gs_cpu.lo gs/bcknd/sx/gs_sx.lo gs/bcknd/device/gs_device.lo gs/gs_bcknd.lo config/neko_config.lo 
+gs/gather_scatter.lo : gs/gather_scatter.f90 device/device.lo common/profiler.lo common/log.lo common/utils.lo math/math.lo comm/crystal_router.lo adt/stack.lo adt/htable.lo config/num_types.lo field/field.lo sem/dofmap.lo comm/comm.lo mesh/mesh.lo gs/bcknd/device/gs_device_shmem.lo gs/bcknd/device/gs_device_nccl.lo gs/bcknd/device/gs_device_mpi.lo gs/gs_utofu.lo gs/gs_caf.lo gs/gs_shmem.lo gs/gs_neighbour.lo gs/gs_mpi.lo gs/gs_comm.lo gs/gs_ops.lo gs/bcknd/cpu/gs_cpu.lo gs/bcknd/sx/gs_sx.lo gs/bcknd/device/gs_device.lo gs/gs_bcknd.lo config/neko_config.lo 
 mesh/entity.lo : mesh/entity.f90 
 mesh/point.lo : mesh/point.f90 mesh/entity.lo math/math.lo config/num_types.lo 
 mesh/element.lo : mesh/element.f90 mesh/point.lo adt/tuple.lo mesh/entity.lo config/num_types.lo 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -64,6 +64,7 @@ neko_fortran_SOURCES = \
 	gs/gs_shmem.F90\
 	gs/gs_caf.F90\
 	gs/gs_neighbour.f90\
+	gs/gs_utofu.F90\
 	gs/bcknd/device/gs_device_mpi.F90\
 	gs/bcknd/device/gs_device_nccl.F90\
 	gs/bcknd/device/gs_device_shmem.F90\
@@ -474,6 +475,10 @@ libneko_la_LIBADD =
 
 if ENABLE_PARMETIS
 libneko_la_SOURCES += comm/parmetis_wrapper.c
+endif
+
+if ENABLE_UTOFU
+libneko_la_SOURCES += gs/gs_utofu_aux.c
 endif
 
 if ENABLE_HIP

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -41,11 +41,12 @@ module gather_scatter
   use gs_ops, only : GS_OP_ADD, GS_OP_MAX, GS_OP_MIN, GS_OP_MUL
   use gs_comm, only : gs_comm_t, GS_COMM_MPI, GS_COMM_MPIGPU, GS_COMM_NCCL, &
        GS_COMM_NVSHMEM, GS_COMM_OPENSHMEM, GS_COMM_CAF, GS_COMM_NEIGHBOUR, &
-       GS_VEC_NC
+       GS_COMM_UTOFU, GS_VEC_NC
   use gs_mpi, only : gs_mpi_t
   use gs_neighbour, only : gs_neighbour_t
   use gs_shmem, only : gs_shmem_t
   use gs_caf, only : gs_caf_t
+  use gs_utofu, only : gs_utofu_t
   use gs_device_mpi, only : gs_device_mpi_t
   use gs_device_nccl, only : gs_device_nccl_t
   use gs_device_shmem, only : gs_device_shmem_t
@@ -118,8 +119,7 @@ module gather_scatter
 
   ! Expose available gather-scatter comm. backends
   public :: GS_COMM_MPI, GS_COMM_MPIGPU, GS_COMM_NCCL, GS_COMM_NVSHMEM, &
-       GS_COMM_OPENSHMEM, GS_COMM_CAF, GS_COMM_NEIGHBOUR
-
+       GS_COMM_OPENSHMEM, GS_COMM_CAF, GS_COMM_NEIGHBOUR, GS_COMM_UTOFU
 
 contains
 
@@ -139,6 +139,7 @@ contains
     logical :: use_host_shmem
     logical :: use_caf
     logical :: use_neighbour
+    logical :: use_utofu
     real(kind=rp), allocatable :: tmp(:)
     type(c_ptr) :: tmp_d = C_NULL_PTR
     integer :: strtgy(4) = [int(B'00'), int(B'01'), int(B'10'), int(B'11')]
@@ -160,6 +161,7 @@ contains
     use_host_shmem = .false.
     use_caf = .false.
     use_neighbour = .false.
+    use_utofu = .false.
 
     ! Check if a comm-backend is requested via env. variables
     call get_environment_variable("NEKO_GS_COMM", env_gscomm, env_len)
@@ -181,6 +183,8 @@ contains
        else if (env_gscomm(1:env_len) .eq. "NEIGHBOUR" .or. &
             env_gscomm(1:env_len) .eq. "NEIGHBOR") then
           use_neighbour = .true.
+       else if (env_gscomm(1:env_len) .eq. "UTOFU") then
+          use_utofu = .true.
        else
           call neko_error('Unknown Gather-scatter comm. backend')
        end if
@@ -203,8 +207,8 @@ contains
        comm_bcknd_ = GS_COMM_CAF
     else if (use_neighbour) then
        comm_bcknd_ = GS_COMM_NEIGHBOUR
-    else if (use_neighbour) then
-       comm_bcknd_ = GS_COMM_NEIGHBOUR
+    else if (use_utofu) then
+       comm_bcknd_ = GS_COMM_UTOFU
     else
        if (NEKO_DEVICE_MPI) then
           comm_bcknd_ = GS_COMM_MPIGPU
@@ -236,6 +240,9 @@ contains
     case (GS_COMM_NEIGHBOUR)
        call neko_log%message('Comm         :   MPI neigh.')
        allocate(gs_neighbour_t::gs%comm)
+    case (GS_COMM_UTOFU)
+       call neko_log%message('Comm         :        uTofu')
+       allocate(gs_utofu_t::gs%comm)
     case default
        call neko_error('Unknown Gather-scatter comm. backend')
     end select

--- a/src/gs/gs_comm.f90
+++ b/src/gs/gs_comm.f90
@@ -42,7 +42,7 @@ module gs_comm
 
   integer, public, parameter :: GS_COMM_MPI = 1, GS_COMM_MPIGPU = 2, &
        GS_COMM_NCCL = 3, GS_COMM_NVSHMEM = 4, GS_COMM_OPENSHMEM = 5, &
-       GS_COMM_CAF = 6, GS_COMM_NEIGHBOUR = 7
+       GS_COMM_CAF = 6, GS_COMM_NEIGHBOUR = 7, GS_COMM_UTOFU = 8
 
   !> Maximum number of components handled by the fused vector (multi-component)
   !! halo exchange used by gs_op_r3. Sizes the backend vector buffers.

--- a/src/gs/gs_utofu.F90
+++ b/src/gs/gs_utofu.F90
@@ -290,11 +290,11 @@ contains
 
     max_tag = 0
     do i = 1, nsend
-       this%rmt_stadd(i)  = msg_in(1, i)
+       this%rmt_stadd(i) = msg_in(1, i)
        this%rmt_vcq_id(i) = msg_in(2, i)
-       this%dst_off0(i)   = msg_in(3, i)
-       this%dst_off1(i)   = msg_in(4, i)
-       this%dst_tag(i)    = int(msg_in(5, i), c_int)
+       this%dst_off0(i) = msg_in(3, i)
+       this%dst_off1(i) = msg_in(4, i)
+       this%dst_tag(i) = int(msg_in(5, i), c_int)
        max_tag = max(max_tag, this%dst_tag(i))
     end do
 

--- a/src/gs/gs_utofu.F90
+++ b/src/gs/gs_utofu.F90
@@ -138,28 +138,32 @@ module gs_utofu
 #ifdef HAVE_UTOFU
   !> Largest edata value the hardware will carry (set once at first init).
   integer(c_int64_t) :: gs_utofu_edata_max = 255
+  !> Receive VCQs requested per instance path (set once at first init;
+  !! instances may be granted fewer when the VCQ budget runs dry).
+  integer(c_int) :: gs_utofu_nrvcq = 1
   !> Log the granted VCQ/TNI counts only once, on the first instance.
   logical, save :: gs_utofu_logged = .false.
 
   interface
      subroutine gs_utofu_init_ep(ntni_req, nthreads, ntni_out, nvcq_out, &
-          edata_max, ierr) bind(c, name = 'gs_utofu_init')
+          nrvcq_out, edata_max, ierr) bind(c, name = 'gs_utofu_init')
        import :: c_int, c_int64_t
        integer(c_int), value :: ntni_req, nthreads
-       integer(c_int) :: ntni_out, nvcq_out
+       integer(c_int) :: ntni_out, nvcq_out, nrvcq_out
        integer(c_int64_t) :: edata_max
        integer(c_int) :: ierr
      end subroutine gs_utofu_init_ep
 
      subroutine gs_utofu_ctx_create(send_buf, send_bytes, recv_buf, &
-          recv_bytes, ctx, recv_vcq_id, recv_stadd, ierr) &
+          recv_bytes, ctx, nrvcq, recv_vcq_id, recv_stadd, ierr) &
           bind(c, name = 'gs_utofu_ctx_create')
        import :: c_ptr, c_size_t, c_int64_t, c_int
        type(c_ptr), value :: send_buf, recv_buf
        integer(c_size_t), value :: send_bytes, recv_bytes
        type(c_ptr) :: ctx
-       integer(c_int64_t) :: recv_vcq_id
-       integer(c_int64_t) :: recv_stadd
+       integer(c_int) :: nrvcq
+       integer(c_int64_t) :: recv_vcq_id(*)
+       integer(c_int64_t) :: recv_stadd(*)
        integer(c_int) :: ierr
      end subroutine gs_utofu_ctx_create
 
@@ -214,8 +218,8 @@ contains
 #ifdef HAVE_UTOFU
     integer :: i, nsend, nrecv, send_total, recv_total
     integer :: ntni_req, env_len, max_tag, nthreads
-    integer(c_int) :: ntni, nvcq, ierr
-    integer(c_int64_t) :: recv_vcq_id, recv_stadd
+    integer(c_int) :: ntni, nvcq, nrv, ierr
+    integer(c_int64_t), allocatable :: recv_vcq_id(:), recv_stadd(:)
     integer(c_size_t) :: send_bytes, recv_bytes
     character(len=32) :: env_val
     character(len=LOG_SIZE) :: log_buf
@@ -268,36 +272,42 @@ contains
     !$ nthreads = omp_get_max_threads()
 
     call gs_utofu_init_ep(int(ntni_req, c_int), int(nthreads, c_int), &
-         ntni, nvcq, gs_utofu_edata_max, ierr)
+         ntni, nvcq, gs_utofu_nrvcq, gs_utofu_edata_max, ierr)
     if (ierr .ne. 0) call neko_error("gs_utofu: endpoint init failed")
 
+    send_bytes = int(size(this%send_buf), c_size_t) * this%elem_size
+    recv_bytes = int(size(this%recv_buf), c_size_t) * this%elem_size
+    ! Filled by gs_utofu_ctx_create: one (vcq_id, stadd) pair per receive
+    ! VCQ granted to this instance; each receive peer is bound to one pair
+    ! below. Initialised to keep the compiler from warning (it cannot see
+    ! the C side write).
+    allocate(recv_vcq_id(gs_utofu_nrvcq), recv_stadd(gs_utofu_nrvcq))
+    recv_vcq_id = 0_c_int64_t
+    recv_stadd = 0_c_int64_t
+    nrv = 1
+    call gs_utofu_ctx_create(c_loc(this%send_buf), send_bytes, &
+         c_loc(this%recv_buf), recv_bytes, this%ctx, nrv, recv_vcq_id, &
+         recv_stadd, ierr)
+    if (ierr .eq. 1) then
+       call neko_error("gs_utofu: out of VCQs for the receive queues " // &
+            "(lower OMP_NUM_THREADS or NEKO_GS_UTOFU_NRVCQ, or set " // &
+            "NEKO_GS_UTOFU_NVCQ)")
+    else if (ierr .ne. 0) then
+       call neko_error("gs_utofu: buffer registration failed")
+    end if
+
     ! Report what the hardware actually granted: requested vs granted can
-    ! differ when ranks on a node share its TNIs, or when a TNI's VCQ budget
-    ! is smaller than the thread count. Once, on rank 0.
+    ! differ when ranks on a node share its TNIs, or when the VCQ budget
+    ! runs dry. Once, on rank 0.
     if (.not. gs_utofu_logged .and. pe_rank .eq. 0) then
        write(log_buf, '(A,I0,A,I0,A,I0,A,I0,A)') 'uTofu inj.   : ', &
             int(nvcq), ' VCQs (', nthreads, ' threads) over ', int(ntni), &
             ' TNIs (', ntni_req, ' requested)'
        call neko_log%message(log_buf)
+       write(log_buf, '(A,I0,A,I0,A)') 'uTofu recv   : ', int(nrv), &
+            ' of ', int(gs_utofu_nrvcq), ' VCQs (first instance)'
+       call neko_log%message(log_buf)
        gs_utofu_logged = .true.
-    end if
-
-    send_bytes = int(size(this%send_buf), c_size_t) * this%elem_size
-    recv_bytes = int(size(this%recv_buf), c_size_t) * this%elem_size
-    ! recv_vcq_id and recv_stadd are set by gs_utofu_ctx_create through its
-    ! reference arguments (the compiler cannot see the C side write, so
-    ! initialise to keep it from warning). This instance gets its own receive
-    ! VCQ, so the advertised vcq_id is per-instance.
-    recv_vcq_id = 0_c_int64_t
-    recv_stadd = 0_c_int64_t
-    call gs_utofu_ctx_create(c_loc(this%send_buf), send_bytes, &
-         c_loc(this%recv_buf), recv_bytes, this%ctx, recv_vcq_id, &
-         recv_stadd, ierr)
-    if (ierr .eq. 1) then
-       call neko_error("gs_utofu: out of VCQs for the receive queue " // &
-            "(lower OMP_NUM_THREADS or set NEKO_GS_UTOFU_NVCQ)")
-    else if (ierr .ne. 0) then
-       call neko_error("gs_utofu: buffer registration failed")
     end if
 
     ! Tell each sender where, and with which tag, to put our slab; learn the
@@ -306,9 +316,11 @@ contains
     allocate(msg_out(5, max(1, nrecv)), msg_in(5, max(1, nsend)))
     allocate(sreq(max(1, nrecv)), rreq(max(1, nsend)))
 
+    ! Receive peer i is bound to receive VCQ mod(i-1, nrv) + 1; advertising
+    ! that VCQ's STADD/id spreads the incoming slabs over the TNIs.
     do i = 1, nrecv
-       msg_out(1, i) = recv_stadd
-       msg_out(2, i) = recv_vcq_id
+       msg_out(1, i) = recv_stadd(mod(i - 1, int(nrv)) + 1)
+       msg_out(2, i) = recv_vcq_id(mod(i - 1, int(nrv)) + 1)
        msg_out(3, i) = int(this%recv_offset(i), c_int64_t)
        msg_out(4, i) = int(this%buf_size + this%recv_offset(i), c_int64_t)
        msg_out(5, i) = int(i - 1, c_int64_t)
@@ -344,7 +356,7 @@ contains
          call neko_error("gs_utofu: neighbour count exceeds edata capacity")
 
     ! Fused vector path: double-buffered slabs sized for GS_VEC_NC
-    ! components, registered under their own context (own receive VCQ).
+    ! components, registered under their own context (own receive VCQs).
     allocate(this%send_buf_v(max(1, 2 * GS_VEC_NC * send_total)))
     allocate(this%recv_buf_v(max(1, 2 * GS_VEC_NC * recv_total)))
     allocate(this%rmt_vcq_id_v(nsend), this%rmt_stadd_v(nsend))
@@ -356,12 +368,14 @@ contains
     recv_bytes = int(size(this%recv_buf_v), c_size_t) * this%elem_size
     recv_vcq_id = 0_c_int64_t
     recv_stadd = 0_c_int64_t
+    nrv = 1
     call gs_utofu_ctx_create(c_loc(this%send_buf_v), send_bytes, &
-         c_loc(this%recv_buf_v), recv_bytes, this%ctx_v, recv_vcq_id, &
+         c_loc(this%recv_buf_v), recv_bytes, this%ctx_v, nrv, recv_vcq_id, &
          recv_stadd, ierr)
     if (ierr .eq. 1) then
        call neko_error("gs_utofu: out of VCQs for the vector receive " // &
-            "queue (lower OMP_NUM_THREADS or set NEKO_GS_UTOFU_NVCQ)")
+            "queues (lower OMP_NUM_THREADS or NEKO_GS_UTOFU_NRVCQ, or " // &
+            "set NEKO_GS_UTOFU_NVCQ)")
     else if (ierr .ne. 0) then
        call neko_error("gs_utofu: vector buffer registration failed")
     end if
@@ -374,9 +388,10 @@ contains
     allocate(msg_out(4, max(1, nrecv)), msg_in(4, max(1, nsend)))
     allocate(sreq(max(1, nrecv)), rreq(max(1, nsend)))
 
+    ! Same peer-to-receive-VCQ binding as the scalar path (its own VCQ set).
     do i = 1, nrecv
-       msg_out(1, i) = recv_stadd
-       msg_out(2, i) = recv_vcq_id
+       msg_out(1, i) = recv_stadd(mod(i - 1, int(nrv)) + 1)
+       msg_out(2, i) = recv_vcq_id(mod(i - 1, int(nrv)) + 1)
        msg_out(3, i) = int(this%recv_offset(i), c_int64_t)
        msg_out(4, i) = int(this%buf_size, c_int64_t)
     end do

--- a/src/gs/gs_utofu.F90
+++ b/src/gs/gs_utofu.F90
@@ -36,10 +36,13 @@
 !! into the descriptor (`edata`) instead of a separate atomic/credit message.
 !! Injection is non-blocking and thread-parallel: each OpenMP thread owns one
 !! injection VCQ (created thread-safe, dealt over the TNIs) and fires the puts
-!! for its share of the peers itself. See gs_utofu_aux.c for the transport.
+!! for its share of the peers itself. The fused vector (multi-component)
+!! exchange of gs_op_r3 is supported through a second, independent context
+!! with its own buffers, receive VCQ, and parity. See gs_utofu_aux.c for the
+!! transport.
 module gs_utofu
   use num_types, only : rp, i8
-  use gs_comm, only : gs_comm_t, GS_COMM_UTOFU
+  use gs_comm, only : gs_comm_t, GS_COMM_UTOFU, GS_VEC_NC
   use gs_ops, only : GS_OP_ADD, GS_OP_MAX, GS_OP_MIN, GS_OP_MUL
   use stack, only : stack_i4_t
   use comm, only : NEKO_COMM, pe_rank
@@ -57,6 +60,8 @@ module gs_utofu
 
   !> MPI tag used for the one-off neighbour metadata exchange at init.
   integer, parameter :: GS_UTOFU_XCHG_TAG = 8123
+  !> Ditto for the fused vector path's metadata exchange.
+  integer, parameter :: GS_UTOFU_XCHG_TAG_V = 8124
 
   !> Gather-scatter communication using one-sided uTofu puts.
   type, public, extends(gs_comm_t) :: gs_utofu_t
@@ -95,12 +100,39 @@ module gs_utofu
      integer :: parity = 0
      !> Opaque per-instance uTofu context (registrations + notice stash).
      type(c_ptr) :: ctx = c_null_ptr
+     !> Fused vector (multi-component) path: double-buffered send/recv slabs
+     !! sized for GS_VEC_NC components. Each peer slab holds nc consecutive
+     !! component blocks, so the scalar layout is reused scaled by nc. The
+     !! path has its OWN uTofu context (registrations, receive VCQ and thus
+     !! private MRQ, completion counters) and its own parity: a neighbour
+     !! racing from a vector round into a scalar round (or vice versa) must
+     !! not land notices in the other path's queue.
+     real(kind=rp), pointer :: send_buf_v(:) => null()
+     real(kind=rp), pointer :: recv_buf_v(:) => null()
+     !> Per send-peer vector-path put targets: the receiver's vector recv
+     !! VCQ id and buffer STADD, our slab's scalar element offset within one
+     !! of its halves, and its scalar half size (both unscaled; the sender
+     !! scales by nc and folds the parity in at round time).
+     integer(c_int64_t), allocatable :: rmt_vcq_id_v(:), rmt_stadd_v(:)
+     integer(c_int64_t), allocatable :: rmt_off_v(:), rmt_bufsz_v(:)
+     !> Per-round scratch, computed by the master each nbsend_vec: the send
+     !! layout scaled by nc and the absolute destination element offsets
+     !! (vector parity already folded in).
+     integer(c_int64_t), allocatable :: send_off64_v(:), send_len64_v(:)
+     integer(c_int64_t), allocatable :: dst_off_v(:)
+     !> Active vector double-buffer half for the next vector round.
+     integer :: parity_v = 0
+     !> Opaque uTofu context of the vector path.
+     type(c_ptr) :: ctx_v = c_null_ptr
    contains
      procedure, pass(this) :: init => gs_utofu_init
      procedure, pass(this) :: free => gs_utofu_free
      procedure, pass(this) :: nbsend => gs_nbsend_utofu
      procedure, pass(this) :: nbrecv => gs_nbrecv_utofu
      procedure, pass(this) :: nbwait => gs_nbwait_utofu
+     procedure, pass(this) :: nbsend_vec => gs_nbsend_vec_utofu
+     procedure, pass(this) :: nbrecv_vec => gs_nbrecv_vec_utofu
+     procedure, pass(this) :: nbwait_vec => gs_nbwait_vec_utofu
   end type gs_utofu_t
 
 #ifdef HAVE_UTOFU
@@ -302,8 +334,65 @@ contains
 
     ! The edata carries the slab tag in its high bits and the parity bit in
     ! bit 0, so a neighbour's count must fit (2*tag + 1) in the edata range.
+    ! The vector path reuses the same tags, so this check covers it too.
     if (int(2 * max_tag + 1, i8) .gt. int(gs_utofu_edata_max, i8)) &
          call neko_error("gs_utofu: neighbour count exceeds edata capacity")
+
+    ! Fused vector path: double-buffered slabs sized for GS_VEC_NC
+    ! components, registered under their own context (own receive VCQ).
+    allocate(this%send_buf_v(max(1, 2 * GS_VEC_NC * send_total)))
+    allocate(this%recv_buf_v(max(1, 2 * GS_VEC_NC * recv_total)))
+    allocate(this%rmt_vcq_id_v(nsend), this%rmt_stadd_v(nsend))
+    allocate(this%rmt_off_v(nsend), this%rmt_bufsz_v(nsend))
+    allocate(this%send_off64_v(nsend), this%send_len64_v(nsend))
+    allocate(this%dst_off_v(nsend))
+
+    send_bytes = int(size(this%send_buf_v), c_size_t) * this%elem_size
+    recv_bytes = int(size(this%recv_buf_v), c_size_t) * this%elem_size
+    recv_vcq_id = 0_c_int64_t
+    recv_stadd = 0_c_int64_t
+    call gs_utofu_ctx_create(c_loc(this%send_buf_v), send_bytes, &
+         c_loc(this%recv_buf_v), recv_bytes, this%ctx_v, recv_vcq_id, &
+         recv_stadd, ierr)
+    if (ierr .ne. 0) &
+         call neko_error("gs_utofu: vector buffer registration failed")
+
+    ! Second metadata exchange for the vector path. Because the component
+    ! count nc varies per round, the receiver advertises its UNSCALED layout
+    ! -- base STADD, VCQ id, our slab's scalar offset, and its scalar half
+    ! size -- and the sender scales by nc and folds the parity in at round
+    ! time. Tags are the scalar ones (same peer ordering).
+    allocate(msg_out(4, max(1, nrecv)), msg_in(4, max(1, nsend)))
+    allocate(sreq(max(1, nrecv)), rreq(max(1, nsend)))
+
+    do i = 1, nrecv
+       msg_out(1, i) = recv_stadd
+       msg_out(2, i) = recv_vcq_id
+       msg_out(3, i) = int(this%recv_offset(i), c_int64_t)
+       msg_out(4, i) = int(this%buf_size, c_int64_t)
+    end do
+
+    do i = 1, nsend
+       call MPI_Irecv(msg_in(:, i), 4, MPI_INTEGER8, this%send_pe(i), &
+            GS_UTOFU_XCHG_TAG_V, NEKO_COMM, rreq(i))
+    end do
+    do i = 1, nrecv
+       call MPI_Isend(msg_out(:, i), 4, MPI_INTEGER8, this%recv_pe(i), &
+            GS_UTOFU_XCHG_TAG_V, NEKO_COMM, sreq(i))
+    end do
+    if (nsend .gt. 0) call MPI_Waitall(nsend, rreq, MPI_STATUSES_IGNORE)
+    if (nrecv .gt. 0) call MPI_Waitall(nrecv, sreq, MPI_STATUSES_IGNORE)
+
+    do i = 1, nsend
+       this%rmt_stadd_v(i) = msg_in(1, i)
+       this%rmt_vcq_id_v(i) = msg_in(2, i)
+       this%rmt_off_v(i) = msg_in(3, i)
+       this%rmt_bufsz_v(i) = msg_in(4, i)
+    end do
+
+    deallocate(msg_out, msg_in, sreq, rreq)
+
+    this%vec_supported = .true.
 #else
     call neko_error("uTofu support not built; reconfigure with --with-utofu")
 #endif
@@ -320,12 +409,25 @@ contains
        this%ctx = c_null_ptr
     end if
 
+    if (c_associated(this%ctx_v)) then
+       call gs_utofu_ctx_free(this%ctx_v, ierr)
+       this%ctx_v = c_null_ptr
+    end if
+
     if (associated(this%send_buf)) then
        deallocate(this%send_buf)
     end if
 
     if (associated(this%recv_buf)) then
        deallocate(this%recv_buf)
+    end if
+
+    if (associated(this%send_buf_v)) then
+       deallocate(this%send_buf_v)
+    end if
+
+    if (associated(this%recv_buf_v)) then
+       deallocate(this%recv_buf_v)
     end if
 
     if (allocated(this%send_len)) then
@@ -374,6 +476,34 @@ contains
 
     if (allocated(this%recv_indices)) then
        deallocate(this%recv_indices)
+    end if
+
+    if (allocated(this%rmt_vcq_id_v)) then
+       deallocate(this%rmt_vcq_id_v)
+    end if
+
+    if (allocated(this%rmt_stadd_v)) then
+       deallocate(this%rmt_stadd_v)
+    end if
+
+    if (allocated(this%rmt_off_v)) then
+       deallocate(this%rmt_off_v)
+    end if
+
+    if (allocated(this%rmt_bufsz_v)) then
+       deallocate(this%rmt_bufsz_v)
+    end if
+
+    if (allocated(this%send_off64_v)) then
+       deallocate(this%send_off64_v)
+    end if
+
+    if (allocated(this%send_len64_v)) then
+       deallocate(this%send_len64_v)
+    end if
+
+    if (allocated(this%dst_off_v)) then
+       deallocate(this%dst_off_v)
     end if
 
     call this%free_order()
@@ -567,5 +697,191 @@ contains
     call neko_error("uTofu support not built")
 #endif
   end subroutine gs_nbwait_utofu
+
+  !> Pack the fused nc-component send slabs and fire the puts (non-blocking).
+  !! @param u compact shared buffer, component-outer: u((c-1)*n + idx).
+  !! Peer i's slab holds nc consecutive blocks of send_len(i) values, so the
+  !! scalar layout is reused scaled by nc. Same protocol as gs_nbsend_utofu,
+  !! on the vector context and parity.
+  subroutine gs_nbsend_vec_utofu(this, u, n, nc, tag, deps, strm)
+    class(gs_utofu_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    integer, intent(in) :: tag
+    type(c_ptr), intent(inout) :: deps
+    type(c_ptr), intent(inout) :: strm
+#ifdef HAVE_UTOFU
+    integer :: i, j, c, dst, off, ndst, send_base, tid, nteam
+    integer(c_int) :: ierr
+    integer, pointer :: sp(:)
+
+    tid = 0
+    nteam = 1
+    !$ tid = omp_get_thread_num()
+    !$ nteam = omp_get_num_threads()
+
+    ! Reclaim the vector send-buffer half we are about to repack (see
+    ! gs_nbsend_utofu for the ownership rules).
+    call gs_utofu_drain_half(this%ctx_v, int(this%parity_v, c_int), &
+         int(tid, c_int), int(nteam, c_int), ierr)
+    if (ierr .ne. 0) call neko_error("gs_utofu: vector send drain failed")
+    !$omp barrier
+
+    ! Scale the scalar per-peer layout by this round's nc and fold the
+    ! vector parity into the destination offsets. Master-only; the pack
+    ! loop's implicit end-do barrier orders these writes before any thread
+    ! posts.
+    send_base = this%parity_v * (GS_VEC_NC * this%send_size)
+    !$omp master
+    do i = 1, size(this%send_pe)
+       this%send_off64_v(i) = int(nc, c_int64_t) * this%send_off64(i)
+       this%send_len64_v(i) = int(nc, c_int64_t) * this%send_len64(i)
+       this%dst_off_v(i) = int(this%parity_v, c_int64_t) &
+            * (GS_VEC_NC * this%rmt_bufsz_v(i)) &
+            + int(nc, c_int64_t) * this%rmt_off_v(i)
+    end do
+    !$omp end master
+
+    ! Pack each peer's slab: nc consecutive component blocks.
+    !$omp do
+    do i = 1, size(this%send_pe)
+       dst = this%send_pe(i)
+       off = this%send_offset(i)
+       ndst = this%send_len(i)
+       sp => this%send_dof(dst)%array()
+       do c = 1, nc
+          !OCL NORECURRENCE, NOVREC, NOALIAS
+          !DIR$ CONCURRENT
+          !GCC$ ivdep
+          !NEC$ IVDEP
+          !$omp simd
+          do j = 1, ndst
+             this%send_buf_v(send_base + nc*off + (c-1)*ndst + j) = &
+                  u((c-1)*n + sp(j))
+          end do
+       end do
+    end do
+    !$omp end do
+
+    ! Fire the puts (see gs_nbsend_utofu). The same dst_off_v serves both
+    ! parity slots of the C transport -- the vector parity is already folded
+    ! into the offsets; the parity argument still stamps the edata bit.
+    call gs_utofu_post_puts(this%ctx_v, int(tid, c_int), &
+         int(nteam, c_int), int(size(this%send_pe), c_int), &
+         this%send_off64_v, this%send_len64_v, this%rmt_vcq_id_v, &
+         this%rmt_stadd_v, this%dst_off_v, this%dst_off_v, this%dst_tag, &
+         int(this%parity_v, c_int), int(send_base, c_int64_t), &
+         int(this%elem_size, c_int), ierr)
+    if (ierr .ne. 0) call neko_error("gs_utofu: vector put failed")
+    !$omp barrier
+#else
+    call neko_error("uTofu support not built")
+#endif
+  end subroutine gs_nbsend_vec_utofu
+
+  !> No-op: the vector receive buffer is registered once at init, so there
+  !! is nothing to post per round.
+  subroutine gs_nbrecv_vec_utofu(this, tag, nc)
+    class(gs_utofu_t), intent(inout) :: this
+    integer, intent(in) :: tag, nc
+  end subroutine gs_nbrecv_vec_utofu
+
+  !> Poll for incoming vector puts, reducing each nc-component slab into u
+  !! as it lands, then flip the vector double-buffer parity. Same protocol
+  !! as gs_nbwait_utofu, on the vector context and parity.
+  subroutine gs_nbwait_vec_utofu(this, u, n, nc, op, strm)
+    class(gs_utofu_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    type(c_ptr), intent(inout) :: strm
+    integer :: op
+#ifdef HAVE_UTOFU
+    integer :: i, j, c, k, src, off, nsrc, nreqs, base
+    integer(c_int) :: ierr
+    integer, pointer :: sp(:)
+    real(kind=rp), pointer :: rbuf(:)
+
+    base = this%parity_v * (GS_VEC_NC * this%buf_size)
+    nreqs = size(this%recv_pe)
+    rbuf => this%recv_buf_v
+
+    do while (nreqs .gt. 0)
+       !$omp master
+       ! Spin on the vector MRQ from the master alone (see gs_nbwait_utofu).
+       this%ncompleted = 0
+       do while (this%ncompleted .eq. 0)
+          call gs_utofu_poll_recv(this%ctx_v, int(this%parity_v, c_int), &
+               int(size(this%recv_pe), c_int), this%ncompleted, &
+               this%recv_indices, ierr)
+          if (ierr .ne. 0) &
+               call neko_error("gs_utofu: vector mrq poll failed")
+       end do
+       !$omp end master
+       !$omp barrier
+
+       do k = 1, this%ncompleted
+          i = this%recv_indices(k)
+          src = this%recv_pe(i)
+          off = this%recv_offset(i)
+          nsrc = this%recv_len(i)
+          sp => this%recv_dof(src)%array()
+          select case (op)
+          case (GS_OP_ADD)
+             !$omp do
+             do j = 1, nsrc
+                do c = 1, nc
+                   u((c-1)*n + sp(j)) = u((c-1)*n + sp(j)) + &
+                        rbuf(base + nc*off + (c-1)*nsrc + j)
+                end do
+             end do
+             !$omp end do
+          case (GS_OP_MUL)
+             !$omp do
+             do j = 1, nsrc
+                do c = 1, nc
+                   u((c-1)*n + sp(j)) = u((c-1)*n + sp(j)) * &
+                        rbuf(base + nc*off + (c-1)*nsrc + j)
+                end do
+             end do
+             !$omp end do
+          case (GS_OP_MIN)
+             !$omp do
+             do j = 1, nsrc
+                do c = 1, nc
+                   u((c-1)*n + sp(j)) = min(u((c-1)*n + sp(j)), &
+                        rbuf(base + nc*off + (c-1)*nsrc + j))
+                end do
+             end do
+             !$omp end do
+          case (GS_OP_MAX)
+             !$omp do
+             do j = 1, nsrc
+                do c = 1, nc
+                   u((c-1)*n + sp(j)) = max(u((c-1)*n + sp(j)), &
+                        rbuf(base + nc*off + (c-1)*nsrc + j))
+                end do
+             end do
+             !$omp end do
+          case default
+             call neko_error("Unknown operation in gs_nbwait_vec_utofu")
+          end select
+       end do
+
+       nreqs = nreqs - this%ncompleted
+       ! Hold the team until every thread has read ncompleted (above) before
+       ! the master re-enters the poll and overwrites recv_indices/ncompleted.
+       !$omp barrier
+    end do
+
+    !$omp master
+    ! Flip to the other vector double-buffer half for the next vector round.
+    ! Send completions are reaped by the next nbsend_vec's drain.
+    this%parity_v = 1 - this%parity_v
+    !$omp end master
+    !$omp barrier
+#else
+    call neko_error("uTofu support not built")
+#endif
+  end subroutine gs_nbwait_vec_utofu
 
 end module gs_utofu

--- a/src/gs/gs_utofu.F90
+++ b/src/gs/gs_utofu.F90
@@ -293,7 +293,12 @@ contains
     call gs_utofu_ctx_create(c_loc(this%send_buf), send_bytes, &
          c_loc(this%recv_buf), recv_bytes, this%ctx, recv_vcq_id, &
          recv_stadd, ierr)
-    if (ierr .ne. 0) call neko_error("gs_utofu: buffer registration failed")
+    if (ierr .eq. 1) then
+       call neko_error("gs_utofu: out of VCQs for the receive queue " // &
+            "(lower OMP_NUM_THREADS or set NEKO_GS_UTOFU_NVCQ)")
+    else if (ierr .ne. 0) then
+       call neko_error("gs_utofu: buffer registration failed")
+    end if
 
     ! Tell each sender where, and with which tag, to put our slab; learn the
     ! same for each receiver we send to. Message layout per peer:
@@ -354,8 +359,12 @@ contains
     call gs_utofu_ctx_create(c_loc(this%send_buf_v), send_bytes, &
          c_loc(this%recv_buf_v), recv_bytes, this%ctx_v, recv_vcq_id, &
          recv_stadd, ierr)
-    if (ierr .ne. 0) &
-         call neko_error("gs_utofu: vector buffer registration failed")
+    if (ierr .eq. 1) then
+       call neko_error("gs_utofu: out of VCQs for the vector receive " // &
+            "queue (lower OMP_NUM_THREADS or set NEKO_GS_UTOFU_NVCQ)")
+    else if (ierr .ne. 0) then
+       call neko_error("gs_utofu: vector buffer registration failed")
+    end if
 
     ! Second metadata exchange for the vector path. Because the component
     ! count nc varies per round, the receiver advertises its UNSCALED layout
@@ -392,7 +401,11 @@ contains
 
     deallocate(msg_out, msg_in, sreq, rreq)
 
-    this%vec_supported = .true.
+    ! Runtime kill-switch for the fused vector path (validation aid):
+    ! NEKO_GS_UTOFU_VEC=0 makes gs_op_r3 fall back to three scalar rounds.
+    ! The vector context stays registered either way; only its use is gated.
+    call get_environment_variable("NEKO_GS_UTOFU_VEC", env_val, env_len)
+    this%vec_supported = .not. (env_len .gt. 0 .and. env_val(1:1) .eq. '0')
 #else
     call neko_error("uTofu support not built; reconfigure with --with-utofu")
 #endif

--- a/src/gs/gs_utofu.F90
+++ b/src/gs/gs_utofu.F90
@@ -1,0 +1,571 @@
+! Copyright (c) 2026, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Defines a gather-scatter backend using the native Tofu interconnect (uTofu).
+!! Each rank registers its receive buffer once and a send is a single one-sided
+!! RDMA put straight into the neighbour's buffer, with the arrival signal fused
+!! into the descriptor (`edata`) instead of a separate atomic/credit message.
+!! Injection is non-blocking and thread-parallel: each OpenMP thread owns one
+!! injection VCQ (created thread-safe, dealt over the TNIs) and fires the puts
+!! for its share of the peers itself. See gs_utofu_aux.c for the transport.
+module gs_utofu
+  use num_types, only : rp, i8
+  use gs_comm, only : gs_comm_t, GS_COMM_UTOFU
+  use gs_ops, only : GS_OP_ADD, GS_OP_MAX, GS_OP_MIN, GS_OP_MUL
+  use stack, only : stack_i4_t
+  use comm, only : NEKO_COMM, pe_rank
+  use logger, only : neko_log, LOG_SIZE
+#ifdef HAVE_UTOFU
+  use mpi_f08, only : MPI_Request, MPI_Isend, MPI_Irecv, MPI_Waitall, &
+       MPI_INTEGER8, MPI_STATUSES_IGNORE
+#endif
+  use utils, only : neko_error
+  !$ use omp_lib, only : omp_get_max_threads, omp_get_thread_num, &
+  !$      omp_get_num_threads
+  use, intrinsic :: iso_c_binding
+  implicit none
+  private
+
+  !> MPI tag used for the one-off neighbour metadata exchange at init.
+  integer, parameter :: GS_UTOFU_XCHG_TAG = 8123
+
+  !> Gather-scatter communication using one-sided uTofu puts.
+  type, public, extends(gs_comm_t) :: gs_utofu_t
+     !> Concatenated send slabs, one per peer (the put sources). Registered
+     !! with uTofu; a pointer (not allocatable) so c_loc can take its address
+     !! -- the standard forbids the target attribute on a type component.
+     real(kind=rp), pointer :: send_buf(:) => null()
+     !> Double-buffered receive slabs: two halves of buf_size elements each,
+     !! selected by parity. Registered with uTofu; pointer for the same reason
+     !! as send_buf.
+     real(kind=rp), pointer :: recv_buf(:) => null()
+     !> Per-peer slab lengths and 0-based offsets into send_buf / recv_buf.
+     integer, allocatable :: send_len(:), recv_len(:)
+     integer, allocatable :: send_offset(:), recv_offset(:)
+     !> Int64 views of the send layout, passed to the C transport.
+     integer(c_int64_t), allocatable :: send_off64(:), send_len64(:)
+     !> Per send-peer remote put targets, learned from each receiver at init:
+     !! its receive VCQ id, buffer STADD, the byte-offsets of our slab in its
+     !! two parity halves, and the edata tag it wants us to stamp.
+     integer(c_int64_t), allocatable :: rmt_vcq_id(:), rmt_stadd(:)
+     integer(c_int64_t), allocatable :: dst_off0(:), dst_off1(:)
+     integer(c_int), allocatable :: dst_tag(:)
+     !> Scratch for the unpack-as-ready loop: receive-peer indices completed
+     !! by the latest poll and how many (c_int to match the C transport).
+     integer(c_int), allocatable :: recv_indices(:)
+     integer(c_int) :: ncompleted = 0
+     !> Size in elements of one receive half (= total receive count).
+     integer :: buf_size = 0
+     !> Size in elements of one send half (= total send count); send_buf is
+     !! double-buffered (2 * send_size) so a round can pack while the previous
+     !! round's puts are still draining.
+     integer :: send_size = 0
+     !> Storage size of one element in bytes.
+     integer :: elem_size = 0
+     !> Active double-buffer half for the next round.
+     integer :: parity = 0
+     !> Opaque per-instance uTofu context (registrations + notice stash).
+     type(c_ptr) :: ctx = c_null_ptr
+   contains
+     procedure, pass(this) :: init => gs_utofu_init
+     procedure, pass(this) :: free => gs_utofu_free
+     procedure, pass(this) :: nbsend => gs_nbsend_utofu
+     procedure, pass(this) :: nbrecv => gs_nbrecv_utofu
+     procedure, pass(this) :: nbwait => gs_nbwait_utofu
+  end type gs_utofu_t
+
+#ifdef HAVE_UTOFU
+  !> Largest edata value the hardware will carry (set once at first init).
+  integer(c_int64_t) :: gs_utofu_edata_max = 255
+  !> Log the granted VCQ/TNI counts only once, on the first instance.
+  logical, save :: gs_utofu_logged = .false.
+
+  interface
+     subroutine gs_utofu_init_ep(ntni_req, nthreads, ntni_out, nvcq_out, &
+          edata_max, ierr) bind(c, name = 'gs_utofu_init')
+       import :: c_int, c_int64_t
+       integer(c_int), value :: ntni_req, nthreads
+       integer(c_int) :: ntni_out, nvcq_out
+       integer(c_int64_t) :: edata_max
+       integer(c_int) :: ierr
+     end subroutine gs_utofu_init_ep
+
+     subroutine gs_utofu_ctx_create(send_buf, send_bytes, recv_buf, &
+          recv_bytes, ctx, recv_vcq_id, recv_stadd, ierr) &
+          bind(c, name = 'gs_utofu_ctx_create')
+       import :: c_ptr, c_size_t, c_int64_t, c_int
+       type(c_ptr), value :: send_buf, recv_buf
+       integer(c_size_t), value :: send_bytes, recv_bytes
+       type(c_ptr) :: ctx
+       integer(c_int64_t) :: recv_vcq_id
+       integer(c_int64_t) :: recv_stadd
+       integer(c_int) :: ierr
+     end subroutine gs_utofu_ctx_create
+
+     subroutine gs_utofu_ctx_free(ctx, ierr) bind(c, name = 'gs_utofu_ctx_free')
+       import :: c_ptr, c_int
+       type(c_ptr), value :: ctx
+       integer(c_int) :: ierr
+     end subroutine gs_utofu_ctx_free
+
+     subroutine gs_utofu_post_puts(ctx, tid, nteam, nsend, send_off, &
+          send_len, rmt_vcq_id, rmt_stadd, dst_off0, dst_off1, dst_tag, &
+          parity, send_base, elem_size, ierr) &
+          bind(c, name = 'gs_utofu_post_puts')
+       import :: c_ptr, c_int, c_int64_t
+       type(c_ptr), value :: ctx
+       integer(c_int), value :: tid, nteam, nsend, parity, elem_size
+       integer(c_int64_t) :: send_off(*), send_len(*)
+       integer(c_int64_t) :: rmt_vcq_id(*), rmt_stadd(*)
+       integer(c_int64_t) :: dst_off0(*), dst_off1(*)
+       integer(c_int) :: dst_tag(*)
+       integer(c_int64_t), value :: send_base
+       integer(c_int) :: ierr
+     end subroutine gs_utofu_post_puts
+
+     subroutine gs_utofu_poll_recv(ctx, parity, cap, ncompleted, out_idx, &
+          ierr) bind(c, name = 'gs_utofu_poll_recv')
+       import :: c_ptr, c_int
+       type(c_ptr), value :: ctx
+       integer(c_int), value :: parity, cap
+       integer(c_int) :: ncompleted
+       integer(c_int) :: out_idx(*)
+       integer(c_int) :: ierr
+     end subroutine gs_utofu_poll_recv
+
+     subroutine gs_utofu_drain_half(ctx, half, tid, nteam, ierr) &
+          bind(c, name = 'gs_utofu_drain_half')
+       import :: c_ptr, c_int
+       type(c_ptr), value :: ctx
+       integer(c_int), value :: half, tid, nteam
+       integer(c_int) :: ierr
+     end subroutine gs_utofu_drain_half
+  end interface
+#endif
+
+contains
+
+  !> Initialise the uTofu communication method. See gs_comm.f90 for details.
+  subroutine gs_utofu_init(this, send_pe, recv_pe)
+    class(gs_utofu_t), intent(inout) :: this
+    type(stack_i4_t), intent(inout) :: send_pe
+    type(stack_i4_t), intent(inout) :: recv_pe
+#ifdef HAVE_UTOFU
+    integer :: i, nsend, nrecv, send_total, recv_total
+    integer :: ntni_req, env_len, max_tag, nthreads
+    integer(c_int) :: ntni, nvcq, ierr
+    integer(c_int64_t) :: recv_vcq_id, recv_stadd
+    integer(c_size_t) :: send_bytes, recv_bytes
+    character(len=32) :: env_val
+    character(len=LOG_SIZE) :: log_buf
+    integer(c_int64_t), allocatable :: msg_out(:,:), msg_in(:,:)
+    type(MPI_Request), allocatable :: sreq(:), rreq(:)
+
+    call this%init_order(send_pe, recv_pe)
+
+    nsend = size(this%send_pe)
+    nrecv = size(this%recv_pe)
+    this%elem_size = int(storage_size(1.0_rp) / 8)
+
+    allocate(this%send_len(nsend), this%send_offset(nsend))
+    allocate(this%send_off64(nsend), this%send_len64(nsend))
+    allocate(this%rmt_vcq_id(nsend), this%rmt_stadd(nsend))
+    allocate(this%dst_off0(nsend), this%dst_off1(nsend), this%dst_tag(nsend))
+    allocate(this%recv_len(nrecv), this%recv_offset(nrecv))
+    allocate(this%recv_indices(nrecv))
+
+    ! Local receive layout (one concatenated half; the other half mirrors it).
+    recv_total = 0
+    do i = 1, nrecv
+       this%recv_len(i) = this%recv_dof(this%recv_pe(i))%size()
+       this%recv_offset(i) = recv_total
+       recv_total = recv_total + this%recv_len(i)
+    end do
+    this%buf_size = recv_total
+
+    ! Local send layout (concatenated per-peer slabs).
+    send_total = 0
+    do i = 1, nsend
+       this%send_len(i) = this%send_dof(this%send_pe(i))%size()
+       this%send_offset(i) = send_total
+       this%send_off64(i) = int(send_total, c_int64_t)
+       this%send_len64(i) = int(this%send_len(i), c_int64_t)
+       send_total = send_total + this%send_len(i)
+    end do
+    this%send_size = send_total
+
+    allocate(this%send_buf(max(1, 2 * send_total)))
+    allocate(this%recv_buf(max(1, 2 * recv_total)))
+
+    ! Create the (process-global) uTofu endpoint and register our buffers.
+    ntni_req = 1
+    call get_environment_variable("NEKO_GS_UTOFU_NTNI", env_val, env_len)
+    if (env_len .gt. 0) read(env_val(1:env_len), *) ntni_req
+
+    ! One injection VCQ is requested per OpenMP thread, dealt over the TNIs.
+    nthreads = 1
+    !$ nthreads = omp_get_max_threads()
+
+    call gs_utofu_init_ep(int(ntni_req, c_int), int(nthreads, c_int), &
+         ntni, nvcq, gs_utofu_edata_max, ierr)
+    if (ierr .ne. 0) call neko_error("gs_utofu: endpoint init failed")
+
+    ! Report what the hardware actually granted: requested vs granted can
+    ! differ when ranks on a node share its TNIs, or when a TNI's VCQ budget
+    ! is smaller than the thread count. Once, on rank 0.
+    if (.not. gs_utofu_logged .and. pe_rank .eq. 0) then
+       write(log_buf, '(A,I0,A,I0,A,I0,A,I0,A)') 'uTofu inj.   : ', &
+            int(nvcq), ' VCQs (', nthreads, ' threads) over ', int(ntni), &
+            ' TNIs (', ntni_req, ' requested)'
+       call neko_log%message(log_buf)
+       gs_utofu_logged = .true.
+    end if
+
+    send_bytes = int(size(this%send_buf), c_size_t) * this%elem_size
+    recv_bytes = int(size(this%recv_buf), c_size_t) * this%elem_size
+    ! recv_vcq_id and recv_stadd are set by gs_utofu_ctx_create through its
+    ! reference arguments (the compiler cannot see the C side write, so
+    ! initialise to keep it from warning). This instance gets its own receive
+    ! VCQ, so the advertised vcq_id is per-instance.
+    recv_vcq_id = 0_c_int64_t
+    recv_stadd = 0_c_int64_t
+    call gs_utofu_ctx_create(c_loc(this%send_buf), send_bytes, &
+         c_loc(this%recv_buf), recv_bytes, this%ctx, recv_vcq_id, &
+         recv_stadd, ierr)
+    if (ierr .ne. 0) call neko_error("gs_utofu: buffer registration failed")
+
+    ! Tell each sender where, and with which tag, to put our slab; learn the
+    ! same for each receiver we send to. Message layout per peer:
+    !   [recv_stadd, recv_vcq_id, byte_off_parity0, byte_off_parity1, tag].
+    allocate(msg_out(5, max(1, nrecv)), msg_in(5, max(1, nsend)))
+    allocate(sreq(max(1, nrecv)), rreq(max(1, nsend)))
+
+    do i = 1, nrecv
+       msg_out(1, i) = recv_stadd
+       msg_out(2, i) = recv_vcq_id
+       msg_out(3, i) = int(this%recv_offset(i), c_int64_t)
+       msg_out(4, i) = int(this%buf_size + this%recv_offset(i), c_int64_t)
+       msg_out(5, i) = int(i - 1, c_int64_t)
+    end do
+
+    do i = 1, nsend
+       call MPI_Irecv(msg_in(:, i), 5, MPI_INTEGER8, this%send_pe(i), &
+            GS_UTOFU_XCHG_TAG, NEKO_COMM, rreq(i))
+    end do
+    do i = 1, nrecv
+       call MPI_Isend(msg_out(:, i), 5, MPI_INTEGER8, this%recv_pe(i), &
+            GS_UTOFU_XCHG_TAG, NEKO_COMM, sreq(i))
+    end do
+    if (nsend .gt. 0) call MPI_Waitall(nsend, rreq, MPI_STATUSES_IGNORE)
+    if (nrecv .gt. 0) call MPI_Waitall(nrecv, sreq, MPI_STATUSES_IGNORE)
+
+    max_tag = 0
+    do i = 1, nsend
+       this%rmt_stadd(i)  = msg_in(1, i)
+       this%rmt_vcq_id(i) = msg_in(2, i)
+       this%dst_off0(i)   = msg_in(3, i)
+       this%dst_off1(i)   = msg_in(4, i)
+       this%dst_tag(i)    = int(msg_in(5, i), c_int)
+       max_tag = max(max_tag, this%dst_tag(i))
+    end do
+
+    deallocate(msg_out, msg_in, sreq, rreq)
+
+    ! The edata carries the slab tag in its high bits and the parity bit in
+    ! bit 0, so a neighbour's count must fit (2*tag + 1) in the edata range.
+    if (int(2 * max_tag + 1, i8) .gt. int(gs_utofu_edata_max, i8)) &
+         call neko_error("gs_utofu: neighbour count exceeds edata capacity")
+#else
+    call neko_error("uTofu support not built; reconfigure with --with-utofu")
+#endif
+  end subroutine gs_utofu_init
+
+  !> Deallocate the uTofu communication method.
+  subroutine gs_utofu_free(this)
+    class(gs_utofu_t), intent(inout) :: this
+#ifdef HAVE_UTOFU
+    integer(c_int) :: ierr
+
+    if (c_associated(this%ctx)) then
+       call gs_utofu_ctx_free(this%ctx, ierr)
+       this%ctx = c_null_ptr
+    end if
+
+    if (associated(this%send_buf)) then
+       deallocate(this%send_buf)
+    end if
+
+    if (associated(this%recv_buf)) then
+       deallocate(this%recv_buf)
+    end if
+
+    if (allocated(this%send_len)) then
+       deallocate(this%send_len)
+    end if
+
+    if (allocated(this%recv_len)) then
+       deallocate(this%recv_len)
+    end if
+
+    if (allocated(this%send_offset)) then
+       deallocate(this%send_offset)
+    end if
+
+    if (allocated(this%recv_offset)) then
+       deallocate(this%recv_offset)
+    end if
+
+    if (allocated(this%send_off64)) then
+       deallocate(this%send_off64)
+    end if
+
+    if (allocated(this%send_len64)) then
+       deallocate(this%send_len64)
+    end if
+
+    if (allocated(this%rmt_vcq_id)) then
+       deallocate(this%rmt_vcq_id)
+    end if
+
+    if (allocated(this%rmt_stadd)) then
+       deallocate(this%rmt_stadd)
+    end if
+
+    if (allocated(this%dst_off0)) then
+       deallocate(this%dst_off0)
+    end if
+
+    if (allocated(this%dst_off1)) then
+       deallocate(this%dst_off1)
+    end if
+
+    if (allocated(this%dst_tag)) then
+       deallocate(this%dst_tag)
+    end if
+
+    if (allocated(this%recv_indices)) then
+       deallocate(this%recv_indices)
+    end if
+
+    call this%free_order()
+    call this%free_dofs()
+#endif
+  end subroutine gs_utofu_free
+
+  !> Pack the send slabs and fire all one-sided puts (non-blocking).
+  subroutine gs_nbsend_utofu(this, u, n, tag, deps, strm)
+    class(gs_utofu_t), intent(inout) :: this
+    integer, intent(in) :: n
+    real(kind=rp), dimension(n), intent(inout) :: u
+    integer, intent(in) :: tag
+    type(c_ptr), intent(inout) :: deps
+    type(c_ptr), intent(inout) :: strm
+#ifdef HAVE_UTOFU
+    integer :: i, j, dst, off, ndst, send_base, tid, nteam
+    integer(c_int) :: ierr
+    integer, pointer :: sp(:)
+
+    ! Entered from inside the gs_op_vector OpenMP parallel region, and every
+    ! phase is work-shared: each thread owns one injection VCQ (created
+    ! THREAD_SAFE) and fires the puts for its share of the peers itself --
+    ! the uTofu substitute for the per-thread MPI_Isend that Fujitsu MPI's
+    ! missing MPI_THREAD_MULTIPLE support rules out.
+    tid = 0
+    nteam = 1
+    !$ tid = omp_get_thread_num()
+    !$ nteam = omp_get_num_threads()
+
+    ! Reclaim the send-buffer half we are about to repack: the team strides
+    ! over the injection VCQs so each one is drained by exactly one thread
+    ! (no atomics on the completion counters). The half was last used two
+    ! rounds ago, so its puts have long completed -- this just reaps their
+    ! TCQ notices. The barrier then guarantees the whole half is free before
+    ! anyone packs into it.
+    call gs_utofu_drain_half(this%ctx, int(this%parity, c_int), &
+         int(tid, c_int), int(nteam, c_int), ierr)
+    if (ierr .ne. 0) call neko_error("gs_utofu: send drain failed")
+    !$omp barrier
+
+    ! Pack each peer's slab in one work-shared loop. Subroutine locals are
+    ! per-thread private (orphaned region); the implicit barrier at end do
+    ! guarantees every slab is packed before any thread fires its puts (a
+    ! peer packed by one thread may be sent by another -- the pack and post
+    ! partitions differ).
+    send_base = this%parity * this%send_size
+    !$omp do
+    do i = 1, size(this%send_pe)
+       dst = this%send_pe(i)
+       off = this%send_offset(i)
+       ndst = this%send_len(i)
+       sp => this%send_dof(dst)%array()
+       !OCL NORECURRENCE, NOVREC, NOALIAS
+       !DIR$ CONCURRENT
+       !GCC$ ivdep
+       !NEC$ IVDEP
+       !$omp simd
+       do j = 1, ndst
+          this%send_buf(send_base + off + j) = u(sp(j))
+       end do
+    end do
+    !$omp end do
+
+    ! Fire the one-sided puts: each thread injects its modulo share of the
+    ! peers on its own VCQ (or thread 0 injects everything when
+    ! NEKO_GS_UTOFU_MASTER_INJECT is set, as an A/B reference). The trailing
+    ! barrier holds the team until every put has been issued.
+    call gs_utofu_post_puts(this%ctx, int(tid, c_int), int(nteam, c_int), &
+         int(size(this%send_pe), c_int), &
+         this%send_off64, this%send_len64, this%rmt_vcq_id, this%rmt_stadd, &
+         this%dst_off0, this%dst_off1, this%dst_tag, &
+         int(this%parity, c_int), int(send_base, c_int64_t), &
+         int(this%elem_size, c_int), ierr)
+    if (ierr .ne. 0) call neko_error("gs_utofu: put failed")
+    !$omp barrier
+#else
+    call neko_error("uTofu support not built")
+#endif
+  end subroutine gs_nbsend_utofu
+
+  !> No-op: the one-sided receive buffer is registered once at init, so there
+  !! is nothing to post per round.
+  subroutine gs_nbrecv_utofu(this, tag)
+    class(gs_utofu_t), intent(inout) :: this
+    integer, intent(in) :: tag
+  end subroutine gs_nbrecv_utofu
+
+  !> Poll for incoming puts, reducing each slab into u as it lands, then wait
+  !! for our own sends to drain and flip the double-buffer parity.
+  subroutine gs_nbwait_utofu(this, u, n, op, strm)
+    class(gs_utofu_t), intent(inout) :: this
+    integer, intent(in) :: n
+    real(kind=rp), dimension(n), intent(inout) :: u
+    type(c_ptr), intent(inout) :: strm
+    integer :: op
+#ifdef HAVE_UTOFU
+    integer :: i, j, k, src, off, nsrc, nreqs, base
+    integer(c_int) :: ierr
+    integer, pointer :: sp(:)
+    ! Bind a local pointer to the receive buffer and index it in the unpack
+    ! loops, mirroring how the CAF backend uses its module-level buffer.
+    real(kind=rp), pointer :: rbuf(:)
+
+    base = this%parity * this%buf_size
+    nreqs = size(this%recv_pe)
+    rbuf => this%recv_buf
+
+    do while (nreqs .gt. 0)
+       !$omp master
+       ! Spin on the MRQ from the master alone until at least one slab lands.
+       ! Polling here (rather than around the whole team) keeps the idle
+       ! threads from paying a barrier on every empty poll -- the dominant
+       ! cost under interconnect latency.
+       this%ncompleted = 0
+       do while (this%ncompleted .eq. 0)
+          call gs_utofu_poll_recv(this%ctx, int(this%parity, c_int), &
+               int(size(this%recv_pe), c_int), this%ncompleted, &
+               this%recv_indices, ierr)
+          if (ierr .ne. 0) call neko_error("gs_utofu: mrq poll failed")
+       end do
+       !$omp end master
+       !$omp barrier
+
+       do k = 1, this%ncompleted
+          i = this%recv_indices(k)
+          src = this%recv_pe(i)
+          off = this%recv_offset(i)
+          nsrc = this%recv_len(i)
+          sp => this%recv_dof(src)%array()
+          select case (op)
+          case (GS_OP_ADD)
+             !OCL NORECURRENCE, NOVREC, NOALIAS
+             !DIR$ CONCURRENT
+             !GCC$ ivdep
+             !NEC$ IVDEP
+             !$omp do
+             do j = 1, nsrc
+                u(sp(j)) = u(sp(j)) + rbuf(base + off + j)
+             end do
+             !$omp end do
+          case (GS_OP_MUL)
+             !OCL NORECURRENCE, NOVREC, NOALIAS
+             !DIR$ CONCURRENT
+             !GCC$ ivdep
+             !NEC$ IVDEP
+             !$omp do
+             do j = 1, nsrc
+                u(sp(j)) = u(sp(j)) * rbuf(base + off + j)
+             end do
+             !$omp end do
+          case (GS_OP_MIN)
+             !OCL NORECURRENCE, NOVREC, NOALIAS
+             !DIR$ CONCURRENT
+             !GCC$ ivdep
+             !NEC$ IVDEP
+             !$omp do
+             do j = 1, nsrc
+                u(sp(j)) = min(u(sp(j)), rbuf(base + off + j))
+             end do
+             !$omp end do
+          case (GS_OP_MAX)
+             !OCL NORECURRENCE, NOVREC, NOALIAS
+             !DIR$ CONCURRENT
+             !GCC$ ivdep
+             !NEC$ IVDEP
+             !$omp do
+             do j = 1, nsrc
+                u(sp(j)) = max(u(sp(j)), rbuf(base + off + j))
+             end do
+             !$omp end do
+          case default
+             call neko_error("Unknown operation in gs_nbwait_utofu")
+          end select
+       end do
+
+       nreqs = nreqs - this%ncompleted
+       ! Hold the team until every thread has read ncompleted (above) before
+       ! the master re-enters the poll and overwrites recv_indices/ncompleted.
+       !$omp barrier
+    end do
+
+    !$omp master
+    ! Flip to the other double-buffer half for the next round. Send completions
+    ! are NOT waited on here; nbsend drains the half it reuses, keeping the
+    ! send-completion wait off the critical path.
+    this%parity = 1 - this%parity
+    !$omp end master
+    !$omp barrier
+#else
+    call neko_error("uTofu support not built")
+#endif
+  end subroutine gs_nbwait_utofu
+
+end module gs_utofu

--- a/src/gs/gs_utofu_aux.c
+++ b/src/gs/gs_utofu_aux.c
@@ -100,6 +100,7 @@ static int              gs_utofu_recv_rr = 0;  /* round-robins recv-VCQ TNIs */
 static uint64_t         gs_utofu_edata_max = 255;
 static unsigned long    gs_utofu_put_flags = GS_UTOFU_PUT_FLAGS_BASE;
 static int              gs_utofu_master_inject = 0;
+static size_t           gs_utofu_nrvcq_def = 1;  /* recv VCQs per ctx (req.) */
 
 /* Longs per counter slot: one A64FX L1/L2 cache line (256 bytes), so the
  * per-VCQ completion counters never false-share between threads. */
@@ -108,8 +109,16 @@ static int              gs_utofu_master_inject = 0;
 /* --- per-instance context (one per gs_utofu_t) -------------------------- */
 typedef struct {
   utofu_stadd_t  *send_stadd;  /* [nvcq] send_buf registered on each inj VCQ */
-  utofu_vcq_hdl_t recv_vcq;    /* this instance's OWN receive VCQ (its MRQ) */
-  utofu_stadd_t   recv_stadd;  /* recv_buf registered on recv_vcq           */
+  /* This instance's OWN receive VCQs, spread over the TNIs. Each receive
+   * peer is bound to one of them at init (the receiver advertises that
+   * VCQ's id/STADD to the peer), so incoming halo traffic is processed by
+   * several TNIs instead of funnelling through one -- the receive-side
+   * counterpart of the per-thread injection pool. All are polled by the
+   * master; the edata tags are per-instance-unique, so which MRQ a notice
+   * appears on carries no protocol meaning. */
+  size_t          nrvcq;       /* receive VCQs actually created (>= 1)      */
+  utofu_vcq_hdl_t *recv_vcq;   /* [nrvcq]                                   */
+  utofu_stadd_t   *recv_stadd; /* [nrvcq] recv_buf registered on each       */
   /* Outstanding (un-reaped) put completions, one padded slot per
    * (injection VCQ, send-buffer half). The put's cbdata points at its
    * slot, so draining a VCQ's TCQ decrements the right counter -- letting
@@ -163,10 +172,13 @@ static void gs_utofu_stash_push(gs_utofu_ctx_t *ctx, uint64_t edata)
  * @param nthreads    OpenMP thread count = requested injection VCQs (>=1)
  * @param ntni_out    number of TNIs actually in use
  * @param nvcq_out    number of injection VCQs actually created
+ * @param nrvcq_out   receive VCQs requested per instance path (the caller
+ *                    sizes its id/STADD arrays with this; ctx_create may
+ *                    grant fewer)
  * @param edata_max   largest usable edata value (for tag-range checking)
  */
 void gs_utofu_init(int ntni_req, int nthreads, int *ntni_out, int *nvcq_out,
-                   uint64_t *edata_max, int *ierr)
+                   int *nrvcq_out, uint64_t *edata_max, int *ierr)
 {
   *ierr = 0;
 
@@ -233,6 +245,19 @@ void gs_utofu_init(int ntni_req, int nthreads, int *ntni_out, int *nvcq_out,
      * receive queues prefer interfaces the pool has not loaded. */
     gs_utofu_recv_rr = (int) (gs_utofu_ntni % gs_utofu_nalltni);
 
+    /* Receive VCQs per instance path: default one per TNI, so an
+     * instance's incoming halo traffic is processed by every interface
+     * instead of funnelling through one. NEKO_GS_UTOFU_NRVCQ overrides
+     * (=1 restores the single-receive-VCQ behaviour). The budget is
+     * shared with the injection pool and across instances/paths;
+     * ctx_create degrades gracefully to fewer when it runs dry. */
+    gs_utofu_nrvcq_def = gs_utofu_nalltni;
+    const char *nr = getenv("NEKO_GS_UTOFU_NRVCQ");
+    if (nr != NULL) {
+      long v = strtol(nr, NULL, 10);
+      if (v > 0 && v <= 64) gs_utofu_nrvcq_def = (size_t) v;
+    }
+
     /* Largest edata the hardware will carry. VERIFY: field name and whether
      * the capability is expressed in bytes (assumed here). */
     struct utofu_onesided_caps *caps = NULL;
@@ -264,47 +289,63 @@ void gs_utofu_init(int ntni_req, int nthreads, int *ntni_out, int *nvcq_out,
   *edata_max   = gs_utofu_edata_max;
   *ntni_out    = (int) gs_utofu_ntni;
   *nvcq_out    = (int) gs_utofu_nvcq;
+  *nrvcq_out   = (int) gs_utofu_nrvcq_def;
 }
 
 /**
  * Register an instance's send/recv buffers and allocate its context.
  * send_buf is registered on every injection VCQ (the source STADD must
- * belong to the VCQ that issues the put). The instance gets its OWN receive
- * VCQ (a private MRQ); recv_buf is registered on it, and its id is advertised
- * to neighbours as the put target so arrivals land only in this instance's
- * queue. The receive VCQ's TNI is round-robined across interfaces.
+ * belong to the VCQ that issues the put). The instance gets its OWN set of
+ * receive VCQs (private MRQs); recv_buf is registered on each, and the
+ * caller binds every receive peer to one of them, advertising that VCQ's
+ * id/STADD as the peer's put target -- so arrivals land only in this
+ * instance's queues, spread over the TNIs.
+ *
+ * recv_vcq_id / recv_stadd are arrays of (at least) the nrvcq_out value
+ * reported by gs_utofu_init; entries [0, *nrvcq_out) are filled. Fewer
+ * than requested may be granted when the VCQ budget runs dry (>= 1, or
+ * ierr = 1 -- remedy: lower OMP_NUM_THREADS, cap NEKO_GS_UTOFU_NVCQ, or
+ * reduce NEKO_GS_UTOFU_NRVCQ).
  */
 void gs_utofu_ctx_create(void *send_buf, size_t send_bytes,
                          void *recv_buf, size_t recv_bytes,
-                         void **ctx_out, uint64_t *recv_vcq_id,
-                         uint64_t *recv_stadd, int *ierr)
+                         void **ctx_out, int *nrvcq_out,
+                         uint64_t *recv_vcq_id, uint64_t *recv_stadd,
+                         int *ierr)
 {
   *ierr = 0;
   gs_utofu_ctx_t *ctx = calloc(1, sizeof(*ctx));
   ctx->send_stadd = malloc(gs_utofu_nvcq * sizeof(*ctx->send_stadd));
   ctx->send_pending = calloc(2 * gs_utofu_nvcq * GS_UTOFU_PEND_STRIDE,
                              sizeof(*ctx->send_pending));
+  ctx->recv_vcq   = malloc(gs_utofu_nrvcq_def * sizeof(*ctx->recv_vcq));
+  ctx->recv_stadd = malloc(gs_utofu_nrvcq_def * sizeof(*ctx->recv_stadd));
 
-  /* The receive VCQ may sit on ANY one-sided TNI: incoming puts are routed
+  /* Receive VCQs may sit on ANY one-sided TNI: incoming puts are routed
    * by the advertised VCQ id, so spreading the receive processing over all
    * interfaces is free (NEKO_GS_UTOFU_NTNI deliberately confines only the
    * injection side). Round-robin over the full set, sweeping past
    * exhausted TNIs -- the injection pool can eat a whole TNI's VCQ budget
-   * (~8 per TNI on Fugaku) and a private MRQ per instance is a correctness
-   * requirement, so only give up when every TNI is out of VCQs (ierr 1;
-   * remedy: lower OMP_NUM_THREADS or cap NEKO_GS_UTOFU_NVCQ).
-   * It stays non-THREAD_SAFE (flags 0): it is strictly master-polled, and
-   * skipping the internal lock keeps the MRQ spin -- the receive hot path
-   * -- cheap. It must never be touched off-master. */
-  int created = 0;
-  for (size_t s = 0; s < gs_utofu_nalltni && !created; s++) {
-    utofu_tni_id_t rtni =
-      gs_utofu_alltni[((size_t) gs_utofu_recv_rr + s) % gs_utofu_nalltni];
-    if (utofu_create_vcq(rtni, 0, &ctx->recv_vcq) == UTOFU_SUCCESS)
-      created = 1;
+   * (~8 per TNI on Fugaku). Stop early when the budget runs dry; at least
+   * one must succeed, since a private MRQ per instance is a correctness
+   * requirement. They stay non-THREAD_SAFE (flags 0): they are strictly
+   * master-polled, and skipping the internal lock keeps the MRQ sweep --
+   * the receive hot path -- cheap. Never touch them off-master. */
+  while (ctx->nrvcq < gs_utofu_nrvcq_def) {
+    int created = 0;
+    for (size_t s = 0; s < gs_utofu_nalltni && !created; s++) {
+      utofu_tni_id_t rtni =
+        gs_utofu_alltni[((size_t) gs_utofu_recv_rr + s) % gs_utofu_nalltni];
+      if (utofu_create_vcq(rtni, 0, &ctx->recv_vcq[ctx->nrvcq])
+          == UTOFU_SUCCESS)
+        created = 1;
+    }
+    gs_utofu_recv_rr++;
+    if (!created)
+      break;
+    ctx->nrvcq++;
   }
-  gs_utofu_recv_rr++;
-  if (!created) {
+  if (ctx->nrvcq == 0) {
     *ierr = 1;
     return;
   }
@@ -316,20 +357,25 @@ void gs_utofu_ctx_create(void *send_buf, size_t send_bytes,
       return;
     }
   }
-  if (utofu_reg_mem(ctx->recv_vcq, recv_buf, recv_bytes, 0,
-                    &ctx->recv_stadd) != UTOFU_SUCCESS) {
-    *ierr = 3;
-    return;
+  for (size_t r = 0; r < ctx->nrvcq; r++) {
+    if (utofu_reg_mem(ctx->recv_vcq[r], recv_buf, recv_bytes, 0,
+                      &ctx->recv_stadd[r]) != UTOFU_SUCCESS) {
+      *ierr = 3;
+      return;
+    }
   }
 
-  utofu_vcq_id_t vid;
-  if (utofu_query_vcq_id(ctx->recv_vcq, &vid) != UTOFU_SUCCESS) {
-    *ierr = 4;
-    return;
+  for (size_t r = 0; r < ctx->nrvcq; r++) {
+    utofu_vcq_id_t vid;
+    if (utofu_query_vcq_id(ctx->recv_vcq[r], &vid) != UTOFU_SUCCESS) {
+      *ierr = 4;
+      return;
+    }
+    recv_vcq_id[r] = (uint64_t) vid;
+    recv_stadd[r]  = (uint64_t) ctx->recv_stadd[r];
   }
 
-  *recv_vcq_id = (uint64_t) vid;
-  *recv_stadd  = (uint64_t) ctx->recv_stadd;
+  *nrvcq_out = (int) ctx->nrvcq;
   *ctx_out = ctx;
 }
 
@@ -349,10 +395,14 @@ void gs_utofu_ctx_free(void *vctx, int *ierr)
 
   for (size_t k = 0; k < gs_utofu_nvcq; k++)
     utofu_dereg_mem(gs_utofu_vcq[k], ctx->send_stadd[k], 0);
-  utofu_dereg_mem(ctx->recv_vcq, ctx->recv_stadd, 0);
-  utofu_free_vcq(ctx->recv_vcq);
+  for (size_t r = 0; r < ctx->nrvcq; r++) {
+    utofu_dereg_mem(ctx->recv_vcq[r], ctx->recv_stadd[r], 0);
+    utofu_free_vcq(ctx->recv_vcq[r]);
+  }
 
   free(ctx->send_stadd);
+  free(ctx->recv_vcq);
+  free(ctx->recv_stadd);
   free(ctx->send_pending);
   free(ctx->stash);
   free(ctx);
@@ -474,23 +524,28 @@ void gs_utofu_poll_recv(void *vctx, int parity, int cap,
   }
   ctx->stash_n = w;
 
-  /* Drain currently-available arrival notices from this instance's MRQ. */
+  /* Drain currently-available arrival notices from every one of this
+   * instance's MRQs. Each peer's notices always land on its bound VCQ, but
+   * the tags are instance-unique, so the queues can be drained in any
+   * order into the one result list / stash. */
   struct utofu_mrq_notice notice;
-  while (n < cap) {
-    int rc = utofu_poll_mrq(ctx->recv_vcq, 0, &notice);
-    if (rc == UTOFU_ERR_NOT_FOUND) break;
-    if (rc != UTOFU_SUCCESS) {
-      *ierr = 1;
-      return;
-    }
-    /* VERIFY: RMT_PUT is the receiver-side notice for an incoming put. */
-    if (notice.notice_type != UTOFU_MRQ_TYPE_RMT_PUT) continue;
+  for (size_t r = 0; r < ctx->nrvcq && n < cap; r++) {
+    while (n < cap) {
+      int rc = utofu_poll_mrq(ctx->recv_vcq[r], 0, &notice);
+      if (rc == UTOFU_ERR_NOT_FOUND) break;
+      if (rc != UTOFU_SUCCESS) {
+        *ierr = 1;
+        return;
+      }
+      /* VERIFY: RMT_PUT is the receiver-side notice for an incoming put. */
+      if (notice.notice_type != UTOFU_MRQ_TYPE_RMT_PUT) continue;
 
-    uint64_t ed = notice.edata;
-    if ((int)(ed & 1u) == parity)
-      out_idx[n++] = (int)(ed >> 1) + 1;
-    else
-      gs_utofu_stash_push(ctx, ed);
+      uint64_t ed = notice.edata;
+      if ((int)(ed & 1u) == parity)
+        out_idx[n++] = (int)(ed >> 1) + 1;
+      else
+        gs_utofu_stash_push(ctx, ed);
+    }
   }
 
   *ncompleted = n;

--- a/src/gs/gs_utofu_aux.c
+++ b/src/gs/gs_utofu_aux.c
@@ -91,9 +91,11 @@
 /* --- process-global endpoint state, created once ------------------------ */
 static int             gs_utofu_ready = 0;
 static size_t          gs_utofu_nvcq  = 0;     /* number of injection VCQs  */
-static size_t          gs_utofu_ntni  = 0;     /* distinct TNIs in use      */
-static utofu_vcq_hdl_t *gs_utofu_vcq   = NULL; /* [nvcq] injection VCQs     */
-static utofu_tni_id_t  *gs_utofu_tniid = NULL; /* [ntni] granted TNI ids    */
+static size_t          gs_utofu_ntni  = 0;     /* TNIs used for injection   */
+static utofu_vcq_hdl_t *gs_utofu_vcq    = NULL; /* [nvcq] injection VCQs    */
+static utofu_tni_id_t  *gs_utofu_alltni = NULL; /* [nalltni] ALL 1-sided TNIs;
+                                                 * first ntni = injection set */
+static size_t           gs_utofu_nalltni = 0;
 static int              gs_utofu_recv_rr = 0;  /* round-robins recv-VCQ TNIs */
 static uint64_t         gs_utofu_edata_max = 255;
 static unsigned long    gs_utofu_put_flags = GS_UTOFU_PUT_FLAGS_BASE;
@@ -180,25 +182,45 @@ void gs_utofu_init(int ntni_req, int nthreads, int *ntni_out, int *nvcq_out,
 
     size_t want_tni = (ntni_req > 0) ? (size_t) ntni_req : 1;
     if (want_tni > num_tnis) want_tni = num_tnis;
-    gs_utofu_ntni  = want_tni;
-    gs_utofu_tniid = malloc(want_tni * sizeof(*gs_utofu_tniid));
-    for (size_t k = 0; k < want_tni; k++)
-      gs_utofu_tniid[k] = tnis[k];
+    gs_utofu_ntni    = want_tni;
+    gs_utofu_nalltni = num_tnis;
+    gs_utofu_alltni  = malloc(num_tnis * sizeof(*gs_utofu_alltni));
+    for (size_t k = 0; k < num_tnis; k++)
+      gs_utofu_alltni[k] = tnis[k];
 
-    /* One injection VCQ per thread. THREAD_SAFE is what makes multithreaded
-     * operation defined at all: without it uTofu takes the unlocked
-     * direct-descriptor injection path and any cross-thread touch corrupts
-     * the TOQ (the "TOQ Direct Descriptor Exception" of the first
-     * multithreaded attempt). With one thread per VCQ the internal lock is
-     * uncontended. If a TNI's VCQ budget runs out mid-loop, keep what was
-     * granted: threads beyond the count simply do not inject (see
-     * gs_utofu_post_puts), and the modulo peer partition shrinks with it. */
+    /* One injection VCQ per thread, capped by NEKO_GS_UTOFU_NVCQ. The VCQ
+     * budget is shared with the per-instance receive VCQs created later
+     * (one scalar + one vector per gs instance) -- on Fugaku a TNI grants
+     * us ~8 VCQs, so a 12-thread pool can eat a whole TNI; the cap lets a
+     * tight budget be rebalanced without rebuilding. THREAD_SAFE is what
+     * makes multithreaded operation defined at all: without it uTofu takes
+     * the unlocked direct-descriptor injection path and any cross-thread
+     * touch corrupts the TOQ (the "TOQ Direct Descriptor Exception" of the
+     * first multithreaded attempt). With one thread per VCQ the internal
+     * lock is uncontended. */
     size_t want_vcq = (nthreads > 0) ? (size_t) nthreads : 1;
+    const char *nv = getenv("NEKO_GS_UTOFU_NVCQ");
+    if (nv != NULL) {
+      long cap = strtol(nv, NULL, 10);
+      if (cap > 0 && (size_t) cap < want_vcq)
+        want_vcq = (size_t) cap;
+    }
+
+    /* Preferred TNI first, then the rest of the injection set: one
+     * exhausted TNI must not end the pool while others still have room.
+     * If every TNI in the set is out of VCQs, keep what was granted:
+     * threads beyond the count simply do not inject (see
+     * gs_utofu_post_puts), and the modulo peer partition shrinks with it. */
     gs_utofu_vcq = malloc(want_vcq * sizeof(*gs_utofu_vcq));
     while (gs_utofu_nvcq < want_vcq) {
-      if (utofu_create_vcq(gs_utofu_tniid[gs_utofu_nvcq % want_tni],
-                           UTOFU_VCQ_FLAG_THREAD_SAFE,
-                           &gs_utofu_vcq[gs_utofu_nvcq]) != UTOFU_SUCCESS)
+      int created = 0;
+      for (size_t s = 0; s < want_tni && !created; s++) {
+        if (utofu_create_vcq(gs_utofu_alltni[(gs_utofu_nvcq + s) % want_tni],
+                             UTOFU_VCQ_FLAG_THREAD_SAFE,
+                             &gs_utofu_vcq[gs_utofu_nvcq]) == UTOFU_SUCCESS)
+          created = 1;
+      }
+      if (!created)
         break;
       gs_utofu_nvcq++;
     }
@@ -206,6 +228,10 @@ void gs_utofu_init(int ntni_req, int nthreads, int *ntni_out, int *nvcq_out,
       *ierr = 2;
       return;
     }
+
+    /* Start the receive-VCQ round-robin just past the injection TNIs, so
+     * receive queues prefer interfaces the pool has not loaded. */
+    gs_utofu_recv_rr = (int) (gs_utofu_ntni % gs_utofu_nalltni);
 
     /* Largest edata the hardware will carry. VERIFY: field name and whether
      * the capability is expressed in bytes (assumed here). */
@@ -259,12 +285,26 @@ void gs_utofu_ctx_create(void *send_buf, size_t send_bytes,
   ctx->send_pending = calloc(2 * gs_utofu_nvcq * GS_UTOFU_PEND_STRIDE,
                              sizeof(*ctx->send_pending));
 
-  /* The receive VCQ stays non-THREAD_SAFE (flags 0): it is strictly
-   * master-polled, and skipping the internal lock keeps the MRQ spin --
-   * the receive hot path -- cheap. It must never be touched off-master. */
-  utofu_tni_id_t rtni = gs_utofu_tniid[gs_utofu_recv_rr % (int) gs_utofu_ntni];
+  /* The receive VCQ may sit on ANY one-sided TNI: incoming puts are routed
+   * by the advertised VCQ id, so spreading the receive processing over all
+   * interfaces is free (NEKO_GS_UTOFU_NTNI deliberately confines only the
+   * injection side). Round-robin over the full set, sweeping past
+   * exhausted TNIs -- the injection pool can eat a whole TNI's VCQ budget
+   * (~8 per TNI on Fugaku) and a private MRQ per instance is a correctness
+   * requirement, so only give up when every TNI is out of VCQs (ierr 1;
+   * remedy: lower OMP_NUM_THREADS or cap NEKO_GS_UTOFU_NVCQ).
+   * It stays non-THREAD_SAFE (flags 0): it is strictly master-polled, and
+   * skipping the internal lock keeps the MRQ spin -- the receive hot path
+   * -- cheap. It must never be touched off-master. */
+  int created = 0;
+  for (size_t s = 0; s < gs_utofu_nalltni && !created; s++) {
+    utofu_tni_id_t rtni =
+      gs_utofu_alltni[((size_t) gs_utofu_recv_rr + s) % gs_utofu_nalltni];
+    if (utofu_create_vcq(rtni, 0, &ctx->recv_vcq) == UTOFU_SUCCESS)
+      created = 1;
+  }
   gs_utofu_recv_rr++;
-  if (utofu_create_vcq(rtni, 0, &ctx->recv_vcq) != UTOFU_SUCCESS) {
+  if (!created) {
     *ierr = 1;
     return;
   }

--- a/src/gs/gs_utofu_aux.c
+++ b/src/gs/gs_utofu_aux.c
@@ -75,7 +75,16 @@
  * and on the remote MRQ (so the receiver learns of arrival). Cache
  * injection (added at init unless NEKO_GS_UTOFU_CACHE_INJECT=0) drops the
  * received slab straight into the peer's cache -- a win if it is consumed
- * immediately, a loss if it pollutes cache, hence the runtime toggle. */
+ * immediately, a loss if it pollutes cache, hence the runtime toggle.
+ *
+ * UTOFU_ONESIDED_FLAG_STRONG_ORDER (which jacobi2d sets) is deliberately
+ * NOT used: it is only required when arrival is detected by watchdog-
+ * polling the payload's last word, which needs the data to land in address
+ * order. The RMT_PUT MRQ notice used here is raised only after the whole
+ * put has been written at the target, so it already carries that
+ * guarantee, and strong ordering would just restrict the NIC's packet-
+ * level freedom on multi-packet slabs. Revisit if the receive side ever
+ * moves to jacobi2d-style payload watchdogs. */
 #define GS_UTOFU_PUT_FLAGS_BASE                                          \
   (UTOFU_ONESIDED_FLAG_TCQ_NOTICE | UTOFU_ONESIDED_FLAG_REMOTE_MRQ_NOTICE)
 

--- a/src/gs/gs_utofu_aux.c
+++ b/src/gs/gs_utofu_aux.c
@@ -1,0 +1,465 @@
+/*
+ Copyright (c) 2026, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/**
+ * Native Tofu (uTofu) helper routines for the gs_utofu gather-scatter
+ * backend (see gs_utofu.F90).
+ *
+ * The transport is a set of one-sided RDMA puts. Each rank registers its
+ * receive buffer once and advertises the (vcq_id, stadd) to its neighbours.
+ * A send is then a single utofu_put straight into the neighbour's receive
+ * buffer, carrying an `edata` tag in the descriptor; the put's arrival
+ * raises a remote MRQ notice carrying that tag, so the *signal is fused
+ * into the data transfer* -- no separate atomic/credit message, unlike the
+ * coarray backend.
+ *
+ * Injection is non-blocking and thread-parallel: one injection VCQ is
+ * created per OpenMP thread (dealt round-robin over the TNIs), and each
+ * thread fires the puts for its share of the peers on its own VCQ -- the
+ * uTofu substitute for the per-thread MPI_Isend that Fujitsu MPI's missing
+ * MPI_THREAD_MULTIPLE support rules out (cf. the RIKEN-LQCD/jacobi2d
+ * reference program). Every VCQ is created with UTOFU_VCQ_FLAG_THREAD_SAFE;
+ * without it uTofu takes the unlocked direct-descriptor injection path and
+ * any cross-thread touch of the VCQ corrupts its TOQ ("TOQ Direct
+ * Descriptor Exception"). With one thread per VCQ the internal lock is
+ * uncontended. The number of TNIs to deal the VCQs over is chosen by the
+ * caller (NEKO_GS_UTOFU_NTNI, default 1 -- multi-TNI is opt-in until
+ * validated on a given machine); NEKO_GS_UTOFU_MASTER_INJECT=1 serialises
+ * all injection onto thread 0 as an A/B reference.
+ *
+ * Build: requires Fujitsu's uTofu headers/runtime (Fugaku). Only compiled
+ * when ENABLE_UTOFU. Link with -ltofucom (verify the exact library name in
+ * your environment).
+ *
+ * Items marked "VERIFY" depend on exact utofu.h symbol/field names that
+ * vary slightly between Tofu library versions and should be checked when
+ * first building on the target system.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <utofu.h>
+
+/* Put flags: notice on the local TCQ (so we can reclaim the send buffer)
+ * and on the remote MRQ (so the receiver learns of arrival). Cache
+ * injection (added at init unless NEKO_GS_UTOFU_CACHE_INJECT=0) drops the
+ * received slab straight into the peer's cache -- a win if it is consumed
+ * immediately, a loss if it pollutes cache, hence the runtime toggle. */
+#define GS_UTOFU_PUT_FLAGS_BASE                                          \
+  (UTOFU_ONESIDED_FLAG_TCQ_NOTICE | UTOFU_ONESIDED_FLAG_REMOTE_MRQ_NOTICE)
+
+/* --- process-global endpoint state, created once ------------------------ */
+static int             gs_utofu_ready = 0;
+static size_t          gs_utofu_nvcq  = 0;     /* number of injection VCQs  */
+static size_t          gs_utofu_ntni  = 0;     /* distinct TNIs in use      */
+static utofu_vcq_hdl_t *gs_utofu_vcq   = NULL; /* [nvcq] injection VCQs     */
+static utofu_tni_id_t  *gs_utofu_tniid = NULL; /* [ntni] granted TNI ids    */
+static int              gs_utofu_recv_rr = 0;  /* round-robins recv-VCQ TNIs */
+static uint64_t         gs_utofu_edata_max = 255;
+static unsigned long    gs_utofu_put_flags = GS_UTOFU_PUT_FLAGS_BASE;
+static int              gs_utofu_master_inject = 0;
+
+/* Longs per counter slot: one A64FX L1/L2 cache line (256 bytes), so the
+ * per-VCQ completion counters never false-share between threads. */
+#define GS_UTOFU_PEND_STRIDE 32
+
+/* --- per-instance context (one per gs_utofu_t) -------------------------- */
+typedef struct {
+  utofu_stadd_t  *send_stadd;  /* [nvcq] send_buf registered on each inj VCQ */
+  utofu_vcq_hdl_t recv_vcq;    /* this instance's OWN receive VCQ (its MRQ) */
+  utofu_stadd_t   recv_stadd;  /* recv_buf registered on recv_vcq           */
+  /* Outstanding (un-reaped) put completions, one padded slot per
+   * (injection VCQ, send-buffer half). The put's cbdata points at its
+   * slot, so draining a VCQ's TCQ decrements the right counter -- letting
+   * nbsend wait only on the half it is about to reuse. The phase barriers
+   * in gs_nbsend_utofu guarantee each VCQ (and thus each slot) has a
+   * single toucher at any time, so no atomics are needed. */
+  long          *send_pending; /* [2 * nvcq * GS_UTOFU_PEND_STRIDE]        */
+  /* notices observed early that belong to the *other* parity (next round)  */
+  uint64_t      *stash;
+  int            stash_n;
+  int            stash_cap;
+} gs_utofu_ctx_t;
+
+static long *gs_utofu_pend_slot(gs_utofu_ctx_t *ctx, size_t k, int half)
+{
+  return &ctx->send_pending[(2 * k + (size_t) half) * GS_UTOFU_PEND_STRIDE];
+}
+
+/* Drain every completion currently sitting on VCQ k's transmit queue,
+ * decrementing the per-(instance, VCQ, half) counter each put carried as
+ * cbdata. Must only be called by VCQ k's single toucher of the current
+ * phase. */
+static void gs_utofu_drain_tcq(size_t k)
+{
+  void *cbdata;
+  while (utofu_poll_tcq(gs_utofu_vcq[k], 0, &cbdata) == UTOFU_SUCCESS) {
+    if (cbdata != NULL) (*(long *) cbdata)--;
+  }
+}
+
+static void gs_utofu_stash_push(gs_utofu_ctx_t *ctx, uint64_t edata)
+{
+  if (ctx->stash_n == ctx->stash_cap) {
+    int cap = ctx->stash_cap ? 2 * ctx->stash_cap : 16;
+    ctx->stash = realloc(ctx->stash, cap * sizeof(*ctx->stash));
+    ctx->stash_cap = cap;
+  }
+  ctx->stash[ctx->stash_n++] = edata;
+}
+
+/**
+ * Create the process-global uTofu endpoint (idempotent).
+ *
+ * Creates the injection VCQs -- one per OpenMP thread, dealt round-robin
+ * over the granted TNIs, every one THREAD_SAFE -- shared by all instances
+ * and driven thread-parallel (thread t owns VCQ t). Receive VCQs are
+ * created per gs instance in gs_utofu_ctx_create, so each instance owns a
+ * private MRQ.
+ *
+ * @param ntni_req    requested number of TNIs (>=1); clamped to availability
+ * @param nthreads    OpenMP thread count = requested injection VCQs (>=1)
+ * @param ntni_out    number of TNIs actually in use
+ * @param nvcq_out    number of injection VCQs actually created
+ * @param edata_max   largest usable edata value (for tag-range checking)
+ */
+void gs_utofu_init(int ntni_req, int nthreads, int *ntni_out, int *nvcq_out,
+                   uint64_t *edata_max, int *ierr)
+{
+  *ierr = 0;
+
+  if (!gs_utofu_ready) {
+    utofu_tni_id_t *tnis = NULL;
+    size_t num_tnis = 0;
+
+    if (utofu_get_onesided_tnis(&tnis, &num_tnis) != UTOFU_SUCCESS
+        || num_tnis == 0) {
+      *ierr = 1;
+      return;
+    }
+
+    size_t want_tni = (ntni_req > 0) ? (size_t) ntni_req : 1;
+    if (want_tni > num_tnis) want_tni = num_tnis;
+    gs_utofu_ntni  = want_tni;
+    gs_utofu_tniid = malloc(want_tni * sizeof(*gs_utofu_tniid));
+    for (size_t k = 0; k < want_tni; k++)
+      gs_utofu_tniid[k] = tnis[k];
+
+    /* One injection VCQ per thread. THREAD_SAFE is what makes multithreaded
+     * operation defined at all: without it uTofu takes the unlocked
+     * direct-descriptor injection path and any cross-thread touch corrupts
+     * the TOQ (the "TOQ Direct Descriptor Exception" of the first
+     * multithreaded attempt). With one thread per VCQ the internal lock is
+     * uncontended. If a TNI's VCQ budget runs out mid-loop, keep what was
+     * granted: threads beyond the count simply do not inject (see
+     * gs_utofu_post_puts), and the modulo peer partition shrinks with it. */
+    size_t want_vcq = (nthreads > 0) ? (size_t) nthreads : 1;
+    gs_utofu_vcq = malloc(want_vcq * sizeof(*gs_utofu_vcq));
+    while (gs_utofu_nvcq < want_vcq) {
+      if (utofu_create_vcq(gs_utofu_tniid[gs_utofu_nvcq % want_tni],
+                           UTOFU_VCQ_FLAG_THREAD_SAFE,
+                           &gs_utofu_vcq[gs_utofu_nvcq]) != UTOFU_SUCCESS)
+        break;
+      gs_utofu_nvcq++;
+    }
+    if (gs_utofu_nvcq == 0) {
+      *ierr = 2;
+      return;
+    }
+
+    /* Largest edata the hardware will carry. VERIFY: field name and whether
+     * the capability is expressed in bytes (assumed here). */
+    struct utofu_onesided_caps *caps = NULL;
+    if (utofu_query_onesided_caps(tnis[0], &caps) == UTOFU_SUCCESS
+        && caps != NULL) {
+      size_t eb = caps->max_edata_size;
+      /* Capped to a positive signed-64 value: the Fortran side receives this
+       * as integer(c_int64_t) and compares against it. */
+      if (eb >= 8) gs_utofu_edata_max = (uint64_t) INT64_MAX;
+      else if (eb > 0) gs_utofu_edata_max = (1ULL << (8 * eb)) - 1ULL;
+    }
+
+    /* Cache injection on by default; NEKO_GS_UTOFU_CACHE_INJECT=0 disables. */
+    const char *ci = getenv("NEKO_GS_UTOFU_CACHE_INJECT");
+    gs_utofu_put_flags = GS_UTOFU_PUT_FLAGS_BASE;
+    if (ci == NULL || ci[0] != '0')
+      gs_utofu_put_flags |= UTOFU_ONESIDED_FLAG_CACHE_INJECTION;
+
+    /* A/B switch: serialise all injection onto thread 0 (still spread over
+     * every VCQ, which is legal now that they are THREAD_SAFE) to isolate
+     * the effect of parallel injection against the same transport. */
+    const char *mi = getenv("NEKO_GS_UTOFU_MASTER_INJECT");
+    gs_utofu_master_inject = (mi != NULL && mi[0] != '0');
+
+    free(tnis);
+    gs_utofu_ready = 1;
+  }
+
+  *edata_max   = gs_utofu_edata_max;
+  *ntni_out    = (int) gs_utofu_ntni;
+  *nvcq_out    = (int) gs_utofu_nvcq;
+}
+
+/**
+ * Register an instance's send/recv buffers and allocate its context.
+ * send_buf is registered on every injection VCQ (the source STADD must
+ * belong to the VCQ that issues the put). The instance gets its OWN receive
+ * VCQ (a private MRQ); recv_buf is registered on it, and its id is advertised
+ * to neighbours as the put target so arrivals land only in this instance's
+ * queue. The receive VCQ's TNI is round-robined across interfaces.
+ */
+void gs_utofu_ctx_create(void *send_buf, size_t send_bytes,
+                         void *recv_buf, size_t recv_bytes,
+                         void **ctx_out, uint64_t *recv_vcq_id,
+                         uint64_t *recv_stadd, int *ierr)
+{
+  *ierr = 0;
+  gs_utofu_ctx_t *ctx = calloc(1, sizeof(*ctx));
+  ctx->send_stadd = malloc(gs_utofu_nvcq * sizeof(*ctx->send_stadd));
+  ctx->send_pending = calloc(2 * gs_utofu_nvcq * GS_UTOFU_PEND_STRIDE,
+                             sizeof(*ctx->send_pending));
+
+  /* The receive VCQ stays non-THREAD_SAFE (flags 0): it is strictly
+   * master-polled, and skipping the internal lock keeps the MRQ spin --
+   * the receive hot path -- cheap. It must never be touched off-master. */
+  utofu_tni_id_t rtni = gs_utofu_tniid[gs_utofu_recv_rr % (int) gs_utofu_ntni];
+  gs_utofu_recv_rr++;
+  if (utofu_create_vcq(rtni, 0, &ctx->recv_vcq) != UTOFU_SUCCESS) {
+    *ierr = 1;
+    return;
+  }
+
+  for (size_t k = 0; k < gs_utofu_nvcq; k++) {
+    if (utofu_reg_mem(gs_utofu_vcq[k], send_buf, send_bytes, 0,
+                      &ctx->send_stadd[k]) != UTOFU_SUCCESS) {
+      *ierr = 2;
+      return;
+    }
+  }
+  if (utofu_reg_mem(ctx->recv_vcq, recv_buf, recv_bytes, 0,
+                    &ctx->recv_stadd) != UTOFU_SUCCESS) {
+    *ierr = 3;
+    return;
+  }
+
+  utofu_vcq_id_t vid;
+  if (utofu_query_vcq_id(ctx->recv_vcq, &vid) != UTOFU_SUCCESS) {
+    *ierr = 4;
+    return;
+  }
+
+  *recv_vcq_id = (uint64_t) vid;
+  *recv_stadd  = (uint64_t) ctx->recv_stadd;
+  *ctx_out = ctx;
+}
+
+void gs_utofu_ctx_free(void *vctx, int *ierr)
+{
+  *ierr = 0;
+  gs_utofu_ctx_t *ctx = vctx;
+  if (ctx == NULL) return;
+
+  /* Make sure no put is still reading send_buf before we deregister it.
+   * Called from a serial region, so one thread draining every VCQ is safe
+   * (the VCQs are THREAD_SAFE, and there is no concurrent toucher). */
+  for (int h = 0; h < 2; h++)
+    for (size_t k = 0; k < gs_utofu_nvcq; k++)
+      while (*gs_utofu_pend_slot(ctx, k, h) > 0)
+        gs_utofu_drain_tcq(k);
+
+  for (size_t k = 0; k < gs_utofu_nvcq; k++)
+    utofu_dereg_mem(gs_utofu_vcq[k], ctx->send_stadd[k], 0);
+  utofu_dereg_mem(ctx->recv_vcq, ctx->recv_stadd, 0);
+  utofu_free_vcq(ctx->recv_vcq);
+
+  free(ctx->send_stadd);
+  free(ctx->send_pending);
+  free(ctx->stash);
+  free(ctx);
+}
+
+/* Post peer i's put on injection VCQ k, charging its completion to the
+ * (k, parity) counter slot so the next reuse of this send-buffer half waits
+ * on exactly its own puts. The caller must be VCQ k's single toucher of the
+ * current phase (the BUSY-retry path drains k's TCQ). */
+static int gs_utofu_put_one(gs_utofu_ctx_t *ctx, size_t k, int i,
+                            const int64_t *send_off, const int64_t *send_len,
+                            const uint64_t *rmt_vcq_id,
+                            const uint64_t *rmt_stadd,
+                            const int64_t *dst_off0, const int64_t *dst_off1,
+                            const int *dst_tag, int parity, int64_t send_base,
+                            int elem_size)
+{
+  const int64_t doff = parity ? dst_off1[i] : dst_off0[i];
+  long *pend = gs_utofu_pend_slot(ctx, k, parity);
+
+  utofu_stadd_t lcl = ctx->send_stadd[k]
+    + (utofu_stadd_t)((send_base + send_off[i]) * elem_size);
+  utofu_stadd_t rmt = (utofu_stadd_t) rmt_stadd[i]
+    + (utofu_stadd_t)(doff * elem_size);
+  size_t   len   = (size_t)(send_len[i] * elem_size);
+  uint64_t edata = (uint64_t) dst_tag[i] * 2u + (uint64_t) parity;
+
+  int rc;
+  do {
+    rc = utofu_put(gs_utofu_vcq[k], (utofu_vcq_id_t) rmt_vcq_id[i],
+                   lcl, rmt, len, edata, gs_utofu_put_flags, pend);
+    /* TOQ full (reported as UTOFU_ERR_BUSY): reclaim completions, retry. */
+    if (rc == UTOFU_ERR_BUSY)
+      gs_utofu_drain_tcq(k);
+  } while (rc == UTOFU_ERR_BUSY);
+
+  if (rc == UTOFU_SUCCESS)
+    (*pend)++;
+  return rc;
+}
+
+/**
+ * Issue this thread's share of the puts. Called by EVERY thread of the
+ * OpenMP team, each passing its own tid: thread tid posts peers
+ * i = tid, tid+npost, ... on its own VCQ, where npost = min(nteam, nvcq),
+ * so threads beyond the VCQ count post nothing and their peers fall to the
+ * others. One thread per VCQ per phase means the completion counters need
+ * no atomics; the VCQs are THREAD_SAFE regardless, so a degraded or odd
+ * configuration is safe, just slower. Offsets/lengths are in elements;
+ * elem_size converts to bytes. The edata tag fuses the slab id (dst_tag)
+ * with the parity bit so the receiver can tell this round's notices from a
+ * neighbour that has already raced into the next round.
+ *
+ * With NEKO_GS_UTOFU_MASTER_INJECT=1, thread 0 instead posts every peer,
+ * round-robined over all VCQs (the pre-threading behaviour, kept as an A/B
+ * reference).
+ */
+void gs_utofu_post_puts(void *vctx, int tid, int nteam, int nsend,
+                        const int64_t *send_off, const int64_t *send_len,
+                        const uint64_t *rmt_vcq_id, const uint64_t *rmt_stadd,
+                        const int64_t *dst_off0, const int64_t *dst_off1,
+                        const int *dst_tag, int parity, int64_t send_base,
+                        int elem_size, int *ierr)
+{
+  *ierr = 0;
+  gs_utofu_ctx_t *ctx = vctx;
+
+  if (gs_utofu_master_inject) {
+    if (tid != 0) return;
+    for (int i = 0; i < nsend; i++) {
+      size_t k = (size_t)(i % (int) gs_utofu_nvcq);
+      if (gs_utofu_put_one(ctx, k, i, send_off, send_len, rmt_vcq_id,
+                           rmt_stadd, dst_off0, dst_off1, dst_tag, parity,
+                           send_base, elem_size) != UTOFU_SUCCESS) {
+        *ierr = 1;
+        return;
+      }
+    }
+    return;
+  }
+
+  int npost = (nteam < (int) gs_utofu_nvcq) ? nteam : (int) gs_utofu_nvcq;
+  if (tid >= npost) return;
+
+  for (int i = tid; i < nsend; i += npost) {
+    if (gs_utofu_put_one(ctx, (size_t) tid, i, send_off, send_len,
+                         rmt_vcq_id, rmt_stadd, dst_off0, dst_off1, dst_tag,
+                         parity, send_base, elem_size) != UTOFU_SUCCESS) {
+      *ierr = 1;
+      return;
+    }
+  }
+}
+
+/**
+ * Collect the receive slabs that have landed for the current parity.
+ *
+ * Returns at most `cap` 1-based receive-peer indices in out_idx. A notice
+ * whose parity bit does not match the current round is stashed and replayed
+ * on the next call (with the flipped parity), keeping the unpack-as-ready
+ * model correct in the face of a neighbour running one round ahead. May
+ * return 0 (nothing yet) -- the caller polls in a loop.
+ */
+void gs_utofu_poll_recv(void *vctx, int parity, int cap,
+                        int *ncompleted, int *out_idx, int *ierr)
+{
+  *ierr = 0;
+  gs_utofu_ctx_t *ctx = vctx;
+  int n = 0;
+
+  /* Replay stashed notices that now match the current parity. */
+  int w = 0;
+  for (int s = 0; s < ctx->stash_n; s++) {
+    uint64_t ed = ctx->stash[s];
+    if ((int)(ed & 1u) == parity && n < cap)
+      out_idx[n++] = (int)(ed >> 1) + 1;
+    else
+      ctx->stash[w++] = ed;
+  }
+  ctx->stash_n = w;
+
+  /* Drain currently-available arrival notices from this instance's MRQ. */
+  struct utofu_mrq_notice notice;
+  while (n < cap) {
+    int rc = utofu_poll_mrq(ctx->recv_vcq, 0, &notice);
+    if (rc == UTOFU_ERR_NOT_FOUND) break;
+    if (rc != UTOFU_SUCCESS) {
+      *ierr = 1;
+      return;
+    }
+    /* VERIFY: RMT_PUT is the receiver-side notice for an incoming put. */
+    if (notice.notice_type != UTOFU_MRQ_TYPE_RMT_PUT) continue;
+
+    uint64_t ed = notice.edata;
+    if ((int)(ed & 1u) == parity)
+      out_idx[n++] = (int)(ed >> 1) + 1;
+    else
+      gs_utofu_stash_push(ctx, ed);
+  }
+
+  *ncompleted = n;
+}
+
+/** Block until every put charged to send-buffer half `half` has completed
+ *  locally, so that half may be repacked. Called by EVERY thread of the
+ *  team: the strided map k = tid, tid+nteam, ... covers each injection VCQ
+ *  exactly once, so each VCQ (and its counter slots) has a single toucher
+ *  and no atomics are needed. The caller must barrier afterwards -- only
+ *  then is the whole half known to be free. With double buffering the half
+ *  being reclaimed was posted two rounds ago, so this normally just reaps
+ *  already-finished completions. */
+void gs_utofu_drain_half(void *vctx, int half, int tid, int nteam, int *ierr)
+{
+  *ierr = 0;
+  gs_utofu_ctx_t *ctx = vctx;
+  for (size_t k = (size_t) tid; k < gs_utofu_nvcq; k += (size_t) nteam)
+    while (*gs_utofu_pend_slot(ctx, k, half) > 0)
+      gs_utofu_drain_tcq(k);
+}


### PR DESCRIPTION
Adds a native Tofu (uTofu) one-sided RDMA gather-scatter backend for
Fugaku/Tofu-D, as a faster successor to the coarray (CAF) backend.

- Selected with `NEKO_GS_COMM=UTOFU` (or `comm_bcknd=GS_COMM_UTOFU`);
  built with `--with-utofu[=DIR]` (links `-ltofucom`, gated on `HAVE_UTOFU`).
- A send is a single `utofu_put` straight into the neighbour's receive
  buffer, with the slab tag fused into the put's `edata` — one network
  op per peer, no separate atomic/credit message.
- Per-instance send/recv buffers and a private receive VCQ/MRQ per
  `gs_t`; double-buffered send/receive with an unpack-as-ready receive
  loop. Packing is parallel over the OpenMP team; puts are issued by the
  master thread (concurrent puts across VCQs are unsupported on TofuD).
- `NEKO_GS_UTOFU_NTNI` selects the number of injection TNIs (default 1);
  `NEKO_GS_UTOFU_CACHE_INJECT` toggles Tofu cache injection.
- Docs (appendices, performance, installation, man page) and build deps
  updated.