### PR TITLE
Add MPI neighbourhood-collective gather-scatter backend

### DIFF
--- a/doc/man/neko.1
+++ b/doc/man/neko.1
@@ -101,8 +101,13 @@ treated as fatal errors. If unset, they are reported as warnings.
 Indentation width used by the logger.
 .TP
 .B NEKO_GS_COMM
-Selects the communication backend used by the gather\-scatter kernel
-(e.g. MPI or device\-aware variants).
+Selects the communication backend used by the gather\-scatter kernel.
+Accepted values are
+.BR MPI ", " MPIGPU ", " NCCL ", " SHMEM ", " CAF " and " NEIGHBOUR ,
+the last being host MPI using an
+.B MPI_Ineighbor_alltoallv
+neighbourhood collective. When unset, a device\-aware variant is used
+on accelerator builds and host MPI otherwise.
 .TP
 .B NEKO_GS_STRTGY
 Selects the gather\-scatter strategy.

--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -47,6 +47,8 @@ A number of gather-scatter backends are supported.
   OpenSHMEM based on CPU builds (requires a native OpenSHMEM library,
   e.g. Cray OpenSHMEMX, enabled at configure time with `--with-openshmem`)
 - `NEKO_GS_COMM=CAF`    : Coarray Fortran (requires a coarray-capable compiler)
+- `NEKO_GS_COMM=NEIGHBOUR` : Host MPI using an `MPI_Ineighbor_alltoallv`
+  neighbourhood collective (`NEIGHBOR` is also accepted; MPI-3, host only)
 
 ### MPI thread level details
 

--- a/doc/pages/user-guide/performance.md
+++ b/doc/pages/user-guide/performance.md
@@ -142,6 +142,7 @@ MPI is available, host MPI otherwise). The supported values are:
 | `NCCL` | NCCL/RCCL (`gs_device_nccl`) | `--with-nccl=...` | Multi-GPU runs where NCCL outperforms MPI |
 | `SHMEM` | NVSHMEM (`gs_device_shmem`) on GPU builds, OpenSHMEM (`gs_shmem`) on CPU builds | `--with-nvshmem=...` (GPU) or `--with-openshmem` (CPU, Cray) | NVIDIA GPUs with NVSHMEM-capable interconnect; CPU systems with a native OpenSHMEM (e.g. Cray OpenSHMEMX) |
 | `CAF` | Coarray Fortran (`gs_caf`) | Coarray-capable Fortran compiler | Systems with a tuned coarray runtime |
+| `NEIGHBOUR` | MPI neighbourhood collective (`gs_neighbour`) | None (MPI-3) | CPU runs where one collective per gs beats many point-to-point messages (e.g. Fugaku / Tofu) |
 
 @note `MPIGPU` and `NCCL` require Neko to be built with GPU support
 and the corresponding optional dependency. `SHMEM` picks the device
@@ -151,8 +152,42 @@ which of NVSHMEM / OpenSHMEM is present at configure time.
 The backend can also be selected programmatically by passing the
 `comm_bcknd` argument to `gs%init`, using the constants `GS_COMM_MPI`,
 `GS_COMM_MPIGPU`, `GS_COMM_NCCL`, `GS_COMM_NVSHMEM`,
-`GS_COMM_OPENSHMEM`, or `GS_COMM_CAF` exposed by the `gather_scatter`
-module. The environment variable wins when both are present.
+`GS_COMM_OPENSHMEM`, `GS_COMM_CAF`, or `GS_COMM_NEIGHBOUR` exposed by
+the `gather_scatter` module. The environment variable wins when both
+are present.
+
+#### MPI neighbourhood collective backend {#performance-neighbour-backend}
+
+The neighbourhood backend (`NEKO_GS_COMM=NEIGHBOUR`, the spelling
+`NEIGHBOR` is also accepted) replaces the per-neighbour
+`MPI_Isend`/`MPI_Irecv` pairs of the host `MPI` backend with a single
+non-blocking neighbourhood collective, `MPI_Ineighbor_alltoallv`, over
+a distributed-graph communicator. The graph is built once at
+initialisation with `MPI_Dist_graph_create_adjacent` (sources are the
+receive peers, destinations the send peers, `reorder = .false.`), so
+the neighbour ordering matches the gs schedule and the concatenated
+per-peer send / receive buffer layout of the host MPI backend is reused
+unchanged. `nbsend` packs the send buffer and launches the collective
+from the master thread; `nbwait` completes it and reduces each received
+slab into `u` with the same serial-across-peers, parallel-within-peer
+reduction as the host MPI backend.
+
+The motivation is to collapse the N point-to-point calls of a halo
+exchange into a single entry to the MPI runtime. On platforms where the
+MPI library serialises concurrent calls internally (for example
+Fujitsu MPI on Fugaku), this is one runtime crossing per gs op instead
+of N, and it hands the striping of the transfers across the network
+interfaces to the vendor runtime. The backend is host-only and requires
+nothing beyond MPI-3, which every modern MPI implementation provides.
+
+@note Whether the collective actually overlaps with the local gs work
+depends on the MPI library making asynchronous progress; with the
+default build of many implementations, progress happens at the
+`MPI_Wait` in `nbwait`. Enable the library's asynchronous-progress
+option to test the overlap benefit. Each `gs_t` instance owns its own
+graph communicator, so multiple instances may coexist, but a given
+instance must complete its `nbsend`/`nbwait` window before the next gs
+op on the same instance.
 
 #### NVSHMEM backend {#performance-nvshmem-backend}
 

--- a/src/.depends
+++ b/src/.depends
@@ -59,10 +59,11 @@ gs/gs_comm.lo : gs/gs_comm.f90 adt/stack.lo comm/comm.lo config/num_types.lo
 gs/gs_mpi.lo : gs/gs_mpi.f90 common/utils.lo comm/comm.lo adt/stack.lo gs/gs_ops.lo gs/gs_comm.lo config/num_types.lo 
 gs/gs_shmem.lo : gs/gs_shmem.F90 common/utils.lo comm/comm.lo adt/stack.lo gs/gs_ops.lo gs/gs_comm.lo config/num_types.lo 
 gs/gs_caf.lo : gs/gs_caf.F90 common/utils.lo comm/comm.lo adt/stack.lo gs/gs_ops.lo gs/gs_comm.lo config/num_types.lo 
+gs/gs_neighbour.lo : gs/gs_neighbour.F90 common/utils.lo comm/comm.lo adt/stack.lo gs/gs_ops.lo gs/gs_comm.lo config/num_types.lo 
 gs/bcknd/device/gs_device_mpi.lo : gs/bcknd/device/gs_device_mpi.F90 common/utils.lo device/device.lo adt/htable.lo comm/comm.lo adt/stack.lo gs/gs_comm.lo config/num_types.lo 
 gs/bcknd/device/gs_device_nccl.lo : gs/bcknd/device/gs_device_nccl.F90 common/utils.lo device/device.lo adt/htable.lo comm/comm.lo adt/stack.lo gs/gs_comm.lo config/num_types.lo 
 gs/bcknd/device/gs_device_shmem.lo : gs/bcknd/device/gs_device_shmem.F90 common/utils.lo comm/comm.lo device/device.lo adt/htable.lo adt/stack.lo gs/gs_comm.lo config/num_types.lo 
-gs/gather_scatter.lo : gs/gather_scatter.f90 device/device.lo common/profiler.lo common/log.lo common/utils.lo adt/stack.lo adt/htable.lo config/num_types.lo field/field.lo sem/dofmap.lo comm/comm.lo mesh/mesh.lo gs/bcknd/device/gs_device_shmem.lo gs/bcknd/device/gs_device_nccl.lo gs/bcknd/device/gs_device_mpi.lo gs/gs_caf.lo gs/gs_shmem.lo gs/gs_mpi.lo gs/gs_comm.lo gs/gs_ops.lo gs/bcknd/cpu/gs_cpu.lo gs/bcknd/sx/gs_sx.lo gs/bcknd/device/gs_device.lo gs/gs_bcknd.lo config/neko_config.lo 
+gs/gather_scatter.lo : gs/gather_scatter.f90 device/device.lo common/profiler.lo common/log.lo common/utils.lo adt/stack.lo adt/htable.lo config/num_types.lo field/field.lo sem/dofmap.lo comm/comm.lo mesh/mesh.lo gs/bcknd/device/gs_device_shmem.lo gs/bcknd/device/gs_device_nccl.lo gs/bcknd/device/gs_device_mpi.lo gs/gs_caf.lo gs/gs_shmem.lo gs/gs_neighbour.lo gs/gs_mpi.lo gs/gs_comm.lo gs/gs_ops.lo gs/bcknd/cpu/gs_cpu.lo gs/bcknd/sx/gs_sx.lo gs/bcknd/device/gs_device.lo gs/gs_bcknd.lo config/neko_config.lo 
 mesh/entity.lo : mesh/entity.f90 
 mesh/point.lo : mesh/point.f90 mesh/entity.lo math/math.lo config/num_types.lo 
 mesh/element.lo : mesh/element.f90 mesh/point.lo adt/tuple.lo mesh/entity.lo config/num_types.lo 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -62,6 +62,7 @@ neko_fortran_SOURCES = \
 	gs/gs_mpi.f90\
 	gs/gs_shmem.F90\
 	gs/gs_caf.F90\
+	gs/gs_neighbour.F90\
 	gs/bcknd/device/gs_device_mpi.F90\
 	gs/bcknd/device/gs_device_nccl.F90\
 	gs/bcknd/device/gs_device_shmem.F90\

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -40,8 +40,9 @@ module gather_scatter
   use gs_cpu, only : gs_cpu_t
   use gs_ops, only : GS_OP_ADD, GS_OP_MAX, GS_OP_MIN, GS_OP_MUL
   use gs_comm, only : gs_comm_t, GS_COMM_MPI, GS_COMM_MPIGPU, GS_COMM_NCCL, &
-       GS_COMM_NVSHMEM, GS_COMM_OPENSHMEM, GS_COMM_CAF
+       GS_COMM_NVSHMEM, GS_COMM_OPENSHMEM, GS_COMM_CAF, GS_COMM_NEIGHBOUR
   use gs_mpi, only : gs_mpi_t
+  use gs_neighbour, only : gs_neighbour_t
   use gs_shmem, only : gs_shmem_t
   use gs_caf, only : gs_caf_t
   use gs_device_mpi, only : gs_device_mpi_t
@@ -106,7 +107,7 @@ module gather_scatter
 
   ! Expose available gather-scatter comm. backends
   public :: GS_COMM_MPI, GS_COMM_MPIGPU, GS_COMM_NCCL, GS_COMM_NVSHMEM, &
-       GS_COMM_OPENSHMEM, GS_COMM_CAF
+       GS_COMM_OPENSHMEM, GS_COMM_CAF, GS_COMM_NEIGHBOUR
 
 
 contains
@@ -126,6 +127,7 @@ contains
     logical :: use_device_mpi, use_device_nccl, use_device_shmem, use_host_mpi
     logical :: use_host_shmem
     logical :: use_caf
+    logical :: use_neighbour
     real(kind=rp), allocatable :: tmp(:)
     type(c_ptr) :: tmp_d = C_NULL_PTR
     integer :: strtgy(4) = [int(B'00'), int(B'01'), int(B'10'), int(B'11')]
@@ -146,6 +148,7 @@ contains
     use_host_mpi = .false.
     use_host_shmem = .false.
     use_caf = .false.
+    use_neighbour = .false.
 
     ! Check if a comm-backend is requested via env. variables
     call get_environment_variable("NEKO_GS_COMM", env_gscomm, env_len)
@@ -164,6 +167,9 @@ contains
           end if
        else if (env_gscomm(1:env_len) .eq. "CAF") then
           use_caf = .true.
+       else if (env_gscomm(1:env_len) .eq. "NEIGHBOUR" .or. &
+            env_gscomm(1:env_len) .eq. "NEIGHBOR") then
+          use_neighbour = .true.
        else
           call neko_error('Unknown Gather-scatter comm. backend')
        end if
@@ -184,6 +190,10 @@ contains
        comm_bcknd_ = GS_COMM_OPENSHMEM
     else if (use_caf) then
        comm_bcknd_ = GS_COMM_CAF
+    else if (use_neighbour) then
+       comm_bcknd_ = GS_COMM_NEIGHBOUR
+    else if (use_neighbour) then
+       comm_bcknd_ = GS_COMM_NEIGHBOUR
     else
        if (NEKO_DEVICE_MPI) then
           comm_bcknd_ = GS_COMM_MPIGPU
@@ -212,6 +222,9 @@ contains
     case (GS_COMM_CAF)
        call neko_log%message('Comm         :          CAF')
        allocate(gs_caf_t::gs%comm)
+    case (GS_COMM_NEIGHBOUR)
+       call neko_log%message('Comm         :   MPI neigh.')
+       allocate(gs_neighbour_t::gs%comm)
     case default
        call neko_error('Unknown Gather-scatter comm. backend')
     end select

--- a/src/gs/gs_comm.f90
+++ b/src/gs/gs_comm.f90
@@ -41,7 +41,7 @@ module gs_comm
 
   integer, public, parameter :: GS_COMM_MPI = 1, GS_COMM_MPIGPU = 2, &
        GS_COMM_NCCL = 3, GS_COMM_NVSHMEM = 4, GS_COMM_OPENSHMEM = 5, &
-       GS_COMM_CAF = 6
+       GS_COMM_CAF = 6, GS_COMM_NEIGHBOUR = 7
 
   !> Gather-scatter communication method
   type, public, abstract :: gs_comm_t

--- a/src/gs/gs_neighbour.F90
+++ b/src/gs/gs_neighbour.F90
@@ -1,0 +1,285 @@
+! Copyright (c) 2026, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Defines gather-scatter communication using MPI neighbourhood collectives
+module gs_neighbour
+  use num_types, only : rp
+  use gs_comm, only : gs_comm_t
+  use gs_ops, only : GS_OP_ADD, GS_OP_MAX, GS_OP_MIN, GS_OP_MUL
+  use stack, only : stack_i4_t
+  use mpi_f08, only : MPI_Comm, MPI_Request, MPI_STATUS_IGNORE, &
+       MPI_INFO_NULL, MPI_Dist_graph_create_adjacent, &
+       MPI_Ineighbor_alltoallv, MPI_Wait, MPI_Comm_free
+  use comm, only : NEKO_COMM, MPI_REAL_PRECISION
+  use, intrinsic :: iso_c_binding
+  use utils, only : neko_error
+  implicit none
+  private
+
+  !> Gather-scatter communication using an MPI neighbourhood collective.
+  !! The whole halo exchange is carried out by a single
+  !! `MPI_Ineighbor_alltoallv` over a distributed-graph communicator built
+  !! once from the send/recv peer lists. Compared to the point-to-point
+  !! `gs_mpi_t` this trades N `Isend`/`Irecv` pairs for one collective call:
+  !! a single entry into the (serialised, on Fugaku) MPI runtime, leaving
+  !! the library free to stripe the transfers across all network interfaces
+  !! internally.
+  type, public, extends(gs_comm_t) :: gs_neighbour_t
+     !> Concatenated send slabs, one per peer, in send_pe order.
+     real(kind=rp), allocatable :: send_buf(:)
+     !> Concatenated recv slabs, one per peer, in recv_pe order.
+     real(kind=rp), allocatable :: recv_buf(:)
+     !> Per-peer counts and 0-based element displacements for the
+     !! neighbourhood collective. send_* follow send_pe (the graph
+     !! destinations), recv_* follow recv_pe (the graph sources).
+     integer, allocatable :: sendcounts(:), sdispls(:)
+     integer, allocatable :: recvcounts(:), rdispls(:)
+     !> Distributed-graph communicator over the halo neighbourhood.
+     type(MPI_Comm) :: neigh_comm
+     !> In-flight non-blocking neighbourhood collective.
+     type(MPI_Request) :: request
+   contains
+     procedure, pass(this) :: init => gs_neighbour_init
+     procedure, pass(this) :: free => gs_neighbour_free
+     !> See gs_comm.f90 for more details on these routines
+     procedure, pass(this) :: nbsend => gs_nbsend_neighbour
+     procedure, pass(this) :: nbrecv => gs_nbrecv_neighbour
+     procedure, pass(this) :: nbwait => gs_nbwait_neighbour
+  end type gs_neighbour_t
+
+contains
+
+  !> Initialise the neighbourhood-collective communication method
+  !! See gs_comm.f90 for details
+  subroutine gs_neighbour_init(this, send_pe, recv_pe)
+    class(gs_neighbour_t), intent(inout) :: this
+    type(stack_i4_t), intent(inout) :: send_pe
+    type(stack_i4_t), intent(inout) :: recv_pe
+    integer :: i, nsend, nrecv, send_total, recv_total, ierr
+    !> Unit weights for the graph. MPI_UNWEIGHTED is the natural choice but
+    !! trips frt's mpi_f08 generic resolution; with reorder = .false. the
+    !! weights never affect the neighbour ordering, so all-ones is equivalent.
+    integer, allocatable :: src_weights(:), dst_weights(:)
+
+    call this%init_order(send_pe, recv_pe)
+
+    nsend = size(this%send_pe)
+    nrecv = size(this%recv_pe)
+
+    ! Allocate the count/displacement arrays with at least one element so
+    ! that a peerless rank (nsend or nrecv == 0) still passes a valid array
+    ! to the collective.
+    allocate(this%sendcounts(max(1, nsend)), this%sdispls(max(1, nsend)))
+    allocate(this%recvcounts(max(1, nrecv)), this%rdispls(max(1, nrecv)))
+    this%sendcounts = 0
+    this%sdispls = 0
+    this%recvcounts = 0
+    this%rdispls = 0
+
+    send_total = 0
+    do i = 1, nsend
+       this%sendcounts(i) = this%send_dof(this%send_pe(i))%size()
+       this%sdispls(i) = send_total
+       send_total = send_total + this%sendcounts(i)
+    end do
+    allocate(this%send_buf(max(1, send_total)))
+
+    recv_total = 0
+    do i = 1, nrecv
+       this%recvcounts(i) = this%recv_dof(this%recv_pe(i))%size()
+       this%rdispls(i) = recv_total
+       recv_total = recv_total + this%recvcounts(i)
+    end do
+    allocate(this%recv_buf(max(1, recv_total)))
+
+    ! Build a distributed-graph communicator over the halo neighbourhood.
+    ! With MPI_Dist_graph_create_adjacent and reorder = .false. the order of
+    ! sources/destinations is preserved, so the j-th block of the collective
+    ! corresponds to recv_pe(j)/send_pe(j) and the count/displacement arrays
+    ! above can be used directly.
+    allocate(src_weights(max(1, nrecv)), dst_weights(max(1, nsend)))
+    src_weights = 1
+    dst_weights = 1
+    call MPI_Dist_graph_create_adjacent(NEKO_COMM, &
+         nrecv, this%recv_pe, src_weights, &
+         nsend, this%send_pe, dst_weights, &
+         MPI_INFO_NULL, .false., this%neigh_comm, ierr)
+    deallocate(src_weights, dst_weights)
+
+  end subroutine gs_neighbour_init
+
+  !> Deallocate the neighbourhood-collective communication method
+  subroutine gs_neighbour_free(this)
+    class(gs_neighbour_t), intent(inout) :: this
+    integer :: ierr
+
+    if (allocated(this%send_buf)) deallocate(this%send_buf)
+    if (allocated(this%recv_buf)) deallocate(this%recv_buf)
+    if (allocated(this%sendcounts)) deallocate(this%sendcounts)
+    if (allocated(this%sdispls)) deallocate(this%sdispls)
+    if (allocated(this%recvcounts)) deallocate(this%recvcounts)
+    if (allocated(this%rdispls)) deallocate(this%rdispls)
+
+    call MPI_Comm_free(this%neigh_comm, ierr)
+
+    call this%free_order()
+    call this%free_dofs()
+
+  end subroutine gs_neighbour_free
+
+  !> Pack the send buffer and initiate the neighbourhood collective.
+  !! The collective covers both directions, so all of the communication is
+  !! launched here; gs_nbrecv_neighbour is a no-op.
+  subroutine gs_nbsend_neighbour(this, u, n, tag, deps, strm)
+    class(gs_neighbour_t), intent(inout) :: this
+    integer, intent(in) :: n
+    real(kind=rp), dimension(n), intent(inout) :: u
+    integer, intent(in) :: tag
+    type(c_ptr), intent(inout) :: deps
+    type(c_ptr), intent(inout) :: strm
+    integer :: i, j, dst, off, ndst, ierr
+
+    ! Gather data from u into the per-peer slab of send_buf according to the
+    ! indices in send_dof. Each thread packs a different peer's slab; the
+    ! implicit barrier at end-do guarantees the buffer is complete before
+    ! the master fires the collective.
+    !$omp do
+    do i = 1, size(this%send_pe)
+       dst = this%send_pe(i)
+       off = this%sdispls(i)
+       ndst = this%sendcounts(i)
+       select type (sp => this%send_dof(dst)%data)
+       type is (integer)
+          !$omp simd
+          do j = 1, ndst
+             this%send_buf(off + j) = u(sp(j))
+          end do
+       end select
+    end do
+    !$omp end do
+
+    ! A neighbourhood collective is one call over neigh_comm and must be
+    ! issued by a single thread.
+    !$omp master
+    call MPI_Ineighbor_alltoallv(this%send_buf, this%sendcounts, &
+         this%sdispls, MPI_REAL_PRECISION, this%recv_buf, this%recvcounts, &
+         this%rdispls, MPI_REAL_PRECISION, this%neigh_comm, this%request, &
+         ierr)
+    !$omp end master
+
+  end subroutine gs_nbsend_neighbour
+
+  !> No-op: the neighbourhood collective issued in nbsend handles both the
+  !! send and receive directions, so there is nothing to pre-post here.
+  subroutine gs_nbrecv_neighbour(this, tag)
+    class(gs_neighbour_t), intent(inout) :: this
+    integer, intent(in) :: tag
+    ! Nothing to do: the collective is launched in nbsend.
+  end subroutine gs_nbrecv_neighbour
+
+  !> Wait for the neighbourhood collective and reduce the received slabs
+  subroutine gs_nbwait_neighbour(this, u, n, op, strm)
+    class(gs_neighbour_t), intent(inout) :: this
+    integer, intent(in) :: n
+    real(kind=rp), dimension(n), intent(inout) :: u
+    type(c_ptr), intent(inout) :: strm
+    integer :: i, j, src, off, nsrc
+    integer :: op
+    integer :: ierr
+
+    ! The collective is master-issued, so wait on it from the master and
+    ! barrier before anyone touches recv_buf.
+    !$omp master
+    call MPI_Wait(this%request, MPI_STATUS_IGNORE, ierr)
+    !$omp end master
+    !$omp barrier
+
+    ! Reduce each received slab into u. The outer loop over peers stays
+    ! serial: a dof shared by 3+ ranks appears in several recv_dof lists, so
+    ! reducing two slabs concurrently would race on that dof. Parallelism is
+    ! taken within each slab instead.
+    do i = 1, size(this%recv_pe)
+       src = this%recv_pe(i)
+       off = this%rdispls(i)
+       nsrc = this%recvcounts(i)
+       select type (sp => this%recv_dof(src)%data)
+       type is (integer)
+          select case (op)
+          case (GS_OP_ADD)
+             !OCL NORECURRENCE, NOVREC, NOALIAS
+             !DIR$ CONCURRENT
+             !GCC$ ivdep
+             !NEC$ IVDEP
+             !$omp do
+             do j = 1, nsrc
+                u(sp(j)) = u(sp(j)) + this%recv_buf(off + j)
+             end do
+             !$omp end do
+          case (GS_OP_MUL)
+             !OCL NORECURRENCE, NOVREC, NOALIAS
+             !DIR$ CONCURRENT
+             !GCC$ ivdep
+             !NEC$ IVDEP
+             !$omp do
+             do j = 1, nsrc
+                u(sp(j)) = u(sp(j)) * this%recv_buf(off + j)
+             end do
+             !$omp end do
+          case (GS_OP_MIN)
+             !OCL NORECURRENCE, NOVREC, NOALIAS
+             !DIR$ CONCURRENT
+             !GCC$ ivdep
+             !NEC$ IVDEP
+             !$omp do
+             do j = 1, nsrc
+                u(sp(j)) = min(u(sp(j)), this%recv_buf(off + j))
+             end do
+             !$omp end do
+          case (GS_OP_MAX)
+             !OCL NORECURRENCE, NOVREC, NOALIAS
+             !DIR$ CONCURRENT
+             !GCC$ ivdep
+             !NEC$ IVDEP
+             !$omp do
+             do j = 1, nsrc
+                u(sp(j)) = max(u(sp(j)), this%recv_buf(off + j))
+             end do
+             !$omp end do
+          case default
+             call neko_error("Unknown operation in gs_nbwait_neighbour")
+          end select
+       end select
+    end do
+
+  end subroutine gs_nbwait_neighbour
+
+end module gs_neighbour

--- a/src/gs/gs_neighbour.F90
+++ b/src/gs/gs_neighbour.F90
@@ -177,11 +177,11 @@ contains
        dst = this%send_pe(i)
        off = this%sdispls(i)
        ndst = this%sendcounts(i)
-       select type (sp => this%send_dof(dst)%data)
+       select type (dofs => this%send_dof(dst)%data)
        type is (integer)
           !$omp simd
           do j = 1, ndst
-             this%send_buf(off + j) = u(sp(j))
+             this%send_buf(off + j) = u(dofs(j))
           end do
        end select
     end do
@@ -231,7 +231,7 @@ contains
        src = this%recv_pe(i)
        off = this%rdispls(i)
        nsrc = this%recvcounts(i)
-       select type (sp => this%recv_dof(src)%data)
+       select type (dofs => this%recv_dof(src)%data)
        type is (integer)
           select case (op)
           case (GS_OP_ADD)
@@ -241,7 +241,7 @@ contains
              !NEC$ IVDEP
              !$omp do
              do j = 1, nsrc
-                u(sp(j)) = u(sp(j)) + this%recv_buf(off + j)
+                u(dofs(j)) = u(dofs(j)) + this%recv_buf(off + j)
              end do
              !$omp end do
           case (GS_OP_MUL)
@@ -251,7 +251,7 @@ contains
              !NEC$ IVDEP
              !$omp do
              do j = 1, nsrc
-                u(sp(j)) = u(sp(j)) * this%recv_buf(off + j)
+                u(dofs(j)) = u(dofs(j)) * this%recv_buf(off + j)
              end do
              !$omp end do
           case (GS_OP_MIN)
@@ -261,7 +261,7 @@ contains
              !NEC$ IVDEP
              !$omp do
              do j = 1, nsrc
-                u(sp(j)) = min(u(sp(j)), this%recv_buf(off + j))
+                u(dofs(j)) = min(u(dofs(j)), this%recv_buf(off + j))
              end do
              !$omp end do
           case (GS_OP_MAX)
@@ -271,7 +271,7 @@ contains
              !NEC$ IVDEP
              !$omp do
              do j = 1, nsrc
-                u(sp(j)) = max(u(sp(j)), this%recv_buf(off + j))
+                u(dofs(j)) = max(u(dofs(j)), this%recv_buf(off + j))
              end do
              !$omp end do
           case default


### PR DESCRIPTION
Adds a host gather-scatter communication backend, `gs_neighbour_t`, that carries out the off-process halo exchange with a single non-blocking neighbourhood collective (`MPI_Ineighbor_alltoallv`) over a distributed-graph communicator, instead of the per-neighbour `MPI_Isend`/`MPI_Irecv` pairs of the existing host `MPI` backend.

The graph is built once at init with `MPI_Dist_graph_create_adjacent` (receive peers as sources, send peers as destinations, `reorder=.false.`), so the neighbour ordering matches the gs schedule and the existing concatenated per-peer send/recv buffer layout is reused unchanged. The pack and the per-slab reduce (serial across peers, parallel within a peer) are identical to `gs_mpi`.

Motivation: collapse the N point-to-point calls of a halo exchange into a single entry to the MPI runtime. On platforms where the MPI library serialises concurrent calls internally (e.g. Fujitsu MPI on Fugaku/Tofu), this is one runtime crossing per gs op instead of N and lets the vendor runtime stripe the transfers across network interfaces. Host-only, requires only MPI-3.

- Selectable at runtime via `NEKO_GS_COMM=NEIGHBOUR` (`NEIGHBOR` also accepted), or programmatically via the new `GS_COMM_NEIGHBOUR` constant.
- Wired into `gs_comm`, `gather_scatter`, `Makefile.am`, and `.depends`.
- Documentation updated (performance guide, appendices, man page).

The backend has been tested on Fugaku, and improves throughput with at least 20% at scale! 🍻 

Timings:

_Current P2P MPI on Fugaku_
```shell
  201 meas:  0.0758 +/-  0.0057 s, range: [  0.0754 ,  0.0766 ], GDoF/s: 14.1612, ranks:  4608 thrds:    12
  201 meas:  0.0682 +/-  0.0047 s, range: [  0.0676 ,  0.0688 ], GDoF/s: 15.7398, ranks:  9216 thrds:    12
  201 meas:  0.0567 +/-  0.0032 s, range: [  0.0562 ,  0.0619 ], GDoF/s: 18.9321, ranks: 18432 thrds:    12
```

_New neigh. MPI on Fugaku_
```shell
  201 meas:  0.0612 +/-  0.0037 s, range: [  0.0603 ,  0.0671 ], GDoF/s: 17.5573, ranks:  4608 thrds:    12
  201 meas:  0.0511 +/-  0.0026 s, range: [  0.0506 ,  0.0517 ], GDoF/s: 21.0283, ranks:  9216 thrds:    12
  201 meas:  0.0419 +/-  0.0018 s, range: [  0.0415 ,  0.0424 ], GDoF/s: 25.6335, ranks: 18432 thrds:    12

```

**Note** Host only for now!