### PR TITLE
Fused multi-component gather-scatter for vector fields

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -56,7 +56,7 @@ gs/bcknd/cpu/gs_cpu.lo : gs/bcknd/cpu/gs_cpu.f90 gs/gs_ops.lo gs/gs_bcknd.lo con
 gs/bcknd/sx/gs_sx.lo : gs/bcknd/sx/gs_sx.f90 gs/gs_ops.lo gs/gs_bcknd.lo config/num_types.lo 
 gs/bcknd/device/gs_device.lo : gs/bcknd/device/gs_device.F90 common/utils.lo device/device.lo gs/gs_bcknd.lo config/num_types.lo 
 gs/gs_ops.lo : gs/gs_ops.f90 
-gs/gs_comm.lo : gs/gs_comm.f90 adt/stack.lo comm/comm.lo config/num_types.lo 
+gs/gs_comm.lo : gs/gs_comm.f90 common/utils.lo adt/stack.lo comm/comm.lo config/num_types.lo 
 gs/gs_mpi.lo : gs/gs_mpi.f90 common/utils.lo comm/comm.lo adt/stack.lo gs/gs_ops.lo gs/gs_comm.lo config/num_types.lo 
 gs/gs_shmem.lo : gs/gs_shmem.F90 common/utils.lo comm/comm.lo adt/stack.lo gs/gs_ops.lo gs/gs_comm.lo config/num_types.lo 
 gs/gs_caf.lo : gs/gs_caf.F90 common/utils.lo comm/comm.lo adt/stack.lo gs/gs_ops.lo gs/gs_comm.lo config/num_types.lo 

--- a/src/fluid/bcknd/cpu/euler_res_cpu.f90
+++ b/src/fluid/bcknd/cpu/euler_res_cpu.f90
@@ -368,9 +368,9 @@ contains
     ! gs
     call gs%op(rhs_rho_field, GS_OP_ADD)
     call rotate_cyc(rhs_m_x%x, rhs_m_y%x, rhs_m_z%x, 1, coef)
-    call gs%op(rhs_m_x, GS_OP_ADD)
-    call gs%op(rhs_m_y, GS_OP_ADD)
-    call gs%op(rhs_m_z, GS_OP_ADD)
+    ! Fused 3-component (momentum) halo exchange; falls back to three scalar
+    ! ops on comm backends without a vector path.
+    call gs%op(rhs_m_x%x, rhs_m_y%x, rhs_m_z%x, n, GS_OP_ADD)
     call rotate_cyc(rhs_m_x%x, rhs_m_y%x, rhs_m_z%x, 0, coef)
     call gs%op(rhs_E, GS_OP_ADD)
 
@@ -403,9 +403,9 @@ contains
     ! because nothing here (gs%op, rotate_cyc) reads coef%h1.
     call gs%op(visc_rho, GS_OP_ADD)
     call rotate_cyc(visc_m_x%x, visc_m_y%x, visc_m_z%x, 1, coef)
-    call gs%op(visc_m_x, GS_OP_ADD)
-    call gs%op(visc_m_y, GS_OP_ADD)
-    call gs%op(visc_m_z, GS_OP_ADD)
+    ! Fused 3-component (momentum) halo exchange; falls back to three scalar
+    ! ops on comm backends without a vector path.
+    call gs%op(visc_m_x%x, visc_m_y%x, visc_m_z%x, n, GS_OP_ADD)
     call rotate_cyc(visc_m_x%x, visc_m_y%x, visc_m_z%x, 0, coef)
     call gs%op(visc_E, GS_OP_ADD)
 

--- a/src/fluid/bcknd/cpu/euler_res_cpu.f90
+++ b/src/fluid/bcknd/cpu/euler_res_cpu.f90
@@ -368,8 +368,6 @@ contains
     ! gs
     call gs%op(rhs_rho_field, GS_OP_ADD)
     call rotate_cyc(rhs_m_x%x, rhs_m_y%x, rhs_m_z%x, 1, coef)
-    ! Fused 3-component (momentum) halo exchange; falls back to three scalar
-    ! ops on comm backends without a vector path.
     call gs%op(rhs_m_x%x, rhs_m_y%x, rhs_m_z%x, n, GS_OP_ADD)
     call rotate_cyc(rhs_m_x%x, rhs_m_y%x, rhs_m_z%x, 0, coef)
     call gs%op(rhs_E, GS_OP_ADD)
@@ -403,8 +401,6 @@ contains
     ! because nothing here (gs%op, rotate_cyc) reads coef%h1.
     call gs%op(visc_rho, GS_OP_ADD)
     call rotate_cyc(visc_m_x%x, visc_m_y%x, visc_m_z%x, 1, coef)
-    ! Fused 3-component (momentum) halo exchange; falls back to three scalar
-    ! ops on comm backends without a vector path.
     call gs%op(visc_m_x%x, visc_m_y%x, visc_m_z%x, n, GS_OP_ADD)
     call rotate_cyc(visc_m_x%x, visc_m_y%x, visc_m_z%x, 0, coef)
     call gs%op(visc_E, GS_OP_ADD)

--- a/src/fluid/bcknd/cpu/pnpn_res_cpu.f90
+++ b/src/fluid/bcknd/cpu/pnpn_res_cpu.f90
@@ -95,8 +95,6 @@ contains
     !$omp end parallel do
 
     call rotate_cyc(ta1%x, ta2%x, ta3%x, 1, c_Xh)
-    ! Fused 3-component halo exchange; falls back to three scalar ops on comm
-    ! backends without a vector path.
     call gs_Xh%op(ta1%x, ta2%x, ta3%x, n, GS_OP_ADD)
     call rotate_cyc(ta1%x, ta2%x, ta3%x, 0, c_Xh)
 

--- a/src/fluid/bcknd/cpu/pnpn_res_cpu.f90
+++ b/src/fluid/bcknd/cpu/pnpn_res_cpu.f90
@@ -95,9 +95,9 @@ contains
     !$omp end parallel do
 
     call rotate_cyc(ta1%x, ta2%x, ta3%x, 1, c_Xh)
-    call gs_Xh%op(ta1, GS_OP_ADD)
-    call gs_Xh%op(ta2, GS_OP_ADD)
-    call gs_Xh%op(ta3, GS_OP_ADD)
+    ! Fused 3-component halo exchange; falls back to three scalar ops on comm
+    ! backends without a vector path.
+    call gs_Xh%op(ta1%x, ta2%x, ta3%x, n, GS_OP_ADD)
     call rotate_cyc(ta1%x, ta2%x, ta3%x, 0, c_Xh)
 
     !OCL NORECURRENCE, NOVREC, NOALIAS

--- a/src/fluid/bcknd/device/euler_res_device.F90
+++ b/src/fluid/bcknd/device/euler_res_device.F90
@@ -652,7 +652,6 @@ contains
 
     call gs%op(rhs_rho_field, GS_OP_ADD)
     call rotate_cyc(rhs_m_x%x_d, rhs_m_y%x_d, rhs_m_z%x_d, 1, coef)
-    ! Fused 3-component (momentum) halo exchange.
     call gs%op(rhs_m_x%x, rhs_m_y%x, rhs_m_z%x, n, GS_OP_ADD)
     call rotate_cyc(rhs_m_x%x_d, rhs_m_y%x_d, rhs_m_z%x_d, 0, coef)
     call gs%op(rhs_E, GS_OP_ADD)
@@ -696,7 +695,6 @@ contains
 
     call gs%op(visc_rho, GS_OP_ADD)
     call rotate_cyc(visc_m_x%x_d, visc_m_y%x_d, visc_m_z%x_d, 1, coef)
-    ! Fused 3-component (momentum) halo exchange.
     call gs%op(visc_m_x%x, visc_m_y%x, visc_m_z%x, n, GS_OP_ADD)
     call rotate_cyc(visc_m_x%x_d, visc_m_y%x_d, visc_m_z%x_d, 0, coef)
     call gs%op(visc_E, GS_OP_ADD)

--- a/src/fluid/bcknd/device/euler_res_device.F90
+++ b/src/fluid/bcknd/device/euler_res_device.F90
@@ -652,9 +652,8 @@ contains
 
     call gs%op(rhs_rho_field, GS_OP_ADD)
     call rotate_cyc(rhs_m_x%x_d, rhs_m_y%x_d, rhs_m_z%x_d, 1, coef)
-    call gs%op(rhs_m_x, GS_OP_ADD)
-    call gs%op(rhs_m_y, GS_OP_ADD)
-    call gs%op(rhs_m_z, GS_OP_ADD)
+    ! Fused 3-component (momentum) halo exchange.
+    call gs%op(rhs_m_x%x, rhs_m_y%x, rhs_m_z%x, n, GS_OP_ADD)
     call rotate_cyc(rhs_m_x%x_d, rhs_m_y%x_d, rhs_m_z%x_d, 0, coef)
     call gs%op(rhs_E, GS_OP_ADD)
 
@@ -697,9 +696,8 @@ contains
 
     call gs%op(visc_rho, GS_OP_ADD)
     call rotate_cyc(visc_m_x%x_d, visc_m_y%x_d, visc_m_z%x_d, 1, coef)
-    call gs%op(visc_m_x, GS_OP_ADD)
-    call gs%op(visc_m_y, GS_OP_ADD)
-    call gs%op(visc_m_z, GS_OP_ADD)
+    ! Fused 3-component (momentum) halo exchange.
+    call gs%op(visc_m_x%x, visc_m_y%x, visc_m_z%x, n, GS_OP_ADD)
     call rotate_cyc(visc_m_x%x_d, visc_m_y%x_d, visc_m_z%x_d, 0, coef)
     call gs%op(visc_E, GS_OP_ADD)
 

--- a/src/fluid/bcknd/device/pnpn_res_device.F90
+++ b/src/fluid/bcknd/device/pnpn_res_device.F90
@@ -338,8 +338,6 @@ contains
     call device_cfill(c_Xh%h1_d, 1.0_rp / rho_val, n)
 
     call rotate_cyc(ta1%x_d, ta2%x_d, ta3%x_d, 1, c_Xh)
-    ! Fused 3-component halo exchange; the event is recorded once, after
-    ! the last component's scatter.
     call gs_Xh%op(ta1%x, ta2%x, ta3%x, n, GS_OP_ADD, event)
     call device_event_sync(event)
     call rotate_cyc(ta1%x_d, ta2%x_d, ta3%x_d, 0, c_Xh)

--- a/src/fluid/bcknd/device/pnpn_res_device.F90
+++ b/src/fluid/bcknd/device/pnpn_res_device.F90
@@ -338,11 +338,9 @@ contains
     call device_cfill(c_Xh%h1_d, 1.0_rp / rho_val, n)
 
     call rotate_cyc(ta1%x_d, ta2%x_d, ta3%x_d, 1, c_Xh)
-    call gs_Xh%op(ta1, GS_OP_ADD, event)
-    call device_event_sync(event)
-    call gs_Xh%op(ta2, GS_OP_ADD, event)
-    call device_event_sync(event)
-    call gs_Xh%op(ta3, GS_OP_ADD, event)
+    ! Fused 3-component halo exchange; the event is recorded once, after
+    ! the last component's scatter.
+    call gs_Xh%op(ta1%x, ta2%x, ta3%x, n, GS_OP_ADD, event)
     call device_event_sync(event)
     call rotate_cyc(ta1%x_d, ta2%x_d, ta3%x_d, 0, c_Xh)
 

--- a/src/fluid/bcknd/sx/pnpn_res_sx.f90
+++ b/src/fluid/bcknd/sx/pnpn_res_sx.f90
@@ -86,9 +86,8 @@ contains
        ta3%x(i,1,1,1) = f_z%x(i,1,1,1) / rho_val - wa3%x(i,1,1,1)
     end do
 
-    call gs_Xh%op(ta1, GS_OP_ADD)
-    call gs_Xh%op(ta2, GS_OP_ADD)
-    call gs_Xh%op(ta3, GS_OP_ADD)
+    ! Fused 3-component halo exchange.
+    call gs_Xh%op(ta1%x, ta2%x, ta3%x, n, GS_OP_ADD)
 
     do i = 1, n
        ta1%x(i,1,1,1) = ta1%x(i,1,1,1) * c_Xh%Binv(i,1,1,1)

--- a/src/fluid/bcknd/sx/pnpn_res_sx.f90
+++ b/src/fluid/bcknd/sx/pnpn_res_sx.f90
@@ -86,7 +86,6 @@ contains
        ta3%x(i,1,1,1) = f_z%x(i,1,1,1) / rho_val - wa3%x(i,1,1,1)
     end do
 
-    ! Fused 3-component halo exchange.
     call gs_Xh%op(ta1%x, ta2%x, ta3%x, n, GS_OP_ADD)
 
     do i = 1, n

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -871,11 +871,10 @@ contains
               dt, dm_Xh%size())
 
          call rotate_cyc(u_res, v_res, w_res, 1, c_Xh)
-         call gs_Xh%op(u_res, GS_OP_ADD, event)
-         call device_event_sync(event)
-         call gs_Xh%op(v_res, GS_OP_ADD, event)
-         call device_event_sync(event)
-         call gs_Xh%op(w_res, GS_OP_ADD, event)
+         ! Fused 3-component halo exchange; the event is recorded once,
+         ! after the last component's scatter.
+         call gs_Xh%op(u_res%x, v_res%x, w_res%x, dm_Xh%size(), &
+              GS_OP_ADD, event)
          call device_event_sync(event)
          call rotate_cyc(u_res, v_res, w_res, 0, c_Xh)
 

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -871,8 +871,6 @@ contains
               dt, dm_Xh%size())
 
          call rotate_cyc(u_res, v_res, w_res, 1, c_Xh)
-         ! Fused 3-component halo exchange; the event is recorded once,
-         ! after the last component's scatter.
          call gs_Xh%op(u_res%x, v_res%x, w_res%x, dm_Xh%size(), &
               GS_OP_ADD, event)
          call device_event_sync(event)

--- a/src/fluid/fluid_volflow.f90
+++ b/src/fluid/fluid_volflow.f90
@@ -282,8 +282,6 @@ contains
       c_Xh%ifh2 = .true.
 
       call rotate_cyc(u_res, v_res, w_res, 1, c_Xh)
-      ! Fused 3-component halo exchange; falls back to three scalar ops on comm
-      ! backends without a vector path.
       call gs_Xh%op(u_res%x, v_res%x, w_res%x, n, GS_OP_ADD)
       call rotate_cyc(u_res, v_res, w_res, 0, c_Xh)
 

--- a/src/fluid/fluid_volflow.f90
+++ b/src/fluid/fluid_volflow.f90
@@ -282,9 +282,9 @@ contains
       c_Xh%ifh2 = .true.
 
       call rotate_cyc(u_res, v_res, w_res, 1, c_Xh)
-      call gs_Xh%op(u_res, GS_OP_ADD)
-      call gs_Xh%op(v_res, GS_OP_ADD)
-      call gs_Xh%op(w_res, GS_OP_ADD)
+      ! Fused 3-component halo exchange; falls back to three scalar ops on comm
+      ! backends without a vector path.
+      call gs_Xh%op(u_res%x, v_res%x, w_res%x, n, GS_OP_ADD)
       call rotate_cyc(u_res, v_res, w_res, 0, c_Xh)
 
       call bclst_vel_res%apply_vector(u_res%x, v_res%x, w_res%x, n)

--- a/src/fluid/stress_formulation/bcknd/cpu/pnpn_res_stress_cpu.f90
+++ b/src/fluid/stress_formulation/bcknd/cpu/pnpn_res_stress_cpu.f90
@@ -143,8 +143,6 @@ contains
     end do
 
     call rotate_cyc(ta1%x, ta2%x, ta3%x, 1, c_Xh)
-    ! Fused 3-component halo exchange; falls back to three scalar ops on comm
-    ! backends without a vector path.
     call gs_Xh%op(ta1%x, ta2%x, ta3%x, n, GS_OP_ADD)
     call rotate_cyc(ta1%x, ta2%x, ta3%x, 0, c_Xh)
 

--- a/src/fluid/stress_formulation/bcknd/cpu/pnpn_res_stress_cpu.f90
+++ b/src/fluid/stress_formulation/bcknd/cpu/pnpn_res_stress_cpu.f90
@@ -143,9 +143,9 @@ contains
     end do
 
     call rotate_cyc(ta1%x, ta2%x, ta3%x, 1, c_Xh)
-    call gs_Xh%op(ta1, GS_OP_ADD)
-    call gs_Xh%op(ta2, GS_OP_ADD)
-    call gs_Xh%op(ta3, GS_OP_ADD)
+    ! Fused 3-component halo exchange; falls back to three scalar ops on comm
+    ! backends without a vector path.
+    call gs_Xh%op(ta1%x, ta2%x, ta3%x, n, GS_OP_ADD)
     call rotate_cyc(ta1%x, ta2%x, ta3%x, 0, c_Xh)
 
     do i = 1, n

--- a/src/fluid/stress_formulation/bcknd/device/pnpn_res_stress_device.F90
+++ b/src/fluid/stress_formulation/bcknd/device/pnpn_res_stress_device.F90
@@ -323,7 +323,6 @@ contains
 #endif
 
     call rotate_cyc(ta1%x_d, ta2%x_d, ta3%x_d, 1, c_Xh)
-    ! Fused 3-component halo exchange.
     call gs_Xh%op(ta1%x, ta2%x, ta3%x, n, GS_OP_ADD)
     call rotate_cyc(ta1%x_d, ta2%x_d, ta3%x_d, 0, c_Xh)
 

--- a/src/fluid/stress_formulation/bcknd/device/pnpn_res_stress_device.F90
+++ b/src/fluid/stress_formulation/bcknd/device/pnpn_res_stress_device.F90
@@ -323,9 +323,8 @@ contains
 #endif
 
     call rotate_cyc(ta1%x_d, ta2%x_d, ta3%x_d, 1, c_Xh)
-    call gs_Xh%op(ta1, GS_OP_ADD)
-    call gs_Xh%op(ta2, GS_OP_ADD)
-    call gs_Xh%op(ta3, GS_OP_ADD)
+    ! Fused 3-component halo exchange.
+    call gs_Xh%op(ta1%x, ta2%x, ta3%x, n, GS_OP_ADD)
     call rotate_cyc(ta1%x_d, ta2%x_d, ta3%x_d, 0, c_Xh)
 
     call device_opcolv(ta1%x_d, ta2%x_d, ta3%x_d, c_Xh%Binv_d, gdim, n)

--- a/src/gs/bcknd/device/cuda/gs.cu
+++ b/src/gs/bcknd/device/cuda/gs.cu
@@ -158,4 +158,56 @@ extern "C" {
 
     CUDA_CHECK(cudaGetLastError());
   }
+
+  /**
+   * Fused nc-component pack. u_d is the compact shared buffer (component-outer,
+   * per-component stride ns); buf_d is interleaved (nc per position).
+   */
+  void cuda_gs_pack_vec(void *u_d, void *buf_d, void *dof_d,
+                        int offset, int n, int nc, int ns,
+                        cudaStream_t stream) {
+
+    const int nthrds = 1024;
+    const int nblcks = (n + nthrds - 1) / nthrds;
+
+    gs_pack_vec_kernel<real>
+      <<<nblcks, nthrds, 0, stream>>>((real *) u_d, (real *) buf_d + nc*offset,
+                                      (int *) dof_d + offset, n, nc, ns);
+
+    CUDA_CHECK(cudaGetLastError());
+  }
+
+  /**
+   * Fused nc-component unpack/reduce.
+   */
+  void cuda_gs_unpack_vec(real *u_d, int op, real *buf_d, int *dof_d,
+                          int offset, int n, int nc, int ns,
+                          cudaStream_t stream) {
+
+    const int nthrds = 1024;
+    const int nblcks = (n + nthrds - 1) / nthrds;
+
+    switch (op) {
+    case GS_OP_ADD:
+      gs_unpack_add_vec_kernel<real>
+        <<<nblcks, nthrds, 0, stream>>>(u_d, buf_d + nc*offset,
+                                        dof_d + offset, n, nc, ns);
+      break;
+    case GS_OP_MIN:
+      gs_unpack_min_vec_kernel<real>
+        <<<nblcks, nthrds, 0, stream>>>(u_d, buf_d + nc*offset,
+                                        dof_d + offset, n, nc, ns);
+      break;
+    case GS_OP_MAX:
+      gs_unpack_max_vec_kernel<real>
+        <<<nblcks, nthrds, 0, stream>>>(u_d, buf_d + nc*offset,
+                                        dof_d + offset, n, nc, ns);
+      break;
+    default:
+      printf("%s: unknown gs op %d\n", __FILE__, op);
+      abort();
+    }
+
+    CUDA_CHECK(cudaGetLastError());
+  }
 }

--- a/src/gs/bcknd/device/cuda/gs_kernels.h
+++ b/src/gs/bcknd/device/cuda/gs_kernels.h
@@ -382,4 +382,95 @@ __global__ void gs_unpack_max_kernel(T * __restrict__ u,
   }
 }
 
+/*
+ * Fused nc-component (vector) pack/unpack kernels. u is the compact shared
+ * buffer, component-outer with per-component stride ns (= nshared):
+ * component c of shared index idx lives at u[c*ns + idx]. buf is interleaved,
+ * nc values per packed position j: buf[nc*j + c].
+ */
+
+template< typename T >
+__global__ void gs_pack_vec_kernel(const T * __restrict__ u,
+                                   T * __restrict__ buf,
+                                   const int32_t * __restrict__ dof,
+                                   const int n, const int nc, const int ns) {
+
+  const int j = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (j >= n)
+    return;
+
+  const int idx = dof[j] - 1;
+  for (int c = 0; c < nc; c++)
+    buf[nc*j + c] = u[c*ns + idx];
+}
+
+template< typename T >
+__global__ void gs_unpack_add_vec_kernel(T * __restrict__ u,
+                                         const T * __restrict__ buf,
+                                         const int32_t * __restrict__ dof,
+                                         const int n, const int nc,
+                                         const int ns) {
+
+  const int j = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (j >= n)
+    return;
+
+  const int32_t idx = dof[j];
+  if (idx < 0) {
+#if __CUDA_ARCH__ >= 600
+    for (int c = 0; c < nc; c++)
+      atomicAdd(&u[c*ns + (-idx-1)], buf[nc*j + c]);
+#endif
+  } else {
+    for (int c = 0; c < nc; c++)
+      u[c*ns + (idx-1)] += buf[nc*j + c];
+  }
+}
+
+template< typename T >
+__global__ void gs_unpack_min_vec_kernel(T * __restrict__ u,
+                                         const T * __restrict__ buf,
+                                         const int32_t * __restrict__ dof,
+                                         const int n, const int nc,
+                                         const int ns) {
+
+  const int j = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (j >= n)
+    return;
+
+  const int32_t idx = dof[j];
+  if (idx < 0) {
+    for (int c = 0; c < nc; c++)
+      atomicMinFloat(&u[c*ns + (-idx-1)], buf[nc*j + c]);
+  } else {
+    for (int c = 0; c < nc; c++)
+      u[c*ns + (idx-1)] = min(u[c*ns + (idx-1)], buf[nc*j + c]);
+  }
+}
+
+template< typename T >
+__global__ void gs_unpack_max_vec_kernel(T * __restrict__ u,
+                                         const T * __restrict__ buf,
+                                         const int32_t * __restrict__ dof,
+                                         const int n, const int nc,
+                                         const int ns) {
+
+  const int j = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (j >= n)
+    return;
+
+  const int32_t idx = dof[j];
+  if (idx < 0) {
+    for (int c = 0; c < nc; c++)
+      atomicMaxFloat(&u[c*ns + (-idx-1)], buf[nc*j + c]);
+  } else {
+    for (int c = 0; c < nc; c++)
+      u[c*ns + (idx-1)] = max(u[c*ns + (idx-1)], buf[nc*j + c]);
+  }
+}
+
 #endif // __GS_GS_KERNELS__

--- a/src/gs/bcknd/device/cuda/gs_nvshmem.cu
+++ b/src/gs/bcknd/device/cuda/gs_nvshmem.cu
@@ -48,40 +48,86 @@ extern "C" {
     CUDA_CHECK(cudaGetLastError());
     cudaMemset(*ptr, 0, size);
     CUDA_CHECK(cudaGetLastError());
-  }    
-  
+  }
+
   void cudafree_nvshmem(void** ptr, size_t size)
   {
     nvshmem_free(*ptr);
     CUDA_CHECK(cudaGetLastError());
   }
-  
+
+  /**
+   * Pack and push one peer slab with rank-indexed signaling. roffset is the
+   * offset in the destination's recv buffer where our slab lands; done_d and
+   * ready_d are the symmetric rank-indexed signal arrays; mype is our rank.
+   * Single-block launch: the kernel packs with a block-stride loop and
+   * pushes from the same block (see gs_nvshmem_kernels.h).
+   */
   void cuda_gs_pack_and_push(void *u_d, void *sbuf_d, void *sdof_d,
                              int soffset, int n, cudaStream_t stream,
-                             int srank,  void *rbuf_d, int roffset, int* remote_offset,
-			     int rrank, int counter, void* notifyDone, void* notifyReady,
-			     int iter)
-
+                             int destRank, void *rbuf_d, int roffset,
+                             int iter, void *done_d, void *ready_d,
+                             int mype)
   {
-    
     const int nthrds = 1024;
-    const int nblcks = (n+nthrds-1)/nthrds;
 
     pack_pushShmemKernel<real>
-      <<<nblcks,nthrds,0,stream>>>((real *) u_d,
-                                   (real *) rbuf_d + remote_offset[iter-1],
-                                   (real *) sbuf_d + soffset,
-                                   (int *) sdof_d + soffset,
-                                   srank, rrank, n, counter,
-                                   (uint64_t*) notifyDone,
-                                   (uint64_t*) notifyReady);         
+      <<<1,nthrds,0,stream>>>((real *) u_d,
+                              (real *) rbuf_d + roffset,
+                              (real *) sbuf_d + soffset,
+                              (int *) sdof_d + soffset,
+                              destRank, n, (uint64_t) iter,
+                              (uint64_t *) done_d + mype,
+                              (uint64_t *) ready_d + destRank);
     CUDA_CHECK(cudaGetLastError());
   }
 
-  void cuda_gs_pack_and_push_wait(cudaStream_t stream, int counter, void* notifyDone)
+  /**
+   * Wait until the slab from srcRank has landed (our local done_sig[srcRank]
+   * reaches iter).
+   */
+  void cuda_gs_pack_and_push_wait(cudaStream_t stream, int iter,
+                                  void *done_d, int srcRank)
   {
-    uint64_t counter_ = (uint64_t) counter;
-    pushShmemKernelWait<<<1,1,0,stream>>>(counter_,(uint64_t*) notifyDone);
+    pushShmemKernelWait<<<1,1,0,stream>>>((uint64_t) iter,
+                                          (uint64_t *) done_d + srcRank);
+    CUDA_CHECK(cudaGetLastError());
+  }
+
+  /**
+   * Post our ready signal to srcRank (sets ready_sig[mype] = iter there),
+   * allowing it to overwrite its send slab for the next round. Launch after
+   * the unpack on the same stream.
+   */
+  void cuda_gs_post_ready(cudaStream_t stream, int iter, void *ready_d,
+                          int mype, int srcRank)
+  {
+    postReadyShmemKernel<<<1,1,0,stream>>>((uint64_t *) ready_d + mype,
+                                           (uint64_t) iter, srcRank);
+    CUDA_CHECK(cudaGetLastError());
+  }
+
+  /**
+   * Fused nc-component pack-and-push. sbuf_d/rbuf_d are interleaved (nc per
+   * position); u_d is the compact shared buffer (component-outer, stride ns).
+   * Single-block launch, see cuda_gs_pack_and_push.
+   */
+  void cuda_gs_pack_and_push_vec(void *u_d, void *sbuf_d, void *sdof_d,
+                                 int soffset, int n, int nc, int ns,
+                                 cudaStream_t stream, int destRank,
+                                 void *rbuf_d, int roffset, int iter,
+                                 void *done_d, void *ready_d, int mype)
+  {
+    const int nthrds = 1024;
+
+    pack_pushShmemKernel_vec<real>
+      <<<1,nthrds,0,stream>>>((real *) u_d,
+                              (real *) rbuf_d + nc*roffset,
+                              (real *) sbuf_d + nc*soffset,
+                              (int *) sdof_d + soffset,
+                              destRank, n, nc, ns, (uint64_t) iter,
+                              (uint64_t *) done_d + mype,
+                              (uint64_t *) ready_d + destRank);
     CUDA_CHECK(cudaGetLastError());
   }
 #endif

--- a/src/gs/bcknd/device/cuda/gs_nvshmem_kernels.h
+++ b/src/gs/bcknd/device/cuda/gs_nvshmem_kernels.h
@@ -33,10 +33,35 @@
 */
 
 #ifndef __GS_NVSHMEM_KERNELS__
-#define __GS_NVHSMEM_KERNELS__
+#define __GS_NVSHMEM_KERNELS__
 
 #include <nvshmemx.h>
 
+/*
+ * Fused pack-and-push kernels with rank-indexed signaling.
+ *
+ * Signaling uses two symmetric arrays of pe_size slots, indexed by the
+ * REMOTE PE's rank (so peer lists need not be uniform in length or aligned
+ * in order across ranks, and the symmetric allocations are collective-safe):
+ *  - doneSig  = &done_sig[my_rank] on the destination: set to iter by our
+ *    put_signal when our slab has landed there.
+ *  - readySlot = &ready_sig[destRank] locally: set to iter by the
+ *    destination once it has consumed our round-iter slab.
+ * The round counter iter advances once per gs op (lockstep across ranks),
+ * and all waits use CMP_GE, so no cross-rank counter matching is needed.
+ *
+ * These are SINGLE-BLOCK kernels (launched with one block): the pack is a
+ * block-stride loop, so the block-local __syncthreads() suffices to order
+ * the pack before the put. A multi-block pack would race with the push --
+ * there is no grid-wide barrier between pack and push. Single-block
+ * transfers were also found to perform best.
+ *
+ * The ready wait comes BEFORE the pack: the destination posts ready(iter-1)
+ * only after consuming our round iter-1 slab, which implies our previous
+ * (non-blocking) put has fully drained src -- so the pack below can safely
+ * overwrite it. Packing before this wait would race with a still-in-flight
+ * nbi put on proxy-based transports.
+ */
 
 template< typename T >
 __global__ void pack_pushShmemKernel(const T * __restrict__ u,
@@ -44,11 +69,10 @@ __global__ void pack_pushShmemKernel(const T * __restrict__ u,
                                      T * __restrict__ src,
                                      const int * __restrict__ dof,
                                      const int destRank,
-                                     const int srcRank,
                                      const int n,
-                                     uint64_t counter,
-                                     uint64_t * notifyDone,
-                                     uint64_t * notifyReady);
+                                     uint64_t iter,
+                                     uint64_t * doneSig,
+                                     uint64_t * readySlot);
 
 template<>
 __global__ void pack_pushShmemKernel(const float * __restrict__ u,
@@ -56,43 +80,28 @@ __global__ void pack_pushShmemKernel(const float * __restrict__ u,
                                      float * __restrict__ src,
                                      const int * __restrict__ dof,
                                      const int destRank,
-                                     const int srcRank,
                                      const int n,
-                                     uint64_t counter,
-                                     uint64_t * notifyDone,
-                                     uint64_t * notifyReady)
+                                     uint64_t iter,
+                                     uint64_t * doneSig,
+                                     uint64_t * readySlot)
 {
 
+  /* Wait until destRank has consumed our previous round (see note above) */
+  if (threadIdx.x == 0) {
+    nvshmem_signal_wait_until(readySlot, NVSHMEM_CMP_GE, iter - 1);
+  }
+  __syncthreads();
 
-  const int j = threadIdx.x + blockDim.x * blockIdx.x;
-
-  if (j <  n) {
+  /* Pack with a block-stride loop (single-block kernel) */
+  for (int j = threadIdx.x; j < n; j += blockDim.x) {
     src[j] = u[dof[j]-1];
   }
   __syncthreads();
-  
-  //TO DO: 1 block transfers seem best from initial investigations, check this more thoroughly
-  size_t numBlocksForTransfer = 1; 
-  if(blockIdx.x < numBlocksForTransfer)
-  {
-    size_t n_per_block = n/numBlocksForTransfer;
-    size_t block_offset = n_per_block*blockIdx.x;
-    size_t dataSize = blockIdx.x != (numBlocksForTransfer - 1) ?
-      n_per_block : max(n - block_offset, n_per_block);
-    
-    // Notify ready to sending rank, and wait until recieving rank is ready
-    if (threadIdx.x == 0) {
-      nvshmemx_signal_op(notifyReady, counter, NVSHMEM_SIGNAL_SET, srcRank);
-      nvshmem_signal_wait_until(notifyReady, NVSHMEM_CMP_EQ, counter);
-    }
-    __syncthreads();
-    
-    // Push data
-    nvshmemx_float_put_signal_nbi_block(dest + block_offset, src +
-                                        block_offset, dataSize,
-                                        notifyDone, counter,
-                                        NVSHMEM_SIGNAL_SET, destRank);
-  }
+
+  /* Push data and set done_sig[my_rank] = iter on the destination */
+  nvshmemx_float_put_signal_nbi_block(dest, src, n,
+                                      doneSig, iter,
+                                      NVSHMEM_SIGNAL_SET, destRank);
 }
 
 template<>
@@ -101,55 +110,137 @@ __global__ void pack_pushShmemKernel(const double * __restrict__ u,
                                      double * __restrict__ src,
                                      const int * __restrict__ dof,
                                      const int destRank,
-                                     const int srcRank,
                                      const int n,
-                                     uint64_t counter,
-                                     uint64_t * notifyDone,
-                                     uint64_t * notifyReady)
+                                     uint64_t iter,
+                                     uint64_t * doneSig,
+                                     uint64_t * readySlot)
 {
 
+  /* Wait until destRank has consumed our previous round (see note above) */
+  if (threadIdx.x == 0) {
+    nvshmem_signal_wait_until(readySlot, NVSHMEM_CMP_GE, iter - 1);
+  }
+  __syncthreads();
 
-  const int j = threadIdx.x + blockDim.x * blockIdx.x;
-
-  if (j <  n) {
+  /* Pack with a block-stride loop (single-block kernel) */
+  for (int j = threadIdx.x; j < n; j += blockDim.x) {
     src[j] = u[dof[j]-1];
   }
   __syncthreads();
-  
-  //TO DO: 1 block transfers seem best from initial investigations, check this more thoroughly
-  size_t numBlocksForTransfer = 1; 
-  if(blockIdx.x < numBlocksForTransfer)
-  {
-    size_t n_per_block = n/numBlocksForTransfer;
-    size_t block_offset = n_per_block*blockIdx.x;
-    size_t dataSize = blockIdx.x != (numBlocksForTransfer - 1) ?
-      n_per_block : max(n - block_offset, n_per_block);
-    
-    // Notify ready to sending rank, and wait until recieving rank is ready
-    if (threadIdx.x == 0) {
-      nvshmemx_signal_op(notifyReady, counter, NVSHMEM_SIGNAL_SET, srcRank);
-      nvshmem_signal_wait_until(notifyReady, NVSHMEM_CMP_EQ, counter);
-    }
-    __syncthreads();
-    
-    // Push data
-    nvshmemx_double_put_signal_nbi_block(dest + block_offset, src +
-                                         block_offset, dataSize,
-                                         notifyDone, counter,
-                                         NVSHMEM_SIGNAL_SET, destRank);
-  }
+
+  /* Push data and set done_sig[my_rank] = iter on the destination */
+  nvshmemx_double_put_signal_nbi_block(dest, src, n,
+                                       doneSig, iter,
+                                       NVSHMEM_SIGNAL_SET, destRank);
 }
 
-__global__ void pushShmemKernelWait(uint64_t counter,
-                                    uint64_t *notifyDone) 
+/* Wait until the slab from a recv peer has landed (doneSlot is our local
+   done_sig[src] slot, set by the peer's put_signal) */
+__global__ void pushShmemKernelWait(uint64_t iter,
+                                    uint64_t *doneSlot)
 {
-  // Notify done to receiving rank, and wait for data from sending rank
   if (blockIdx.x==0 && threadIdx.x == 0) {
-    nvshmem_signal_wait_until(notifyDone, NVSHMEM_CMP_EQ, counter);
+    nvshmem_signal_wait_until(doneSlot, NVSHMEM_CMP_GE, iter);
   }
 }
 
+/* Post our ready signal to the peer we receive from: sets
+   ready_sig[my_rank] = iter on srcRank, allowing it to overwrite its send
+   slab for the next round. Launched after the unpack on the same stream. */
+__global__ void postReadyShmemKernel(uint64_t *readySlot,
+                                     uint64_t iter,
+                                     const int srcRank)
+{
+  if (blockIdx.x==0 && threadIdx.x == 0) {
+    nvshmemx_signal_op(readySlot, iter, NVSHMEM_SIGNAL_SET, srcRank);
+  }
+}
 
+/*
+ * Fused nc-component pack-and-push (single-block, rank-indexed signaling,
+ * see the scalar kernels above). u is the compact shared buffer,
+ * component-outer with per-component stride ns; src/dest are interleaved
+ * (nc per position). The pushed payload is nc*n elements.
+ */
+template< typename T >
+__global__ void pack_pushShmemKernel_vec(const T * __restrict__ u,
+                                         T * dest,
+                                         T * __restrict__ src,
+                                         const int * __restrict__ dof,
+                                         const int destRank,
+                                         const int n,
+                                         const int nc,
+                                         const int ns,
+                                         uint64_t iter,
+                                         uint64_t * doneSig,
+                                         uint64_t * readySlot);
 
+template<>
+__global__ void pack_pushShmemKernel_vec(const float * __restrict__ u,
+                                         float * dest,
+                                         float * __restrict__ src,
+                                         const int * __restrict__ dof,
+                                         const int destRank,
+                                         const int n,
+                                         const int nc,
+                                         const int ns,
+                                         uint64_t iter,
+                                         uint64_t * doneSig,
+                                         uint64_t * readySlot)
+{
+
+  /* Wait until destRank has consumed our previous round */
+  if (threadIdx.x == 0) {
+    nvshmem_signal_wait_until(readySlot, NVSHMEM_CMP_GE, iter - 1);
+  }
+  __syncthreads();
+
+  /* Pack with a block-stride loop (single-block kernel) */
+  for (int j = threadIdx.x; j < n; j += blockDim.x) {
+    const int idx = dof[j] - 1;
+    for (int c = 0; c < nc; c++)
+      src[nc*j + c] = u[c*ns + idx];
+  }
+  __syncthreads();
+
+  /* Push data and set done_sig[my_rank] = iter on the destination */
+  nvshmemx_float_put_signal_nbi_block(dest, src, (size_t) nc * n,
+                                      doneSig, iter,
+                                      NVSHMEM_SIGNAL_SET, destRank);
+}
+
+template<>
+__global__ void pack_pushShmemKernel_vec(const double * __restrict__ u,
+                                         double * dest,
+                                         double * __restrict__ src,
+                                         const int * __restrict__ dof,
+                                         const int destRank,
+                                         const int n,
+                                         const int nc,
+                                         const int ns,
+                                         uint64_t iter,
+                                         uint64_t * doneSig,
+                                         uint64_t * readySlot)
+{
+
+  /* Wait until destRank has consumed our previous round */
+  if (threadIdx.x == 0) {
+    nvshmem_signal_wait_until(readySlot, NVSHMEM_CMP_GE, iter - 1);
+  }
+  __syncthreads();
+
+  /* Pack with a block-stride loop (single-block kernel) */
+  for (int j = threadIdx.x; j < n; j += blockDim.x) {
+    const int idx = dof[j] - 1;
+    for (int c = 0; c < nc; c++)
+      src[nc*j + c] = u[c*ns + idx];
+  }
+  __syncthreads();
+
+  /* Push data and set done_sig[my_rank] = iter on the destination */
+  nvshmemx_double_put_signal_nbi_block(dest, src, (size_t) nc * n,
+                                       doneSig, iter,
+                                       NVSHMEM_SIGNAL_SET, destRank);
+}
 
 #endif

--- a/src/gs/bcknd/device/gs_device_mpi.F90
+++ b/src/gs/bcknd/device/gs_device_mpi.F90
@@ -33,7 +33,7 @@
 !> Defines GPU aware MPI gather-scatter communication
 module gs_device_mpi
   use num_types, only : rp, c_rp
-  use gs_comm, only : gs_comm_t
+  use gs_comm, only : gs_comm_t, GS_VEC_NC
   use stack, only : stack_i4_t
   use comm, only : pe_size, pe_rank
   use htable, only : htable_i4_t
@@ -55,6 +55,7 @@ module gs_device_mpi
      integer :: total !< Total number of dofs
      type(c_ptr) :: reqs = C_NULL_PTR !< MPI request array in C
      type(c_ptr) :: buf_d = C_NULL_PTR !< Device buffer
+     type(c_ptr) :: buf_v_d = C_NULL_PTR !< Device buffer, fused vector (x nc)
      type(c_ptr) :: dof_d = C_NULL_PTR !< Dof mapping for pack/unpack
    contains
      procedure, pass(this) :: init => gs_device_mpi_buf_init
@@ -76,6 +77,9 @@ module gs_device_mpi
      procedure, pass(this) :: nbsend => gs_device_mpi_nbsend
      procedure, pass(this) :: nbrecv => gs_device_mpi_nbrecv
      procedure, pass(this) :: nbwait => gs_device_mpi_nbwait
+     procedure, pass(this) :: nbsend_vec => gs_device_mpi_nbsend_vec
+     procedure, pass(this) :: nbrecv_vec => gs_device_mpi_nbrecv_vec
+     procedure, pass(this) :: nbwait_vec => gs_device_mpi_nbwait_vec
   end type gs_device_mpi_t
 
 #ifdef HAVE_HIP
@@ -98,6 +102,26 @@ module gs_device_mpi
        type(c_ptr), value :: u_d, buf_d, dof_d, stream
      end subroutine hip_gs_unpack
   end interface
+
+  interface
+     subroutine hip_gs_pack_vec(u_d, buf_d, dof_d, offset, n, nc, ns, stream) &
+          bind(c, name = 'hip_gs_pack_vec')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int), value :: offset, n, nc, ns
+       type(c_ptr), value :: u_d, buf_d, dof_d, stream
+     end subroutine hip_gs_pack_vec
+  end interface
+
+  interface
+     subroutine hip_gs_unpack_vec(u_d, op, buf_d, dof_d, offset, n, nc, ns, &
+          stream) bind(c, name = 'hip_gs_unpack_vec')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int), value :: op, offset, n, nc, ns
+       type(c_ptr), value :: u_d, buf_d, dof_d, stream
+     end subroutine hip_gs_unpack_vec
+  end interface
 #elif HAVE_CUDA
   interface
      subroutine cuda_gs_pack(u_d, buf_d, dof_d, offset, n, stream) &
@@ -117,6 +141,26 @@ module gs_device_mpi
        integer(c_int), value :: op, offset, n
        type(c_ptr), value :: u_d, buf_d, dof_d, stream
      end subroutine cuda_gs_unpack
+  end interface
+
+  interface
+     subroutine cuda_gs_pack_vec(u_d, buf_d, dof_d, offset, n, nc, ns, stream) &
+          bind(c, name = 'cuda_gs_pack_vec')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int), value :: offset, n, nc, ns
+       type(c_ptr), value :: u_d, buf_d, dof_d, stream
+     end subroutine cuda_gs_pack_vec
+  end interface
+
+  interface
+     subroutine cuda_gs_unpack_vec(u_d, op, buf_d, dof_d, offset, n, nc, ns, &
+          stream) bind(c, name = 'cuda_gs_unpack_vec')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int), value :: op, offset, n, nc, ns
+       type(c_ptr), value :: u_d, buf_d, dof_d, stream
+     end subroutine cuda_gs_unpack_vec
   end interface
 #endif
 
@@ -223,6 +267,11 @@ contains
     call device_alloc(this%buf_d, sz)
     call device_memset(this%buf_d, 0, sz, sync = .true.)
 
+    ! Fused vector buffer, sized for up to GS_VEC_NC components.
+    sz = c_sizeof(rp_dummy) * GS_VEC_NC * total
+    call device_alloc(this%buf_v_d, sz)
+    call device_memset(this%buf_v_d, 0, sz, sync = .true.)
+
     sz = c_sizeof(i4_dummy) * total
     call device_alloc(this%dof_d, sz)
 
@@ -275,6 +324,7 @@ contains
     if (allocated(this%offset)) deallocate(this%offset)
 
     if (c_associated(this%buf_d)) call device_free(this%buf_d)
+    if (c_associated(this%buf_v_d)) call device_free(this%buf_v_d)
     if (c_associated(this%dof_d)) call device_free(this%dof_d)
   end subroutine gs_device_mpi_buf_free
 
@@ -283,7 +333,7 @@ contains
     class(gs_device_mpi_t), intent(inout) :: this
     type(stack_i4_t), intent(inout) :: send_pe
     type(stack_i4_t), intent(inout) :: recv_pe
-    integer :: i
+    integer :: i, nstrm
 
     call this%init_order(send_pe, recv_pe)
 
@@ -291,21 +341,26 @@ contains
     call this%recv_buf%init(this%recv_pe, this%recv_dof, .true.)
 
 #if defined(HAVE_HIP) || defined(HAVE_CUDA)
-    ! Create a set of non-blocking streams
-    allocate(this%stream(size(this%recv_pe)))
-    do i = 1, size(this%recv_pe)
+    ! Create a set of non-blocking streams. The per-peer streams and events
+    ! are indexed over both send_pe (pack) and recv_pe (unpack, sync), so
+    ! size them for the larger of the two peer lists.
+    nstrm = max(size(this%send_pe), size(this%recv_pe))
+    allocate(this%stream(nstrm))
+    do i = 1, nstrm
        call device_stream_create_with_priority(this%stream(i), 1, &
             STRM_HIGH_PRIO)
     end do
 
-    allocate(this%event(size(this%recv_pe)))
-    do i = 1, size(this%recv_pe)
+    allocate(this%event(nstrm))
+    do i = 1, nstrm
        call device_event_create(this%event(i), 2)
     end do
 #endif
 
 
     this%nb_strtgy = 0
+
+    this%vec_supported = .true.
 
   end subroutine gs_device_mpi_init
 
@@ -491,5 +546,85 @@ contains
     end if
 
   end subroutine gs_device_mpi_nbwait
+
+  !> Fused nc-component send. @a u is the compact shared device buffer
+  !! (component-outer, per-component stride n = nshared). Packs nc components
+  !! into the interleaved send buffer and issues one Isend of nc*ndofs per peer.
+  subroutine gs_device_mpi_nbsend_vec(this, u, n, nc, tag, deps, strm)
+    class(gs_device_mpi_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    integer, intent(in) :: tag
+    type(c_ptr), intent(inout) :: deps
+    type(c_ptr), intent(inout) :: strm
+    integer :: i
+    type(c_ptr) :: u_d
+
+    u_d = device_get_ptr(u)
+
+#ifdef HAVE_HIP
+    call hip_gs_pack_vec(u_d, this%send_buf%buf_v_d, this%send_buf%dof_d, &
+         0, this%send_buf%total, nc, n, strm)
+#elif HAVE_CUDA
+    call cuda_gs_pack_vec(u_d, this%send_buf%buf_v_d, this%send_buf%dof_d, &
+         0, this%send_buf%total, nc, n, strm)
+#else
+    call neko_error('gs_device_mpi: no backend')
+#endif
+
+    call device_sync(strm)
+
+    do i = 1, size(this%send_pe)
+       call device_mpi_isend(this%send_buf%buf_v_d, &
+            rp*nc*this%send_buf%offset(i), &
+            rp*nc*this%send_buf%ndofs(i), this%send_pe(i), tag, &
+            this%send_buf%reqs, i)
+    end do
+
+  end subroutine gs_device_mpi_nbsend_vec
+
+  !> Post non-blocking receives for a fused nc-component exchange.
+  subroutine gs_device_mpi_nbrecv_vec(this, tag, nc)
+    class(gs_device_mpi_t), intent(inout) :: this
+    integer, intent(in) :: tag, nc
+    integer :: i
+
+    do i = 1, size(this%recv_pe)
+       call device_mpi_irecv(this%recv_buf%buf_v_d, &
+            rp*nc*this%recv_buf%offset(i), &
+            rp*nc*this%recv_buf%ndofs(i), this%recv_pe(i), tag, &
+            this%recv_buf%reqs, i)
+    end do
+
+  end subroutine gs_device_mpi_nbrecv_vec
+
+  !> Wait for a fused nc-component exchange and unpack/reduce into @a u.
+  subroutine gs_device_mpi_nbwait_vec(this, u, n, nc, op, strm)
+    class(gs_device_mpi_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    type(c_ptr), intent(inout) :: strm
+    integer :: op
+    type(c_ptr) :: u_d
+
+    u_d = device_get_ptr(u)
+
+    call device_mpi_waitall(size(this%recv_pe), this%recv_buf%reqs)
+
+#ifdef HAVE_HIP
+    call hip_gs_unpack_vec(u_d, op, this%recv_buf%buf_v_d, &
+         this%recv_buf%dof_d, 0, this%recv_buf%total, nc, n, strm)
+#elif HAVE_CUDA
+    call cuda_gs_unpack_vec(u_d, op, this%recv_buf%buf_v_d, &
+         this%recv_buf%dof_d, 0, this%recv_buf%total, nc, n, strm)
+#else
+    call neko_error('gs_device_mpi: no backend')
+#endif
+
+    call device_mpi_waitall(size(this%send_pe), this%send_buf%reqs)
+
+    call device_sync(strm)
+
+  end subroutine gs_device_mpi_nbwait_vec
 
 end module gs_device_mpi

--- a/src/gs/bcknd/device/gs_device_nccl.F90
+++ b/src/gs/bcknd/device/gs_device_nccl.F90
@@ -33,7 +33,7 @@
 !> Defines NCCL based gather-scatter communication
 module gs_device_nccl
   use num_types, only : rp, c_rp
-  use gs_comm, only : gs_comm_t
+  use gs_comm, only : gs_comm_t, GS_VEC_NC
   use stack, only : stack_i4_t
   use comm, only : pe_size, pe_rank
   use htable, only : htable_i4_t
@@ -50,6 +50,7 @@ module gs_device_nccl
      integer, allocatable :: offset(:) !< Offset into buf
      integer :: total !< Total number of dofs
      type(c_ptr) :: buf_d = C_NULL_PTR !< Device buffer
+     type(c_ptr) :: buf_v_d = C_NULL_PTR !< Device buffer, fused vector (x nc)
      type(c_ptr) :: dof_d = C_NULL_PTR !< Dof mapping for pack/unpack
    contains
      procedure, pass(this) :: init => gs_device_nccl_buf_init
@@ -71,6 +72,9 @@ module gs_device_nccl
      procedure, pass(this) :: nbsend => gs_device_nccl_nbsend
      procedure, pass(this) :: nbrecv => gs_device_nccl_nbrecv
      procedure, pass(this) :: nbwait => gs_device_nccl_nbwait
+     procedure, pass(this) :: nbsend_vec => gs_device_nccl_nbsend_vec
+     procedure, pass(this) :: nbrecv_vec => gs_device_nccl_nbrecv_vec
+     procedure, pass(this) :: nbwait_vec => gs_device_nccl_nbwait_vec
   end type gs_device_nccl_t
 
 #ifdef HAVE_HIP
@@ -93,6 +97,26 @@ module gs_device_nccl
        type(c_ptr), value :: u_d, buf_d, dof_d, stream
      end subroutine hip_gs_unpack
   end interface
+
+  interface
+     subroutine hip_gs_pack_vec(u_d, buf_d, dof_d, offset, n, nc, ns, stream) &
+          bind(c, name = 'hip_gs_pack_vec')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int), value :: offset, n, nc, ns
+       type(c_ptr), value :: u_d, buf_d, dof_d, stream
+     end subroutine hip_gs_pack_vec
+  end interface
+
+  interface
+     subroutine hip_gs_unpack_vec(u_d, op, buf_d, dof_d, offset, n, nc, ns, &
+          stream) bind(c, name = 'hip_gs_unpack_vec')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int), value :: op, offset, n, nc, ns
+       type(c_ptr), value :: u_d, buf_d, dof_d, stream
+     end subroutine hip_gs_unpack_vec
+  end interface
 #elif HAVE_CUDA
   interface
      subroutine cuda_gs_pack(u_d, buf_d, dof_d, offset, n, stream) &
@@ -112,6 +136,26 @@ module gs_device_nccl
        integer(c_int), value :: op, offset, n
        type(c_ptr), value :: u_d, buf_d, dof_d, stream
      end subroutine cuda_gs_unpack
+  end interface
+
+  interface
+     subroutine cuda_gs_pack_vec(u_d, buf_d, dof_d, offset, n, nc, ns, stream) &
+          bind(c, name = 'cuda_gs_pack_vec')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int), value :: offset, n, nc, ns
+       type(c_ptr), value :: u_d, buf_d, dof_d, stream
+     end subroutine cuda_gs_pack_vec
+  end interface
+
+  interface
+     subroutine cuda_gs_unpack_vec(u_d, op, buf_d, dof_d, offset, n, nc, ns, &
+          stream) bind(c, name = 'cuda_gs_unpack_vec')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int), value :: op, offset, n, nc, ns
+       type(c_ptr), value :: u_d, buf_d, dof_d, stream
+     end subroutine cuda_gs_unpack_vec
   end interface
 #endif
 
@@ -157,6 +201,10 @@ contains
 
     sz = c_sizeof(rp_dummy) * total
     call device_alloc(this%buf_d, sz)
+
+    ! Fused vector buffer, sized for up to GS_VEC_NC components.
+    sz = c_sizeof(rp_dummy) * GS_VEC_NC * total
+    call device_alloc(this%buf_v_d, sz)
 
     sz = c_sizeof(i4_dummy) * total
     call device_alloc(this%dof_d, sz)
@@ -205,6 +253,7 @@ contains
     if (allocated(this%offset)) deallocate(this%offset)
 
     if (c_associated(this%buf_d)) call device_free(this%buf_d)
+    if (c_associated(this%buf_v_d)) call device_free(this%buf_v_d)
     if (c_associated(this%dof_d)) call device_free(this%dof_d)
   end subroutine gs_device_nccl_buf_free
 
@@ -213,7 +262,7 @@ contains
     class(gs_device_nccl_t), intent(inout) :: this
     type(stack_i4_t), intent(inout) :: send_pe
     type(stack_i4_t), intent(inout) :: recv_pe
-    integer :: i
+    integer :: i, nstrm
 
     call this%init_order(send_pe, recv_pe)
 
@@ -221,18 +270,23 @@ contains
     call this%recv_buf%init(this%recv_pe, this%recv_dof, .true.)
 
 #if defined(HAVE_HIP) || defined(HAVE_CUDA)
-    ! Create a set of non-blocking streams
-    allocate(this%stream(size(this%recv_pe)))
-    do i = 1, size(this%recv_pe)
+    ! Create a set of non-blocking streams. The per-peer streams and events
+    ! are indexed over both send_pe (pack, sendrecv) and recv_pe (unpack,
+    ! sync), so size them for the larger of the two peer lists.
+    nstrm = max(size(this%send_pe), size(this%recv_pe))
+    allocate(this%stream(nstrm))
+    do i = 1, nstrm
        call device_stream_create_with_priority(this%stream(i), 1, &
             STRM_HIGH_PRIO)
     end do
 
-    allocate(this%event(size(this%recv_pe)))
-    do i = 1, size(this%recv_pe)
+    allocate(this%event(nstrm))
+    do i = 1, nstrm
        call device_event_create(this%event(i), 2)
     end do
 #endif
+
+    this%vec_supported = .true.
 
   end subroutine gs_device_nccl_init
 
@@ -361,5 +415,92 @@ contains
     end do
 
   end subroutine gs_device_nccl_nbwait
+
+  !> Fused nc-component send. @a u is the compact shared device buffer
+  !! (component-outer, per-component stride n = nshared). Packs each peer's
+  !! nc-component slab on its own stream.
+  subroutine gs_device_nccl_nbsend_vec(this, u, n, nc, tag, deps, strm)
+    class(gs_device_nccl_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    integer, intent(in) :: tag
+    type(c_ptr), intent(inout) :: deps
+    type(c_ptr), intent(inout) :: strm
+    integer :: i
+    type(c_ptr) :: u_d
+
+    u_d = device_get_ptr(u)
+
+    do i = 1, size(this%send_pe)
+       call device_stream_wait_event(this%stream(i), deps, 0)
+#ifdef HAVE_HIP
+       call hip_gs_pack_vec(u_d, this%send_buf%buf_v_d, this%send_buf%dof_d, &
+            this%send_buf%offset(i), this%send_buf%ndofs(i), nc, n, &
+            this%stream(i))
+#elif HAVE_CUDA
+       call cuda_gs_pack_vec(u_d, this%send_buf%buf_v_d, this%send_buf%dof_d, &
+            this%send_buf%offset(i), this%send_buf%ndofs(i), nc, n, &
+            this%stream(i))
+#else
+       call neko_error('gs_device_nccl: no backend')
+#endif
+    end do
+
+  end subroutine gs_device_nccl_nbsend_vec
+
+  !> No-op: send/recv and unpack happen in nbwait_vec.
+  subroutine gs_device_nccl_nbrecv_vec(this, tag, nc)
+    class(gs_device_nccl_t), intent(inout) :: this
+    integer, intent(in) :: tag, nc
+  end subroutine gs_device_nccl_nbrecv_vec
+
+  !> Fused nc-component send/recv + unpack.
+  subroutine gs_device_nccl_nbwait_vec(this, u, n, nc, op, strm)
+    class(gs_device_nccl_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    type(c_ptr), intent(inout) :: strm
+    integer :: op, done_req, i
+    type(c_ptr) :: u_d
+    real(c_rp) :: rp_dummy
+    integer(c_int) :: nbytes
+
+    u_d = device_get_ptr(u)
+    nbytes = c_sizeof(rp_dummy)
+
+    do i = 1, size(this%send_pe)
+
+       call device_nccl_sendrecv(this%send_buf%buf_v_d, &
+            nbytes*nc*this%send_buf%offset(i), &
+            nc*this%send_buf%ndofs(i), &
+            this%send_pe(i), &
+            this%recv_buf%buf_v_d, &
+            nbytes*nc*this%recv_buf%offset(i), &
+            nc*this%recv_buf%ndofs(i), &
+            this%recv_pe(i), &
+            nbytes, &
+            this%stream(i))
+
+#ifdef HAVE_HIP
+       call hip_gs_unpack_vec(u_d, op, this%recv_buf%buf_v_d, &
+            this%recv_buf%dof_d, this%recv_buf%offset(i), &
+            this%recv_buf%ndofs(i), nc, n, this%stream(i))
+#elif HAVE_CUDA
+       call cuda_gs_unpack_vec(u_d, op, this%recv_buf%buf_v_d, &
+            this%recv_buf%dof_d, this%recv_buf%offset(i), &
+            this%recv_buf%ndofs(i), nc, n, this%stream(i))
+#else
+       call neko_error('gs_device_nccl: no backend')
+#endif
+       call device_event_record(this%event(i), this%stream(i))
+    end do
+
+    ! Sync non-blocking streams
+    do done_req = 1, size(this%recv_pe)
+       call device_stream_wait_event(strm, &
+            this%event(done_req), 0)
+    end do
+
+  end subroutine gs_device_nccl_nbwait_vec
 
 end module gs_device_nccl

--- a/src/gs/bcknd/device/gs_device_shmem.F90
+++ b/src/gs/bcknd/device/gs_device_shmem.F90
@@ -33,15 +33,14 @@
 !> Defines GPU aware MPI gather-scatter communication
 module gs_device_shmem
   use num_types, only : rp, c_rp
-  use gs_comm, only : gs_comm_t
+  use gs_comm, only : gs_comm_t, GS_VEC_NC
   use stack, only : stack_i4_t
   use htable, only : htable_i4_t
   use device
   use comm, only : pe_size, pe_rank, NEKO_COMM
-  use mpi_f08, only : MPI_Allreduce, MPI_INTEGER, &
-       MPI_MAX, MPI_Sendrecv, MPI_STATUS_IGNORE
+  use mpi_f08, only : MPI_Allreduce, MPI_Alltoall, MPI_INTEGER, MPI_MAX
   use utils, only : neko_error
-  use, intrinsic :: iso_c_binding, only : c_sizeof, c_int32_t, &
+  use, intrinsic :: iso_c_binding, only : c_sizeof, c_int32_t, c_int64_t, &
        c_ptr, C_NULL_PTR, c_size_t, c_associated
   implicit none
   private
@@ -53,6 +52,7 @@ module gs_device_shmem
      integer, allocatable :: remote_offset(:) !< Offset into buf for remote rank
      integer :: total !< Total number of dofs
      type(c_ptr) :: buf_d = C_NULL_PTR !< Device buffer
+     type(c_ptr) :: buf_v_d = C_NULL_PTR !< Symmetric buffer, fused vector (x nc)
      type(c_ptr) :: dof_d = C_NULL_PTR !< Dof mapping for pack/unpack
    contains
      procedure, pass(this) :: init => gs_device_shmem_buf_init
@@ -66,15 +66,28 @@ module gs_device_shmem
      type(gs_device_shmem_buf_t) :: recv_buf
      type(c_ptr), allocatable :: stream(:)
      type(c_ptr), allocatable :: event(:)
-     integer :: nvshmem_counter = 1
-     type(c_ptr), allocatable :: notifyDone(:)
-     type(c_ptr), allocatable :: notifyReady(:)
+     !> Round counter for the rank-indexed signal protocol. Advances once per
+     !! gs op (lockstep across ranks, SPMD); all waits use CMP_GE, so no
+     !! cross-rank counter matching is required and peer counts may differ
+     !! between ranks.
+     integer :: iter = 0
+     !> Symmetric rank-indexed signal arrays, pe_size slots each (a single
+     !! collective allocation per array, so nvshmem_malloc collectivity is
+     !! independent of the local peer count). done_sig(r) on our PE is set to
+     !! iter by rank r's put_signal when its slab has landed in our recv
+     !! buffer; ready_sig(r) on our PE is set to iter by rank r once it has
+     !! consumed our round-iter slab (so we may overwrite our send slab).
+     type(c_ptr) :: done_sig_d = C_NULL_PTR
+     type(c_ptr) :: ready_sig_d = C_NULL_PTR
    contains
      procedure, pass(this) :: init => gs_device_shmem_init
      procedure, pass(this) :: free => gs_device_shmem_free
      procedure, pass(this) :: nbsend => gs_device_shmem_nbsend
      procedure, pass(this) :: nbrecv => gs_device_shmem_nbrecv
      procedure, pass(this) :: nbwait => gs_device_shmem_nbwait
+     procedure, pass(this) :: nbsend_vec => gs_device_shmem_nbsend_vec
+     procedure, pass(this) :: nbrecv_vec => gs_device_shmem_nbrecv_vec
+     procedure, pass(this) :: nbwait_vec => gs_device_shmem_nbwait_vec
   end type gs_device_shmem_t
 
 
@@ -101,28 +114,34 @@ module gs_device_shmem
 
   interface
      subroutine cuda_gs_pack_and_push(u_d, buf_d, dof_d, offset, n, stream, &
-          srank, rbuf_d, roffset, remote_offset, &
-          rrank, nvshmem_counter, notifyDone, &
-          notifyReady, iter) &
+          dest_rank, rbuf_d, roffset, iter, done_d, ready_d, mype) &
           bind(c, name = 'cuda_gs_pack_and_push')
        use, intrinsic :: iso_c_binding
        implicit none
-       integer(c_int), value :: n, offset, srank, roffset, rrank, iter
-       integer(c_int), value :: nvshmem_counter
-       type(c_ptr), value :: u_d, buf_d, dof_d, stream, rbuf_d, notifyDone, &
-            notifyReady
-       integer(c_int), dimension(*) :: remote_offset
+       integer(c_int), value :: n, offset, dest_rank, roffset, iter, mype
+       type(c_ptr), value :: u_d, buf_d, dof_d, stream, rbuf_d, done_d, &
+            ready_d
      end subroutine cuda_gs_pack_and_push
   end interface
 
   interface
-     subroutine cuda_gs_pack_and_push_wait(stream, nvshmem_counter, &
-          notifyDone) bind(c, name = 'cuda_gs_pack_and_push_wait')
+     subroutine cuda_gs_pack_and_push_wait(stream, iter, done_d, src_rank) &
+          bind(c, name = 'cuda_gs_pack_and_push_wait')
        use, intrinsic :: iso_c_binding
        implicit none
-       integer(c_int), value :: nvshmem_counter
-       type(c_ptr), value :: stream, notifyDone
+       integer(c_int), value :: iter, src_rank
+       type(c_ptr), value :: stream, done_d
      end subroutine cuda_gs_pack_and_push_wait
+  end interface
+
+  interface
+     subroutine cuda_gs_post_ready(stream, iter, ready_d, mype, src_rank) &
+          bind(c, name = 'cuda_gs_post_ready')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int), value :: iter, mype, src_rank
+       type(c_ptr), value :: stream, ready_d
+     end subroutine cuda_gs_post_ready
   end interface
 
   interface
@@ -133,6 +152,29 @@ module gs_device_shmem
        integer(c_int), value :: op, offset, n
        type(c_ptr), value :: u_d, buf_d, dof_d, stream
      end subroutine cuda_gs_unpack
+  end interface
+
+  interface
+     subroutine cuda_gs_pack_and_push_vec(u_d, buf_d, dof_d, offset, n, nc, &
+          ns, stream, dest_rank, rbuf_d, roffset, iter, done_d, ready_d, &
+          mype) bind(c, name = 'cuda_gs_pack_and_push_vec')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int), value :: n, nc, ns, offset, dest_rank, roffset, iter
+       integer(c_int), value :: mype
+       type(c_ptr), value :: u_d, buf_d, dof_d, stream, rbuf_d, done_d, &
+            ready_d
+     end subroutine cuda_gs_pack_and_push_vec
+  end interface
+
+  interface
+     subroutine cuda_gs_unpack_vec(u_d, op, buf_d, dof_d, offset, n, nc, ns, &
+          stream) bind(c, name = 'cuda_gs_unpack_vec')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int), value :: op, offset, n, nc, ns
+       type(c_ptr), value :: u_d, buf_d, dof_d, stream
+     end subroutine cuda_gs_unpack_vec
   end interface
 #endif
 
@@ -173,6 +215,9 @@ contains
     sz = c_sizeof(rp_dummy) * max_total
 #ifdef HAVE_NVSHMEM
     call cudamalloc_nvshmem(this%buf_d, sz)
+    ! Fused vector symmetric buffer, sized for up to GS_VEC_NC components.
+    sz = c_sizeof(rp_dummy) * GS_VEC_NC * max_total
+    call cudamalloc_nvshmem(this%buf_v_d, sz)
 #endif
 
     sz = c_sizeof(i4_dummy) * total
@@ -224,6 +269,7 @@ contains
 
 #ifdef HAVE_NVSHMEM
     if (c_associated(this%buf_d)) call cudafree_nvshmem(this%buf_d)
+    if (c_associated(this%buf_v_d)) call cudafree_nvshmem(this%buf_v_d)
 #endif
     if (c_associated(this%dof_d)) call device_free(this%dof_d)
 
@@ -234,35 +280,65 @@ contains
     class(gs_device_shmem_t), intent(inout) :: this
     type(stack_i4_t), intent(inout) :: send_pe
     type(stack_i4_t), intent(inout) :: recv_pe
-    integer :: i
+    integer :: i, nstrm, ierr
+    integer, allocatable :: local_offsets(:), remote_offsets(:)
+    integer(c_size_t) :: sz
+    integer(c_int64_t) :: i64_dummy
 
     call this%init_order(send_pe, recv_pe)
 
     call this%send_buf%init(this%send_pe, this%send_dof, .false.)
     call this%recv_buf%init(this%recv_pe, this%recv_dof, .true.)
 
-#if defined(HAVE_HIP) || defined(HAVE_CUDA)
-    ! Create a set of non-blocking streams
-    allocate(this%stream(size(this%recv_pe)))
+    ! Exchange, for every send peer, the offset in the receiver's recv buffer
+    ! where our slab must land. A single Alltoall keeps the exchange
+    ! deadlock-free for arbitrary, non-uniform peer sets (same rationale as
+    ! the host OpenSHMEM backend); the lazy pairwise exchange this replaces
+    ! indexed send_pe/recv_pe with the same loop index and required uniform,
+    ! index-aligned peer lists on every rank.
+    allocate(local_offsets(0:pe_size - 1))
+    allocate(remote_offsets(0:pe_size - 1))
+    local_offsets = -1
     do i = 1, size(this%recv_pe)
+       local_offsets(this%recv_pe(i)) = this%recv_buf%offset(i)
+    end do
+    call MPI_Alltoall(local_offsets, 1, MPI_INTEGER, &
+         remote_offsets, 1, MPI_INTEGER, NEKO_COMM, ierr)
+    do i = 1, size(this%send_pe)
+       this%send_buf%remote_offset(i) = remote_offsets(this%send_pe(i))
+    end do
+    deallocate(local_offsets)
+    deallocate(remote_offsets)
+
+#if defined(HAVE_HIP) || defined(HAVE_CUDA)
+    ! Create a set of non-blocking streams. The per-peer streams, events and
+    ! notify signals are indexed over both send_pe (pack-and-push) and
+    ! recv_pe (unpack, sync), so size them for the larger of the two peer
+    ! lists.
+    nstrm = max(size(this%send_pe), size(this%recv_pe))
+    allocate(this%stream(nstrm))
+    do i = 1, nstrm
        call device_stream_create_with_priority(this%stream(i), 1, &
             STRM_HIGH_PRIO)
     end do
 
-    allocate(this%event(size(this%recv_pe)))
-    do i = 1, size(this%recv_pe)
+    allocate(this%event(nstrm))
+    do i = 1, nstrm
        call device_event_create(this%event(i), 2)
     end do
 
 #ifdef HAVE_NVSHMEM
-    allocate(this%notifyDone(size(this%recv_pe)))
-    allocate(this%notifyReady(size(this%recv_pe)))
-    do i = 1, size(this%recv_pe)
-       call cudamalloc_nvshmem(this%notifyDone(i), 8_8)
-       call cudamalloc_nvshmem(this%notifyReady(i), 8_8)
-    end do
+    ! Rank-indexed symmetric signal arrays; zero-initialised by
+    ! cudamalloc_nvshmem, so the first round's CMP_GE waits on iter-1 = 0
+    ! pass immediately.
+    sz = c_sizeof(i64_dummy) * pe_size
+    call cudamalloc_nvshmem(this%done_sig_d, sz)
+    call cudamalloc_nvshmem(this%ready_sig_d, sz)
 #endif
 #endif
+
+    this%iter = 0
+    this%vec_supported = .true.
 
   end subroutine gs_device_shmem_init
 
@@ -273,6 +349,18 @@ contains
 
     call this%send_buf%free()
     call this%recv_buf%free()
+
+#ifdef HAVE_NVSHMEM
+    ! Collective frees; every rank allocated both arrays exactly once.
+    if (c_associated(this%done_sig_d)) then
+       call cudafree_nvshmem(this%done_sig_d)
+       this%done_sig_d = C_NULL_PTR
+    end if
+    if (c_associated(this%ready_sig_d)) then
+       call cudafree_nvshmem(this%ready_sig_d)
+       this%ready_sig_d = C_NULL_PTR
+    end if
+#endif
 
     call this%free_order()
     call this%free_dofs()
@@ -301,11 +389,16 @@ contains
 
     u_d = device_get_ptr(u)
 
+    ! Order each per-peer stream after the gather (deps); the pack-and-push
+    ! kernels in nbwait are stream-ordered behind this wait. The historic
+    ! host-side device_sync here papered over a send-buffer reuse race: the
+    ! pack-and-push kernel used to overwrite the send buffer BEFORE its
+    ! ready handshake, while the previous round's non-blocking put could
+    ! still be draining it. The kernel now performs the handshake before
+    ! packing (see gs_nvshmem_kernels.h), which closes that race properly,
+    ! so no host synchronisation is needed.
     do i = 1, size(this%send_pe)
        call device_stream_wait_event(this%stream(i), deps, 0)
-       ! Not clear why this sync is required, but there seems to be a race condition
-       ! without it for certain run configs
-       call device_sync(this%stream(i))
     end do
 
     ! We do the rest in the "wait" routine below
@@ -333,14 +426,14 @@ contains
 
     u_d = device_get_ptr(u)
 #ifdef HAVE_NVSHMEM
-    do i = 1, size(this%send_pe)
-       if (this%recv_buf%remote_offset(i) .eq. -1) then
-          call MPI_Sendrecv(this%recv_buf%offset(i), 1, MPI_INTEGER, &
-               this%recv_pe(i), 0, &
-               this%recv_buf%remote_offset(i), 1, MPI_INTEGER, &
-               this%send_pe(i), 0, NEKO_COMM, MPI_STATUS_IGNORE)
-       end if
+    ! One round counter per gs op; the rank-indexed signal slots make the
+    ! exchange independent of peer counts and peer-list ordering.
+    this%iter = this%iter + 1
 
+    ! Push our slab to every send peer. The kernel waits for the peer's
+    ! ready signal (previous round consumed) before overwriting the send
+    ! slab, then puts with a done signal.
+    do i = 1, size(this%send_pe)
        call cuda_gs_pack_and_push(u_d, &
             this%send_buf%buf_d, &
             this%send_buf%dof_d, &
@@ -349,29 +442,23 @@ contains
             this%stream(i), &
             this%send_pe(i), &
             this%recv_buf%buf_d, &
-            this%recv_buf%offset(i), &
-            this%recv_buf%remote_offset, &
-            this%recv_pe(i), &
-            this%nvshmem_counter, &
-            this%notifyDone(i), &
-            this%notifyReady(i), &
-            i)
-       this%nvshmem_counter = this%nvshmem_counter + 1
+            this%send_buf%remote_offset(i), &
+            this%iter, this%done_sig_d, this%ready_sig_d, pe_rank)
     end do
 
-    do i = 1, size(this%send_pe)
-       call cuda_gs_pack_and_push_wait(this%stream(i), &
-            this%nvshmem_counter - size(this%send_pe) + i - 1, &
-            this%notifyDone(i))
-    end do
-
+    ! For every recv peer: wait until its slab has landed, reduce it into u,
+    ! then post our ready signal so the peer may start its next round.
     do done_req = 1, size(this%recv_pe)
+       call cuda_gs_pack_and_push_wait(this%stream(done_req), this%iter, &
+            this%done_sig_d, this%recv_pe(done_req))
        call cuda_gs_unpack(u_d, op, &
             this%recv_buf%buf_d, &
             this%recv_buf%dof_d, &
             this%recv_buf%offset(done_req), &
             this%recv_buf%ndofs(done_req), &
             this%stream(done_req))
+       call cuda_gs_post_ready(this%stream(done_req), this%iter, &
+            this%ready_sig_d, pe_rank, this%recv_pe(done_req))
        call device_event_record(this%event(done_req), this%stream(done_req))
     end do
 
@@ -382,5 +469,86 @@ contains
     end do
 #endif
   end subroutine gs_device_shmem_nbwait
+
+  !> Fused nc-component send. @a u is the compact shared device buffer
+  !! (component-outer, per-component stride n = nshared). All the work is done
+  !! in nbwait_vec; this only orders against the packing dependencies.
+  subroutine gs_device_shmem_nbsend_vec(this, u, n, nc, tag, deps, strm)
+    class(gs_device_shmem_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    integer, intent(in) :: tag
+    type(c_ptr), intent(inout) :: deps
+    type(c_ptr), intent(inout) :: strm
+    integer :: i
+
+    ! Order each per-peer stream after the gather/copies (deps); no host
+    ! synchronisation needed, see gs_device_shmem_nbsend.
+    do i = 1, size(this%send_pe)
+       call device_stream_wait_event(this%stream(i), deps, 0)
+    end do
+
+  end subroutine gs_device_shmem_nbsend_vec
+
+  !> No-op: everything happens in nbwait_vec.
+  subroutine gs_device_shmem_nbrecv_vec(this, tag, nc)
+    class(gs_device_shmem_t), intent(inout) :: this
+    integer, intent(in) :: tag, nc
+  end subroutine gs_device_shmem_nbrecv_vec
+
+  !> Fused nc-component pack-and-push + unpack.
+  subroutine gs_device_shmem_nbwait_vec(this, u, n, nc, op, strm)
+    class(gs_device_shmem_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    type(c_ptr), intent(inout) :: strm
+    integer :: op, done_req, i
+    type(c_ptr) :: u_d
+
+    u_d = device_get_ptr(u)
+#ifdef HAVE_NVSHMEM
+    ! One round counter per gs op (shared with the scalar path; all ranks
+    ! execute the same op sequence, so counters stay in lockstep).
+    this%iter = this%iter + 1
+
+    ! Push our nc-component slab to every send peer.
+    do i = 1, size(this%send_pe)
+       call cuda_gs_pack_and_push_vec(u_d, &
+            this%send_buf%buf_v_d, &
+            this%send_buf%dof_d, &
+            this%send_buf%offset(i), &
+            this%send_buf%ndofs(i), &
+            nc, n, &
+            this%stream(i), &
+            this%send_pe(i), &
+            this%recv_buf%buf_v_d, &
+            this%send_buf%remote_offset(i), &
+            this%iter, this%done_sig_d, this%ready_sig_d, pe_rank)
+    end do
+
+    ! For every recv peer: wait until its slab has landed, reduce it into u,
+    ! then post our ready signal so the peer may start its next round.
+    do done_req = 1, size(this%recv_pe)
+       call cuda_gs_pack_and_push_wait(this%stream(done_req), this%iter, &
+            this%done_sig_d, this%recv_pe(done_req))
+       call cuda_gs_unpack_vec(u_d, op, &
+            this%recv_buf%buf_v_d, &
+            this%recv_buf%dof_d, &
+            this%recv_buf%offset(done_req), &
+            this%recv_buf%ndofs(done_req), &
+            nc, n, &
+            this%stream(done_req))
+       call cuda_gs_post_ready(this%stream(done_req), this%iter, &
+            this%ready_sig_d, pe_rank, this%recv_pe(done_req))
+       call device_event_record(this%event(done_req), this%stream(done_req))
+    end do
+
+    ! Sync non-blocking streams
+    do done_req = 1, size(this%recv_pe)
+       call device_stream_wait_event(strm, &
+            this%event(done_req), 0)
+    end do
+#endif
+  end subroutine gs_device_shmem_nbwait_vec
 
 end module gs_device_shmem

--- a/src/gs/bcknd/device/hip/gs.hip
+++ b/src/gs/bcknd/device/hip/gs.hip
@@ -168,4 +168,56 @@ extern "C" {
 
     HIP_CHECK(hipGetLastError());
   }
+
+  /**
+   * Fused nc-component pack. u_d is the compact shared buffer (component-outer,
+   * per-component stride ns); buf_d is interleaved (nc per position).
+   */
+  void hip_gs_pack_vec(void *u_d, void *buf_d, void *dof_d,
+                       int offset, int n, int nc, int ns,
+                       hipStream_t stream) {
+
+    const int nthrds = 1024;
+    const int nblcks = (n + nthrds - 1) / nthrds;
+
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_pack_vec_kernel<real>),
+                       nblcks, nthrds, 0, stream,
+                       (real *) u_d, (real *) buf_d + nc*offset,
+                       (int *) dof_d + offset, n, nc, ns);
+    HIP_CHECK(hipGetLastError());
+  }
+
+  /**
+   * Fused nc-component unpack/reduce.
+   */
+  void hip_gs_unpack_vec(real *u_d, int op, real *buf_d, int *dof_d,
+                         int offset, int n, int nc, int ns,
+                         hipStream_t stream) {
+
+    const int nthrds = 1024;
+    const int nblcks = (n + nthrds - 1) / nthrds;
+
+    switch (op) {
+    case GS_OP_ADD:
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_unpack_add_vec_kernel<real>),
+                         nblcks, nthrds, 0, stream,
+                         u_d, buf_d + nc*offset, dof_d + offset, n, nc, ns);
+      break;
+    case GS_OP_MIN:
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_unpack_min_vec_kernel<real>),
+                         nblcks, nthrds, 0, stream,
+                         u_d, buf_d + nc*offset, dof_d + offset, n, nc, ns);
+      break;
+    case GS_OP_MAX:
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(gs_unpack_max_vec_kernel<real>),
+                         nblcks, nthrds, 0, stream,
+                         u_d, buf_d + nc*offset, dof_d + offset, n, nc, ns);
+      break;
+    default:
+      printf("%s: unknown gs op %d\n", __FILE__, op);
+      abort();
+    }
+
+    HIP_CHECK(hipGetLastError());
+  }
 }

--- a/src/gs/bcknd/device/hip/gs_kernels.h
+++ b/src/gs/bcknd/device/hip/gs_kernels.h
@@ -378,4 +378,93 @@ __global__ void gs_unpack_max_kernel(T * __restrict__ u,
   }
 }
 
+/*
+ * Fused nc-component (vector) pack/unpack kernels. u is the compact shared
+ * buffer, component-outer with per-component stride ns (= nshared):
+ * component c of shared index idx lives at u[c*ns + idx]. buf is interleaved,
+ * nc values per packed position j: buf[nc*j + c].
+ */
+
+template< typename T >
+__global__ void gs_pack_vec_kernel(const T * __restrict__ u,
+                                   T * __restrict__ buf,
+                                   const int32_t * __restrict__ dof,
+                                   const int n, const int nc, const int ns) {
+
+  const int j = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (j >= n)
+    return;
+
+  const int idx = dof[j] - 1;
+  for (int c = 0; c < nc; c++)
+    buf[nc*j + c] = u[c*ns + idx];
+}
+
+template< typename T >
+__global__ void gs_unpack_add_vec_kernel(T * __restrict__ u,
+                                         const T * __restrict__ buf,
+                                         const int32_t * __restrict__ dof,
+                                         const int n, const int nc,
+                                         const int ns) {
+
+  const int j = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (j >= n)
+    return;
+
+  const int32_t idx = dof[j];
+  if (idx < 0) {
+    for (int c = 0; c < nc; c++)
+      atomicAdd(&u[c*ns + (-idx-1)], buf[nc*j + c]);
+  } else {
+    for (int c = 0; c < nc; c++)
+      u[c*ns + (idx-1)] += buf[nc*j + c];
+  }
+}
+
+template< typename T >
+__global__ void gs_unpack_min_vec_kernel(T * __restrict__ u,
+                                         const T * __restrict__ buf,
+                                         const int32_t * __restrict__ dof,
+                                         const int n, const int nc,
+                                         const int ns) {
+
+  const int j = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (j >= n)
+    return;
+
+  const int32_t idx = dof[j];
+  if (idx < 0) {
+    for (int c = 0; c < nc; c++)
+      atomicMinFloat(&u[c*ns + (-idx-1)], buf[nc*j + c]);
+  } else {
+    for (int c = 0; c < nc; c++)
+      u[c*ns + (idx-1)] = min(u[c*ns + (idx-1)], buf[nc*j + c]);
+  }
+}
+
+template< typename T >
+__global__ void gs_unpack_max_vec_kernel(T * __restrict__ u,
+                                         const T * __restrict__ buf,
+                                         const int32_t * __restrict__ dof,
+                                         const int n, const int nc,
+                                         const int ns) {
+
+  const int j = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (j >= n)
+    return;
+
+  const int32_t idx = dof[j];
+  if (idx < 0) {
+    for (int c = 0; c < nc; c++)
+      atomicMaxFloat(&u[c*ns + (-idx-1)], buf[nc*j + c]);
+  } else {
+    for (int c = 0; c < nc; c++)
+      u[c*ns + (idx-1)] = max(u[c*ns + (idx-1)], buf[nc*j + c]);
+  }
+}
+
 #endif // __GS_GS_KERNELS__

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -40,7 +40,8 @@ module gather_scatter
   use gs_cpu, only : gs_cpu_t
   use gs_ops, only : GS_OP_ADD, GS_OP_MAX, GS_OP_MIN, GS_OP_MUL
   use gs_comm, only : gs_comm_t, GS_COMM_MPI, GS_COMM_MPIGPU, GS_COMM_NCCL, &
-       GS_COMM_NVSHMEM, GS_COMM_OPENSHMEM, GS_COMM_CAF, GS_COMM_NEIGHBOUR
+       GS_COMM_NVSHMEM, GS_COMM_OPENSHMEM, GS_COMM_CAF, GS_COMM_NEIGHBOUR, &
+       GS_VEC_NC
   use gs_mpi, only : gs_mpi_t
   use gs_neighbour, only : gs_neighbour_t
   use gs_shmem, only : gs_shmem_t
@@ -54,7 +55,7 @@ module gather_scatter
        MPI_Wtime, MPI_SUM, MPI_INTEGER, MPI_INTEGER8
   use dofmap, only : dofmap_t
   use field, only : field_t
-  use num_types, only : rp, dp, i8
+  use num_types, only : rp, dp, i2, i8, c_rp
   use htable, only : htable_i8_t, htable_iter_i8_t
   use stack, only : stack_i4_t, stack_i8_t
   use crystal_router, only : crystal_router_transfer, crystal_router_pack
@@ -62,9 +63,11 @@ module gather_scatter
   use utils, only : neko_error, linear_index
   use logger, only : neko_log, LOG_SIZE
   use profiler, only : profiler_start_region, profiler_end_region
-  use device, only : device_memcpy, HOST_TO_DEVICE, device_sync, device_map, &
-       device_unmap
-  use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR
+  use device, only : device_memcpy, HOST_TO_DEVICE, DEVICE_TO_DEVICE, &
+       device_sync, device_map, device_unmap, device_get_ptr, &
+       device_event_record
+  use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR, c_intptr_t, &
+       c_sizeof, c_associated, c_size_t
   !$ use omp_lib, only : omp_get_thread_num
   implicit none
   private
@@ -76,6 +79,11 @@ module gather_scatter
      integer, allocatable :: local_blk_len(:) !< Local non-facet blocks
      integer, allocatable :: local_blk_off(:) !< Local non-facet blocks offset
      real(kind=rp), allocatable :: shared_gs(:) !< Buffer for shared gs-op
+     !> Compact multi-component shared buffer for the fused vector gs (gs_op_r3),
+     !! sized GS_VEC_NC*nshared, component-outer. On device it is device-mapped
+     !! and the fused exchange operates on its device pointer.
+     real(kind=rp), allocatable :: shared_gs_v(:)
+     type(c_ptr) :: shared_gs_v_d = C_NULL_PTR !< Dev. ptr for shared_gs_v
      integer, allocatable :: shared_dof_gs(:) !< Shared dof to gs map.
      integer, allocatable :: shared_gs_dof(:) !< Shared gs to dof map.
      integer, allocatable :: shared_blk_len(:) !< Shared non-facet blocks
@@ -94,9 +102,12 @@ module gather_scatter
      procedure, private, pass(gs) :: gs_op_fld
      procedure, private, pass(gs) :: gs_op_r4
      procedure, pass(gs) :: gs_op_vector
+     procedure, pass(gs) :: gs_op_r3
+     procedure, pass(gs) :: gs_op_vector3
      procedure, pass(gs) :: init => gs_init
      procedure, pass(gs) :: free => gs_free
-     generic :: op => gs_op_fld, gs_op_r4, gs_op_vector
+     generic :: op => gs_op_fld, gs_op_r4, gs_op_vector, gs_op_r3, &
+          gs_op_vector3
   end type gs_t
 
   ! Expose available gather-scatter operation
@@ -407,6 +418,13 @@ contains
 
     if (allocated(gs%shared_gs)) then
        deallocate(gs%shared_gs)
+    end if
+
+    if (allocated(gs%shared_gs_v)) then
+       if (NEKO_BCKND_DEVICE .eq. 1 .and. c_associated(gs%shared_gs_v_d)) then
+          call device_unmap(gs%shared_gs_v, gs%shared_gs_v_d)
+       end if
+       deallocate(gs%shared_gs_v)
     end if
 
     if (allocated(gs%shared_dof_gs)) then
@@ -1181,6 +1199,14 @@ contains
     ! Allocate buffer for shared gs-ops
     allocate(gs%shared_gs(gs%nshared))
 
+    ! Compact multi-component shared buffer for the fused vector gs. On the
+    ! device it is mapped so the fused exchange can use its device pointer.
+    allocate(gs%shared_gs_v(max(1, GS_VEC_NC * gs%nshared)))
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_map(gs%shared_gs_v, gs%shared_gs_v_d, &
+            max(1, GS_VEC_NC * gs%nshared))
+    end if
+
     if (gs%nshared .gt. 0) then
        call gs_qsort_dofmap(gs%shared_dof_gs, gs%shared_gs_dof, &
             gs%nshared, 1, gs%nshared)
@@ -1607,5 +1633,297 @@ contains
     call profiler_end_region("gather_scatter", 5)
     !$omp end parallel
   end subroutine gs_op_vector
+
+  !> Gather-scatter operation on a 3-component vector of rank-4 arrays
+  !! (@a u1, @a u2, @a u3) with op @a op; see gs_op_vector3.
+  subroutine gs_op_r3(gs, u1, u2, u3, n, op, event)
+    class(gs_t), intent(inout) :: gs
+    integer, intent(in) :: n
+    real(kind=rp), contiguous, dimension(:,:,:,:), intent(inout) :: u1, u2, u3
+    type(c_ptr), optional, intent(inout) :: event
+    integer :: op
+
+    if (present(event)) then
+       call gs_op_vector3(gs, u1, u2, u3, n, op, event)
+    else
+       call gs_op_vector3(gs, u1, u2, u3, n, op)
+    end if
+
+  end subroutine gs_op_r3
+
+  !> Gather-scatter operation on a 3-component vector (@a u1, @a u2, @a u3)
+  !! with op @a op. When the comm backend supports a fused vector halo
+  !! exchange, the three components are communicated in a single round;
+  !! otherwise this falls back to three independent scalar gs_op_vector
+  !! calls (identical result, 3 rounds). The on-node gather/scatter is
+  !! always done per component (scalar), so only the communication cost is
+  !! reduced. On device backends the caller's event is recorded once, after
+  !! the last component's scatter (or superseded by hard synchronisation on
+  !! host-mirrored comms), so a single event sync covers all components.
+  subroutine gs_op_vector3(gs, u1, u2, u3, n, op, event)
+    class(gs_t), intent(inout) :: gs
+    integer, intent(in) :: n
+    real(kind=rp), dimension(n), intent(inout) :: u1, u2, u3
+    type(c_ptr), optional, intent(inout) :: event
+    integer :: m, l, op, lo, so, tid
+    integer, parameter :: nc = 3
+    type(c_ptr) :: scatter_event
+
+    ! Fall back to nc independent scalar exchanges when the comm backend has
+    ! no fused vector path.
+    if (.not. gs%comm%vec_supported) then
+       if (present(event)) then
+          call gs_op_vector(gs, u1, n, op, event)
+          call gs_op_vector(gs, u2, n, op, event)
+          call gs_op_vector(gs, u3, n, op, event)
+       else
+          call gs_op_vector(gs, u1, n, op)
+          call gs_op_vector(gs, u2, n, op)
+          call gs_op_vector(gs, u3, n, op)
+       end if
+       return
+    end if
+
+    lo = gs%local_facet_offset
+    so = -gs%shared_facet_offset
+    m = gs%nlocal
+    l = gs%nshared
+
+    tid = 0
+    !$ tid = omp_get_thread_num()
+
+    scatter_event = C_NULL_PTR
+    if (present(event)) scatter_event = event
+
+    if (NEKO_BCKND_DEVICE .eq. 0) then
+
+       !$omp parallel
+       call profiler_start_region("gather_scatter", 5)
+
+       ! Gather each component's shared dofs directly into its column of
+       ! shared_gs_v (the host backends write the actual argument), then
+       ! launch ONE fused exchange covering all nc components.
+       if (pe_size .gt. 1 .and. n .gt. 0) then
+          call gs%comm%nbrecv_vec(tid, nc)
+          call gs%bcknd%gather(gs%shared_gs_v(1), l, so, gs%shared_dof_gs, &
+               u1, n, gs%shared_gs_dof, gs%nshared_blks, gs%shared_blk_len, &
+               gs%shared_blk_off, op, .true.)
+          call gs%bcknd%gather(gs%shared_gs_v(l + 1), l, so, &
+               gs%shared_dof_gs, u2, n, gs%shared_gs_dof, gs%nshared_blks, &
+               gs%shared_blk_len, gs%shared_blk_off, op, .true.)
+          call gs%bcknd%gather(gs%shared_gs_v(2*l + 1), l, so, &
+               gs%shared_dof_gs, u3, n, gs%shared_gs_dof, gs%nshared_blks, &
+               gs%shared_blk_len, gs%shared_blk_off, op, .true.)
+          call gs%comm%nbsend_vec(gs%shared_gs_v, l, nc, tid, &
+               gs%bcknd%gather_event, gs%bcknd%gs_stream)
+       end if
+
+       ! Local gather-scatter, one scalar pass per component (reuses local_gs;
+       ! the internal barriers make the sequential reuse safe).
+       call gs%bcknd%gather(gs%local_gs, m, lo, gs%local_dof_gs, u1, n, &
+            gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, &
+            gs%local_blk_off, op, .false.)
+       call gs%bcknd%scatter(gs%local_gs, m, gs%local_dof_gs, u1, n, &
+            gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, &
+            gs%local_blk_off, .false., C_NULL_PTR)
+       call gs%bcknd%gather(gs%local_gs, m, lo, gs%local_dof_gs, u2, n, &
+            gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, &
+            gs%local_blk_off, op, .false.)
+       call gs%bcknd%scatter(gs%local_gs, m, gs%local_dof_gs, u2, n, &
+            gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, &
+            gs%local_blk_off, .false., C_NULL_PTR)
+       call gs%bcknd%gather(gs%local_gs, m, lo, gs%local_dof_gs, u3, n, &
+            gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, &
+            gs%local_blk_off, op, .false.)
+       call gs%bcknd%scatter(gs%local_gs, m, gs%local_dof_gs, u3, n, &
+            gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, &
+            gs%local_blk_off, .false., C_NULL_PTR)
+
+       ! Wait for the fused exchange and scatter each component back.
+       if (pe_size .gt. 1 .and. n .gt. 0) then
+          call gs%comm%nbwait_vec(gs%shared_gs_v, l, nc, op, &
+               gs%bcknd%gs_stream)
+          call gs%bcknd%scatter(gs%shared_gs_v(1), l, gs%shared_dof_gs, u1, &
+               n, gs%shared_gs_dof, gs%nshared_blks, gs%shared_blk_len, &
+               gs%shared_blk_off, .true., scatter_event)
+          call gs%bcknd%scatter(gs%shared_gs_v(l + 1), l, gs%shared_dof_gs, &
+               u2, n, gs%shared_gs_dof, gs%nshared_blks, gs%shared_blk_len, &
+               gs%shared_blk_off, .true., scatter_event)
+          call gs%bcknd%scatter(gs%shared_gs_v(2*l + 1), l, &
+               gs%shared_dof_gs, u3, n, gs%shared_gs_dof, gs%nshared_blks, &
+               gs%shared_blk_len, gs%shared_blk_off, .true., scatter_event)
+       end if
+
+       call profiler_end_region("gather_scatter", 5)
+       !$omp end parallel
+
+    else
+
+       call gs_op_r3_device(gs, u1, u2, u3, n, op, nc, lo, so, m, l, tid, &
+            scatter_event)
+
+    end if
+
+  end subroutine gs_op_vector3
+
+  !> Device path for the fused 3-component gs. The device backend's shared
+  !! gather/scatter always operate on its internal shared buffer, so each
+  !! component is staged between that buffer and its column of the compact
+  !! vector buffer gs%shared_gs_v: through the host mirror when the comm
+  !! backend is a host backend (shared_on_host, e.g. OpenCL/Metal or a device
+  !! build with host MPI), or with device-to-device copies when the comm is
+  !! device-resident (device MPI/NCCL/NVSHMEM). Apart from the column staging
+  !! the two modes are identical; the comm backends transparently pick the
+  !! host array or its device pointer, as in gs_op_vector.
+  subroutine gs_op_r3_device(gs, u1, u2, u3, n, op, nc, lo, so, m, l, tid, &
+       scatter_event)
+    class(gs_t), intent(inout) :: gs
+    integer, intent(in) :: n, op, nc, lo, so, m, l, tid
+    real(kind=rp), dimension(n), intent(inout) :: u1, u2, u3
+    type(c_ptr), intent(inout) :: scatter_event
+    type(c_ptr) :: sgs_d, col_d, col_event
+    integer(c_intptr_t) :: sv_addr, off_bytes
+    integer(c_size_t) :: colbytes
+    real(c_rp) :: rp_dummy
+    logical :: on_host
+
+    on_host = .true.
+    sgs_d = C_NULL_PTR
+    select type (b => gs%bcknd)
+    type is (gs_device_t)
+       on_host = b%shared_on_host
+       sgs_d = b%shared_gs_d
+    end select
+
+    sv_addr = transfer(gs%shared_gs_v_d, sv_addr)
+    colbytes = c_sizeof(rp_dummy) * int(l, c_size_t)
+    off_bytes = int(l, c_intptr_t) * int(c_sizeof(rp_dummy), c_intptr_t)
+
+    ! With a host-mirrored shared buffer, each scatter below issues an
+    ! asynchronous host-to-device copy of shared_gs; a null event makes the
+    ! scatter sync so the next column may safely overwrite the host buffer.
+    ! Device-resident staging is stream-ordered and carries the caller's
+    ! event.
+    if (on_host) then
+       col_event = C_NULL_PTR
+    else
+       col_event = scatter_event
+    end if
+
+    if (pe_size .gt. 1 .and. n .gt. 0) then
+       call gs%comm%nbrecv_vec(tid, nc)
+
+       ! Gather each component into the backend's shared buffer, then stage
+       ! it into its column of shared_gs_v.
+       call gs%bcknd%gather(gs%shared_gs, l, so, gs%shared_dof_gs, u1, n, &
+            gs%shared_gs_dof, gs%nshared_blks, gs%shared_blk_len, &
+            gs%shared_blk_off, op, .true.)
+       if (on_host) then
+          ! The gather mirrored the shared buffer to the host (synchronous).
+          gs%shared_gs_v(1:l) = gs%shared_gs(1:l)
+       else
+          ! shared_gs_d is created lazily on the first gather.
+          if (.not. c_associated(sgs_d)) then
+             select type (b => gs%bcknd)
+             type is (gs_device_t)
+                sgs_d = b%shared_gs_d
+             end select
+          end if
+          col_d = transfer(sv_addr, col_d)
+          call device_memcpy(col_d, sgs_d, colbytes, DEVICE_TO_DEVICE, &
+               sync = .false., strm = gs%bcknd%gs_stream)
+       end if
+
+       call gs%bcknd%gather(gs%shared_gs, l, so, gs%shared_dof_gs, u2, n, &
+            gs%shared_gs_dof, gs%nshared_blks, gs%shared_blk_len, &
+            gs%shared_blk_off, op, .true.)
+       if (on_host) then
+          gs%shared_gs_v(l + 1:2*l) = gs%shared_gs(1:l)
+       else
+          col_d = transfer(sv_addr + off_bytes, col_d)
+          call device_memcpy(col_d, sgs_d, colbytes, DEVICE_TO_DEVICE, &
+               sync = .false., strm = gs%bcknd%gs_stream)
+       end if
+
+       call gs%bcknd%gather(gs%shared_gs, l, so, gs%shared_dof_gs, u3, n, &
+            gs%shared_gs_dof, gs%nshared_blks, gs%shared_blk_len, &
+            gs%shared_blk_off, op, .true.)
+       if (on_host) then
+          gs%shared_gs_v(2*l + 1:3*l) = gs%shared_gs(1:l)
+       else
+          col_d = transfer(sv_addr + 2_c_intptr_t*off_bytes, col_d)
+          call device_memcpy(col_d, sgs_d, colbytes, DEVICE_TO_DEVICE, &
+               sync = .false., strm = gs%bcknd%gs_stream)
+          ! Re-record the gather event so it covers the column copies above.
+          ! Comm backends that order their per-peer packing streams on this
+          ! event (NCCL, NVSHMEM) would otherwise race with the copies; the
+          ! device MPI backend packs on gs_stream itself and is unaffected.
+          call device_event_record(gs%bcknd%gather_event, gs%bcknd%gs_stream)
+       end if
+
+       call gs%comm%nbsend_vec(gs%shared_gs_v, l, nc, tid, &
+            gs%bcknd%gather_event, gs%bcknd%gs_stream)
+    end if
+
+    ! Local gather-scatter per component.
+    call gs%bcknd%gather(gs%local_gs, m, lo, gs%local_dof_gs, u1, n, &
+         gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, gs%local_blk_off, &
+         op, .false.)
+    call gs%bcknd%scatter(gs%local_gs, m, gs%local_dof_gs, u1, n, &
+         gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, gs%local_blk_off, &
+         .false., C_NULL_PTR)
+    call gs%bcknd%gather(gs%local_gs, m, lo, gs%local_dof_gs, u2, n, &
+         gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, gs%local_blk_off, &
+         op, .false.)
+    call gs%bcknd%scatter(gs%local_gs, m, gs%local_dof_gs, u2, n, &
+         gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, gs%local_blk_off, &
+         .false., C_NULL_PTR)
+    call gs%bcknd%gather(gs%local_gs, m, lo, gs%local_dof_gs, u3, n, &
+         gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, gs%local_blk_off, &
+         op, .false.)
+    call gs%bcknd%scatter(gs%local_gs, m, gs%local_dof_gs, u3, n, &
+         gs%local_gs_dof, gs%nlocal_blks, gs%local_blk_len, gs%local_blk_off, &
+         .false., C_NULL_PTR)
+
+    ! Wait for the fused exchange (reduces into shared_gs_v), then stage each
+    ! column back into the shared buffer and scatter.
+    if (pe_size .gt. 1 .and. n .gt. 0) then
+       call gs%comm%nbwait_vec(gs%shared_gs_v, l, nc, op, gs%bcknd%gs_stream)
+
+       if (on_host) then
+          gs%shared_gs(1:l) = gs%shared_gs_v(1:l)
+       else
+          col_d = transfer(sv_addr, col_d)
+          call device_memcpy(sgs_d, col_d, colbytes, DEVICE_TO_DEVICE, &
+               sync = .false., strm = gs%bcknd%gs_stream)
+       end if
+       call gs%bcknd%scatter(gs%shared_gs, l, gs%shared_dof_gs, u1, n, &
+            gs%shared_gs_dof, gs%nshared_blks, gs%shared_blk_len, &
+            gs%shared_blk_off, .true., col_event)
+
+       if (on_host) then
+          gs%shared_gs(1:l) = gs%shared_gs_v(l + 1:2*l)
+       else
+          col_d = transfer(sv_addr + off_bytes, col_d)
+          call device_memcpy(sgs_d, col_d, colbytes, DEVICE_TO_DEVICE, &
+               sync = .false., strm = gs%bcknd%gs_stream)
+       end if
+       call gs%bcknd%scatter(gs%shared_gs, l, gs%shared_dof_gs, u2, n, &
+            gs%shared_gs_dof, gs%nshared_blks, gs%shared_blk_len, &
+            gs%shared_blk_off, .true., col_event)
+
+       if (on_host) then
+          gs%shared_gs(1:l) = gs%shared_gs_v(2*l + 1:3*l)
+       else
+          col_d = transfer(sv_addr + 2_c_intptr_t*off_bytes, col_d)
+          call device_memcpy(sgs_d, col_d, colbytes, DEVICE_TO_DEVICE, &
+               sync = .false., strm = gs%bcknd%gs_stream)
+       end if
+       call gs%bcknd%scatter(gs%shared_gs, l, gs%shared_dof_gs, u3, n, &
+            gs%shared_gs_dof, gs%nshared_blks, gs%shared_blk_len, &
+            gs%shared_blk_off, .true., col_event)
+    end if
+
+  end subroutine gs_op_r3_device
 
 end module gather_scatter

--- a/src/gs/gs_caf.F90
+++ b/src/gs/gs_caf.F90
@@ -33,7 +33,7 @@
 !> Defines Coarray Fortran gather-scatter communication
 module gs_caf
   use num_types, only : rp
-  use gs_comm, only : gs_comm_t
+  use gs_comm, only : gs_comm_t, GS_VEC_NC
   use gs_ops, only : GS_OP_ADD, GS_OP_MAX, GS_OP_MIN, GS_OP_MUL
   use stack, only : stack_i4_t
   use comm, only : pe_size
@@ -154,6 +154,9 @@ module gs_caf
      procedure, pass(this) :: nbsend => gs_nbsend_caf
      procedure, pass(this) :: nbrecv => gs_nbrecv_caf
      procedure, pass(this) :: nbwait => gs_nbwait_caf
+     procedure, pass(this) :: nbsend_vec => gs_nbsend_vec_caf
+     procedure, pass(this) :: nbrecv_vec => gs_nbrecv_vec_caf
+     procedure, pass(this) :: nbwait_vec => gs_nbwait_vec_caf
   end type gs_caf_t
 
 contains
@@ -240,7 +243,9 @@ contains
        send_total = send_total + this%send_len(i)
        this%send_img(i) = this%send_pe(i) + 1
     end do
-    allocate(this%send_buf(max(1, send_total)))
+    ! Sized for up to GS_VEC_NC components; scalar path uses the first
+    ! send_total elements, the fused vector path uses nc*send_total.
+    allocate(this%send_buf(max(1, GS_VEC_NC*send_total)))
 
     ! Symmetric coarray sized to twice the global max total receive
     ! count (double buffering). gs_caf_buf_size tracks the size of one
@@ -250,11 +255,16 @@ contains
     max_total = recv_total
     call co_max(max_total)
     max_total = max(1, max_total)
-    if (max_total .gt. gs_caf_buf_size) then
+    ! Half size = GS_VEC_NC * max_total, so the single double-buffered coarray
+    ! serves both the scalar path (which uses only the low max_total of each
+    ! half) and the fused vector path (which uses the full half). gs_caf_buf_size
+    ! is the half size; half_off = parity * gs_caf_buf_size in both paths.
+    if (GS_VEC_NC * max_total .gt. gs_caf_buf_size) then
        if (allocated(gs_caf_recv_buf)) deallocate(gs_caf_recv_buf)
-       allocate(gs_caf_recv_buf(2 * max_total)[*])
-       gs_caf_buf_size = max_total
+       allocate(gs_caf_recv_buf(2 * GS_VEC_NC * max_total)[*])
+       gs_caf_buf_size = GS_VEC_NC * max_total
     end if
+    this%vec_supported = .true.
 
     ! Tell each sender at what offset in our recv_buf to place their slab,
     ! and learn at what offset in each receiver's recv_buf our slab should go.
@@ -552,5 +562,222 @@ contains
     call neko_error("Coarray Fortran support not built")
 #endif
   end subroutine gs_nbwait_caf
+
+  !> Fused nc-component put. Each peer slab is nc consecutive component
+  !! blocks; the remote placement offset and slab length scale by nc, the
+  !! per-peer signalling (sync/atomic/event) is unchanged.
+  !! @param u compact shared buffer, component-outer: u((c-1)*n + idx).
+  subroutine gs_nbsend_vec_caf(this, u, n, nc, tag, deps, strm)
+    class(gs_caf_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    integer, intent(in) :: tag
+    type(c_ptr), intent(inout) :: deps
+    type(c_ptr), intent(inout) :: strm
+#ifdef HAVE_COARRAY
+    integer :: i, j, c, dst, off, dimg, ndst, doff, half_off
+    integer, pointer :: sp(:)
+    integer(kind=atomic_int_kind) :: flag
+    integer :: me_rank
+
+    half_off = this%parity * gs_caf_buf_size
+
+    if (gs_caf_mode .eq. GS_CAF_SIGNAL_SYNC) then
+       do i = 1, size(this%send_pe)
+          dst = this%send_pe(i)
+          off = this%send_offset(i)
+          ndst = this%send_len(i)
+          dimg = this%send_img(i)
+          doff = this%dest_offset(i)
+          sp => this%send_dof(dst)%array()
+          do c = 1, nc
+             do concurrent (j = 1:ndst)
+                this%send_buf(nc*off + (c-1)*ndst + j) = u((c-1)*n + sp(j))
+             end do
+          end do
+          gs_caf_recv_buf(half_off + nc*doff + 1 : half_off + nc*doff + nc*ndst) &
+               [dimg] = this%send_buf(nc*off + 1 : nc*off + nc*ndst)
+       end do
+#ifdef HAVE_COARRAY_EVENTS
+    else if (gs_caf_mode .eq. GS_CAF_SIGNAL_EVENT) then
+       if (gs_caf_event_in_use) then
+          call neko_error("Event-mode coarray gather-scatter does not " // &
+               "support overlapping gs ops on different instances")
+       end if
+       gs_caf_event_in_use = .true.
+
+       if (this%send_started) then
+          if (size(this%send_pe) .gt. 0) then
+             event wait(gs_caf_buf_ready_ev, until_count=size(this%send_pe))
+          end if
+       else
+          this%send_started = .true.
+       end if
+
+       do i = 1, size(this%send_pe)
+          dst = this%send_pe(i)
+          off = this%send_offset(i)
+          ndst = this%send_len(i)
+          dimg = this%send_img(i)
+          doff = this%dest_offset(i)
+          sp => this%send_dof(dst)%array()
+          do c = 1, nc
+             do concurrent (j = 1:ndst)
+                this%send_buf(nc*off + (c-1)*ndst + j) = u((c-1)*n + sp(j))
+             end do
+          end do
+          gs_caf_recv_buf(half_off + nc*doff + 1 : half_off + nc*doff + nc*ndst) &
+               [dimg] = this%send_buf(nc*off + 1 : nc*off + nc*ndst)
+          sync memory
+          event post(gs_caf_data_ready_ev[dimg])
+       end do
+#endif
+    else
+       me_rank = this_image() - 1
+
+       do i = 1, size(this%send_pe)
+          dst = this%send_pe(i)
+          off = this%send_offset(i)
+          ndst = this%send_len(i)
+          sp => this%send_dof(dst)%array()
+          do c = 1, nc
+             do concurrent (j = 1:ndst)
+                this%send_buf(nc*off + (c-1)*ndst + j) = u((c-1)*n + sp(j))
+             end do
+          end do
+       end do
+
+       do i = 1, size(this%send_pe)
+          off = this%send_offset(i)
+          ndst = this%send_len(i)
+          dimg = this%send_img(i)
+          doff = this%dest_offset(i)
+
+          do
+             call atomic_ref(flag, gs_caf_buf_ready(this%send_pe(i)))
+             if (int(flag) .ge. gs_caf_send_count(this%send_pe(i)) - 1) exit
+          end do
+
+          gs_caf_recv_buf(half_off + nc*doff + 1 : half_off + nc*doff + nc*ndst) &
+               [dimg] = this%send_buf(nc*off + 1 : nc*off + nc*ndst)
+
+          gs_caf_send_count(this%send_pe(i)) = &
+               gs_caf_send_count(this%send_pe(i)) + 1
+          call atomic_define(gs_caf_data_ready(me_rank)[dimg], &
+               int(gs_caf_send_count(this%send_pe(i)), atomic_int_kind))
+       end do
+    end if
+#else
+    call neko_error("Coarray Fortran support not built")
+#endif
+  end subroutine gs_nbsend_vec_caf
+
+  !> No-op: senders push into the receiver's buffer.
+  subroutine gs_nbrecv_vec_caf(this, tag, nc)
+    class(gs_caf_t), intent(inout) :: this
+    integer, intent(in) :: tag, nc
+  end subroutine gs_nbrecv_vec_caf
+
+  !> Fused nc-component wait/reduce for the coarray backend.
+  subroutine gs_nbwait_vec_caf(this, u, n, nc, op, strm)
+    class(gs_caf_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    type(c_ptr), intent(inout) :: strm
+    integer :: op
+#ifdef HAVE_COARRAY
+    integer :: i, j, c, src, off, nsrc, half_off
+    integer, pointer :: sp(:)
+    integer(kind=atomic_int_kind) :: flag
+    integer :: me_rank
+
+    half_off = this%parity * gs_caf_buf_size
+
+    if (gs_caf_mode .eq. GS_CAF_SIGNAL_SYNC) then
+       if (allocated(this%sync_img)) then
+          if (size(this%sync_img) .gt. 0) then
+             sync images(this%sync_img)
+          end if
+       end if
+#ifdef HAVE_COARRAY_EVENTS
+    else if (gs_caf_mode .eq. GS_CAF_SIGNAL_EVENT) then
+       if (size(this%recv_pe) .gt. 0) then
+          event wait(gs_caf_data_ready_ev, until_count=size(this%recv_pe))
+       end if
+#endif
+    else
+       do i = 1, size(this%recv_pe)
+          gs_caf_recv_count(this%recv_pe(i)) = &
+               gs_caf_recv_count(this%recv_pe(i)) + 1
+          do
+             call atomic_ref(flag, gs_caf_data_ready(this%recv_pe(i)))
+             if (int(flag) .ge. gs_caf_recv_count(this%recv_pe(i))) exit
+          end do
+       end do
+    end if
+
+    do i = 1, size(this%recv_pe)
+       src = this%recv_pe(i)
+       off = this%recv_offset(i)
+       nsrc = this%recv_len(i)
+       sp => this%recv_dof(src)%array()
+       select case (op)
+       case (GS_OP_ADD)
+          do c = 1, nc
+             !NEC$ IVDEP
+             do concurrent (j = 1:nsrc)
+                u((c-1)*n + sp(j)) = u((c-1)*n + sp(j)) + &
+                     gs_caf_recv_buf(half_off + nc*off + (c-1)*nsrc + j)
+             end do
+          end do
+       case (GS_OP_MUL)
+          do c = 1, nc
+             !NEC$ IVDEP
+             do concurrent (j = 1:nsrc)
+                u((c-1)*n + sp(j)) = u((c-1)*n + sp(j)) * &
+                     gs_caf_recv_buf(half_off + nc*off + (c-1)*nsrc + j)
+             end do
+          end do
+       case (GS_OP_MIN)
+          do c = 1, nc
+             !NEC$ IVDEP
+             do concurrent (j = 1:nsrc)
+                u((c-1)*n + sp(j)) = min(u((c-1)*n + sp(j)), &
+                     gs_caf_recv_buf(half_off + nc*off + (c-1)*nsrc + j))
+             end do
+          end do
+       case (GS_OP_MAX)
+          do c = 1, nc
+             !NEC$ IVDEP
+             do concurrent (j = 1:nsrc)
+                u((c-1)*n + sp(j)) = max(u((c-1)*n + sp(j)), &
+                     gs_caf_recv_buf(half_off + nc*off + (c-1)*nsrc + j))
+             end do
+          end do
+       case default
+          call neko_error("Unknown operation in gs_nbwait_vec_caf")
+       end select
+    end do
+
+    if (gs_caf_mode .eq. GS_CAF_SIGNAL_ATOMIC) then
+       me_rank = this_image() - 1
+       do i = 1, size(this%recv_pe)
+          call atomic_define(gs_caf_buf_ready(me_rank)[this%recv_img(i)], &
+               int(gs_caf_recv_count(this%recv_pe(i)), atomic_int_kind))
+       end do
+#ifdef HAVE_COARRAY_EVENTS
+    else if (gs_caf_mode .eq. GS_CAF_SIGNAL_EVENT) then
+       do i = 1, size(this%recv_pe)
+          event post(gs_caf_buf_ready_ev[this%recv_img(i)])
+       end do
+       gs_caf_event_in_use = .false.
+#endif
+    end if
+
+    this%parity = 1 - this%parity
+#else
+    call neko_error("Coarray Fortran support not built")
+#endif
+  end subroutine gs_nbwait_vec_caf
 
 end module gs_caf

--- a/src/gs/gs_comm.f90
+++ b/src/gs/gs_comm.f90
@@ -35,6 +35,7 @@ module gs_comm
   use num_types, only : rp
   use comm, only : pe_size
   use stack, only : stack_i4_t
+  use utils, only : neko_error
   use, intrinsic :: iso_c_binding
   implicit none
   private
@@ -42,6 +43,10 @@ module gs_comm
   integer, public, parameter :: GS_COMM_MPI = 1, GS_COMM_MPIGPU = 2, &
        GS_COMM_NCCL = 3, GS_COMM_NVSHMEM = 4, GS_COMM_OPENSHMEM = 5, &
        GS_COMM_CAF = 6, GS_COMM_NEIGHBOUR = 7
+
+  !> Maximum number of components handled by the fused vector (multi-component)
+  !! halo exchange used by gs_op_r3. Sizes the backend vector buffers.
+  integer, public, parameter :: GS_VEC_NC = 3
 
   !> Gather-scatter communication method
   type, public, abstract :: gs_comm_t
@@ -56,6 +61,10 @@ module gs_comm
      integer, allocatable :: send_pe(:)
      !> array of ranks that this process will receive messages from
      integer, allocatable :: recv_pe(:)
+     !> Whether this backend implements the fused vector (multi-component)
+     !! halo exchange (nbsend_vec/nbrecv_vec/nbwait_vec). When .false., the
+     !! gs_op_r3 caller falls back to nc independent scalar exchanges.
+     logical :: vec_supported = .false.
    contains
      procedure(gs_comm_init), pass(this), deferred :: init
      procedure(gs_comm_free), pass(this), deferred :: free
@@ -66,6 +75,11 @@ module gs_comm
      procedure, pass(this) :: free_dofs
      procedure, pass(this) :: init_order
      procedure, pass(this) :: free_order
+     !> Fused vector halo exchange. Default implementations abort; backends
+     !! that set vec_supported = .true. override them.
+     procedure, pass(this) :: nbsend_vec => gs_nbsend_vec
+     procedure, pass(this) :: nbrecv_vec => gs_nbrecv_vec
+     procedure, pass(this) :: nbwait_vec => gs_nbwait_vec
   end type gs_comm_t
 
   !> Abstract interface for initializing a Gather-scatter communication method
@@ -220,5 +234,36 @@ contains
     end if
 
   end subroutine free_order
+
+  !> Default fused vector send. Abort unless a backend overrides it.
+  !! @param u compact shared buffer, component-outer: u((c-1)*n + idx)
+  !! @param n number of shared dofs (per component)
+  !! @param nc number of components
+  subroutine gs_nbsend_vec(this, u, n, nc, tag, deps, strm)
+    class(gs_comm_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    integer, intent(in) :: tag
+    type(c_ptr), intent(inout) :: deps
+    type(c_ptr), intent(inout) :: strm
+    call neko_error('Vector gather-scatter not supported by this comm backend')
+  end subroutine gs_nbsend_vec
+
+  !> Default fused vector receive. Abort unless a backend overrides it.
+  subroutine gs_nbrecv_vec(this, tag, nc)
+    class(gs_comm_t), intent(inout) :: this
+    integer, intent(in) :: tag, nc
+    call neko_error('Vector gather-scatter not supported by this comm backend')
+  end subroutine gs_nbrecv_vec
+
+  !> Default fused vector wait/reduce. Abort unless a backend overrides it.
+  subroutine gs_nbwait_vec(this, u, n, nc, op, strm)
+    class(gs_comm_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    integer :: op
+    type(c_ptr), intent(inout) :: strm
+    call neko_error('Vector gather-scatter not supported by this comm backend')
+  end subroutine gs_nbwait_vec
 
 end module gs_comm

--- a/src/gs/gs_mpi.f90
+++ b/src/gs/gs_mpi.f90
@@ -33,7 +33,7 @@
 !> Defines MPI gather-scatter communication
 module gs_mpi
   use num_types, only : rp
-  use gs_comm, only : gs_comm_t, GS_COMM_MPI, GS_COMM_MPIGPU
+  use gs_comm, only : gs_comm_t, GS_COMM_MPI, GS_COMM_MPIGPU, GS_VEC_NC
   use gs_ops, only : GS_OP_ADD, GS_OP_MAX, GS_OP_MIN, GS_OP_MUL
   use stack, only : stack_i4_t
   use mpi_f08, only : MPI_STATUSES_IGNORE, MPI_Status, &
@@ -62,6 +62,11 @@ module gs_mpi
      integer, allocatable :: recv_indices(:)
      type(MPI_Status), allocatable :: recv_statuses(:)
      integer :: ncompleted
+     !> Fused vector (multi-component) send/recv slabs, sized for up to
+     !! GS_VEC_NC components. Each peer slab holds nc consecutive component
+     !! blocks; the scalar send_len/offset arrays are reused, scaled by nc.
+     real(kind=rp), allocatable :: send_buf_v(:)
+     real(kind=rp), allocatable :: recv_buf_v(:)
    contains
      procedure, pass(this) :: init => gs_mpi_init
      procedure, pass(this) :: free => gs_mpi_free
@@ -69,6 +74,9 @@ module gs_mpi
      procedure, pass(this) :: nbsend => gs_nbsend_mpi
      procedure, pass(this) :: nbrecv => gs_nbrecv_mpi
      procedure, pass(this) :: nbwait => gs_nbwait_mpi
+     procedure, pass(this) :: nbsend_vec => gs_nbsend_vec_mpi
+     procedure, pass(this) :: nbrecv_vec => gs_nbrecv_vec_mpi
+     procedure, pass(this) :: nbwait_vec => gs_nbwait_vec_mpi
   end type gs_mpi_t
 
 contains
@@ -108,6 +116,11 @@ contains
        recv_total = recv_total + this%recv_len(i)
     end do
     allocate(this%recv_buf(max(1, recv_total)))
+
+    ! Fused vector exchange buffers, sized for GS_VEC_NC components.
+    allocate(this%send_buf_v(max(1, GS_VEC_NC*send_total)))
+    allocate(this%recv_buf_v(max(1, GS_VEC_NC*recv_total)))
+    this%vec_supported = .true.
 
   end subroutine gs_mpi_init
 
@@ -153,6 +166,14 @@ contains
 
     if (allocated(this%recv_statuses)) then
        deallocate(this%recv_statuses)
+    end if
+
+    if (allocated(this%send_buf_v)) then
+       deallocate(this%send_buf_v)
+    end if
+
+    if (allocated(this%recv_buf_v)) then
+       deallocate(this%recv_buf_v)
     end if
 
     call this%free_order()
@@ -350,5 +371,179 @@ contains
     !$omp barrier
 
   end subroutine gs_nbwait_mpi
+
+  !> Post non-blocking sends for a fused nc-component exchange.
+  !! @param u compact shared buffer, component-outer: u((c-1)*n + idx).
+  !! Peer i's slab holds nc consecutive blocks of send_len(i) values, so the
+  !! scalar offsets/lengths are reused scaled by nc.
+  subroutine gs_nbsend_vec_mpi(this, u, n, nc, tag, deps, strm)
+    class(gs_mpi_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    integer, intent(in) :: tag
+    type(c_ptr), intent(inout) :: deps
+    type(c_ptr), intent(inout) :: strm
+    integer :: i, j, c, ierr, dst, off, ndst
+
+    if (NEKO_MPI_THREAD_PROVIDED .lt. MPI_THREAD_MULTIPLE) then
+       do i = 1, size(this%send_pe)
+          dst = this%send_pe(i)
+          off = this%send_offset(i)
+          ndst = this%send_len(i)
+          select type (sp => this%send_dof(dst)%data)
+          type is (integer)
+             !$omp do
+             do j = 1, ndst
+                do c = 1, nc
+                   this%send_buf_v(nc*off + (c-1)*ndst + j) = &
+                        u((c-1)*n + sp(j))
+                end do
+             end do
+             !$omp end do
+          end select
+          !$omp master
+          call MPI_Isend(this%send_buf_v(nc*off + 1), nc*ndst, &
+               MPI_REAL_PRECISION, dst, tag, &
+               NEKO_COMM, this%send_request(i), ierr)
+          !$omp end master
+       end do
+       !$omp barrier
+    else
+       !$omp do
+       do i = 1, size(this%send_pe)
+          dst = this%send_pe(i)
+          off = this%send_offset(i)
+          ndst = this%send_len(i)
+          select type (sp => this%send_dof(dst)%data)
+          type is (integer)
+             do c = 1, nc
+                !$omp simd
+                do j = 1, ndst
+                   this%send_buf_v(nc*off + (c-1)*ndst + j) = &
+                        u((c-1)*n + sp(j))
+                end do
+             end do
+          end select
+          call MPI_Isend(this%send_buf_v(nc*off + 1), nc*ndst, &
+               MPI_REAL_PRECISION, dst, tag, &
+               NEKO_COMM, this%send_request(i), ierr)
+       end do
+       !$omp end do
+    end if
+
+  end subroutine gs_nbsend_vec_mpi
+
+  !> Post non-blocking receives for a fused nc-component exchange.
+  subroutine gs_nbrecv_vec_mpi(this, tag, nc)
+    class(gs_mpi_t), intent(inout) :: this
+    integer, intent(in) :: tag, nc
+    integer :: i, ierr, off, nsrc
+
+    if (NEKO_MPI_THREAD_PROVIDED .lt. MPI_THREAD_MULTIPLE) then
+       !$omp master
+       do i = 1, size(this%recv_pe)
+          off = this%recv_offset(i)
+          nsrc = this%recv_len(i)
+          call MPI_IRecv(this%recv_buf_v(nc*off + 1), nc*nsrc, &
+               MPI_REAL_PRECISION, this%recv_pe(i), tag, &
+               NEKO_COMM, this%recv_request(i), ierr)
+       end do
+       !$omp end master
+       !$omp barrier
+    else
+       !$omp do
+       do i = 1, size(this%recv_pe)
+          off = this%recv_offset(i)
+          nsrc = this%recv_len(i)
+          call MPI_IRecv(this%recv_buf_v(nc*off + 1), nc*nsrc, &
+               MPI_REAL_PRECISION, this%recv_pe(i), tag, &
+               NEKO_COMM, this%recv_request(i), ierr)
+       end do
+       !$omp end do
+    end if
+  end subroutine gs_nbrecv_vec_mpi
+
+  !> Wait for a fused nc-component exchange and reduce each received slab.
+  subroutine gs_nbwait_vec_mpi(this, u, n, nc, op, strm)
+    class(gs_mpi_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    type(c_ptr), intent(inout) :: strm
+    integer :: i, j, c, k, src, off, nsrc, ierr
+    integer :: op
+    integer :: nreqs
+    logical :: sends_done
+
+    nreqs = size(this%recv_pe)
+    do while (nreqs .gt. 0)
+       !$omp master
+       call MPI_Testsome(size(this%recv_request), this%recv_request, &
+            this%ncompleted, this%recv_indices, this%recv_statuses, ierr)
+       !$omp end master
+       !$omp barrier
+       do k = 1, this%ncompleted
+          i = this%recv_indices(k)
+          src = this%recv_pe(i)
+          off = this%recv_offset(i)
+          nsrc = this%recv_len(i)
+          select type (sp => this%recv_dof(src)%data)
+          type is (integer)
+             select case (op)
+             case (GS_OP_ADD)
+                !$omp do
+                do j = 1, nsrc
+                   do c = 1, nc
+                      u((c-1)*n + sp(j)) = u((c-1)*n + sp(j)) + &
+                           this%recv_buf_v(nc*off + (c-1)*nsrc + j)
+                   end do
+                end do
+                !$omp end do
+             case (GS_OP_MUL)
+                !$omp do
+                do j = 1, nsrc
+                   do c = 1, nc
+                      u((c-1)*n + sp(j)) = u((c-1)*n + sp(j)) * &
+                           this%recv_buf_v(nc*off + (c-1)*nsrc + j)
+                   end do
+                end do
+                !$omp end do
+             case (GS_OP_MIN)
+                !$omp do
+                do j = 1, nsrc
+                   do c = 1, nc
+                      u((c-1)*n + sp(j)) = min(u((c-1)*n + sp(j)), &
+                           this%recv_buf_v(nc*off + (c-1)*nsrc + j))
+                   end do
+                end do
+                !$omp end do
+             case (GS_OP_MAX)
+                !$omp do
+                do j = 1, nsrc
+                   do c = 1, nc
+                      u((c-1)*n + sp(j)) = max(u((c-1)*n + sp(j)), &
+                           this%recv_buf_v(nc*off + (c-1)*nsrc + j))
+                   end do
+                end do
+                !$omp end do
+             case default
+                call neko_error("Unknown operation in gs_nbwait_vec_mpi")
+             end select
+          end select
+       end do
+       nreqs = nreqs - this%ncompleted
+       !$omp barrier
+    end do
+    !$omp master
+    if (size(this%send_request) .gt. 0) then
+       sends_done = .false.
+       do while (.not. sends_done)
+          call MPI_Testall(size(this%send_request), this%send_request, &
+               sends_done, MPI_STATUSES_IGNORE, ierr)
+       end do
+    end if
+    !$omp end master
+    !$omp barrier
+
+  end subroutine gs_nbwait_vec_mpi
 
 end module gs_mpi

--- a/src/gs/gs_neighbour.f90
+++ b/src/gs/gs_neighbour.f90
@@ -33,7 +33,7 @@
 !> Defines gather-scatter communication using MPI neighbourhood collectives
 module gs_neighbour
   use num_types, only : rp
-  use gs_comm, only : gs_comm_t
+  use gs_comm, only : gs_comm_t, GS_VEC_NC
   use gs_ops, only : GS_OP_ADD, GS_OP_MAX, GS_OP_MIN, GS_OP_MUL
   use stack, only : stack_i4_t
   use mpi_f08, only : MPI_Comm, MPI_Request, MPI_STATUS_IGNORE, &
@@ -67,6 +67,14 @@ module gs_neighbour
      type(MPI_Comm) :: neigh_comm
      !> In-flight non-blocking neighbourhood collective.
      type(MPI_Request) :: request
+     !> Fused vector (multi-component) exchange buffers, sized for up to
+     !! GS_VEC_NC components. Each peer slab holds nc consecutive component
+     !! blocks. sendcounts_v/sdispls_v etc. are the nc-scaled collective
+     !! descriptors, filled per call.
+     real(kind=rp), allocatable :: send_buf_v(:)
+     real(kind=rp), allocatable :: recv_buf_v(:)
+     integer, allocatable :: sendcounts_v(:), sdispls_v(:)
+     integer, allocatable :: recvcounts_v(:), rdispls_v(:)
    contains
      procedure, pass(this) :: init => gs_neighbour_init
      procedure, pass(this) :: free => gs_neighbour_free
@@ -74,6 +82,9 @@ module gs_neighbour
      procedure, pass(this) :: nbsend => gs_nbsend_neighbour
      procedure, pass(this) :: nbrecv => gs_nbrecv_neighbour
      procedure, pass(this) :: nbwait => gs_nbwait_neighbour
+     procedure, pass(this) :: nbsend_vec => gs_nbsend_vec_neighbour
+     procedure, pass(this) :: nbrecv_vec => gs_nbrecv_vec_neighbour
+     procedure, pass(this) :: nbwait_vec => gs_nbwait_vec_neighbour
   end type gs_neighbour_t
 
 contains
@@ -121,6 +132,17 @@ contains
     end do
     allocate(this%recv_buf(max(1, recv_total)))
 
+    ! Fused vector exchange buffers/descriptors, sized for GS_VEC_NC comps.
+    allocate(this%send_buf_v(max(1, GS_VEC_NC*send_total)))
+    allocate(this%recv_buf_v(max(1, GS_VEC_NC*recv_total)))
+    allocate(this%sendcounts_v(max(1, nsend)), this%sdispls_v(max(1, nsend)))
+    allocate(this%recvcounts_v(max(1, nrecv)), this%rdispls_v(max(1, nrecv)))
+    this%sendcounts_v = 0
+    this%sdispls_v = 0
+    this%recvcounts_v = 0
+    this%rdispls_v = 0
+    this%vec_supported = .true.
+
     ! Build a distributed-graph communicator over the halo neighbourhood.
     ! With MPI_Dist_graph_create_adjacent and reorder = .false. the order of
     ! sources/destinations is preserved, so the j-th block of the collective
@@ -148,6 +170,13 @@ contains
     if (allocated(this%sdispls)) deallocate(this%sdispls)
     if (allocated(this%recvcounts)) deallocate(this%recvcounts)
     if (allocated(this%rdispls)) deallocate(this%rdispls)
+
+    if (allocated(this%send_buf_v)) deallocate(this%send_buf_v)
+    if (allocated(this%recv_buf_v)) deallocate(this%recv_buf_v)
+    if (allocated(this%sendcounts_v)) deallocate(this%sendcounts_v)
+    if (allocated(this%sdispls_v)) deallocate(this%sdispls_v)
+    if (allocated(this%recvcounts_v)) deallocate(this%recvcounts_v)
+    if (allocated(this%rdispls_v)) deallocate(this%rdispls_v)
 
     call MPI_Comm_free(this%neigh_comm, ierr)
 
@@ -281,5 +310,131 @@ contains
     end do
 
   end subroutine gs_nbwait_neighbour
+
+  !> Pack the nc components and launch a single neighbourhood collective.
+  !! @param u compact shared buffer, component-outer: u((c-1)*n + idx).
+  !! Peer i's slab in send_buf_v holds nc consecutive blocks of sendcounts(i)
+  !! values, so the collective descriptors are simply nc times the scalar ones.
+  subroutine gs_nbsend_vec_neighbour(this, u, n, nc, tag, deps, strm)
+    class(gs_neighbour_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    integer, intent(in) :: tag
+    type(c_ptr), intent(inout) :: deps
+    type(c_ptr), intent(inout) :: strm
+    integer :: i, j, c, dst, off, ndst, ierr
+
+    !$omp do
+    do i = 1, size(this%send_pe)
+       dst = this%send_pe(i)
+       off = this%sdispls(i)
+       ndst = this%sendcounts(i)
+       select type (dofs => this%send_dof(dst)%data)
+       type is (integer)
+          do c = 1, nc
+             !$omp simd
+             do j = 1, ndst
+                this%send_buf_v(nc*off + (c-1)*ndst + j) = u((c-1)*n + dofs(j))
+             end do
+          end do
+       end select
+    end do
+    !$omp end do
+
+    ! A neighbourhood collective is one call over neigh_comm and must be
+    ! issued by a single thread. The end-do barrier above guarantees the
+    ! send buffer is fully packed first.
+    !$omp master
+    do i = 1, size(this%send_pe)
+       this%sendcounts_v(i) = nc * this%sendcounts(i)
+       this%sdispls_v(i) = nc * this%sdispls(i)
+    end do
+    do i = 1, size(this%recv_pe)
+       this%recvcounts_v(i) = nc * this%recvcounts(i)
+       this%rdispls_v(i) = nc * this%rdispls(i)
+    end do
+    call MPI_Ineighbor_alltoallv(this%send_buf_v, this%sendcounts_v, &
+         this%sdispls_v, MPI_REAL_PRECISION, this%recv_buf_v, &
+         this%recvcounts_v, this%rdispls_v, MPI_REAL_PRECISION, &
+         this%neigh_comm, this%request, ierr)
+    !$omp end master
+
+  end subroutine gs_nbsend_vec_neighbour
+
+  !> No-op: the collective is launched in nbsend_vec.
+  subroutine gs_nbrecv_vec_neighbour(this, tag, nc)
+    class(gs_neighbour_t), intent(inout) :: this
+    integer, intent(in) :: tag, nc
+    ! Nothing to do: the collective is launched in nbsend_vec.
+  end subroutine gs_nbrecv_vec_neighbour
+
+  !> Wait for the vector collective and reduce each received slab into u.
+  !! Peer i's received slab holds nc consecutive blocks of recvcounts(i)
+  !! values, matching the sender's packing convention.
+  subroutine gs_nbwait_vec_neighbour(this, u, n, nc, op, strm)
+    class(gs_neighbour_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    type(c_ptr), intent(inout) :: strm
+    integer :: i, j, c, src, off, nsrc, ierr
+    integer :: op
+
+    !$omp master
+    call MPI_Wait(this%request, MPI_STATUS_IGNORE, ierr)
+    !$omp end master
+    !$omp barrier
+
+    ! Serial over peers (a dof shared by 3+ ranks appears in several recv
+    ! lists); parallelism is taken within each slab.
+    do i = 1, size(this%recv_pe)
+       src = this%recv_pe(i)
+       off = this%rdispls(i)
+       nsrc = this%recvcounts(i)
+       select type (dofs => this%recv_dof(src)%data)
+       type is (integer)
+          select case (op)
+          case (GS_OP_ADD)
+             !$omp do
+             do j = 1, nsrc
+                do c = 1, nc
+                   u((c-1)*n + dofs(j)) = u((c-1)*n + dofs(j)) + &
+                        this%recv_buf_v(nc*off + (c-1)*nsrc + j)
+                end do
+             end do
+             !$omp end do
+          case (GS_OP_MUL)
+             !$omp do
+             do j = 1, nsrc
+                do c = 1, nc
+                   u((c-1)*n + dofs(j)) = u((c-1)*n + dofs(j)) * &
+                        this%recv_buf_v(nc*off + (c-1)*nsrc + j)
+                end do
+             end do
+             !$omp end do
+          case (GS_OP_MIN)
+             !$omp do
+             do j = 1, nsrc
+                do c = 1, nc
+                   u((c-1)*n + dofs(j)) = min(u((c-1)*n + dofs(j)), &
+                        this%recv_buf_v(nc*off + (c-1)*nsrc + j))
+                end do
+             end do
+             !$omp end do
+          case (GS_OP_MAX)
+             !$omp do
+             do j = 1, nsrc
+                do c = 1, nc
+                   u((c-1)*n + dofs(j)) = max(u((c-1)*n + dofs(j)), &
+                        this%recv_buf_v(nc*off + (c-1)*nsrc + j))
+                end do
+             end do
+             !$omp end do
+          case default
+             call neko_error("Unknown operation in gs_nbwait_vec_neighbour")
+          end select
+       end select
+    end do
+
+  end subroutine gs_nbwait_vec_neighbour
 
 end module gs_neighbour

--- a/src/gs/gs_shmem.F90
+++ b/src/gs/gs_shmem.F90
@@ -33,7 +33,7 @@
 !> Defines OpenSHMEM gather-scatter communication
 module gs_shmem
   use num_types, only : rp, c_rp, i8
-  use gs_comm, only : gs_comm_t
+  use gs_comm, only : gs_comm_t, GS_VEC_NC
   use gs_ops, only : GS_OP_ADD, GS_OP_MAX, GS_OP_MIN, GS_OP_MUL
   use stack, only : stack_i4_t
   use comm, only : NEKO_COMM, pe_rank, pe_size
@@ -110,6 +110,9 @@ module gs_shmem
      procedure, pass(this) :: nbsend => gs_shmem_nbsend
      procedure, pass(this) :: nbrecv => gs_shmem_nbrecv
      procedure, pass(this) :: nbwait => gs_shmem_nbwait
+     procedure, pass(this) :: nbsend_vec => gs_shmem_nbsend_vec
+     procedure, pass(this) :: nbrecv_vec => gs_shmem_nbrecv_vec
+     procedure, pass(this) :: nbwait_vec => gs_shmem_nbwait_vec
   end type gs_shmem_t
 
 contains
@@ -151,7 +154,10 @@ contains
     call MPI_Allreduce(this%total, this%max_total, 1, MPI_INTEGER, MPI_MAX, &
          NEKO_COMM, ierr)
 
-    sz = c_sizeof(rp_dummy) * int(max(this%max_total, 1), c_size_t)
+    ! Sized for up to GS_VEC_NC components so the fused vector path can
+    ! reuse the same symmetric buffer; the scalar path uses the first
+    ! max_total elements.
+    sz = c_sizeof(rp_dummy) * int(max(GS_VEC_NC*this%max_total, 1), c_size_t)
     this%buf_ptr = shmem_malloc(sz)
     if (.not. c_associated(this%buf_ptr)) then
        call neko_error('shmem_malloc failed for gs_shmem buffer')
@@ -232,6 +238,7 @@ contains
     deallocate(remote_offsets)
 
     this%iter = 0
+    this%vec_supported = .true.
 
     ! Ensure all PEs have completed symmetric allocation before any
     ! one-sided communication is issued.
@@ -397,5 +404,138 @@ contains
     end do
 #endif
   end subroutine gs_shmem_nbwait
+
+  !> Fused nc-component send: pack nc contiguous component blocks per peer
+  !! slab and put nc*ndofs reals with a single signal. Buffer indexing and
+  !! put size scale by nc; the per-rank signalling is unchanged.
+  !! @param u compact shared buffer, component-outer: u((c-1)*n + idx).
+  subroutine gs_shmem_nbsend_vec(this, u, n, nc, tag, deps, strm)
+    class(gs_shmem_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    integer, intent(in) :: tag
+    type(c_ptr), intent(inout) :: deps
+    type(c_ptr), intent(inout) :: strm
+    integer :: i, j, c, dst, base, ndst
+    integer(c_size_t) :: nbytes
+    integer, pointer :: sp(:)
+    real(kind=rp), pointer :: send_data(:), recv_data(:)
+    integer(c_int64_t), pointer :: data_signals(:), ack_signals(:)
+    real(c_rp) :: rp_dummy
+#ifdef HAVE_OPENSHMEM
+
+    this%iter = this%iter + 1
+
+    call c_f_pointer(this%send_buf%buf_ptr, send_data, &
+         [max(nc*this%send_buf%max_total, 1)])
+    call c_f_pointer(this%recv_buf%buf_ptr, recv_data, &
+         [max(nc*this%recv_buf%max_total, 1)])
+    call c_f_pointer(this%data_signals_ptr, data_signals, [pe_size])
+    call c_f_pointer(this%ack_signals_ptr, ack_signals, [pe_size])
+
+    do i = 1, size(this%send_pe)
+       dst = this%send_pe(i)
+
+       call shmem_uint64_wait_until(c_loc(ack_signals(dst + 1)), &
+            SHMEM_CMP_GE, this%iter - 1_8)
+
+       sp => this%send_dof(dst)%array()
+       base = this%send_buf%offset(i)
+       ndst = this%send_buf%ndofs(i)
+       do c = 1, nc
+          do concurrent (j = 1:ndst)
+             send_data(nc*base + (c-1)*ndst + j) = u((c-1)*n + sp(j))
+          end do
+       end do
+
+       nbytes = int(nc*ndst, c_size_t) * c_sizeof(rp_dummy)
+       call shmem_putmem_signal_nbi( &
+            c_loc(recv_data(nc*this%send_buf%remote_offset(i) + 1)), &
+            c_loc(send_data(nc*base + 1)), &
+            nbytes, &
+            c_loc(data_signals(pe_rank + 1)), &
+            this%iter, SHMEM_SIGNAL_SET, dst)
+    end do
+#endif
+  end subroutine gs_shmem_nbsend_vec
+
+  !> No-op: receives are completed via remote put-with-signal.
+  subroutine gs_shmem_nbrecv_vec(this, tag, nc)
+    class(gs_shmem_t), intent(inout) :: this
+    integer, intent(in) :: tag, nc
+  end subroutine gs_shmem_nbrecv_vec
+
+  !> Fused nc-component wait/reduce: per peer, wait on the data signal and
+  !! reduce nc component blocks into u, then ack the sender.
+  subroutine gs_shmem_nbwait_vec(this, u, n, nc, op, strm)
+    class(gs_shmem_t), intent(inout) :: this
+    integer, intent(in) :: n, nc
+    real(kind=rp), dimension(nc*n), intent(inout) :: u
+    type(c_ptr), intent(inout) :: strm
+    integer :: op
+    integer :: i, j, c, src, base, nsrc
+    integer(c_int64_t) :: dummy
+    integer, pointer :: sp(:)
+    real(kind=rp), pointer :: recv_data(:)
+    integer(c_int64_t), pointer :: data_signals(:), ack_signals(:)
+#ifdef HAVE_OPENSHMEM
+
+    call c_f_pointer(this%recv_buf%buf_ptr, recv_data, &
+         [max(nc*this%recv_buf%max_total, 1)])
+    call c_f_pointer(this%data_signals_ptr, data_signals, [pe_size])
+    call c_f_pointer(this%ack_signals_ptr, ack_signals, [pe_size])
+
+    do i = 1, size(this%recv_pe)
+       src = this%recv_pe(i)
+
+       dummy = shmem_signal_wait_until(c_loc(data_signals(src + 1)), &
+            SHMEM_CMP_GE, this%iter)
+
+       sp => this%recv_dof(src)%array()
+       base = this%recv_buf%offset(i)
+       nsrc = this%recv_buf%ndofs(i)
+       select case (op)
+       case (GS_OP_ADD)
+          do c = 1, nc
+             !NEC$ IVDEP
+             do concurrent (j = 1:nsrc)
+                u((c-1)*n + sp(j)) = u((c-1)*n + sp(j)) + &
+                     recv_data(nc*base + (c-1)*nsrc + j)
+             end do
+          end do
+       case (GS_OP_MUL)
+          do c = 1, nc
+             !NEC$ IVDEP
+             do concurrent (j = 1:nsrc)
+                u((c-1)*n + sp(j)) = u((c-1)*n + sp(j)) * &
+                     recv_data(nc*base + (c-1)*nsrc + j)
+             end do
+          end do
+       case (GS_OP_MIN)
+          do c = 1, nc
+             !NEC$ IVDEP
+             do concurrent (j = 1:nsrc)
+                u((c-1)*n + sp(j)) = min(u((c-1)*n + sp(j)), &
+                     recv_data(nc*base + (c-1)*nsrc + j))
+             end do
+          end do
+       case (GS_OP_MAX)
+          do c = 1, nc
+             !NEC$ IVDEP
+             do concurrent (j = 1:nsrc)
+                u((c-1)*n + sp(j)) = max(u((c-1)*n + sp(j)), &
+                     recv_data(nc*base + (c-1)*nsrc + j))
+             end do
+          end do
+       case default
+          call neko_error("Unknown operation in gs_shmem_nbwait_vec")
+       end select
+
+       call shmem_uint64_atomic_set( &
+            c_loc(ack_signals(pe_rank + 1)), &
+            this%iter, src)
+    end do
+#endif
+  end subroutine gs_shmem_nbwait_vec
 
 end module gs_shmem

--- a/src/krylov/bcknd/cpu/cg_coupled.f90
+++ b/src/krylov/bcknd/cpu/cg_coupled.f90
@@ -293,9 +293,8 @@ contains
          call Ax%compute_vector(w1, w2, w3, p1, p2, p3, coef, x%msh, x%Xh)
 
          call rotate_cyc(w1, w2, w3, 1, coef)
-         call gs_h%op(w1, n, GS_OP_ADD)
-         call gs_h%op(w2, n, GS_OP_ADD)
-         call gs_h%op(w3, n, GS_OP_ADD)
+         ! Fused 3-component halo exchange.
+         call gs_h%op(w1, w2, w3, n, GS_OP_ADD)
          call rotate_cyc(w1, w2, w3, 0, coef)
 
          call blstx%apply_scalar(w1, n)

--- a/src/krylov/bcknd/cpu/cg_coupled.f90
+++ b/src/krylov/bcknd/cpu/cg_coupled.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2024, The Neko Authors
+! Copyright (c) 2024-2026, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -293,7 +293,6 @@ contains
          call Ax%compute_vector(w1, w2, w3, p1, p2, p3, coef, x%msh, x%Xh)
 
          call rotate_cyc(w1, w2, w3, 1, coef)
-         ! Fused 3-component halo exchange.
          call gs_h%op(w1, w2, w3, n, GS_OP_ADD)
          call rotate_cyc(w1, w2, w3, 0, coef)
 

--- a/src/krylov/bcknd/device/cg_cpld_device.f90
+++ b/src/krylov/bcknd/device/cg_cpld_device.f90
@@ -376,11 +376,10 @@ contains
               this%p1, this%p2, this%p3, coef, x%msh, x%Xh)
 
          call rotate_cyc(w1_d, w2_d, w3_d, 1, coef)
-         call gs_h%op(this%w1, n, GS_OP_ADD, this%gs_event)
-         call device_event_sync(this%gs_event)
-         call gs_h%op(this%w2, n, GS_OP_ADD, this%gs_event)
-         call device_event_sync(this%gs_event)
-         call gs_h%op(this%w3, n, GS_OP_ADD, this%gs_event)
+         ! Fused 3-component halo exchange; the event is recorded once,
+         ! after the last component's scatter.
+         call gs_h%op(this%w1, this%w2, this%w3, n, GS_OP_ADD, &
+              this%gs_event)
          call device_event_sync(this%gs_event)
          call rotate_cyc(w1_d, w2_d, w3_d, 0, coef)
 

--- a/src/krylov/bcknd/device/cg_cpld_device.f90
+++ b/src/krylov/bcknd/device/cg_cpld_device.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2025, The Neko Authors
+! Copyright (c) 2025-2026, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -376,8 +376,6 @@ contains
               this%p1, this%p2, this%p3, coef, x%msh, x%Xh)
 
          call rotate_cyc(w1_d, w2_d, w3_d, 1, coef)
-         ! Fused 3-component halo exchange; the event is recorded once,
-         ! after the last component's scatter.
          call gs_h%op(this%w1, this%w2, this%w3, n, GS_OP_ADD, &
               this%gs_event)
          call device_event_sync(this%gs_event)

--- a/src/krylov/bcknd/device/fusedcg_cpld_device.F90
+++ b/src/krylov/bcknd/device/fusedcg_cpld_device.F90
@@ -609,14 +609,12 @@ contains
               p1(1, p_cur), p2(1, p_cur), p3(1, p_cur), coef, x%msh, x%Xh)
 
          call rotate_cyc(w1_d, w2_d, w3_d, 1, coef)
-         call gs_h%op(w1, n, GS_OP_ADD, this%gs_event1)
+         ! Fused 3-component halo exchange; one event covers all three
+         ! components' scatters.
+         call gs_h%op(w1, w2, w3, n, GS_OP_ADD, this%gs_event1)
          call device_event_sync(this%gs_event1)
          call blstx%apply(w1, n)
-         call gs_h%op(w2, n, GS_OP_ADD, this%gs_event2)
-         call device_event_sync(this%gs_event2)
          call blsty%apply(w2, n)
-         call gs_h%op(w3, n, GS_OP_ADD, this%gs_event3)
-         call device_event_sync(this%gs_event3)
          call blstz%apply(w3, n)
          call rotate_cyc(w1_d, w2_d, w3_d, 0, coef)
 

--- a/src/krylov/bcknd/device/fusedcg_cpld_device.F90
+++ b/src/krylov/bcknd/device/fusedcg_cpld_device.F90
@@ -1,4 +1,4 @@
-! Copyright (c) 2021-2024, The Neko Authors
+! Copyright (c) 2021-2026, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -609,8 +609,6 @@ contains
               p1(1, p_cur), p2(1, p_cur), p3(1, p_cur), coef, x%msh, x%Xh)
 
          call rotate_cyc(w1_d, w2_d, w3_d, 1, coef)
-         ! Fused 3-component halo exchange; one event covers all three
-         ! components' scatters.
          call gs_h%op(w1, w2, w3, n, GS_OP_ADD, this%gs_event1)
          call device_event_sync(this%gs_event1)
          call blstx%apply(w1, n)

--- a/src/math/bcknd/cpu/opr_cpu.f90
+++ b/src/math/bcknd/cpu/opr_cpu.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2021-2024, The Neko Authors
+! Copyright (c) 2021-2026, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -173,8 +173,6 @@ contains
 
     call opcolv(w1, w2, w3, c_Xh%B, gdim, n)
     if (c_Xh%cyclic) call opr_cpu_rotate_cyc_r4(w1, w2, w3, 1, c_Xh)
-    ! Fused 3-component halo exchange (falls back to three scalar ops on comm
-    ! backends without a vector path).
     call c_Xh%gs_h%op(w1, w2, w3, n, GS_OP_ADD)
     if (c_Xh%cyclic) call opr_cpu_rotate_cyc_r4(w1, w2, w3, 0, c_Xh)
     call opcolv(w1, w2, w3, c_Xh%Binv, gdim, n)

--- a/src/math/bcknd/cpu/opr_cpu.f90
+++ b/src/math/bcknd/cpu/opr_cpu.f90
@@ -173,9 +173,9 @@ contains
 
     call opcolv(w1, w2, w3, c_Xh%B, gdim, n)
     if (c_Xh%cyclic) call opr_cpu_rotate_cyc_r4(w1, w2, w3, 1, c_Xh)
-    call c_Xh%gs_h%op(w1, n, GS_OP_ADD)
-    call c_Xh%gs_h%op(w2, n, GS_OP_ADD)
-    call c_Xh%gs_h%op(w3, n, GS_OP_ADD)
+    ! Fused 3-component halo exchange (falls back to three scalar ops on comm
+    ! backends without a vector path).
+    call c_Xh%gs_h%op(w1, w2, w3, n, GS_OP_ADD)
     if (c_Xh%cyclic) call opr_cpu_rotate_cyc_r4(w1, w2, w3, 0, c_Xh)
     call opcolv(w1, w2, w3, c_Xh%Binv, gdim, n)
 

--- a/src/math/bcknd/device/opr_device.F90
+++ b/src/math/bcknd/device/opr_device.F90
@@ -989,22 +989,16 @@ contains
 
     call device_opcolv(w1%x_d, w2%x_d, w3%x_d, c_Xh%B_d, gdim, n)
 
+    ! Fused 3-component halo exchange; with an event it is recorded once,
+    ! after the last component's scatter.
+    if(c_Xh%cyclic) call opr_device_rotate_cyc(w1%x_d, w2%x_d, w3%x_d, 1, c_Xh)
     if (present(event)) then
-       if(c_Xh%cyclic) call opr_device_rotate_cyc(w1%x_d, w2%x_d, w3%x_d, 1, c_Xh)
-       call c_Xh%gs_h%op(w1, GS_OP_ADD, event)
+       call c_Xh%gs_h%op(w1%x, w2%x, w3%x, n, GS_OP_ADD, event)
        call device_event_sync(event)
-       call c_Xh%gs_h%op(w2, GS_OP_ADD, event)
-       call device_event_sync(event)
-       call c_Xh%gs_h%op(w3, GS_OP_ADD, event)
-       call device_event_sync(event)
-       if(c_Xh%cyclic) call opr_device_rotate_cyc(w1%x_d, w2%x_d, w3%x_d, 0, c_Xh)
     else
-       if(c_Xh%cyclic) call opr_device_rotate_cyc(w1%x_d, w2%x_d, w3%x_d, 1, c_Xh)
-       call c_Xh%gs_h%op(w1, GS_OP_ADD)
-       call c_Xh%gs_h%op(w2, GS_OP_ADD)
-       call c_Xh%gs_h%op(w3, GS_OP_ADD)
-       if(c_Xh%cyclic) call opr_device_rotate_cyc(w1%x_d, w2%x_d, w3%x_d, 0, c_Xh)
+       call c_Xh%gs_h%op(w1%x, w2%x, w3%x, n, GS_OP_ADD)
     end if
+    if(c_Xh%cyclic) call opr_device_rotate_cyc(w1%x_d, w2%x_d, w3%x_d, 0, c_Xh)
 
     call device_opcolv(w1%x_d, w2%x_d, w3%x_d, c_Xh%Binv_d, gdim, n)
 

--- a/src/math/bcknd/device/opr_device.F90
+++ b/src/math/bcknd/device/opr_device.F90
@@ -989,8 +989,6 @@ contains
 
     call device_opcolv(w1%x_d, w2%x_d, w3%x_d, c_Xh%B_d, gdim, n)
 
-    ! Fused 3-component halo exchange; with an event it is recorded once,
-    ! after the last component's scatter.
     if(c_Xh%cyclic) call opr_device_rotate_cyc(w1%x_d, w2%x_d, w3%x_d, 1, c_Xh)
     if (present(event)) then
        call c_Xh%gs_h%op(w1%x, w2%x, w3%x, n, GS_OP_ADD, event)

--- a/src/math/bcknd/sx/opr_sx.f90
+++ b/src/math/bcknd/sx/opr_sx.f90
@@ -147,9 +147,8 @@ contains
     !!    BC dependent, Needs to change if cyclic
 
     call opcolv(w1, w2, w3, c_Xh%B, gdim, n)
-    call c_Xh%gs_h%op(w1, n, GS_OP_ADD)
-    call c_Xh%gs_h%op(w2, n, GS_OP_ADD)
-    call c_Xh%gs_h%op(w3, n, GS_OP_ADD)
+    ! Fused 3-component halo exchange.
+    call c_Xh%gs_h%op(w1, w2, w3, n, GS_OP_ADD)
     call opcolv(w1, w2, w3, c_Xh%Binv, gdim, n)
 
   end subroutine opr_sx_curl

--- a/src/math/bcknd/sx/opr_sx.f90
+++ b/src/math/bcknd/sx/opr_sx.f90
@@ -147,7 +147,6 @@ contains
     !!    BC dependent, Needs to change if cyclic
 
     call opcolv(w1, w2, w3, c_Xh%B, gdim, n)
-    ! Fused 3-component halo exchange.
     call c_Xh%gs_h%op(w1, w2, w3, n, GS_OP_ADD)
     call opcolv(w1, w2, w3, c_Xh%Binv, gdim, n)
 

--- a/src/math/bcknd/xsmm/opr_xsmm.F90
+++ b/src/math/bcknd/xsmm/opr_xsmm.F90
@@ -465,9 +465,8 @@ contains
     !!    BC dependent, Needs to change if cyclic
 
     call opcolv(w1, w2, w3, c_Xh%B, gdim, n)
-    call c_Xh%gs_h%op(w1, n, GS_OP_ADD)
-    call c_Xh%gs_h%op(w2, n, GS_OP_ADD)
-    call c_Xh%gs_h%op(w3, n, GS_OP_ADD)
+    ! Fused 3-component halo exchange.
+    call c_Xh%gs_h%op(w1, w2, w3, n, GS_OP_ADD)
     call opcolv(w1, w2, w3, c_Xh%Binv, gdim, n)
 
   end subroutine opr_xsmm_curl

--- a/src/math/bcknd/xsmm/opr_xsmm.F90
+++ b/src/math/bcknd/xsmm/opr_xsmm.F90
@@ -465,7 +465,6 @@ contains
     !!    BC dependent, Needs to change if cyclic
 
     call opcolv(w1, w2, w3, c_Xh%B, gdim, n)
-    ! Fused 3-component halo exchange.
     call c_Xh%gs_h%op(w1, w2, w3, n, GS_OP_ADD)
     call opcolv(w1, w2, w3, c_Xh%Binv, gdim, n)
 


### PR DESCRIPTION
This PR adds a fused 3-component gather-scatter, `gs%op(u1, u2, u3, n, op)`, that exchanges the halo of all three components of a vector field in a single communication round instead of three, cutting the latency-bound cost of vector gs ops at scale. Only the communication is fused, the on-node gather/scatter remains per component.

**Summary of changes**
- New `gs_op_r3`/`gs_op_vector3` entry points behind the generic `gs%op`, staging components in a persistent component-outer shared buffer (`shared_gs_v`, device-mapped on accelerator builds).
- New `nbsend_vec`/`nbrecv_vec`/`nbwait_vec` methods on `gs_comm_t` with a `vec_supported` capability flag; backends without a fused path transparently fall back to three scalar exchanges with identical results.
- Fused exchange implemented in all seven comm backends: `gs_mpi`, `gs_neighbour`, `gs_shmem` (OpenSHMEM), `gs_caf`, `gs_device_mpi`, `gs_device_nccl`, and `gs_device_shmem` (NVSHMEM). Per-peer slabs hold `nc` consecutive component blocks, reusing the scalar length/offset tables scaled by `nc`.
- New CUDA/HIP `pack_vec`/`unpack_{add,min,max}_vec` kernels; the NVSHMEM backend gets a fused vector pack-and-push path.
- On device builds a single event is recorded after the last component's scatter, so one event sync replaces the previous per-component op+sync triplets (e.g. the velocity residual in `fluid_pnpn`).

**Expected performance impact**
The fused exchange moves the same halo volume in one message per peer instead of three, cutting the latency term of every vector gs op by 3× while leaving the bandwidth term unchanged. The gain is therefore largest in the strong-scaling limit, where messages are small and gather-scatter is latency bound.