### PR TITLE
Fix cuda issue when using dealiasing for P > 9

### DIFF
--- a/src/math/bcknd/device/cuda/tensor.cu
+++ b/src/math/bcknd/device/cuda/tensor.cu
@@ -63,12 +63,18 @@ extern "C" {
     break
 
 #define CASE_LARGE(N)                                                        \
-    case N:                                                                  \
+    case N: {                                                                \
+    const size_t shmem_size = 2 * N * N * N * sizeof(real);                  \
+    CUDA_CHECK(cudaFuncSetAttribute(tnsr3d_kernel_large<real, N>,            \
+                                    cudaFuncAttributeMaxDynamicSharedMemorySize, \
+                                    shmem_size));                            \
     tnsr3d_kernel_large<real, N>                                             \
-      <<<nblcks, nthrds, 0, stream>>>((real *) v, *nv,                       \
-                                      (real *) u, *nu,                       \
-                                      (real *) A, (real *) Bt, (real *) Ct); \
+      <<<nblcks, nthrds, shmem_size, stream>>>((real *) v, *nv,              \
+                                               (real *) u, *nu,              \
+                                               (real *) A, (real *) Bt,      \
+                                               (real *) Ct);                 \
     CUDA_CHECK(cudaGetLastError());                                          \
+    }                                                                        \
     break
 
     switch(n) {

--- a/src/math/bcknd/device/cuda/tensor.cu
+++ b/src/math/bcknd/device/cuda/tensor.cu
@@ -42,6 +42,17 @@
      __typeof__ (b) _b = (b);   \
      _a > _b ? _a : _b; })
 
+template<const int N>
+static void set_tnsr3d_large_shmem_attr(const size_t shmem_size) {
+  static bool is_set = false;
+
+  if (!is_set) {
+    CUDA_CHECK(cudaFuncSetAttribute(tnsr3d_kernel_large<real, N>,
+                                    cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                    shmem_size));
+    is_set = true;
+  }
+}
 
 extern "C" {
 
@@ -65,9 +76,7 @@ extern "C" {
 #define CASE_LARGE(N)                                                        \
     case N: {                                                                \
     const size_t shmem_size = 2 * N * N * N * sizeof(real);                  \
-    CUDA_CHECK(cudaFuncSetAttribute(tnsr3d_kernel_large<real, N>,            \
-                                    cudaFuncAttributeMaxDynamicSharedMemorySize, \
-                                    shmem_size));                            \
+    set_tnsr3d_large_shmem_attr<N>(shmem_size);                              \
     tnsr3d_kernel_large<real, N>                                             \
       <<<nblcks, nthrds, shmem_size, stream>>>((real *) v, *nv,              \
                                                (real *) u, *nu,              \

--- a/src/math/bcknd/device/cuda/tensor_kernel.h
+++ b/src/math/bcknd/device/cuda/tensor_kernel.h
@@ -159,8 +159,9 @@ __global__ void tnsr3d_kernel_large(T  * __restrict__  v,
                                     const T * __restrict__ A,
                                     const T * __restrict__ Bt,
                                     const T * __restrict__ Ct) {
-  extern __shared__ T shwork[];
-  T *shwork2 = shwork + N*N*N;
+  extern __shared__ T shmem[];
+  T *shwork = shmem;
+  T *shwork2 = shmem + N*N*N;
   
   const int idx = threadIdx.x;
   const int str = blockDim.x;

--- a/src/math/bcknd/device/cuda/tensor_kernel.h
+++ b/src/math/bcknd/device/cuda/tensor_kernel.h
@@ -159,8 +159,8 @@ __global__ void tnsr3d_kernel_large(T  * __restrict__  v,
                                     const T * __restrict__ A,
                                     const T * __restrict__ Bt,
                                     const T * __restrict__ Ct) {
-  __shared__ T shwork[N*N*N];
-  T shwork2[N*N*N];
+  extern __shared__ T shwork[];
+  T *shwork2 = shwork + N*N*N;
   
   const int idx = threadIdx.x;
   const int str = blockDim.x;


### PR DESCRIPTION
Algorithmically it makes no difference. However, cuda has some memory management issues when the local shwork2 gets too large (maybe @njansson knows much more). The fix here is to allocate a global array and use it with offset for each thread. For the sake of code consistency, work1 is also allocated in this way instead of declared in the kernel. The result is shown by a cylinder case at Re=100 and t=2.0
Before the fix:
<img width="1024" height="966" alt="before0000" src="https://github.com/user-attachments/assets/d2832eae-033d-418f-83be-38fb3874e0a4" />

 After the fix:
<img width="1024" height="966" alt="after0000" src="https://github.com/user-attachments/assets/d06e7c9c-5a2b-45ed-9e31-904d807d828c" />


