### PR TITLE
Add project-level neko simulation AI skill

### DIFF
--- a/.agents/skills/neko-simulation-setup/SKILL.md
+++ b/.agents/skills/neko-simulation-setup/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: neko-simulation-setup
+description: Help set up, explain, or modify Neko CFD simulation cases, including case files, meshes, and optional user files.
+---
+
+# Neko Simulation Setup
+
+Use this skill when helping with a concrete Neko simulation case, advising on
+simulation settings, explaining an existing case setup, or creating the files
+needed to run a case.
+
+## Core Workflow
+
+- Treat each simulation as a separate case folder.
+- The goal is to produce:
+  - A computational mesh file, if not already provided by the user.
+  - A JSON configuration file, usually `.case` or `.json`, referred to as the
+    case file.
+  - A Fortran user file, **only** when the setup really needs custom behavior.
+- Prefer starting from an existing example instead of creating a case from
+  scratch. Read `examples/README.md`, then the relevant example `README.md`.
+- Ask the user whether a particular example is a good starting point when this
+  is not already clear.
+- Prompt for missing CFD-specific details. Avoid relying on educated guesses for
+  physical setup, boundary conditions, mesh resolution, or solver choices. When
+  making assumptions, state them explicitly.
+
+## Case File
+
+- Use `doc/pages/user-guide/case-file.md` as the definitive reference for case
+  file contents, and acknowledge that you got access to this file.
+- Name generated case files after the case folder, using `.json` unless the user
+  specifically asks for `.case`.
+- Pretty-format generated JSON.
+
+## Mesh File
+
+- Read `doc/pages/user-guide/meshing.md` before advising on or creating meshes.
+- Handle meshes according to the available source:
+  - If the user provides `.nmsh`, use it directly.
+  - If the user provides `.re2`, convert it to `.nmsh` with `rea2nbin`.
+  - If the user provides another format, help convert it first to `.re2` and
+    then to `.nmsh`, using the meshing guide.
+  - If there is no mesh and the geometry is a box, generate it with
+    `genmeshbox`.
+    - Before using `genmeshbox`, study `contrib/genmeshbox/genmeshbox.f90`
+      closely enough to understand its inputs and behavior.
+    - For non-uniform box meshes, generate edge-location files when needed,
+      because `genmeshbox` reads non-uniform element distributions from files.
+  - Always run `mesh_checker` on any generated or existing `.nmsh` file and make
+  sure it reports no errors.
+
+## User File
+
+- Read `doc/pages/user-guide/user-file.md` before creating or changing a user
+  file.
+- Create a user file only when the case cannot be expressed cleanly through the
+  case file.
+- Name the user file after the case folder with a `.f90` extension.
+- Look at `examples/programming/README.md` and the documented `.f90` examples
+  there before writing custom user-file logic. Other examples may also contain
+  relevant user files.
+- Follow `doc/pages/developer-guide/code-style.md` for Fortran style.
+- Use `doc/pages/developer-guide/important_types.md` and the corresponding
+  source files under `src` when working with important Neko types.
+- Be generous with explanatory comments in generated user files.
+- Run `makeneko` on any generated user file and make sure it compiles.
+
+## Completion Checks
+
+- Confirm the case folder contains the expected case file, mesh file, and any
+  necessary user file.
+- Confirm generated JSON is formatted and named consistently.
+- Confirm `mesh_checker` passed for the `.nmsh` mesh.
+- Confirm `makeneko` passed when a user file was created or modified.
+- If any check cannot be run locally, clearly tell the user what remains to be
+  run and why.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,86 +15,9 @@ of turbulent flows.
 - `contrib`, misc scripts and utilities for working with Neko.
 
 ## Helping users set up new Neko simulation cases
-Neko is simulation software, and a common scenario is that the user will ask
-you to help set up a simulation. Alternatively, they may want tips about specific
-settings or an explanation about a setup they find in an existing case. The
-instructions under this header are specifically for these scenarios. We will
-refer to a concrete simulation as "the case".
-
-### General guidelines
-Below are the main guidelines you should follow for retrieving information and
-making decisions about how to set up a case.
-
-- A simulation case typically lives in its own separate folder, which we will call
-  the case folder.
-- Input to the simulation consists of at least two files
-  - A file with the computational mesh. More instructions on meshing follow.
-  - A JSON file, which is either a .json or a .case (most often the latter),
-    containing the configuration of the various components of the simulation.
-    This file is referred to as the **case file**.
-- In many cases, an additional Fortran source file, referred to as the **user
-  file** is part of the case setup. This allows advanced customization.
-- The folder `examples` contains already set up cases to demonstrate Neko's
-  functionality. The `examples/README.md` contains an overview of the cases in
-  the different sub-folders, and each of them has a `README.md` of its own. If
-  you are tasked with creating a new case, it is a very good idea to base it on
-  one of the examples instead of starting from scratch. Think of the examples as
-  templates for your work. It is a very good idea to ask the user, whether there
-  is a particular example, which would serve as a good starting point for the
-  setup.
-- When unsure, try to prompt the user for possible details. Most CFD simulations
-  will be unique and require a lot of input to setup correctly. "Educated
-  guesses" may often not work. If you make assumptions, you should explicitly
-  tell the user about them.
-
-### The case file
-- Your definitive reference for the contents of the case file is the file
-  `doc/pages/user-guide/case-file.md`. You should acknowledge that you got
-  access to this file.
-- Save the case files as the name of the case folder plus .json, and try to
-  pretty-format as good as you can.
-
-### The mesh file
-- The general guide for meshing is `doc/pages/user-guide/meshing.md`.
-- There are essentially four possible options.
-  - The user provides you a mesh file as an .nmsh and you use that.
-  - The user has a mesh in .re2 format and you can convert that to .nmsh by
-    running `rea2nbin` on that file.
-  - The user has a mesh in a different format and you should try to help them
-    convert it first to .re2 and then to .nmsh. This is the most difficult
-    scenario but you can try to provide guidance based on the meshing.md
-    referenced above.
-  - There is no mesh, but the geometry is a box. In this case you can generate
-    the mesh yourself using the `genmeshbox` utility. The source code for this
-    utility is in `contrib/genmeshbox/genmeshbox.f90`. Study it so that you have
-    perfect understanding of how it works. Then, follow the user's instructions
-    about the mesh: its element sizes (uniform or not), periodicity. Observe
-    that for non-uniform element size distributions `genmeshbox` takes the
-    location of element edges from files. You may therefore need to generate
-    these files based on the user's specifications.
-- **Always** run the utility `mesh_checker` on the generated or existing .nmsh
-  and make sure it reports no errors.
-
-### The user file
-- The general guide for the user file is `doc/pages/user-guide/user-file.md`.
-- The file is just a Fortran module.
-- Name the user file as the name of the case folder plus .f90.
-- If it is possible to set up the case without a user file, you should always do
-  that. Only create a user file if it is really necessary for the case setup.
-- A **very good** idea is to look into the `examples/programming` directory,
-  which contains examples for some basic things you can do in the user file.
-  Look at the `README.md` in that subfolder for a description of what is in the
-  files, but all the .f90 there are heavily documented.
-  Other examples may also contain user files.
-- General development guidelines apply:
-  - `doc/pages/developer-guide/code-style.md` for the Fortran code style.
-  - `doc/pages/developer-guide/important_types.md` provides an overview of
-    the most important types for Neko. It is a very good idea to look at their
-    implementation in the respective .f90 files under the `src` structure.
-- Be generous with comments in the user file you generate, so that one can
-  easily follow what your code does.
-- At the end always run `makeneko` on the generated user file and make sure it
-  compiles.
+When the user asks for help setting up, explaining, or modifying a Neko
+simulation case, use the project-level skill in
+`.agents/skills/neko-simulation-setup/SKILL.md`.
 
 ## Writing tests for Neko
 


### PR DESCRIPTION
This cleans up the main AGENTS.md by removing the instruction for case building and instead encapsulating them into an AI skill file.

Less token eating and context pollution, since the main AGENTS.md is always read. 

I am hoping we can build up more skills over time, I have a prototype for pfunit tests lying around. We should really polish these since they will be / are an integral part of the user and development experience. So treat the current text as a starting point.