### PR TITLE
Fix OIFS advection on device backends

### DIFF
--- a/src/.depends
+++ b/src/.depends
@@ -119,7 +119,7 @@ math/operators.lo : math/operators.f90 common/log.lo comm/comm.lo math/vector.lo
 math/bcknd/cpu/opr_cpu.lo : math/bcknd/cpu/opr_cpu.f90 math/mathops.lo sem/interpolation.lo gs/gather_scatter.lo math/math.lo sem/coef.lo sem/space.lo config/num_types.lo 
 math/bcknd/sx/opr_sx.lo : math/bcknd/sx/opr_sx.f90 math/mathops.lo math/math.lo sem/coef.lo sem/space.lo config/num_types.lo sem/interpolation.lo gs/gather_scatter.lo 
 math/bcknd/xsmm/opr_xsmm.lo : math/bcknd/xsmm/opr_xsmm.F90 math/mathops.lo gs/gather_scatter.lo sem/interpolation.lo mesh/mesh.lo math/math.lo sem/coef.lo sem/space.lo math/mxm_wrapper.lo config/num_types.lo 
-math/bcknd/device/opr_device.lo : math/bcknd/device/opr_device.F90 math/bcknd/device/device_mathops.lo math/bcknd/device/device_math.lo sem/interpolation.lo common/utils.lo field/field.lo sem/coef.lo sem/space.lo device/device.lo config/num_types.lo gs/gather_scatter.lo 
+math/bcknd/device/opr_device.lo : math/bcknd/device/opr_device.F90 math/bcknd/device/device_mathops.lo math/bcknd/device/device_math.lo sem/interpolation.lo common/utils.lo registries/scratch_registry.lo math/vector.lo field/field.lo sem/coef.lo sem/space.lo device/device.lo config/num_types.lo gs/gather_scatter.lo 
 math/tensor.lo : math/tensor.f90 device/device.lo config/neko_config.lo math/mxm_wrapper.lo config/num_types.lo math/bcknd/device/tensor_device.lo math/bcknd/sx/tensor_sx.lo math/bcknd/cpu/tensor_cpu.lo math/bcknd/xsmm/tensor_xsmm.lo 
 math/bcknd/cpu/tensor_cpu.lo : math/bcknd/cpu/tensor_cpu.f90 math/mxm_wrapper.lo config/num_types.lo 
 math/bcknd/sx/tensor_sx.lo : math/bcknd/sx/tensor_sx.f90 math/mxm_wrapper.lo config/num_types.lo 

--- a/src/common/time_interpolator.f90
+++ b/src/common/time_interpolator.f90
@@ -135,10 +135,20 @@ contains
     type(c_ptr) :: f_interpolated_d
     integer :: i, l
 
-    real(kind=rp), dimension(0:this%order - 1) :: wt
+    ! Weights for up to three interpolation points; during time-scheme
+    ! start-up this%order < 3 and the weights of the missing lag
+    ! fields must stay zero
+    real(kind=rp), dimension(0:2) :: wt
+
+    if (this%order .gt. 3) then
+       call neko_error("Time interpolation of required order &
+       &is not implemented")
+    end if
+
     wt = 0
 
-    call fd_weights_full(t, tlag, this%order - 1, 0, wt) ! interpolation weights
+    ! interpolation weights
+    call fd_weights_full(t, tlag, this%order - 1, 0, wt(0:this%order - 1))
 
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_add4s3(f_interpolated%x_d, f_n%f%x_d, f_n%lf(1)%x_d, &

--- a/src/math/bcknd/device/opr_device.F90
+++ b/src/math/bcknd/device/opr_device.F90
@@ -34,10 +34,12 @@
 module opr_device
   use gather_scatter, only : GS_OP_ADD
   use num_types, only : rp, c_rp, i8
-  use device, only : device_get_ptr, device_event_sync, device_map, device_unmap
+  use device, only : device_get_ptr, device_event_sync
   use space, only : space_t
   use coefs, only : coef_t
   use field, only : field_t
+  use vector, only : vector_t
+  use scratch_registry, only : neko_scratch_registry
   use utils, only : neko_error
   use interpolation, only : interpolator_t
   use device_math, only : device_sub3, device_rzero, device_copy, device_col2, &
@@ -777,18 +779,20 @@ contains
     real(kind=rp), intent(inout) :: &
          du(Xh_GLL%lx, Xh_GLL%ly, Xh_GLL%lz, coef_GL%msh%nelv)
     type(c_ptr) :: cr_d, cs_d, ct_d, u_d
-    real(kind=rp) :: ud(Xh_GL%lx*Xh_GL%lx*Xh_GL%lx)
-    type(c_ptr) :: du_d, ud_d
+    type(vector_t), pointer :: ud
+    type(c_ptr) :: du_d
+    integer :: temp_index
     integer :: n_GL, n_GLL
 
     n_GL = coef_GL%msh%nelv * Xh_GL%lxyz
     n_GLL = coef_GL%msh%nelv * Xh_GLL%lxyz
 
-    call device_map(ud, ud_d, n_GL)
+    call neko_scratch_registry%request_vector(ud, temp_index, n_GL, .false.)
 
     du_d = device_get_ptr(du)
 
-    associate(Xh => Xh_GL, nelv => coef_GL%msh%nelv, lx => Xh_GL%lx)
+    associate(Xh => Xh_GL, nelv => coef_GL%msh%nelv, lx => Xh_GL%lx, &
+         ud_d => ud%x_d)
 #ifdef HAVE_HIP
       call hip_convect_scalar(ud_d, u_d, cr_d, cs_d, ct_d, &
            Xh%dx_d, Xh%dy_d, Xh%dz_d, nelv, lx)
@@ -805,13 +809,13 @@ contains
       call neko_error('No device backend configured')
 #endif
 
-      call GLL_to_GL%map(du, ud, nelv, Xh_GLL)
+      call GLL_to_GL%map(du, ud%x, nelv, Xh_GLL)
       call coef_GLL%gs_h%op(du, n_GLL, GS_OP_ADD)
       call device_col2(du_d, coef_GLL%Binv_d, n_GLL)
 
     end associate
 
-    call device_unmap(ud, ud_d)
+    call neko_scratch_registry%relinquish(temp_index)
 
   end subroutine opr_device_convect_scalar
 


### PR DESCRIPTION
Fixes several issues in the OIFS device path that made it crash, and slow:

- **Uninitialized buffer size in `opr_device_convect_scalar`**: a copy-paste error assigned `n_GLL` twice, leaving `n_GL` uninitialized when used as the `device_map` size — broken since the device OIFS implementation in #2036.
- **Per-call device allocation in `opr_device_convect_scalar`**: the GL work buffer was a `lx³`-sized stack array mapped/unmapped on every call (claiming `n_GL` elements), costing a synchronizing `cudaMalloc`/`cudaFree` pair per RK stage — ~72 per timestep for the fluid with BDF3. Replaced with a scratch-registry vector, allocated once and reused.
- **Out-of-bounds interpolation weights during time-scheme start-up**: `time_interpolator_scalar` sized `wt(0:order-1)` but always reads `wt(1)`/`wt(2)`, so the first two steps of any OIFS run (`ndiff` = 1, 2) blended lag fields with garbage weights, on all backends. Weights are now fixed at three entries and zero-filled, so missing lag fields contribute exactly zero.

No changes to numerics beyond removing the undefined start-up behaviour.