### PR TITLE
overwriting of lgenc is pached in mesh.f90 by preserving the already set value

### DIFF
--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -194,9 +194,16 @@ contains
     integer, intent(in) :: gdim !< Geometric dimension
     integer, intent(in) :: nelv !< Local number of elements
     integer :: ierr
+    logical :: lgenc
     character(len=LOG_SIZE) :: log_buf
 
+    ! Preserve the caller's connectivity-generation choice across free(), which
+    ! resets lgenc to its .true. default (see mesh_free). Without this, setting
+    ! `msh%lgenc = .false.` before init has no effect, and connectivity is always
+    ! generated.
+    lgenc = this%lgenc
     call this%free()
+    this%lgenc = lgenc
 
     this%nelv = nelv
     this%gdim = gdim
@@ -222,9 +229,14 @@ contains
     class(mesh_t), intent(inout) :: this !< Mesh
     integer, intent(in) :: gdim !< Geometric dimension
     type(linear_dist_t), intent(in) :: dist !< Data distribution
+    logical :: lgenc
     character(len=LOG_SIZE) :: log_buf
 
+    ! Preserve the caller's connectivity-generation choice across free()
+    ! (see mesh_init_nelv / mesh_free).
+    lgenc = this%lgenc
     call this%free()
+    this%lgenc = lgenc
 
     this%nelv = dist%num_local()
     if (this%nelv < 1) then


### PR DESCRIPTION
## The fix

Preserve the caller's `lgenc` across the internal `free()` in both `mesh_init`
entry points — capture it before `call this%free()`, restore it after — so that
setting `msh%lgenc = .false.` before `init` finally takes effect. Two subroutines
in `src/mesh/mesh.f90`, ~6 lines each; the three tools need **no change** (their
existing `lgenc = .false.` lines now work).

Explicit `mesh_free()` still resets `lgenc` to the default, so no other code path
changes: a freshly declared mesh defaults to `.true.` and generates connectivity
exactly as before; the redistribution path (`mesh_free` then `mesh_init`) also
preserves `.true.` because the mesh being redistributed carries connectivity.

## Verification

**Rebuilt and compared against the pre-patch binary.** `neko` + `genmeshbox` were
built with and without the patch and run on three boxes — `18×18×18` (1 periodic
direction), `8×8×8` (3 periodic), `5×5×1` (2 periodic). Results:

- The patch **builds cleanly** (`make -j`, no new warnings) and `genmeshbox` runs
  to completion.
- The **triply-periodic** output is **byte-for-byte identical** (same md5).
- The other two differ **only** in the `glb_pt_ids` field of **type-7 (labeled)
  boundary-zone records** — and those bytes are **pre-existing uninitialised
  memory, not a patch effect**: the writer never assigns `glb_pt_ids` for labeled
  zones (only type-5/periodic zones get it), the reader never reads it for type-7
  zones, and **the same binary produces different bytes there run-to-run**. Zeroing
  that one field makes all three cases byte-identical, patched vs. unpatched.

So the patch is **output-preserving** — full geometry and every meaningful zone
field are unchanged; the connectivity it stops building was never part of the
output.

> Incidental finding (independent of this PR): Neko's `.nmsh` writer leaves the
> `glb_pt_ids` field of labeled (type-7) zones uninitialised, so those bytes are
> non-deterministic run-to-run. Harmless (the reader ignores them for type-7), but
> worth zeroing for reproducible mesh files.

- **Memory.** With the patch, `genmeshbox`/`rea2nbin`/`prepart` no longer allocate
  `htf`/`hte`/`facet_map`/`point_neigh`; peak memory drops accordingly (for a large
  box, from the multi-hundred-GB connectivity build down to the point-table +
  element storage).

## Scope

- Files changed: `src/mesh/mesh.f90` (`mesh_init_nelv`, `mesh_init_dist`).
- Behaviour change limited to callers that explicitly set `lgenc = .false.` before
  `init`; all other callers are unaffected.

***Note:*** this was copy pasted from my dear friend :-) 