### PR TITLE
Fix pack/unpack race in the NVSHMEM gs backend

### DIFF
--- a/src/gs/bcknd/device/cuda/gs_kernels.h
+++ b/src/gs/bcknd/device/cuda/gs_kernels.h
@@ -293,7 +293,7 @@ template<typename T>
 __device__ T atomicMinFloat(T* address, T val);
 
 template<>
-__device__ float atomicMinFloat<float>(float* address, float val) {
+__device__ inline float atomicMinFloat<float>(float* address, float val) {
     float old;
     old = !signbit(val) ? __int_as_float(atomicMin((int*)address, __float_as_int(val))) :
         __uint_as_float(atomicMax((unsigned int*)address, __float_as_uint(val)));
@@ -302,7 +302,7 @@ __device__ float atomicMinFloat<float>(float* address, float val) {
 }
 
 template<>
-__device__ double atomicMinFloat<double>(double* address, double val) {
+__device__ inline double atomicMinFloat<double>(double* address, double val) {
     double old;
 #if __CUDA_ARCH__ >= 600
     old = !signbit(val) ? __longlong_as_double(atomicMin((unsigned long long*)address, 
@@ -340,7 +340,7 @@ template<typename T>
 __device__ T atomicMaxFloat(T* address, T val);
 
 template<>
-__device__ float atomicMaxFloat<float>(float* address, float val) {
+__device__ inline float atomicMaxFloat<float>(float* address, float val) {
     float old;
     old = !signbit(val) ? __int_as_float(atomicMax((int*)address, __float_as_int(val))) :
         __uint_as_float(atomicMin((unsigned int*)address, __float_as_uint(val)));
@@ -348,7 +348,7 @@ __device__ float atomicMaxFloat<float>(float* address, float val) {
 }
 
 template<>
-__device__ double atomicMaxFloat<double>(double* address, double val) {
+__device__ inline double atomicMaxFloat<double>(double* address, double val) {
     double old;
 #if __CUDA_ARCH__ >= 600
     old = !signbit(val) ? __longlong_as_double(atomicMax((unsigned long long*)address, 

--- a/src/gs/bcknd/device/cuda/gs_nvshmem.cu
+++ b/src/gs/bcknd/device/cuda/gs_nvshmem.cu
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2024-2025, The Neko Authors
+ Copyright (c) 2024-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -36,6 +36,7 @@
 #include <device/cuda/check.h>
 #ifdef HAVE_NVSHMEM
 #include <nvshmem.h>
+#include "gs_kernels.h"
 #include "gs_nvshmem_kernels.h"
 #endif
 
@@ -57,26 +58,63 @@ extern "C" {
   }
 
   /**
-   * Pack and push one peer slab with rank-indexed signaling. roffset is the
-   * offset in the destination's recv buffer where our slab lands; done_d and
-   * ready_d are the symmetric rank-indexed signal arrays; mype is our rank.
-   * Single-block launch: the kernel packs with a block-stride loop and
-   * pushes from the same block (see gs_nvshmem_kernels.h).
+   * Bulk-pack every peer's slab into one parity half of the double-buffered
+   * send buffer. boffset is the parity slab offset (in elements); the dof
+   * map always starts at 0 and covers all peers. Launched on the main
+   * stream in nbsend, before any per-peer work, so every read of u
+   * precedes any unpack write to u (see gs_nvshmem_kernels.h).
    */
-  void cuda_gs_pack_and_push(void *u_d, void *sbuf_d, void *sdof_d,
-                             int soffset, int n, cudaStream_t stream,
-                             int destRank, void *rbuf_d, int roffset,
-                             int iter, void *done_d, void *ready_d,
-                             int mype)
+  void cuda_gs_nvshmem_pack(void *u_d, void *buf_d, void *dof_d,
+                            int boffset, int n, cudaStream_t stream)
+  {
+    if (n == 0) return;
+
+    const int nthrds = 1024;
+    const int nblcks = (n + nthrds - 1) / nthrds;
+
+    gs_pack_kernel<real>
+      <<<nblcks, nthrds, 0, stream>>>((real *) u_d, (real *) buf_d + boffset,
+                                      (int *) dof_d, n);
+    CUDA_CHECK(cudaGetLastError());
+  }
+
+  /**
+   * Fused nc-component bulk pack (see cuda_gs_nvshmem_pack). u_d is the
+   * compact shared buffer (component-outer, per-component stride ns);
+   * buf_d is interleaved (nc per position).
+   */
+  void cuda_gs_nvshmem_pack_vec(void *u_d, void *buf_d, void *dof_d,
+                                int boffset, int n, int nc, int ns,
+                                cudaStream_t stream)
+  {
+    if (n == 0) return;
+
+    const int nthrds = 1024;
+    const int nblcks = (n + nthrds - 1) / nthrds;
+
+    gs_pack_vec_kernel<real>
+      <<<nblcks, nthrds, 0, stream>>>((real *) u_d, (real *) buf_d + boffset,
+                                      (int *) dof_d, n, nc, ns);
+    CUDA_CHECK(cudaGetLastError());
+  }
+
+  /**
+   * Push one packed peer slab with rank-indexed signaling. soffset/roffset/n
+   * are in elements (the fused vector path passes nc-scaled values); roffset
+   * is the offset in the destination's recv buffer where our slab lands;
+   * done_d and ready_d are the symmetric rank-indexed signal arrays; mype is
+   * our rank. Single-block launch (see gs_nvshmem_kernels.h).
+   */
+  void cuda_gs_push(void *sbuf_d, int soffset, int n, cudaStream_t stream,
+                    int destRank, void *rbuf_d, int roffset, int iter,
+                    void *done_d, void *ready_d, int mype)
   {
     const int nthrds = 1024;
 
-    pack_pushShmemKernel<real>
-      <<<1,nthrds,0,stream>>>((real *) u_d,
-                              (real *) rbuf_d + roffset,
+    pushShmemKernel<real>
+      <<<1,nthrds,0,stream>>>((real *) rbuf_d + roffset,
                               (real *) sbuf_d + soffset,
-                              (int *) sdof_d + soffset,
-                              destRank, n, (uint64_t) iter,
+                              (size_t) n, destRank, (uint64_t) iter,
                               (uint64_t *) done_d + mype,
                               (uint64_t *) ready_d + destRank);
     CUDA_CHECK(cudaGetLastError());
@@ -86,8 +124,8 @@ extern "C" {
    * Wait until the slab from srcRank has landed (our local done_sig[srcRank]
    * reaches iter).
    */
-  void cuda_gs_pack_and_push_wait(cudaStream_t stream, int iter,
-                                  void *done_d, int srcRank)
+  void cuda_gs_push_wait(cudaStream_t stream, int iter,
+                         void *done_d, int srcRank)
   {
     pushShmemKernelWait<<<1,1,0,stream>>>((uint64_t) iter,
                                           (uint64_t *) done_d + srcRank);
@@ -104,30 +142,6 @@ extern "C" {
   {
     postReadyShmemKernel<<<1,1,0,stream>>>((uint64_t *) ready_d + mype,
                                            (uint64_t) iter, srcRank);
-    CUDA_CHECK(cudaGetLastError());
-  }
-
-  /**
-   * Fused nc-component pack-and-push. sbuf_d/rbuf_d are interleaved (nc per
-   * position); u_d is the compact shared buffer (component-outer, stride ns).
-   * Single-block launch, see cuda_gs_pack_and_push.
-   */
-  void cuda_gs_pack_and_push_vec(void *u_d, void *sbuf_d, void *sdof_d,
-                                 int soffset, int n, int nc, int ns,
-                                 cudaStream_t stream, int destRank,
-                                 void *rbuf_d, int roffset, int iter,
-                                 void *done_d, void *ready_d, int mype)
-  {
-    const int nthrds = 1024;
-
-    pack_pushShmemKernel_vec<real>
-      <<<1,nthrds,0,stream>>>((real *) u_d,
-                              (real *) rbuf_d + nc*roffset,
-                              (real *) sbuf_d + nc*soffset,
-                              (int *) sdof_d + soffset,
-                              destRank, n, nc, ns, (uint64_t) iter,
-                              (uint64_t *) done_d + mype,
-                              (uint64_t *) ready_d + destRank);
     CUDA_CHECK(cudaGetLastError());
   }
 #endif

--- a/src/gs/bcknd/device/cuda/gs_nvshmem_kernels.h
+++ b/src/gs/bcknd/device/cuda/gs_nvshmem_kernels.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2024-2025, The Neko Authors
+ Copyright (c) 2024-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -38,11 +38,11 @@
 #include <nvshmemx.h>
 
 /*
- * Fused pack-and-push kernels with rank-indexed signaling.
+ * Push kernels with rank-indexed signaling.
  *
  * Signaling uses two symmetric arrays of pe_size slots, indexed by the
- * REMOTE PE's rank (so peer lists need not be uniform in length or aligned
- * in order across ranks, and the symmetric allocations are collective-safe):
+ * REMOTE PE's rank (so peer lists need not be uniform in length across
+ * ranks, and the symmetric allocations are collective-safe):
  *  - doneSig  = &done_sig[my_rank] on the destination: set to iter by our
  *    put_signal when our slab has landed there.
  *  - readySlot = &ready_sig[destRank] locally: set to iter by the
@@ -50,51 +50,48 @@
  * The round counter iter advances once per gs op (lockstep across ranks),
  * and all waits use CMP_GE, so no cross-rank counter matching is needed.
  *
- * These are SINGLE-BLOCK kernels (launched with one block): the pack is a
- * block-stride loop, so the block-local __syncthreads() suffices to order
- * the pack before the put. A multi-block pack would race with the push --
- * there is no grid-wide barrier between pack and push. Single-block
- * transfers were also found to perform best.
+ * Packing is NOT done here: all peer slabs are packed by one bulk kernel
+ * on the main stream in nbsend, into the round's parity half of the
+ * double-buffered send buffer (see gs_device_shmem.F90). That orders every
+ * read of the shared buffer u before any unpack writes u. Packing inside
+ * the push kernel, gated on the remote ready signal, let an unpack from a
+ * fast peer modify u before the pack for a slow peer had read it -- for a
+ * dof shared with both peers the slow peer then received an already
+ * partially reduced value (observed as divergence at large rank counts,
+ * where multi-peer dofs and round-level skew are common).
  *
- * The ready wait comes BEFORE the pack: the destination posts ready(iter-1)
- * only after consuming our round iter-1 slab, which implies our previous
- * (non-blocking) put has fully drained src -- so the pack below can safely
- * overwrite it. Packing before this wait would race with a still-in-flight
- * nbi put on proxy-based transports.
+ * The ready wait below therefore gates only the put: the destination posts
+ * ready(iter-1) once it has consumed our round iter-1 slab, so its recv
+ * slab may be overwritten. The pack needs no remote gate; see the nbsend
+ * comment in gs_device_shmem.F90 for why the parity slab has always
+ * drained by the time it is repacked.
+ *
+ * These are SINGLE-BLOCK kernels (launched with one block); single-block
+ * transfers were found to perform best at gs slab sizes.
  */
 
 template< typename T >
-__global__ void pack_pushShmemKernel(const T * __restrict__ u,
-                                     T * dest,
-                                     T * __restrict__ src,
-                                     const int * __restrict__ dof,
-                                     const int destRank,
-                                     const int n,
-                                     uint64_t iter,
-                                     uint64_t * doneSig,
-                                     uint64_t * readySlot);
+__global__ void pushShmemKernel(T * dest,
+                                const T * __restrict__ src,
+                                const size_t n,
+                                const int destRank,
+                                uint64_t iter,
+                                uint64_t * doneSig,
+                                uint64_t * readySlot);
 
 template<>
-__global__ void pack_pushShmemKernel(const float * __restrict__ u,
-                                     float * dest,
-                                     float * __restrict__ src,
-                                     const int * __restrict__ dof,
-                                     const int destRank,
-                                     const int n,
-                                     uint64_t iter,
-                                     uint64_t * doneSig,
-                                     uint64_t * readySlot)
+__global__ void pushShmemKernel(float * dest,
+                                const float * __restrict__ src,
+                                const size_t n,
+                                const int destRank,
+                                uint64_t iter,
+                                uint64_t * doneSig,
+                                uint64_t * readySlot)
 {
 
   /* Wait until destRank has consumed our previous round (see note above) */
   if (threadIdx.x == 0) {
     nvshmem_signal_wait_until(readySlot, NVSHMEM_CMP_GE, iter - 1);
-  }
-  __syncthreads();
-
-  /* Pack with a block-stride loop (single-block kernel) */
-  for (int j = threadIdx.x; j < n; j += blockDim.x) {
-    src[j] = u[dof[j]-1];
   }
   __syncthreads();
 
@@ -105,26 +102,18 @@ __global__ void pack_pushShmemKernel(const float * __restrict__ u,
 }
 
 template<>
-__global__ void pack_pushShmemKernel(const double * __restrict__ u,
-                                     double * dest,
-                                     double * __restrict__ src,
-                                     const int * __restrict__ dof,
-                                     const int destRank,
-                                     const int n,
-                                     uint64_t iter,
-                                     uint64_t * doneSig,
-                                     uint64_t * readySlot)
+__global__ void pushShmemKernel(double * dest,
+                                const double * __restrict__ src,
+                                const size_t n,
+                                const int destRank,
+                                uint64_t iter,
+                                uint64_t * doneSig,
+                                uint64_t * readySlot)
 {
 
   /* Wait until destRank has consumed our previous round (see note above) */
   if (threadIdx.x == 0) {
     nvshmem_signal_wait_until(readySlot, NVSHMEM_CMP_GE, iter - 1);
-  }
-  __syncthreads();
-
-  /* Pack with a block-stride loop (single-block kernel) */
-  for (int j = threadIdx.x; j < n; j += blockDim.x) {
-    src[j] = u[dof[j]-1];
   }
   __syncthreads();
 
@@ -145,8 +134,8 @@ __global__ void pushShmemKernelWait(uint64_t iter,
 }
 
 /* Post our ready signal to the peer we receive from: sets
-   ready_sig[my_rank] = iter on srcRank, allowing it to overwrite its send
-   slab for the next round. Launched after the unpack on the same stream. */
+   ready_sig[my_rank] = iter on srcRank, allowing it to put its next round
+   into our recv slab. Launched after the unpack on the same stream. */
 __global__ void postReadyShmemKernel(uint64_t *readySlot,
                                      uint64_t iter,
                                      const int srcRank)
@@ -154,93 +143,6 @@ __global__ void postReadyShmemKernel(uint64_t *readySlot,
   if (blockIdx.x==0 && threadIdx.x == 0) {
     nvshmemx_signal_op(readySlot, iter, NVSHMEM_SIGNAL_SET, srcRank);
   }
-}
-
-/*
- * Fused nc-component pack-and-push (single-block, rank-indexed signaling,
- * see the scalar kernels above). u is the compact shared buffer,
- * component-outer with per-component stride ns; src/dest are interleaved
- * (nc per position). The pushed payload is nc*n elements.
- */
-template< typename T >
-__global__ void pack_pushShmemKernel_vec(const T * __restrict__ u,
-                                         T * dest,
-                                         T * __restrict__ src,
-                                         const int * __restrict__ dof,
-                                         const int destRank,
-                                         const int n,
-                                         const int nc,
-                                         const int ns,
-                                         uint64_t iter,
-                                         uint64_t * doneSig,
-                                         uint64_t * readySlot);
-
-template<>
-__global__ void pack_pushShmemKernel_vec(const float * __restrict__ u,
-                                         float * dest,
-                                         float * __restrict__ src,
-                                         const int * __restrict__ dof,
-                                         const int destRank,
-                                         const int n,
-                                         const int nc,
-                                         const int ns,
-                                         uint64_t iter,
-                                         uint64_t * doneSig,
-                                         uint64_t * readySlot)
-{
-
-  /* Wait until destRank has consumed our previous round */
-  if (threadIdx.x == 0) {
-    nvshmem_signal_wait_until(readySlot, NVSHMEM_CMP_GE, iter - 1);
-  }
-  __syncthreads();
-
-  /* Pack with a block-stride loop (single-block kernel) */
-  for (int j = threadIdx.x; j < n; j += blockDim.x) {
-    const int idx = dof[j] - 1;
-    for (int c = 0; c < nc; c++)
-      src[nc*j + c] = u[c*ns + idx];
-  }
-  __syncthreads();
-
-  /* Push data and set done_sig[my_rank] = iter on the destination */
-  nvshmemx_float_put_signal_nbi_block(dest, src, (size_t) nc * n,
-                                      doneSig, iter,
-                                      NVSHMEM_SIGNAL_SET, destRank);
-}
-
-template<>
-__global__ void pack_pushShmemKernel_vec(const double * __restrict__ u,
-                                         double * dest,
-                                         double * __restrict__ src,
-                                         const int * __restrict__ dof,
-                                         const int destRank,
-                                         const int n,
-                                         const int nc,
-                                         const int ns,
-                                         uint64_t iter,
-                                         uint64_t * doneSig,
-                                         uint64_t * readySlot)
-{
-
-  /* Wait until destRank has consumed our previous round */
-  if (threadIdx.x == 0) {
-    nvshmem_signal_wait_until(readySlot, NVSHMEM_CMP_GE, iter - 1);
-  }
-  __syncthreads();
-
-  /* Pack with a block-stride loop (single-block kernel) */
-  for (int j = threadIdx.x; j < n; j += blockDim.x) {
-    const int idx = dof[j] - 1;
-    for (int c = 0; c < nc; c++)
-      src[nc*j + c] = u[c*ns + idx];
-  }
-  __syncthreads();
-
-  /* Push data and set done_sig[my_rank] = iter on the destination */
-  nvshmemx_double_put_signal_nbi_block(dest, src, (size_t) nc * n,
-                                       doneSig, iter,
-                                       NVSHMEM_SIGNAL_SET, destRank);
 }
 
 #endif

--- a/src/gs/bcknd/device/gs_device_shmem.F90
+++ b/src/gs/bcknd/device/gs_device_shmem.F90
@@ -51,6 +51,10 @@ module gs_device_shmem
      integer, allocatable :: offset(:) !< Offset into buf
      integer, allocatable :: remote_offset(:) !< Offset into buf for remote rank
      integer :: total !< Total number of dofs
+     !> Elements per parity slab of buf_d (the global max dof count); the
+     !! stride of a buf_v_d parity slab is GS_VEC_NC times this. Send buffers
+     !! hold two parity slabs, recv buffers one (see nslabs in init).
+     integer :: slab_stride
      type(c_ptr) :: buf_d = C_NULL_PTR !< Device buffer
      type(c_ptr) :: buf_v_d = C_NULL_PTR !< Symmetric buffer, fused vector (x nc)
      type(c_ptr) :: dof_d = C_NULL_PTR !< Dof mapping for pack/unpack
@@ -76,9 +80,13 @@ module gs_device_shmem
      !! independent of the local peer count). done_sig(r) on our PE is set to
      !! iter by rank r's put_signal when its slab has landed in our recv
      !! buffer; ready_sig(r) on our PE is set to iter by rank r once it has
-     !! consumed our round-iter slab (so we may overwrite our send slab).
+     !! consumed our round-iter slab (so we may put into its recv slab again).
      type(c_ptr) :: done_sig_d = C_NULL_PTR
      type(c_ptr) :: ready_sig_d = C_NULL_PTR
+     !> Records the bulk pack on the main stream in nbsend; every per-peer
+     !! stream waits on it, ordering all reads of the shared buffer u before
+     !! any unpack write to u.
+     type(c_ptr) :: pack_event = C_NULL_PTR
    contains
      procedure, pass(this) :: init => gs_device_shmem_init
      procedure, pass(this) :: free => gs_device_shmem_free
@@ -113,25 +121,44 @@ module gs_device_shmem
   end interface
 
   interface
-     subroutine cuda_gs_pack_and_push(u_d, buf_d, dof_d, offset, n, stream, &
-          dest_rank, rbuf_d, roffset, iter, done_d, ready_d, mype) &
-          bind(c, name = 'cuda_gs_pack_and_push')
+     subroutine cuda_gs_nvshmem_pack(u_d, buf_d, dof_d, boffset, n, stream) &
+          bind(c, name = 'cuda_gs_nvshmem_pack')
        use, intrinsic :: iso_c_binding
        implicit none
-       integer(c_int), value :: n, offset, dest_rank, roffset, iter, mype
-       type(c_ptr), value :: u_d, buf_d, dof_d, stream, rbuf_d, done_d, &
-            ready_d
-     end subroutine cuda_gs_pack_and_push
+       integer(c_int), value :: boffset, n
+       type(c_ptr), value :: u_d, buf_d, dof_d, stream
+     end subroutine cuda_gs_nvshmem_pack
   end interface
 
   interface
-     subroutine cuda_gs_pack_and_push_wait(stream, iter, done_d, src_rank) &
-          bind(c, name = 'cuda_gs_pack_and_push_wait')
+     subroutine cuda_gs_nvshmem_pack_vec(u_d, buf_d, dof_d, boffset, n, nc, &
+          ns, stream) bind(c, name = 'cuda_gs_nvshmem_pack_vec')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int), value :: boffset, n, nc, ns
+       type(c_ptr), value :: u_d, buf_d, dof_d, stream
+     end subroutine cuda_gs_nvshmem_pack_vec
+  end interface
+
+  interface
+     subroutine cuda_gs_push(buf_d, offset, n, stream, dest_rank, rbuf_d, &
+          roffset, iter, done_d, ready_d, mype) &
+          bind(c, name = 'cuda_gs_push')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       integer(c_int), value :: n, offset, dest_rank, roffset, iter, mype
+       type(c_ptr), value :: buf_d, stream, rbuf_d, done_d, ready_d
+     end subroutine cuda_gs_push
+  end interface
+
+  interface
+     subroutine cuda_gs_push_wait(stream, iter, done_d, src_rank) &
+          bind(c, name = 'cuda_gs_push_wait')
        use, intrinsic :: iso_c_binding
        implicit none
        integer(c_int), value :: iter, src_rank
        type(c_ptr), value :: stream, done_d
-     end subroutine cuda_gs_pack_and_push_wait
+     end subroutine cuda_gs_push_wait
   end interface
 
   interface
@@ -155,19 +182,6 @@ module gs_device_shmem
   end interface
 
   interface
-     subroutine cuda_gs_pack_and_push_vec(u_d, buf_d, dof_d, offset, n, nc, &
-          ns, stream, dest_rank, rbuf_d, roffset, iter, done_d, ready_d, &
-          mype) bind(c, name = 'cuda_gs_pack_and_push_vec')
-       use, intrinsic :: iso_c_binding
-       implicit none
-       integer(c_int), value :: n, nc, ns, offset, dest_rank, roffset, iter
-       integer(c_int), value :: mype
-       type(c_ptr), value :: u_d, buf_d, dof_d, stream, rbuf_d, done_d, &
-            ready_d
-     end subroutine cuda_gs_pack_and_push_vec
-  end interface
-
-  interface
      subroutine cuda_gs_unpack_vec(u_d, op, buf_d, dof_d, offset, n, nc, ns, &
           stream) bind(c, name = 'cuda_gs_unpack_vec')
        use, intrinsic :: iso_c_binding
@@ -180,11 +194,17 @@ module gs_device_shmem
 
 contains
 
-  subroutine gs_device_shmem_buf_init(this, pe_order, dof_stack, mark_dupes)
+  !> @param nslabs number of parity slabs (2 for send buffers, which are
+  !! round-parity double-buffered so a slab is never repacked while a
+  !! previous non-blocking put may still be draining it; 1 for recv buffers,
+  !! whose overwrite is gated by the ready signal).
+  subroutine gs_device_shmem_buf_init(this, pe_order, dof_stack, mark_dupes, &
+       nslabs)
     class(gs_device_shmem_buf_t), intent(inout) :: this
     integer, allocatable, intent(inout) :: pe_order(:)
     type(stack_i4_t), allocatable, intent(inout) :: dof_stack(:)
     logical, intent(in) :: mark_dupes
+    integer, intent(in) :: nslabs
     integer, allocatable :: dofs(:)
     integer :: i, j, total, max_total
     integer(c_size_t) :: sz
@@ -211,12 +231,13 @@ contains
     call MPI_Allreduce(total, max_total, 1, MPI_INTEGER, MPI_MAX, NEKO_COMM)
 
     this%total = total
+    this%slab_stride = max_total
 
-    sz = c_sizeof(rp_dummy) * max_total
+    sz = c_sizeof(rp_dummy) * nslabs * max_total
 #ifdef HAVE_NVSHMEM
     call cudamalloc_nvshmem(this%buf_d, sz)
     ! Fused vector symmetric buffer, sized for up to GS_VEC_NC components.
-    sz = c_sizeof(rp_dummy) * GS_VEC_NC * max_total
+    sz = c_sizeof(rp_dummy) * nslabs * GS_VEC_NC * max_total
     call cudamalloc_nvshmem(this%buf_v_d, sz)
 #endif
 
@@ -288,8 +309,24 @@ contains
 
     call this%init_order(send_pe, recv_pe)
 
-    call this%send_buf%init(this%send_pe, this%send_dof, .false.)
-    call this%recv_buf%init(this%recv_pe, this%recv_dof, .true.)
+    ! The gs schedule registers every sharing peer for both directions, so
+    ! the two lists are identical and index-aligned. Both the per-peer
+    ! stream reuse below (stream(i) serves send_pe(i) and recv_pe(i)) and
+    ! the ungated repack of the parity send slab in nbsend (see there)
+    ! depend on this; fail loudly if a future schedule breaks it.
+    if (size(this%send_pe) .ne. size(this%recv_pe)) then
+       call neko_error('gs_device_shmem requires symmetric peer lists')
+    end if
+    do i = 1, size(this%send_pe)
+       if (this%send_pe(i) .ne. this%recv_pe(i)) then
+          call neko_error('gs_device_shmem requires aligned peer lists')
+       end if
+    end do
+
+    ! Send buffers are parity double-buffered (nslabs = 2), recv buffers
+    ! single (nslabs = 1); see gs_device_shmem_buf_init.
+    call this%send_buf%init(this%send_pe, this%send_dof, .false., 2)
+    call this%recv_buf%init(this%recv_pe, this%recv_dof, .true., 1)
 
     ! Exchange, for every send peer, the offset in the receiver's recv buffer
     ! where our slab must land. A single Alltoall keeps the exchange
@@ -327,6 +364,8 @@ contains
     do i = 1, nstrm
        call device_event_create(this%event(i), 2)
     end do
+
+    call device_event_create(this%pack_event, 2)
 
 #ifdef HAVE_NVSHMEM
     ! Rank-indexed symmetric signal arrays; zero-initialised by
@@ -380,6 +419,11 @@ contains
        end do
        deallocate(this%event)
     end if
+
+    if (c_associated(this%pack_event)) then
+       call device_event_destroy(this%pack_event)
+       this%pack_event = C_NULL_PTR
+    end if
 #endif
 
   end subroutine gs_device_shmem_free
@@ -392,22 +436,47 @@ contains
     integer, intent(in) :: tag
     type(c_ptr), intent(inout) :: deps
     type(c_ptr), intent(inout) :: strm
-    integer :: i
+    integer :: i, parity
     type(c_ptr) :: u_d
 
     u_d = device_get_ptr(u)
 
-    ! Order each per-peer stream after the gather (deps); the pack-and-push
-    ! kernels in nbwait are stream-ordered behind this wait. The historic
-    ! host-side device_sync here papered over a send-buffer reuse race: the
-    ! pack-and-push kernel used to overwrite the send buffer BEFORE its
-    ! ready handshake, while the previous round's non-blocking put could
-    ! still be draining it. The kernel now performs the handshake before
-    ! packing (see gs_nvshmem_kernels.h), which closes that race properly,
-    ! so no host synchronisation is needed.
+#ifdef HAVE_NVSHMEM
+    ! One round counter per gs op; advanced here so nbsend and nbwait agree
+    ! on the round's parity slab. The rank-indexed signal slots make the
+    ! exchange independent of peer counts and peer-list ordering.
+    this%iter = this%iter + 1
+    parity = mod(this%iter, 2)
+
+    ! Bulk-pack every peer's slab on the main stream, ordered after the
+    ! gather (deps), BEFORE any per-peer work. This orders all reads of the
+    ! shared buffer u before any unpack write to u. Packing inside the push
+    ! kernel, gated on the peer's ready signal, let an unpack from a fast
+    ! peer modify u before the pack for a slow peer had read it, so a dof
+    ! shared with both peers reached the slow peer already partially
+    ! reduced (divergence at large rank counts, where multi-peer dofs and
+    ! round-level skew are common).
+    !
+    ! The pack needs no remote gate: the parity slab was last put in round
+    ! iter-2, and this pack is stream-ordered (via strm's event joins at
+    ! the end of the previous nbwait) after the unpack of every peer's
+    ! round iter-1 slab. Peer i putting its round iter-1 slab here implies,
+    ! by stream order on peer i -- its push to us and its unpack of our
+    ! data run on one stream, since peer lists are index-aligned (checked
+    ! in init) -- that peer i consumed our round iter-2 slab, which in turn
+    ! implies that put has drained the parity slab.
+    call device_stream_wait_event(strm, deps, 0)
+    call cuda_gs_nvshmem_pack(u_d, this%send_buf%buf_d, &
+         this%send_buf%dof_d, parity * this%send_buf%slab_stride, &
+         this%send_buf%total, strm)
+    call device_event_record(this%pack_event, strm)
+
+    ! Order each per-peer stream after the pack; the push kernels in nbwait
+    ! read the packed parity slab.
     do i = 1, size(this%send_pe)
-       call device_stream_wait_event(this%stream(i), deps, 0)
+       call device_stream_wait_event(this%stream(i), this%pack_event, 0)
     end do
+#endif
 
     ! We do the rest in the "wait" routine below
 
@@ -429,23 +498,19 @@ contains
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
     type(c_ptr), intent(inout) :: strm
-    integer :: op, done_req, i
+    integer :: op, done_req, i, parity
     type(c_ptr) :: u_d
 
     u_d = device_get_ptr(u)
 #ifdef HAVE_NVSHMEM
-    ! One round counter per gs op; the rank-indexed signal slots make the
-    ! exchange independent of peer counts and peer-list ordering.
-    this%iter = this%iter + 1
+    parity = mod(this%iter, 2)
 
-    ! Push our slab to every send peer. The kernel waits for the peer's
-    ! ready signal (previous round consumed) before overwriting the send
-    ! slab, then puts with a done signal.
+    ! Push the packed parity slab to every send peer. The kernel waits for
+    ! the peer's ready signal (previous round consumed, so its recv slab is
+    ! free) before the put; the pack already happened in nbsend.
     do i = 1, size(this%send_pe)
-       call cuda_gs_pack_and_push(u_d, &
-            this%send_buf%buf_d, &
-            this%send_buf%dof_d, &
-            this%send_buf%offset(i), &
+       call cuda_gs_push(this%send_buf%buf_d, &
+            parity * this%send_buf%slab_stride + this%send_buf%offset(i), &
             this%send_buf%ndofs(i), &
             this%stream(i), &
             this%send_pe(i), &
@@ -457,7 +522,7 @@ contains
     ! For every recv peer: wait until its slab has landed, reduce it into u,
     ! then post our ready signal so the peer may start its next round.
     do done_req = 1, size(this%recv_pe)
-       call cuda_gs_pack_and_push_wait(this%stream(done_req), this%iter, &
+       call cuda_gs_push_wait(this%stream(done_req), this%iter, &
             this%done_sig_d, this%recv_pe(done_req))
        call cuda_gs_unpack(u_d, op, &
             this%recv_buf%buf_d, &
@@ -479,8 +544,9 @@ contains
   end subroutine gs_device_shmem_nbwait
 
   !> Fused nc-component send. @a u is the compact shared device buffer
-  !! (component-outer, per-component stride n = nshared). All the work is done
-  !! in nbwait_vec; this only orders against the packing dependencies.
+  !! (component-outer, per-component stride n = nshared). Bulk-packs the
+  !! parity slab of the fused vector send buffer; see gs_device_shmem_nbsend
+  !! for the ordering and parity-slab rationale.
   subroutine gs_device_shmem_nbsend_vec(this, u, n, nc, tag, deps, strm)
     class(gs_device_shmem_t), intent(inout) :: this
     integer, intent(in) :: n, nc
@@ -488,13 +554,30 @@ contains
     integer, intent(in) :: tag
     type(c_ptr), intent(inout) :: deps
     type(c_ptr), intent(inout) :: strm
-    integer :: i
+    integer :: i, parity
+    type(c_ptr) :: u_d
 
-    ! Order each per-peer stream after the gather/copies (deps); no host
-    ! synchronisation needed, see gs_device_shmem_nbsend.
+    u_d = device_get_ptr(u)
+
+#ifdef HAVE_NVSHMEM
+    ! Shared round counter with the scalar path; all ranks execute the same
+    ! op sequence, so counters stay in lockstep.
+    this%iter = this%iter + 1
+    parity = mod(this%iter, 2)
+
+    call device_stream_wait_event(strm, deps, 0)
+    call cuda_gs_nvshmem_pack_vec(u_d, this%send_buf%buf_v_d, &
+         this%send_buf%dof_d, &
+         parity * GS_VEC_NC * this%send_buf%slab_stride, &
+         this%send_buf%total, nc, n, strm)
+    call device_event_record(this%pack_event, strm)
+
+    ! Order each per-peer stream after the pack; the push kernels in
+    ! nbwait_vec read the packed parity slab.
     do i = 1, size(this%send_pe)
-       call device_stream_wait_event(this%stream(i), deps, 0)
+       call device_stream_wait_event(this%stream(i), this%pack_event, 0)
     end do
+#endif
 
   end subroutine gs_device_shmem_nbsend_vec
 
@@ -504,40 +587,38 @@ contains
     integer, intent(in) :: tag, nc
   end subroutine gs_device_shmem_nbrecv_vec
 
-  !> Fused nc-component pack-and-push + unpack.
+  !> Fused nc-component push + unpack (the pack happens in nbsend_vec).
   subroutine gs_device_shmem_nbwait_vec(this, u, n, nc, op, strm)
     class(gs_device_shmem_t), intent(inout) :: this
     integer, intent(in) :: n, nc
     real(kind=rp), dimension(nc*n), intent(inout) :: u
     type(c_ptr), intent(inout) :: strm
-    integer :: op, done_req, i
+    integer :: op, done_req, i, parity
     type(c_ptr) :: u_d
 
     u_d = device_get_ptr(u)
 #ifdef HAVE_NVSHMEM
-    ! One round counter per gs op (shared with the scalar path; all ranks
-    ! execute the same op sequence, so counters stay in lockstep).
-    this%iter = this%iter + 1
+    parity = mod(this%iter, 2)
 
-    ! Push our nc-component slab to every send peer.
+    ! Push the packed nc-component parity slab to every send peer. Offsets
+    ! and counts are in elements (nc values per packed position); the recv
+    ! buffer holds a single slab, so only the local parity offset applies.
     do i = 1, size(this%send_pe)
-       call cuda_gs_pack_and_push_vec(u_d, &
-            this%send_buf%buf_v_d, &
-            this%send_buf%dof_d, &
-            this%send_buf%offset(i), &
-            this%send_buf%ndofs(i), &
-            nc, n, &
+       call cuda_gs_push(this%send_buf%buf_v_d, &
+            parity * GS_VEC_NC * this%send_buf%slab_stride &
+            + nc * this%send_buf%offset(i), &
+            nc * this%send_buf%ndofs(i), &
             this%stream(i), &
             this%send_pe(i), &
             this%recv_buf%buf_v_d, &
-            this%send_buf%remote_offset(i), &
+            nc * this%send_buf%remote_offset(i), &
             this%iter, this%done_sig_d, this%ready_sig_d, pe_rank)
     end do
 
     ! For every recv peer: wait until its slab has landed, reduce it into u,
     ! then post our ready signal so the peer may start its next round.
     do done_req = 1, size(this%recv_pe)
-       call cuda_gs_pack_and_push_wait(this%stream(done_req), this%iter, &
+       call cuda_gs_push_wait(this%stream(done_req), this%iter, &
             this%done_sig_d, this%recv_pe(done_req))
        call cuda_gs_unpack_vec(u_d, op, &
             this%recv_buf%buf_v_d, &


### PR DESCRIPTION
At large rank counts the NVSHMEM gather-scatter backend diverges. The fused pack-and-push kernel gates its pack on the peer's ready signal, so the read of the shared buffer for a slow peer can be delayed past an unpack from a fast peer, which reduces into the same buffer on a concurrent stream. A dof shared with both peers then reaches the slow peer already partially reduced, double-counting contributions. The race needs dofs shared with several peers plus round-level skew between ranks, so it only shows up at scale.

This change packs all peer slabs with one bulk kernel on the main stream in `nbsend`, before any per-peer work, ordering every read of the shared buffer ahead of any unpack write. Send buffers become round-parity double-buffered so the pack needs no remote gate (stream ordering guarantees the parity slab has drained), and the ready signal now gates only the put. Signal protocol, recv buffering, and the single-block put path are unchanged.