### PR TITLE
Fix linking failure with CUDA 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Develop
 
+- Fixed a linking failure with CUDA 13, which no longer implicitly links the
+  host C++ runtime (`undefined reference to __cxa_guard_acquire`); `configure`
+  now links `libstdc++` explicitly for CUDA >= 13, except with the Cray
+  compiler (CCE/PrgEnv-cray) which provides its own C++ runtime.
 - Added a native Tofu (uTofu) gather-scatter backend for Fugaku and other
   Tofu-D systems (`NEKO_GS_COMM=UTOFU`, `--with-utofu`), using one-sided
   RDMA puts with fused arrival signalling and thread-parallel injection;

--- a/configure.ac
+++ b/configure.ac
@@ -264,6 +264,25 @@ else
   AX_CUDA
 fi
 
+# CUDA >= 13 no longer implicitly links the host C++ runtime, so the
+# device object files fail to link with e.g. an undefined reference to
+# __cxa_guard_acquire. Link libstdc++ explicitly for CUDA >= 13, unless
+# the Cray compiler (CCE/PrgEnv-cray) is used, which provides its own C++
+# runtime. Note that PrgEnv-gnu still needs it, even though it is driven
+# through the Cray compiler wrappers (ftn/cc/CC).
+if (test "x${have_cuda}" = xyes &&
+    test "x$ax_cv_fc_compiler_vendor" != xcray); then
+   AC_MSG_CHECKING([CUDA major version])
+   cuda_version_major=`$NVCC --version 2>/dev/null | \
+                       $SED -n 's/.*release \(@<:@0-9@:>@*\).*/\1/p'`
+   AS_IF([test -n "$cuda_version_major"],
+         [AC_MSG_RESULT([$cuda_version_major])],
+         [AC_MSG_RESULT([unknown])])
+   AS_IF([test -n "$cuda_version_major" && test "$cuda_version_major" -ge 13],
+         [AC_MSG_NOTICE([Linking libstdc++ for CUDA >= 13])
+          LIBS="$LIBS -lstdc++"])
+fi
+
 # Checks for OpenCL backend
 AX_OPENCL
 


### PR DESCRIPTION
CUDA 13 no longer implicitly links the host C++ runtime, so Neko's device object files fail to link with `undefined reference to __cxa_guard_acquire`.

`configure` now links `libstdc++` explicitly when the CUDA backend is enabled and `nvcc` reports major version >= 13. The version is parsed from `nvcc --version` so older CUDA toolkits are left untouched.

This is gated on the compiler *vendor*, not the machine: the Cray compiler (CCE / PrgEnv-cray) provides its own C++ runtime and works out of the box, so it is skipped, while PrgEnv-gnu still gets `-lstdc++` even though it is driven through the Cray `ftn`/`cc` wrappers. 

Replaces the manual `./configure LDFLAGS=-lstdc++` workaround.

Closes #2129.