### PR TITLE
fixed stale facet-normals in pressure surface terms (ALE-rotation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Develop
 
+- Fixed stale facet-normals in fluid_pnpn pressure surface terms.
+  This was only affecting ALE simulations containing rotations.
 - *BREAKING* Changed the size of mesh velocity lag arrays in ALE to 2. 
   Old ALE restart files (before this commit) should not be used anymore. 
   Non-ALE restart files are totally unaffected.

--- a/src/bc/facet_normal.f90
+++ b/src/bc/facet_normal.f90
@@ -53,6 +53,7 @@ module facet_normal
   !> Dirichlet condition in facet normal direction
   type, public, extends(bc_t) :: facet_normal_t
      integer, allocatable :: unique_mask(:)
+     integer, allocatable :: msk_to_unique(:)
      type(c_ptr) :: unique_mask_d = c_null_ptr
      type(vector_t) :: nx, ny, nz, work
    contains
@@ -63,6 +64,8 @@ module facet_normal
      procedure, pass(this) :: apply_surfvec => facet_normal_apply_surfvec
      procedure, pass(this) :: apply_surfvec_dev => &
           facet_normal_apply_surfvec_dev
+     ! > Recompute normals
+     procedure, pass(this) :: recompute_normals => facet_normal_recompute_normals
      !> Constructor.
      procedure, pass(this) :: init => facet_normal_init
      !> Constructor from components.
@@ -217,6 +220,7 @@ contains
        end if
        deallocate(this%unique_mask)
     end if
+    if (allocated(this%msk_to_unique)) deallocate(this%msk_to_unique)
 
     call this%nx%free()
     call this%ny%free()
@@ -257,6 +261,7 @@ contains
        end if
        deallocate(this%unique_mask)
     end if
+    if (allocated(this%msk_to_unique)) deallocate(this%msk_to_unique)
 
     call unique_point_idx%init(this%msk(0), htable_data)
     j = 0
@@ -276,6 +281,7 @@ contains
        call this%work%init(unique_point_idx%num_entries())
     end if
     allocate(this%unique_mask(0:unique_point_idx%num_entries()))
+    allocate(this%msk_to_unique(this%msk(0)))
 
     this%unique_mask(0) = unique_point_idx%num_entries()
     do i = 1, this%unique_mask(0)
@@ -287,6 +293,9 @@ contains
        rcode = unique_point_idx%get(this%msk(i), htable_data)
        if (rcode .ne. 0) call neko_error("Facet normal: htable get failed.")
        this%unique_mask(htable_data) = this%msk(i)
+
+       ! Save the slot so recompute_normals can use it without the hash table.
+       this%msk_to_unique(i) = htable_data
        facet = this%facet(i)
 
        idx = nonlinear_index(this%msk(i), this%Xh%lx, this%Xh%lx, this%Xh%lx)
@@ -315,5 +324,44 @@ contains
     call unique_point_idx%free()
 
   end subroutine facet_normal_finalize
+
+  !> Recompute area-weighted normals from the current mesh.
+  subroutine facet_normal_recompute_normals(this)
+    class(facet_normal_t), target, intent(inout) :: this
+    integer :: i, htable_data, idx(4), facet
+    real(kind=rp) :: area, normal(3)
+
+    if (.not. allocated(this%unique_mask)) return
+    if (this%unique_mask(0) .eq. 0) return
+
+    do i = 1, this%unique_mask(0)
+       this%nx%x(i) = 0.0_rp
+       this%ny%x(i) = 0.0_rp
+       this%nz%x(i) = 0.0_rp
+    end do
+
+    do i = 1, this%msk(0)
+       htable_data = this%msk_to_unique(i)
+       facet = this%facet(i)
+
+       idx = nonlinear_index(this%msk(i), this%Xh%lx, this%Xh%lx, this%Xh%lx)
+       normal = this%coef%get_normal(idx(1), idx(2), idx(3), idx(4), facet)
+       area = this%coef%get_area(idx(1), idx(2), idx(3), idx(4), facet)
+       normal = normal * area !Scale normal by area
+       this%nx%x(htable_data) = this%nx%x(htable_data) + normal(1)
+       this%ny%x(htable_data) = this%ny%x(htable_data) + normal(2)
+       this%nz%x(htable_data) = this%nz%x(htable_data) + normal(3)
+    end do
+
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_memcpy(this%nx%x, this%nx%x_d, &
+            this%nx%size(), HOST_TO_DEVICE, sync = .false.)
+       call device_memcpy(this%ny%x, this%ny%x_d, &
+            this%ny%size(), HOST_TO_DEVICE, sync = .false.)
+       call device_memcpy(this%nz%x, this%nz%x_d, &
+            this%nz%size(), HOST_TO_DEVICE, sync = .true.)
+    end if
+
+  end subroutine facet_normal_recompute_normals
 
 end module facet_normal

--- a/src/fluid/fluid_pnpn.f90
+++ b/src/fluid/fluid_pnpn.f90
@@ -557,7 +557,10 @@ contains
     end if
 
     call this%ale%sync_chkp(this%c_Xh, this%Xh, this%adv, chkp, this%gs_Xh)
-
+    if (this%ale%active) then
+       call this%bc_prs_surface%recompute_normals()
+       call this%bc_sym_surface%recompute_normals()
+    end if
 
   end subroutine fluid_pnpn_restart
 
@@ -783,6 +786,9 @@ contains
          ! Update the metrics used by the adv operator for delaiasing (coef_GL)
          ! Maps the updated coef_GLL to coef_GL.
          call this%adv%recompute_metrics(c_Xh, .true.)
+
+         call this%bc_prs_surface%recompute_normals()
+         call this%bc_sym_surface%recompute_normals()
          call profiler_end_region('ALE recompute metrics')
       end if
 


### PR DESCRIPTION
In facet_normal_t, normal vectors are only initialized once, and they are not linked to normals from coef. 
So for ALE problems involving rotation, it was giving wrong results since `this%bc_prs_surface` in `prs_res%compute` was using stale normal vectors. This PR  fixes the problem. 

I also put the recompute_normals for `symmetry`. Right now, symmetry BCs should be axis aligned, so their normal vectors do not change. But I put it their so in future we won't forget to fix that when we have non-axis aligned BCs.