### PR TITLE
Scale gather-scatter and mesh setup to high MPI rank counts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([neko],[1.99.4])
+AC_INIT([neko],[1.99.5])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_MAINTAINER_MODE
 AC_CONFIG_MACRO_DIR([m4])

--- a/src/.depends
+++ b/src/.depends
@@ -17,6 +17,7 @@ io/buffer/buffer_4d.lo : io/buffer/buffer_4d.F90 io/buffer/buffer.lo math/vector
 io/buffer/buffer_4d_npar.lo : io/buffer/buffer_4d_npar.F90 io/buffer/buffer.lo math/vector.lo config/num_types.lo 
 common/log.lo : common/log.f90 common/utils.lo comm/comm.lo config/neko_config.lo 
 comm/comm.lo : comm/comm.F90 comm/shmem.lo config/neko_config.lo common/utils.lo 
+comm/crystal_router.lo : comm/crystal_router.f90 common/utils.lo config/num_types.lo comm/comm.lo 
 mesh/curve.lo : mesh/curve.f90 common/utils.lo adt/stack.lo common/structs.lo config/num_types.lo 
 comm/mpi_types.lo : comm/mpi_types.f90 io/format/stl.lo io/format/nmsh.lo io/format/re2.lo comm/comm.lo 
 comm/shmem.lo : comm/shmem.F90 
@@ -63,7 +64,7 @@ gs/gs_neighbour.lo : gs/gs_neighbour.f90 common/utils.lo comm/comm.lo adt/stack.
 gs/bcknd/device/gs_device_mpi.lo : gs/bcknd/device/gs_device_mpi.F90 common/utils.lo device/device.lo adt/htable.lo comm/comm.lo adt/stack.lo gs/gs_comm.lo config/num_types.lo 
 gs/bcknd/device/gs_device_nccl.lo : gs/bcknd/device/gs_device_nccl.F90 common/utils.lo device/device.lo adt/htable.lo comm/comm.lo adt/stack.lo gs/gs_comm.lo config/num_types.lo 
 gs/bcknd/device/gs_device_shmem.lo : gs/bcknd/device/gs_device_shmem.F90 common/utils.lo comm/comm.lo device/device.lo adt/htable.lo adt/stack.lo gs/gs_comm.lo config/num_types.lo 
-gs/gather_scatter.lo : gs/gather_scatter.f90 device/device.lo common/profiler.lo common/log.lo common/utils.lo adt/stack.lo adt/htable.lo config/num_types.lo field/field.lo sem/dofmap.lo comm/comm.lo mesh/mesh.lo gs/bcknd/device/gs_device_shmem.lo gs/bcknd/device/gs_device_nccl.lo gs/bcknd/device/gs_device_mpi.lo gs/gs_caf.lo gs/gs_shmem.lo gs/gs_neighbour.lo gs/gs_mpi.lo gs/gs_comm.lo gs/gs_ops.lo gs/bcknd/cpu/gs_cpu.lo gs/bcknd/sx/gs_sx.lo gs/bcknd/device/gs_device.lo gs/gs_bcknd.lo config/neko_config.lo 
+gs/gather_scatter.lo : gs/gather_scatter.f90 device/device.lo common/profiler.lo common/log.lo common/utils.lo math/math.lo comm/crystal_router.lo adt/stack.lo adt/htable.lo config/num_types.lo field/field.lo sem/dofmap.lo comm/comm.lo mesh/mesh.lo gs/bcknd/device/gs_device_shmem.lo gs/bcknd/device/gs_device_nccl.lo gs/bcknd/device/gs_device_mpi.lo gs/gs_caf.lo gs/gs_shmem.lo gs/gs_neighbour.lo gs/gs_mpi.lo gs/gs_comm.lo gs/gs_ops.lo gs/bcknd/cpu/gs_cpu.lo gs/bcknd/sx/gs_sx.lo gs/bcknd/device/gs_device.lo gs/gs_bcknd.lo config/neko_config.lo 
 mesh/entity.lo : mesh/entity.f90 
 mesh/point.lo : mesh/point.f90 mesh/entity.lo math/math.lo config/num_types.lo 
 mesh/element.lo : mesh/element.f90 mesh/point.lo adt/tuple.lo mesh/entity.lo config/num_types.lo 
@@ -84,7 +85,7 @@ mesh/point_zones/cylinder_point_zone.lo : mesh/point_zones/cylinder_point_zone.f
 mesh/point_zones/combine_point_zone.lo : mesh/point_zones/combine_point_zone.f90 common/log.lo common/utils.lo common/json_utils.lo config/num_types.lo mesh/point_zones/cylinder_point_zone.lo mesh/point_zones/sphere_point_zone.lo mesh/point_zones/box_point_zone.lo mesh/point_zone.lo 
 mesh/point_zone_fctry.lo : mesh/point_zone_fctry.f90 common/utils.lo common/json_utils.lo mesh/point_zones/cylinder_point_zone.lo mesh/point_zones/sphere_point_zone.lo mesh/point_zones/box_point_zone.lo mesh/point_zone.lo 
 mesh/point_zone_registry.lo : mesh/point_zone_registry.f90 common/json_utils.lo common/utils.lo sem/space.lo mesh/mesh.lo sem/dofmap.lo mesh/point_zones/combine_point_zone.lo mesh/point_zone.lo 
-mesh/mesh.lo : mesh/mesh.f90 common/log.lo mesh/curve.lo adt/uset.lo math/math.lo mesh/facet_zone.lo comm/comm.lo common/distdata.lo common/datadist.lo adt/htable.lo adt/tuple.lo adt/stack.lo common/mask.lo common/utils.lo mesh/quad.lo mesh/hex.lo mesh/element.lo mesh/point.lo config/num_types.lo 
+mesh/mesh.lo : mesh/mesh.f90 common/log.lo mesh/curve.lo adt/uset.lo comm/crystal_router.lo math/math.lo mesh/facet_zone.lo comm/comm.lo common/distdata.lo common/datadist.lo adt/htable.lo adt/tuple.lo adt/stack.lo common/mask.lo common/utils.lo mesh/quad.lo mesh/hex.lo mesh/element.lo mesh/point.lo config/num_types.lo 
 mesh/octree.lo : mesh/octree.f90 common/utils.lo mesh/point.lo config/num_types.lo 
 mesh/search_tree/aabb.lo : mesh/search_tree/aabb.f90 common/utils.lo mesh/tet_mesh.lo mesh/tri_mesh.lo mesh/mesh.lo mesh/hex.lo mesh/tet.lo mesh/quad.lo mesh/tri.lo mesh/point.lo mesh/element.lo config/num_types.lo 
 mesh/aabb_tree.lo : mesh/aabb_tree.f90 common/utils.lo adt/stack.lo config/num_types.lo mesh/tri.lo mesh/search_tree/aabb.lo 

--- a/src/.depends
+++ b/src/.depends
@@ -17,7 +17,7 @@ io/buffer/buffer_4d.lo : io/buffer/buffer_4d.F90 io/buffer/buffer.lo math/vector
 io/buffer/buffer_4d_npar.lo : io/buffer/buffer_4d_npar.F90 io/buffer/buffer.lo math/vector.lo config/num_types.lo 
 common/log.lo : common/log.f90 common/utils.lo comm/comm.lo config/neko_config.lo 
 comm/comm.lo : comm/comm.F90 comm/shmem.lo config/neko_config.lo common/utils.lo 
-comm/crystal_router.lo : comm/crystal_router.f90 common/utils.lo config/num_types.lo comm/comm.lo 
+comm/crystal_router.lo : comm/crystal_router.f90 common/utils.lo adt/stack.lo config/num_types.lo comm/comm.lo 
 mesh/curve.lo : mesh/curve.f90 common/utils.lo adt/stack.lo common/structs.lo config/num_types.lo 
 comm/mpi_types.lo : comm/mpi_types.f90 io/format/stl.lo io/format/nmsh.lo io/format/re2.lo comm/comm.lo 
 comm/shmem.lo : comm/shmem.F90 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,6 +20,7 @@ neko_fortran_SOURCES = \
 	io/buffer/buffer_4d_npar.F90\
 	common/log.f90\
 	comm/comm.F90\
+	comm/crystal_router.f90\
 	mesh/curve.f90\
 	comm/mpi_types.f90\
 	comm/shmem.F90\

--- a/src/comm/crystal_router.f90
+++ b/src/comm/crystal_router.f90
@@ -1,0 +1,285 @@
+! Copyright (c) 2026, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Crystal router: scalable all-to-some personalized exchange
+!! @details
+!! Routes a set of variable-length records, each tagged with a destination
+!! rank, from any source to any destination in @f$ \lceil \log_2 P \rceil @f$
+!! communication stages. This replaces dense @f$ O(P) @f$-round neighbour
+!! discovery / personalized exchange (which is @f$ O(P^2) @f$ globally and,
+!! under flat MPI at high rank counts, exhausts the MPI runtime's internal
+!! unexpected-message buffers) with a recursive-bisection routing that talks
+!! to at most one or two partners per stage.
+!!
+!! Records are passed in a single packed `integer(i8)` buffer as a sequence of
+!! self-describing entries
+!! @verbatim
+!!     [ dest, len, payload(1), ..., payload(len) ]
+!! @endverbatim
+!! where `dest` is the destination rank in @f$ [0, P) @f$ and `len` is the
+!! payload length. On return the buffer holds exactly the records whose `dest`
+!! equals `pe_rank`, in the same packed format (the `dest`/`len` headers are
+!! preserved so the caller can unpack uniformly).
+!!
+!! ### Algorithm and correctness
+!! The active rank range `[lo, hi)` always contains `pe_rank`; it starts as
+!! `[0, P)` and is halved each stage at `mid = lo + (hi-lo)/2`. A record is
+!! kept if its destination lies in the local half and otherwise shipped to a
+!! partner in the opposite half. Since a record is always moved into the half
+!! containing its destination, the range invariant "`dest in [lo, hi)`" is
+!! preserved, and when the range collapses to a single rank that rank is the
+!! destination -- so every record is delivered exactly once and none is
+!! dropped.
+!!
+!! For odd-sized ranges the upper half has exactly one more rank than the
+!! lower half, leaving one unpaired upper rank (`hi-1`). That rank still holds
+!! records destined for the lower half; it offloads them to rank `lo`, which
+!! performs one extra receive. All other ranks exchange with a single partner
+!! via `MPI_Sendrecv`, and the unpaired transfers use `MPI_PROC_NULL` for the
+!! idle direction, so every stage is fully matched and deadlock-free for any
+!! `P` (not only powers of two). Message sizes are negotiated per stage (a
+!! one-integer count exchange precedes each data exchange), so no global
+!! maximum buffer is ever allocated.
+module crystal_router
+  use comm, only : pe_rank, pe_size, NEKO_COMM
+  use num_types, only : i8
+  use stack, only : stack_i8_t
+  use utils, only : neko_error
+  use mpi_f08, only : MPI_Sendrecv, MPI_Status, MPI_INTEGER, MPI_INTEGER8, &
+       MPI_PROC_NULL
+  implicit none
+  private
+
+  !> Message tag used for all crystal-router exchanges. Stages are fully
+  !! synchronised (blocking `MPI_Sendrecv`), so a single tag suffices.
+  integer, parameter :: CR_TAG = 0
+
+  public :: crystal_router_transfer, crystal_router_pack
+
+contains
+
+  !> Append one record to a packed crystal-router buffer.
+  !! @details Writes the self-describing entry `[dest, size(body), body...]`
+  !! that crystal_router_transfer consumes. Owning the record format here means
+  !! call sites only supply a destination rank and a payload, and never encode
+  !! the `[dest, len, ...]` envelope themselves.
+  !! @param out   Stack accumulating the packed records.
+  !! @param dest  Destination rank for this record, in @f$ [0, P) @f$.
+  !! @param body  The record payload (its length becomes the `len` field).
+  subroutine crystal_router_pack(out, dest, body)
+    type(stack_i8_t), intent(inout) :: out
+    integer, intent(in) :: dest
+    integer(i8), intent(in) :: body(:)
+    integer(i8) :: w
+    integer :: i
+
+    w = int(dest, i8)
+    call out%push(w)
+    w = int(size(body), i8)
+    call out%push(w)
+    do i = 1, size(body)
+       w = body(i)
+       call out%push(w)
+    end do
+  end subroutine crystal_router_pack
+
+  !> Route packed records to their destination ranks.
+  !! @param buf  Packed records `[dest, len, payload...]` repeated. On entry,
+  !!             arbitrary destinations in @f$ [0, P) @f$; on exit, only the
+  !!             records addressed to `pe_rank` (may be reallocated).
+  !! @param n    Used length of @a buf (number of `integer(i8)` words). Updated
+  !!             on exit to the length of the received set.
+  subroutine crystal_router_transfer(buf, n)
+    integer(i8), allocatable, intent(inout) :: buf(:)
+    integer, intent(inout) :: n
+    integer(i8), allocatable :: keep(:), snd(:), rcv(:), extra(:)
+    integer :: nkeep, nsnd, nrcv, nextra
+    integer :: lo, hi, m, half, mid, r, partner
+    logical :: lower
+
+    ! Validate destinations up front so a packing bug surfaces here rather
+    ! than as a silently misrouted (lost) record at scale.
+    call cr_check_dest(buf, n)
+
+    lo = 0
+    hi = pe_size
+
+    do while (hi - lo > 1)
+       m = hi - lo
+       half = m / 2
+       mid = lo + half
+       lower = (pe_rank < mid)
+
+       ! Split the local buffer: records staying in our half vs. those bound
+       ! for the opposite half.
+       call cr_partition(buf, n, mid, lower, keep, nkeep, snd, nsnd)
+
+       ! Pick the partner in the opposite half. Lower ranks always have one;
+       ! in an odd-sized range the last upper rank (r == half) is unpaired.
+       if (lower) then
+          partner = mid + (pe_rank - lo)
+       else
+          r = pe_rank - mid
+          if (r .lt. half) then
+             partner = lo + r
+          else
+             partner = MPI_PROC_NULL
+          end if
+       end if
+
+       ! Bidirectional exchange with the partner, then rebuild the local
+       ! buffer as (kept records) ++ (received records).
+       call cr_exchange(snd, nsnd, partner, rcv, nrcv, partner)
+       call cr_concat(buf, n, keep, nkeep, rcv, nrcv)
+
+       ! Odd-sized range: the unpaired upper rank (hi-1) hands its lower-half
+       ! records to rank lo, which absorbs them with one extra receive.
+       if (iand(m, 1) .eq. 1) then
+          if ((.not. lower) .and. ((pe_rank - mid) .eq. half)) then
+             call cr_exchange(snd, nsnd, lo, extra, nextra, MPI_PROC_NULL)
+          else if (pe_rank .eq. lo) then
+             call cr_exchange(snd, 0, MPI_PROC_NULL, extra, nextra, hi - 1)
+             call cr_append(buf, n, extra, nextra)
+          end if
+       end if
+
+       ! Narrow the active range to the half containing pe_rank.
+       if (lower) then
+          hi = mid
+       else
+          lo = mid
+       end if
+    end do
+
+  end subroutine crystal_router_transfer
+
+  !> Abort if any record destination falls outside @f$ [0, P) @f$.
+  subroutine cr_check_dest(buf, n)
+    integer(i8), allocatable, intent(in) :: buf(:)
+    integer, intent(in) :: n
+    integer :: p, dest, rlen
+
+    p = 1
+    do while (p .le. n)
+       dest = int(buf(p))
+       rlen = int(buf(p + 1))
+       if (dest .lt. 0 .or. dest .ge. pe_size) then
+          call neko_error('crystal_router: record destination out of range')
+       end if
+       p = p + 2 + rlen
+    end do
+  end subroutine cr_check_dest
+
+  !> Partition @a buf into records kept locally and records to be sent.
+  !! A record is kept when the side of its destination (relative to @a mid)
+  !! matches @a lower, i.e. it already belongs to our half.
+  subroutine cr_partition(buf, n, mid, lower, keep, nkeep, snd, nsnd)
+    integer(i8), allocatable, intent(in) :: buf(:)
+    integer, intent(in) :: n, mid
+    logical, intent(in) :: lower
+    integer(i8), allocatable, intent(out) :: keep(:), snd(:)
+    integer, intent(out) :: nkeep, nsnd
+    integer :: p, dest, rlen, reclen
+    logical :: in_lower
+
+    allocate(keep(max(n, 1)))
+    allocate(snd(max(n, 1)))
+    nkeep = 0
+    nsnd = 0
+
+    p = 1
+    do while (p .le. n)
+       dest = int(buf(p))
+       rlen = int(buf(p + 1))
+       reclen = 2 + rlen
+       in_lower = dest .lt. mid
+       if (in_lower .eqv. lower) then
+          keep(nkeep + 1:nkeep + reclen) = buf(p:p + reclen - 1)
+          nkeep = nkeep + reclen
+       else
+          snd(nsnd + 1:nsnd + reclen) = buf(p:p + reclen - 1)
+          nsnd = nsnd + reclen
+       end if
+       p = p + reclen
+    end do
+  end subroutine cr_partition
+
+  !> Size-negotiated bidirectional exchange with a partner. Either @a dst or
+  !! @a src may be `MPI_PROC_NULL` to make that direction a no-op.
+  subroutine cr_exchange(sbuf, sn, dst, rbuf, rn, src)
+    integer(i8), intent(in) :: sbuf(:)
+    integer, intent(in) :: sn, dst, src
+    integer(i8), allocatable, intent(out) :: rbuf(:)
+    integer, intent(out) :: rn
+    type(MPI_Status) :: status
+    integer :: ierr
+
+    rn = 0
+    call MPI_Sendrecv(sn, 1, MPI_INTEGER, dst, CR_TAG, &
+         rn, 1, MPI_INTEGER, src, CR_TAG, NEKO_COMM, status, ierr)
+
+    allocate(rbuf(max(rn, 1)))
+    call MPI_Sendrecv(sbuf, sn, MPI_INTEGER8, dst, CR_TAG, &
+         rbuf, rn, MPI_INTEGER8, src, CR_TAG, NEKO_COMM, status, ierr)
+  end subroutine cr_exchange
+
+  !> Rebuild @a buf as the concatenation @a a(1:na) ++ @a b(1:nb).
+  subroutine cr_concat(buf, n, a, na, b, nb)
+    integer(i8), allocatable, intent(inout) :: buf(:)
+    integer, intent(out) :: n
+    integer(i8), allocatable, intent(in) :: a(:), b(:)
+    integer, intent(in) :: na, nb
+
+    if (allocated(buf)) deallocate(buf)
+    allocate(buf(max(na + nb, 1)))
+    if (na .gt. 0) buf(1:na) = a(1:na)
+    if (nb .gt. 0) buf(na + 1:na + nb) = b(1:nb)
+    n = na + nb
+  end subroutine cr_concat
+
+  !> Append @a e(1:ne) to @a buf(1:n) in place.
+  subroutine cr_append(buf, n, e, ne)
+    integer(i8), allocatable, intent(inout) :: buf(:)
+    integer, intent(inout) :: n
+    integer(i8), allocatable, intent(in) :: e(:)
+    integer, intent(in) :: ne
+    integer(i8), allocatable :: tmp(:)
+
+    if (ne .le. 0) return
+    allocate(tmp(n + ne))
+    if (n .gt. 0) tmp(1:n) = buf(1:n)
+    tmp(n + 1:n + ne) = e(1:ne)
+    call move_alloc(tmp, buf)
+    n = n + ne
+  end subroutine cr_append
+
+end module crystal_router

--- a/src/comm/crystal_router.f90
+++ b/src/comm/crystal_router.f90
@@ -180,6 +180,12 @@ contains
        end if
     end do
 
+    ! Release the per-stage scratch buffers (buf is returned to the caller).
+    if (allocated(keep)) deallocate(keep)
+    if (allocated(snd)) deallocate(snd)
+    if (allocated(rcv)) deallocate(rcv)
+    if (allocated(extra)) deallocate(extra)
+
   end subroutine crystal_router_transfer
 
   !> Abort if any record destination falls outside @f$ [0, P) @f$.

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -1355,11 +1355,11 @@ contains
     !   every other holder of the same dof.
     !   reply = [dest=holder, len=2, gid, peer]
     !
-    nrec = n / 4   ! every record here has the fixed form [me, 2, gid, origin]
+    nrec = n / 4 ! every record here has the fixed form [me, 2, gid, origin]
     allocate(rgid(max(nrec, 1)), rgsid(max(nrec, 1)), gperm(max(nrec, 1)))
     do i = 1, nrec
-       rgid(i) = buf((i - 1) * 4 + 3)        ! gid
-       rgsid(i) = int(buf((i - 1) * 4 + 4))  ! origin rank (reuse array)
+       rgid(i) = buf((i - 1) * 4 + 3) ! gid
+       rgsid(i) = int(buf((i - 1) * 4 + 4)) ! origin rank (reuse array)
     end do
     if (nrec .gt. 0) call gs_sort_i8(rgid, gperm, nrec)
 
@@ -1373,8 +1373,8 @@ contains
        end do
        ! Reflect, to each holder, every other holder of this dof.
        if (j - i .gt. 1) then
-          do a = i, j - 1                 ! recipient holder
-             do b = i, j - 1              ! the other holder
+          do a = i, j - 1  ! recipient holder
+             do b = i, j - 1  ! the other holder
                 if (a .eq. b) cycle
                 call crystal_router_pack(cr_buf, rgsid(gperm(a)), &
                      [rgid(i), int(rgsid(gperm(b)), i8)])
@@ -1400,7 +1400,7 @@ contains
     ! Phase 3: register each (dof, peer) for both send and receive. Order each
     !   peer's dof list by gid so both ranks of a pair agree on the order.
     !
-    nrec = n / 4   ! replies are [me, 2, gid, peer]
+    nrec = n / 4 ! replies are [me, 2, gid, peer]
     allocate(rgid(max(nrec, 1)), rpeer(max(nrec, 1)), rgsid(max(nrec, 1)), &
          rperm(max(nrec, 1)))
     do i = 1, nrec

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -1373,8 +1373,8 @@ contains
        end do
        ! Reflect, to each holder, every other holder of this dof.
        if (j - i .gt. 1) then
-          do a = i, j - 1  ! recipient holder
-             do b = i, j - 1  ! the other holder
+          do a = i, j - 1 ! recipient holder
+             do b = i, j - 1 ! the other holder
                 if (a .eq. b) cycle
                 call crystal_router_pack(cr_buf, rgsid(gperm(a)), &
                      [rgid(i), int(rgsid(gperm(b)), i8)])

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -51,14 +51,14 @@ module gather_scatter
   use mesh, only : mesh_t
   use comm, only : pe_rank, pe_size, NEKO_COMM
   use mpi_f08, only : MPI_Reduce, MPI_Allreduce, MPI_Barrier, MPI_IN_PLACE, &
-       MPI_Wait, MPI_Irecv, MPI_Isend, MPI_Wtime, MPI_SUM, MPI_MAX, &
-       MPI_INTEGER, MPI_INTEGER2, MPI_INTEGER8, MPI_Request, MPI_Status, &
-       MPI_STATUS_IGNORE, MPI_Get_Count
+       MPI_Wtime, MPI_SUM, MPI_INTEGER, MPI_INTEGER8
   use dofmap, only : dofmap_t
   use field, only : field_t
-  use num_types, only : rp, dp, i2, i8
+  use num_types, only : rp, dp, i8
   use htable, only : htable_i8_t, htable_iter_i8_t
-  use stack, only : stack_i4_t
+  use stack, only : stack_i4_t, stack_i8_t
+  use crystal_router, only : crystal_router_transfer, crystal_router_pack
+  use math, only : sort
   use utils, only : neko_error, linear_index
   use logger, only : neko_log, LOG_SIZE
   use profiler, only : profiler_start_region, profiler_end_region
@@ -1302,121 +1302,207 @@ contains
   end subroutine gs_init_mapping
 
   !> Schedule shared gather-scatter operations
+  !! @details Discovers, for every shared dof, the set of ranks that also hold
+  !! it, using a canonical-owner rendezvous routed through the crystal router
+  !! instead of the previous O(P) shifted neighbour exchange. Each dof global
+  !! id is hashed to an owner rank, `mod(gid, P)`; the owner gathers all holders
+  !! and reflects, to each holder, the other holders. Each holder then registers
+  !! the dof for both send and receive with every peer. The per-peer dof lists
+  !! are ordered by dof global id, which gives the same ordering on both ranks
+  !! of a pair (the matching invariant the gather-scatter exchange relies on)
+  !! without ever transmitting a single sequenced key list. Scales to >1e5 ranks
+  !! without O(P) buffers or unexpected-message buffer exhaustion.
   subroutine gs_schedule(gs)
     type(gs_t), target, intent(inout) :: gs
-    integer(kind=i8), allocatable :: send_buf(:), recv_buf(:)
-    integer(kind=i2), allocatable :: shared_flg(:), recv_flg(:)
     type(htable_iter_i8_t) :: it
     type(stack_i4_t) :: send_pe, recv_pe
-    type(MPI_Status) :: status
-    type(MPI_Request) :: send_req, recv_req
-    integer :: i, j, max_recv, src, dst, ierr, n_recv
-    integer :: tmp, shared_gs_id
-    integer :: nshared_unique
-
-    nshared_unique = gs%shared_dofs%num_entries()
-
-    call it%init(gs%shared_dofs)
-    allocate(send_buf(nshared_unique))
-    i = 1
-    do while (it%next())
-       send_buf(i) = it%key()
-       i = i + 1
-    end do
+    type(stack_i8_t) :: cr_buf
+    integer(i8), allocatable :: buf(:)
+    integer(i8), pointer :: cr_data(:)
+    integer(i8), allocatable :: rgid(:), gtmp(:)
+    integer, allocatable :: rpeer(:), rgsid(:), rperm(:), gperm(:)
+    integer(i8) :: gid
+    integer :: i, j, n, owner, nrec, peer, shared_gs_id, tmp
+    integer :: a, b, cnt, t
 
     call send_pe%init()
     call recv_pe%init()
 
-
     !
-    ! Schedule exchange of shared dofs
+    ! Phase 1: route every local shared dof to its canonical owner.
+    !   record = [dest=owner, len=2, gid, origin]
     !
-
-    call MPI_Allreduce(nshared_unique, max_recv, 1, &
-         MPI_INTEGER, MPI_MAX, NEKO_COMM, ierr)
-
-    allocate(recv_buf(max_recv))
-    allocate(shared_flg(max_recv))
-    allocate(recv_flg(max_recv))
-
-    !> @todo Consider switching to a crystal router...
-    do i = 1, size(gs%dofmap%msh%neigh_order)
-       src = modulo(pe_rank - gs%dofmap%msh%neigh_order(i) + pe_size, pe_size)
-       dst = modulo(pe_rank + gs%dofmap%msh%neigh_order(i), pe_size)
-
-       if (gs%dofmap%msh%neigh(src)) then
-          call MPI_Irecv(recv_buf, max_recv, MPI_INTEGER8, &
-               src, 0, NEKO_COMM, recv_req, ierr)
-       end if
-
-       if (gs%dofmap%msh%neigh(dst)) then
-          call MPI_Isend(send_buf, nshared_unique, MPI_INTEGER8, &
-               dst, 0, NEKO_COMM, send_req, ierr)
-       end if
-
-       if (gs%dofmap%msh%neigh(src)) then
-          call MPI_Wait(recv_req, status, ierr)
-          call MPI_Get_count(status, MPI_INTEGER8, n_recv, ierr)
-
-          do j = 1, n_recv
-             shared_flg(j) = gs%shared_dofs%get(recv_buf(j), shared_gs_id)
-             if (shared_flg(j) .eq. 0) then
-                !> @todo don't touch others data...
-                call gs%comm%recv_dof(src)%push(shared_gs_id)
-             end if
-          end do
-
-          if (gs%comm%recv_dof(src)%size() .gt. 0) then
-             call recv_pe%push(src)
-          end if
-       end if
-
-       if (gs%dofmap%msh%neigh(dst)) then
-          call MPI_Wait(send_req, MPI_STATUS_IGNORE, ierr)
-          call MPI_Irecv(recv_flg, max_recv, MPI_INTEGER2, &
-               dst, 0, NEKO_COMM, recv_req, ierr)
-       end if
-
-       if (gs%dofmap%msh%neigh(src)) then
-          call MPI_Isend(shared_flg, n_recv, MPI_INTEGER2, &
-               src, 0, NEKO_COMM, send_req, ierr)
-       end if
-
-       if (gs%dofmap%msh%neigh(dst)) then
-          call MPI_Wait(recv_req, status, ierr)
-          call MPI_Get_count(status, MPI_INTEGER2, n_recv, ierr)
-
-          do j = 1, n_recv
-             if (recv_flg(j) .eq. 0) then
-                tmp = gs%shared_dofs%get(send_buf(j), shared_gs_id)
-                !> @todo don't touch others data...
-                call gs%comm%send_dof(dst)%push(shared_gs_id)
-             end if
-          end do
-
-          if (gs%comm%send_dof(dst)%size() .gt. 0) then
-             call send_pe%push(dst)
-          end if
-       end if
-
-       if (gs%dofmap%msh%neigh(src)) then
-          call MPI_Wait(send_req, MPI_STATUS_IGNORE, ierr)
-       end if
-
+    call cr_buf%init(max(gs%shared_dofs%num_entries(), 1) * 4)
+    call it%init(gs%shared_dofs)
+    do while (it%next())
+       gid = it%key()
+       owner = int(modulo(gid, int(pe_size, i8)))
+       call crystal_router_pack(cr_buf, owner, [gid, int(pe_rank, i8)])
     end do
+
+    n = cr_buf%size()
+    allocate(buf(max(n, 1)))
+    if (n .gt. 0) then
+       cr_data => cr_buf%array()
+       buf(1:n) = cr_data(1:n)
+    end if
+    call cr_buf%free()
+
+    call crystal_router_transfer(buf, n)
+
+    !
+    ! Phase 2: at the owner, group holders by gid and reflect, to each holder,
+    !   every other holder of the same dof.
+    !   reply = [dest=holder, len=2, gid, peer]
+    !
+    nrec = n / 4   ! every record here has the fixed form [me, 2, gid, origin]
+    allocate(rgid(max(nrec, 1)), rgsid(max(nrec, 1)), gperm(max(nrec, 1)))
+    do i = 1, nrec
+       rgid(i) = buf((i - 1) * 4 + 3)        ! gid
+       rgsid(i) = int(buf((i - 1) * 4 + 4))  ! origin rank (reuse array)
+    end do
+    if (nrec .gt. 0) call gs_sort_i8(rgid, gperm, nrec)
+
+    call cr_buf%init(max(n, 1))
+    i = 1
+    do while (i .le. nrec)
+       j = i
+       do while (j .le. nrec)
+          if (rgid(j) .ne. rgid(i)) exit
+          j = j + 1
+       end do
+       ! Reflect, to each holder, every other holder of this dof.
+       if (j - i .gt. 1) then
+          do a = i, j - 1                 ! recipient holder
+             do b = i, j - 1              ! the other holder
+                if (a .eq. b) cycle
+                call crystal_router_pack(cr_buf, rgsid(gperm(a)), &
+                     [rgid(i), int(rgsid(gperm(b)), i8)])
+             end do
+          end do
+       end if
+       i = j
+    end do
+    deallocate(rgid, rgsid, gperm)
+
+    n = cr_buf%size()
+    if (allocated(buf)) deallocate(buf)
+    allocate(buf(max(n, 1)))
+    if (n .gt. 0) then
+       cr_data => cr_buf%array()
+       buf(1:n) = cr_data(1:n)
+    end if
+    call cr_buf%free()
+
+    call crystal_router_transfer(buf, n)
+
+    !
+    ! Phase 3: register each (dof, peer) for both send and receive. Order each
+    !   peer's dof list by gid so both ranks of a pair agree on the order.
+    !
+    nrec = n / 4   ! replies are [me, 2, gid, peer]
+    allocate(rgid(max(nrec, 1)), rpeer(max(nrec, 1)), rgsid(max(nrec, 1)), &
+         rperm(max(nrec, 1)))
+    do i = 1, nrec
+       gid = buf((i - 1) * 4 + 3)
+       rgid(i) = gid
+       rpeer(i) = int(buf((i - 1) * 4 + 4))
+       tmp = gs%shared_dofs%get(gid, shared_gs_id)
+       rgsid(i) = shared_gs_id
+    end do
+
+    ! Sort by peer; within each peer run, sort by gid and register in that order.
+    if (nrec .gt. 0) call sort(rpeer, rperm, nrec)
+    a = 1
+    do while (a .le. nrec)
+       b = a
+       do while (b .le. nrec)
+          if (rpeer(b) .ne. rpeer(a)) exit
+          b = b + 1
+       end do
+       peer = rpeer(a)
+       cnt = b - a
+       allocate(gtmp(cnt), gperm(cnt))
+       do t = 1, cnt
+          gtmp(t) = rgid(rperm(a + t - 1))
+       end do
+       call gs_sort_i8(gtmp, gperm, cnt)
+       do t = 1, cnt
+          shared_gs_id = rgsid(rperm(a + gperm(t) - 1))
+          call gs%comm%send_dof(peer)%push(shared_gs_id)
+          call gs%comm%recv_dof(peer)%push(shared_gs_id)
+       end do
+       deallocate(gtmp, gperm)
+       call send_pe%push(peer)
+       call recv_pe%push(peer)
+       a = b
+    end do
+    deallocate(rgid, rpeer, rgsid, rperm)
+    if (allocated(buf)) deallocate(buf)
 
     call gs%comm%init(send_pe, recv_pe)
 
     call send_pe%free()
     call recv_pe%free()
 
-    deallocate(send_buf)
-    deallocate(recv_flg)
-    deallocate(shared_flg)
     !This arrays seems to take massive amounts of memory...
     call gs%shared_dofs%free()
 
   end subroutine gs_schedule
+
+  !> Heap sort for 64-bit integer arrays, returning the permutation @a ind.
+  !! Local helper for gs_schedule (the generic math sort has no i8 variant).
+  subroutine gs_sort_i8(a, ind, n)
+    integer, intent(in) :: n
+    integer(i8), intent(inout) :: a(n)
+    integer, intent(out) :: ind(n)
+    integer(i8) :: aa
+    integer :: j, ir, i, ii, l
+
+    do j = 1, n
+       ind(j) = j
+    end do
+
+    if (n .le. 1) return
+
+    l = n/2 + 1
+    ir = n
+    do while (.true.)
+       if (l .gt. 1) then
+          l = l - 1
+          aa = a(l)
+          ii = ind(l)
+       else
+          aa = a(ir)
+          ii = ind(ir)
+          a(ir) = a(1)
+          ind(ir) = ind(1)
+          ir = ir - 1
+          if (ir .eq. 1) then
+             a(1) = aa
+             ind(1) = ii
+             return
+          end if
+       end if
+       i = l
+       j = l + l
+       do while (j .le. ir)
+          if (j .lt. ir) then
+             if (a(j) .lt. a(j + 1)) j = j + 1
+          end if
+          if (aa .lt. a(j)) then
+             a(i) = a(j)
+             ind(i) = ind(j)
+             i = j
+             j = j + j
+          else
+             j = ir + 1
+          end if
+       end do
+       a(i) = aa
+       ind(i) = ii
+    end do
+  end subroutine gs_sort_i8
 
   !> Gather-scatter operation on a field @a u with op @a op
   subroutine gs_op_fld(gs, u, op, event)

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -48,11 +48,12 @@ module mesh
   use distdata, only : distdata_t
   use comm, only : pe_size, pe_rank, NEKO_COMM
   use facet_zone, only : facet_zone_t, facet_zone_periodic_t
-  use math, only : abscmp
+  use math, only : abscmp, sort
+  use crystal_router, only : crystal_router_transfer, crystal_router_pack
   use mpi_f08, only : MPI_INTEGER, MPI_MAX, MPI_SUM, MPI_IN_PLACE, &
        MPI_Allreduce, MPI_Exscan, MPI_Request, MPI_Status, MPI_Wait, &
-       MPI_Isend, MPI_Irecv, MPI_STATUS_IGNORE, MPI_Integer8, &
-       MPI_Get_count, MPI_Sendrecv
+       MPI_Issend, MPI_Irecv, MPI_STATUS_IGNORE, MPI_Integer8, &
+       MPI_Get_count
   use uset, only : uset_i8_t
   use curve, only : curve_t
   use logger, only : LOG_SIZE
@@ -739,7 +740,11 @@ contains
        end if
 
        if (this%neigh(dst)) then
-          call MPI_Isend(buffer%array(), buffer%size(), MPI_INTEGER, &
+          ! Synchronous send so the buffer is never eager-buffered as an
+          ! unexpected message, which exhausts the MPI internal buffer pool
+          ! (SIGBUS) under flat MPI at high rank counts. Deadlock-safe: the
+          ! matching recv is pre-posted at the top of the peer's iteration.
+          call MPI_Issend(buffer%array(), buffer%size(), MPI_INTEGER, &
                dst, 0, NEKO_COMM, send_req, ierr)
        end if
 
@@ -841,68 +846,143 @@ contains
   end subroutine mesh_generate_external_facet_conn
 
   !> Generate element-element connectivity via points between PEs
+  !! @details Uses a canonical-owner rendezvous routed through the crystal
+  !! router instead of a dense O(P) all-to-all. Each local point is hashed to
+  !! an owner rank, `mod(glb_idx, P)`; the owner gathers every rank holding
+  !! that point and reflects, back to each holder, the other holders' element
+  !! lists. Shared points (held by more than one rank) are thus discovered in
+  !! O(log P) communication stages, the neigh array becomes symmetric by
+  !! construction, and no O(P) buffers are ever allocated.
   subroutine mesh_generate_external_point_conn(this)
     type(mesh_t), intent(inout) :: this
-    type(stack_i4_t) :: send_buffer
-    type(MPI_Status) :: status
-    integer, allocatable :: recv_buffer(:)
-    integer :: i, j, k
-    integer :: max_recv, ierr, src, dst, n_recv, neigh_el
-    integer :: pt_glb_idx, pt_loc_idx, num_neigh
+    type(stack_i8_t) :: cr_buf
+    integer(i8), allocatable :: buf(:), body(:)
+    integer(i8), pointer :: cr_data(:)
+    integer, allocatable :: gkey(:), gperm(:), rpos(:)
     integer, contiguous, pointer :: neighs(:)
+    integer :: i, j, k, n, p, owner, num_neigh, nrec, rlen
+    integer :: pt_glb_idx, pt_loc_idx, src_rank, neigh_el, rk, rp
 
-
-    call send_buffer%init(this%mpts * 2)
-
-    ! Build send buffers containing
-    ! [pt_glb_idx, #neigh, neigh id_1 ....neigh_id_n]
+    !
+    ! Phase 1: route every local point's element list to its canonical owner.
+    !   record payload = [glb_idx, origin, elems...]
+    !
+    call cr_buf%init(this%mpts * 4)
+    allocate(body(8))
     do i = 1, this%mpts
        pt_glb_idx = this%points(i)%id() ! Adhere to standards...
        num_neigh = this%point_neigh(i)%size()
-       call send_buffer%push(pt_glb_idx)
-       call send_buffer%push(num_neigh)
-
+       if (2 + num_neigh .gt. size(body)) then
+          deallocate(body)
+          allocate(body(2 + num_neigh))
+       end if
+       body(1) = int(pt_glb_idx, i8)   ! glb_idx
+       body(2) = int(pe_rank, i8)      ! origin
        neighs => this%point_neigh(i)%array()
-       do j = 1, this%point_neigh(i)%size()
-          call send_buffer%push(neighs(j))
+       do j = 1, num_neigh
+          body(2 + j) = int(neighs(j), i8)   ! element ids
        end do
+       owner = modulo(pt_glb_idx, pe_size)
+       call crystal_router_pack(cr_buf, owner, body(1:2 + num_neigh))
+    end do
+    deallocate(body)
+
+    n = cr_buf%size()
+    allocate(buf(max(n, 1)))
+    if (n .gt. 0) then
+       cr_data => cr_buf%array()
+       buf(1:n) = cr_data(1:n)
+    end if
+    call cr_buf%free()
+
+    call crystal_router_transfer(buf, n)
+
+    !
+    ! Phase 2: at the owner, group received records by glb_idx and reflect,
+    !   to each holder, the element lists of every *other* holder.
+    !   reply = [dest=holder, len=2+num_neigh, glb_idx, src_rank, elems...]
+    !
+    ! Index the received records and sort their keys (glb_idx) so equal keys
+    ! form contiguous runs; per-point holder counts are small, so the
+    ! all-pairs reflection within a run is cheap.
+    nrec = 0
+    p = 1
+    do while (p .le. n)
+       nrec = nrec + 1
+       p = p + 2 + int(buf(p + 1))
     end do
 
-    call MPI_Allreduce(send_buffer%size(), max_recv, 1, &
-         MPI_INTEGER, MPI_MAX, NEKO_COMM, ierr)
-    allocate(recv_buffer(max_recv))
+    allocate(gkey(max(nrec, 1)), gperm(max(nrec, 1)), rpos(max(nrec, 1)))
+    nrec = 0
+    p = 1
+    do while (p .le. n)
+       nrec = nrec + 1
+       rpos(nrec) = p                 ! record start offset in buf
+       gkey(nrec) = int(buf(p + 2))   ! glb_idx
+       p = p + 2 + int(buf(p + 1))
+    end do
+    if (nrec .gt. 0) call sort(gkey, gperm, nrec)
 
-    do i = 1, pe_size - 1
-       src = modulo(pe_rank - i + pe_size, pe_size)
-       dst = modulo(pe_rank + i, pe_size)
-
-       call MPI_Sendrecv(send_buffer%array(), send_buffer%size(), &
-            MPI_INTEGER, dst, 0, recv_buffer, max_recv, MPI_INTEGER, src, 0, &
-            NEKO_COMM, status, ierr)
-
-       call MPI_Get_count(status, MPI_INTEGER, n_recv, ierr)
-
-       j = 1
-       do while (j .le. n_recv)
-          pt_glb_idx = recv_buffer(j)
-          num_neigh = recv_buffer(j + 1)
-          ! Check if the point is present on this PE
-          pt_loc_idx = this%have_point_glb_idx(pt_glb_idx)
-          if (pt_loc_idx .gt. 0) then
-             this%neigh(src) = .true.
-             do k = 1, num_neigh
-                neigh_el = -recv_buffer(j + 1 + k)
-                call this%point_neigh(pt_loc_idx)%push(neigh_el)
-                call this%ddata%set_shared_point(pt_loc_idx)
+    call cr_buf%init(max(n, 1))
+    i = 1
+    do while (i .le. nrec)
+       ! [i, j) is the run of records sharing the same glb_idx
+       j = i
+       do while (j .le. nrec)
+          if (gkey(j) .ne. gkey(i)) exit
+          j = j + 1
+       end do
+       ! All-pairs reflection within the run (skip singletons = unshared):
+       ! send source holder p's record body (glb_idx, origin, elems) to
+       ! recipient holder k, addressed to k's origin rank.
+       if (j - i .gt. 1) then
+          do k = i, j - 1                    ! recipient holder
+             rk = rpos(gperm(k))
+             do p = i, j - 1                 ! source holder
+                if (p .eq. k) cycle
+                rp = rpos(gperm(p))
+                call crystal_router_pack(cr_buf, int(buf(rk + 3)), &
+                     buf(rp + 2 : rp + 1 + int(buf(rp + 1))))
              end do
-          end if
-          j = j + (2 + num_neigh)
-       end do
+          end do
+       end if
+       i = j
+    end do
+    deallocate(gkey, gperm, rpos)
 
+    n = cr_buf%size()
+    if (allocated(buf)) deallocate(buf)
+    allocate(buf(max(n, 1)))
+    if (n .gt. 0) then
+       cr_data => cr_buf%array()
+       buf(1:n) = cr_data(1:n)
+    end if
+    call cr_buf%free()
+
+    call crystal_router_transfer(buf, n)
+
+    !
+    ! Phase 3: finalise locally. Each reply names a remote holder of one of our
+    !   points; mark it as a neighbour and absorb its (remote) element list.
+    !
+    p = 1
+    do while (p .le. n)
+       rlen = int(buf(p + 1))
+       pt_glb_idx = int(buf(p + 2))
+       src_rank = int(buf(p + 3))
+       pt_loc_idx = this%have_point_glb_idx(pt_glb_idx)
+       if (pt_loc_idx .gt. 0) then
+          this%neigh(src_rank) = .true.
+          call this%ddata%set_shared_point(pt_loc_idx)
+          do k = 1, rlen - 2
+             neigh_el = -int(buf(p + 3 + k))
+             call this%point_neigh(pt_loc_idx)%push(neigh_el)
+          end do
+       end if
+       p = p + 2 + rlen
     end do
 
-    deallocate(recv_buffer)
-    call send_buffer%free()
+    if (allocated(buf)) deallocate(buf)
 
   end subroutine mesh_generate_external_point_conn
 
@@ -1030,7 +1110,10 @@ contains
           ! certain data types
           select type(sbarray=>send_buff%data)
           type is (integer(i8))
-             call MPI_Isend(sbarray, send_buff%size(), MPI_INTEGER8, &
+             ! Synchronous send to avoid eager-buffering the key list as an
+             ! unexpected message (FJMPI buffer-pool exhaustion / SIGBUS under
+             ! flat MPI); matching recv is pre-posted by the peer.
+             call MPI_Issend(sbarray, send_buff%size(), MPI_INTEGER8, &
                   dst, 0, NEKO_COMM, send_req, ierr)
           end select
        end if
@@ -1115,7 +1198,10 @@ contains
           ! certain data types
           select type(sbarray=>send_buff%data)
           type is (integer(i8))
-             call MPI_Isend(sbarray, send_buff%size(), MPI_INTEGER8, &
+             ! Synchronous send to avoid eager-buffering the key list as an
+             ! unexpected message (FJMPI buffer-pool exhaustion / SIGBUS under
+             ! flat MPI); matching recv is pre-posted by the peer.
+             call MPI_Issend(sbarray, send_buff%size(), MPI_INTEGER8, &
                   dst, 0, NEKO_COMM, send_req, ierr)
           end select
        end if
@@ -1337,7 +1423,10 @@ contains
        end if
 
        if (this%neigh(dst)) then
-          call MPI_Isend(send_buff%array(), send_buff%size(), MPI_INTEGER, &
+          ! Synchronous send to avoid eager-buffered unexpected messages
+          ! (FJMPI buffer-pool exhaustion / SIGBUS under flat MPI); the
+          ! matching recv is pre-posted at the top of the peer's iteration.
+          call MPI_Issend(send_buff%array(), send_buff%size(), MPI_INTEGER, &
                dst, 0, NEKO_COMM, send_req, ierr)
        end if
 

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -876,11 +876,11 @@ contains
           deallocate(body)
           allocate(body(2 + num_neigh))
        end if
-       body(1) = int(pt_glb_idx, i8)   ! glb_idx
-       body(2) = int(pe_rank, i8)      ! origin
+       body(1) = int(pt_glb_idx, i8) ! glb_idx
+       body(2) = int(pe_rank, i8) ! origin
        neighs => this%point_neigh(i)%array()
        do j = 1, num_neigh
-          body(2 + j) = int(neighs(j), i8)   ! element ids
+          body(2 + j) = int(neighs(j), i8) ! element ids
        end do
        owner = modulo(pt_glb_idx, pe_size)
        call crystal_router_pack(cr_buf, owner, body(1:2 + num_neigh))
@@ -917,8 +917,8 @@ contains
     p = 1
     do while (p .le. n)
        nrec = nrec + 1
-       rpos(nrec) = p                 ! record start offset in buf
-       gkey(nrec) = int(buf(p + 2))   ! glb_idx
+       rpos(nrec) = p ! record start offset in buf
+       gkey(nrec) = int(buf(p + 2)) ! glb_idx
        p = p + 2 + int(buf(p + 1))
     end do
     if (nrec .gt. 0) call sort(gkey, gperm, nrec)
@@ -936,9 +936,9 @@ contains
        ! send source holder p's record body (glb_idx, origin, elems) to
        ! recipient holder k, addressed to k's origin rank.
        if (j - i .gt. 1) then
-          do k = i, j - 1                    ! recipient holder
+          do k = i, j - 1 ! recipient holder
              rk = rpos(gperm(k))
-             do p = i, j - 1                 ! source holder
+             do p = i, j - 1 ! source holder
                 if (p .eq. k) cycle
                 rp = rpos(gperm(p))
                 call crystal_router_pack(cr_buf, int(buf(rk + 3)), &

--- a/tests/unit/crystal_router/Makefile.in
+++ b/tests/unit/crystal_router/Makefile.in
@@ -1,0 +1,29 @@
+USEMPI=YES
+ifneq ("$(wildcard @PFUNIT_DIR@/include/PFUNIT.mk)", "")
+include @PFUNIT_DIR@/include/PFUNIT.mk
+endif
+FFLAGS += $(PFUNIT_EXTRA_FFLAGS) @NEKO_PKG_FCFLAGS@ -I@top_builddir@/src
+FC = @FC@
+
+%.o : %.F90
+	$(FC) -c $(FFLAGS) $<
+
+
+check: crystal_router_test
+
+
+crystal_router_test_TESTS := test_crystal_router_parallel.pf
+crystal_router_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
+$(eval $(call make_pfunit_test,crystal_router_test))
+crystal_router_test.inc: Makefile
+
+distclean:
+clean:
+	$(RM) *.o *.mod *.a  *.inc *.F90 crystal_router_test crystal_router_suite
+
+
+
+all:
+html:
+install:
+distdir:

--- a/tests/unit/crystal_router/test_crystal_router_parallel.pf
+++ b/tests/unit/crystal_router/test_crystal_router_parallel.pf
@@ -1,0 +1,106 @@
+module test_crystal_router_parallel
+  use mpi
+  use pfunit
+  use num_types, only : i8
+  use crystal_router, only : crystal_router_transfer
+  use comm, only : NEKO_COMM, pe_rank, pe_size
+  implicit none
+
+contains
+
+  !> Complete all-to-all stress test: every rank sends exactly one record to
+  !! every destination, tagged with its own rank as payload. After routing,
+  !! each rank must hold exactly pe_size records, all addressed to it, with
+  !! origins forming a permutation of [0, pe_size). This exercises every
+  !! routing path, including the odd-sized-range handling for npes 3, 5, 7.
+  @test(npes=[1,2,3,4,5,7,8])
+  subroutine test_cr_all_to_all(this)
+    class(MpiTestMethod), intent(inout) :: this
+    integer(i8), allocatable :: buf(:)
+    integer :: n, i, p, dest, rlen, origin, nrec, ierr
+    logical, allocatable :: seen(:)
+
+    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
+
+    ! One record per destination: [dest, len=1, payload=origin]
+    n = pe_size * 3
+    allocate(buf(n))
+    do i = 0, pe_size - 1
+       buf(3*i + 1) = int(i, i8)         ! dest
+       buf(3*i + 2) = 1_i8               ! len
+       buf(3*i + 3) = int(pe_rank, i8)   ! payload: origin rank
+    end do
+
+    call crystal_router_transfer(buf, n)
+
+    allocate(seen(0:pe_size - 1))
+    seen = .false.
+    nrec = 0
+    p = 1
+    do while (p .le. n)
+       dest = int(buf(p))
+       rlen = int(buf(p + 1))
+       origin = int(buf(p + 2))
+       @assertEqual(pe_rank, dest)
+       @assertEqual(1, rlen)
+       @assertTrue(origin .ge. 0 .and. origin .lt. pe_size)
+       @assertFalse(seen(origin))
+       seen(origin) = .true.
+       nrec = nrec + 1
+       p = p + 2 + rlen
+    end do
+    @assertEqual(pe_size, nrec)
+    @assertTrue(all(seen))
+
+    deallocate(buf, seen)
+  end subroutine test_cr_all_to_all
+
+  !> Sparse, variable-length test: each rank sends one record only to a single
+  !! destination (rank+1 mod P), with a payload whose length and contents
+  !! depend on the rank. Verifies variable-length records survive routing and
+  !! that records keep their integrity end to end.
+  @test(npes=[1,2,3,4,5,7,8])
+  subroutine test_cr_variable_length(this)
+    class(MpiTestMethod), intent(inout) :: this
+    integer(i8), allocatable :: buf(:)
+    integer :: n, p, dest, rlen, origin, k, expect_origin, ierr
+
+    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
+
+    ! Send to neighbour (rank+1 mod P). Payload: [origin, then origin+1..origin+L].
+    rlen = 1 + mod(pe_rank, 4) + 1   ! varies per rank, >= 2
+    n = 2 + rlen
+    allocate(buf(n))
+    buf(1) = int(modulo(pe_rank + 1, pe_size), i8)   ! dest
+    buf(2) = int(rlen, i8)                           ! len
+    buf(3) = int(pe_rank, i8)                        ! payload(1): origin
+    do k = 2, rlen
+       buf(2 + k) = int(pe_rank + k - 1, i8)         ! payload(k)
+    end do
+
+    call crystal_router_transfer(buf, n)
+
+    ! We must receive exactly one record, from our left neighbour.
+    expect_origin = modulo(pe_rank - 1, pe_size)
+    @assertTrue(n .ge. 3)
+    p = 1
+    dest = int(buf(p))
+    rlen = int(buf(p + 1))
+    origin = int(buf(p + 2))
+    @assertEqual(pe_rank, dest)
+    @assertEqual(expect_origin, origin)
+    ! Verify the variable-length payload tail is intact.
+    do k = 2, rlen
+       @assertEqual(int(expect_origin + k - 1, i8), buf(p + 1 + k))
+    end do
+    ! Exactly one record, nothing trailing.
+    @assertEqual(2 + rlen, n)
+
+    deallocate(buf)
+  end subroutine test_cr_variable_length
+
+end module test_crystal_router_parallel


### PR DESCRIPTION
 At high MPI rank counts (targeting >10⁵ ranks), the one-time setup exchanges in gs_schedule and the mesh connectivity routines overflow the MPI runtime's internal unexpected-message buffers, faulting with SIGBUS/SIGSEGV (mostly on Fugaku). The personalized MPI exchanges were also O(P) (gather-scatter, mesh edge/facet renumbering) or O(P²) (mesh point connectivity).

This PR removes both the failure and the scaling cost:
- New crystal_router module (src/comm/crystal_router.f90) — a generic all-to-some personalized MPI exchange in ⌈log₂P stages, correct for non-power-of-two P, with per-stage size negotiation so no O(P) buffer is ever allocated. crystal_router_pack owns the packed record format.
- gs_schedule and mesh_generate_external_point_conn rewritten as canonical-owner rendezvous (mod(gid, P)) routed through the crystal router. This drops the O(P²)/O(P) cost and the buffer-exhaustion crash. The neigh array is now symmetric by construction, and gather-scatter's per-peer dof lists are ordered by global id so both ranks of a pair agree on ordering without transmitting a sequenced key list.
- Remaining mesh neigh_order exchanges (external facet connectivity, shared edge/facet renumbering) converted from standard MPI_Isend to synchronous MPI_Issend, so they can't eager-buffer either. These stay point-to-point — they loop actual neighbours, not all ranks.