### PR TITLE
Add `*_light` contrib tools: low-memory, standalone mesh utilities

### DIFF
--- a/contrib/README_neko_light_tools.md
+++ b/contrib/README_neko_light_tools.md
@@ -1,0 +1,44 @@
+```text
+     _  __  ____  __ __  ____
+    / |/ / / __/ / //_/ / __ \
+   /    / / _/  / ,<   / /_/ /
+  /_/|_/ /___/ /_/|_|  \____/
+```
+
+# Neko light tools
+
+Five standalone, CPU-only companions to Neko's `contrib/` tools. Each folder is
+self-contained (tool + validation harness + Makefile + doc) and is designed to
+sit at `contrib/<tool>/` inside a Neko source checkout, so that `make check` can
+find the meshes shipped with Neko (`../../examples`, `../../tests`). Using the
+tools on your own meshes needs no Neko tree at all.
+
+The common idea: Neko's own `contrib` tools build a full `mesh_t` through Neko's
+general-purpose, production data structures — robust and reused everywhere, but
+memory-hungry on large meshes, and CPU-only (so a GPU-configured Neko must be
+rebuilt for CPU just to run them). These reimplementations use plain typed
+arrays and no Neko initialisation: the same results in a small fraction of the
+memory, needing only a Fortran compiler or a Python interpreter.
+
+| Tool | What it does | Build / run needs | `make check` needs |
+|---|---|---|---|
+| `rea2nbin_light` | Serial `.re2` → `.nmsh` converter, byte-exact with `contrib/rea2nbin` (periodic BCs, curved elements) | gfortran | python3 |
+| `genmeshbox_light` | O(1)-memory box-mesh generator, byte-exact with `contrib/genmeshbox` | gfortran | python3 |
+| `mesh_checker_light` | Low-memory `.nmsh` diagnostics (sizes, BC zones, Jacobian, zone-index field) | gfortran | python3 |
+| `genmap_light` | Spectral-bisection mesh partitioner (Nek5000 `genmap` algorithm), reorders like `prepart` | gfortran | python3 + numpy + scipy |
+| `prepart_light` | Mesh partitioner in scientific Python: spectral / METIS / geometric backends | python3 + numpy + scipy (optional: pymetis, pyamg) | python3 + numpy + scipy |
+
+Two partitioners are included on purpose: `genmap_light` when a Fortran compiler
+is all you have (deterministic, dependency-free), `prepart_light` when Python
+with NumPy/SciPy is available (faster; best cut with `pip install pymetis`; a
+near-instant geometric mode for very large meshes). Both write a reordered
+`.nmsh` whose linear read reproduces the partition — the same contract as
+Neko's `contrib/prepart`.
+
+Every tool prints a `--help`/usage message, validates its inputs with clean
+one-line errors, and is deterministic (same input, same output bytes). See each
+folder's `.md` for the algorithm, the validation evidence, and the scope and
+limitations. All tools are validated against the meshes shipped with Neko, but
+it remains your responsibility to confirm the result is correct for your own
+mesh — each folder's `make check` (or validator script) makes that easy to do
+on a case you trust.

--- a/contrib/genmap_light/genmap_light.f90
+++ b/contrib/genmap_light/genmap_light.f90
@@ -1,0 +1,1153 @@
+! Copyright (c) 2026, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!     _  __  ____  __ __  ____
+!    / |/ / / __/ / //_/ / __ \
+!   /    / / _/  / ,<   / /_/ /
+!  /_/|_/ /___/ /_/|_|  \____/
+!
+!> genmap_light -- a lightweight, CPU-only spectral-bisection mesh partitioner
+!! for Neko `.nmsh` files.
+!!
+!! This is a standalone reimplementation of the partitioning algorithm in
+!! Nek5000's `genmap`: recursive spectral bisection (RSB) of the element dual
+!! graph using the Fiedler vector of the graph Laplacian, computed with a
+!! restarted Lanczos iteration. Like `contrib/prepart` it then reorders the mesh
+!! so that a later *linear* read reproduces the partition -- it reads an `.nmsh`,
+!! partitions into `nparts` parts, and writes a new `.nmsh` whose elements are
+!! grouped into contiguous per-partition blocks (curves and zones carried
+!! through). It does **no Neko initialisation** and needs only a Fortran compiler
+!! (no MPI, no Neko library, no ParMETIS), so -- like the other *_light tools --
+!! it runs anywhere and needs no separate CPU build of a GPU-configured Neko.
+!!
+!! genmap vs ParMETIS: genmap's spectral bisection is lighter weight and has no
+!! external dependency; ParMETIS (used by Neko's `prepart` / load balancer) is
+!! multilevel k-way and often gives a slightly lower edge cut, but pulls in an
+!! MPI library. genmap_light is the drop-in, dependency-free alternative.
+!!
+!! Usage (mirrors prepart):
+!!   genmap_light mesh.nmsh nparts [out.nmsh]
+!! Default output is <base>_<nparts>.nmsh (same convention as prepart).
+!!
+!! Tested against the meshes shipped with Neko and cross-checked against an
+!! independent (SciPy) Fiedler eigensolver, but it remains your responsibility to
+!! confirm the result is correct for your own mesh -- `make check` on a case you
+!! trust first. See genmap_light.md for the algorithm, validation, and scope.
+!!
+!! 3D hex meshes only (genmap's common case); 2D exits with a clear error.
+
+!> Compact open-addressing int32 -> int32 hash, used for the periodic point
+!! merge (raw id -> merged id) and for compressing point ids to 1..nrnk.
+module gm_hash
+  use, intrinsic :: iso_fortran_env, only: i4 => int32, i8 => int64
+  implicit none
+  private
+  public :: imap_t
+
+  type :: imap_t
+     integer(i4), allocatable :: key(:), val(:)
+     integer(i8) :: cap = 0, mask = 0, n = 0
+   contains
+     procedure :: init => im_init
+     procedure :: set  => im_set      !< insert/overwrite key -> val
+     procedure :: getor => im_getor   !< val if present, else the supplied default
+     procedure :: intern => im_intern !< map key to a dense 1..n id, assigning on first sight
+     procedure :: free => im_free
+  end type imap_t
+
+contains
+
+  pure function mix(k) result(h)
+    integer(i4), intent(in) :: k
+    integer(i8) :: h
+    h = int(k, i8)
+    h = ieor(h, ishft(h, -33)) * (-49064778989728563_i8)
+    h = ieor(h, ishft(h, -29)) * (-4417276706812531889_i8)
+    h = ieor(h, ishft(h, -32))
+  end function mix
+
+  subroutine im_init(this, cap0)
+    class(imap_t), intent(inout) :: this
+    integer(i8), intent(in) :: cap0
+    integer(i8) :: c
+    c = 1024
+    do while (c < cap0 * 2_i8)
+       c = ishft(c, 1)
+    end do
+    this%cap = c; this%mask = c - 1; this%n = 0
+    allocate(this%key(0:c-1), this%val(0:c-1)); this%key = 0
+  end subroutine im_init
+
+  subroutine im_set(this, k, v)
+    class(imap_t), intent(inout) :: this
+    integer(i4), intent(in) :: k, v
+    integer(i8) :: h
+    if (this%cap == 0) call im_init(this, 1024_i8)
+    if (this%n * 3_i8 > this%cap * 2_i8) call im_grow(this)
+    h = iand(mix(k), this%mask)
+    do
+       if (this%key(h) == 0) then
+          this%key(h) = k; this%val(h) = v; this%n = this%n + 1; return
+       else if (this%key(h) == k) then
+          this%val(h) = v; return
+       end if
+       h = iand(h + 1_i8, this%mask)
+    end do
+  end subroutine im_set
+
+  function im_getor(this, k, default) result(v)
+    class(imap_t), intent(in) :: this
+    integer(i4), intent(in) :: k, default
+    integer(i4) :: v
+    integer(i8) :: h
+    if (this%cap == 0) then; v = default; return; end if
+    h = iand(mix(k), this%mask)
+    do
+       if (this%key(h) == 0) then
+          v = default; return
+       else if (this%key(h) == k) then
+          v = this%val(h); return
+       end if
+       h = iand(h + 1_i8, this%mask)
+    end do
+  end function im_getor
+
+  !> Return a dense id in 1..(#distinct keys) for k, assigning the next free id
+  !! the first time k is seen. `next` is the running counter (caller-owned).
+  function im_intern(this, k, next) result(id)
+    class(imap_t), intent(inout) :: this
+    integer(i4), intent(in) :: k
+    integer(i4), intent(inout) :: next
+    integer(i4) :: id
+    integer(i8) :: h
+    if (this%cap == 0) call im_init(this, 1024_i8)
+    if (this%n * 3_i8 > this%cap * 2_i8) call im_grow(this)
+    h = iand(mix(k), this%mask)
+    do
+       if (this%key(h) == 0) then
+          next = next + 1
+          this%key(h) = k; this%val(h) = next; this%n = this%n + 1
+          id = next; return
+       else if (this%key(h) == k) then
+          id = this%val(h); return
+       end if
+       h = iand(h + 1_i8, this%mask)
+    end do
+  end function im_intern
+
+  subroutine im_grow(this)
+    class(imap_t), intent(inout) :: this
+    integer(i4), allocatable :: ok(:), ov(:)
+    integer(i8) :: i, h, oldcap
+    oldcap = this%cap
+    call move_alloc(this%key, ok); call move_alloc(this%val, ov)
+    this%cap = ishft(this%cap, 1); this%mask = this%cap - 1
+    allocate(this%key(0:this%cap-1), this%val(0:this%cap-1)); this%key = 0
+    do i = 0, oldcap - 1
+       if (ok(i) /= 0) then
+          h = iand(mix(ok(i)), this%mask)
+          do while (this%key(h) /= 0)
+             h = iand(h + 1_i8, this%mask)
+          end do
+          this%key(h) = ok(i); this%val(h) = ov(i)
+       end if
+    end do
+    deallocate(ok, ov)
+  end subroutine im_grow
+
+  subroutine im_free(this)
+    class(imap_t), intent(inout) :: this
+    if (allocated(this%key)) deallocate(this%key, this%val)
+    this%cap = 0; this%mask = 0; this%n = 0
+  end subroutine im_free
+
+end module gm_hash
+
+
+!> The genmap numerics: element dual-graph Laplacian (weight = # shared
+!! vertices, exactly as Nek5000 genmap's c2c), the Fiedler vector via a restarted
+!! Lanczos iteration on that Laplacian (glanczos/calcvec/lanczos2), a
+!! connectivity (DFS) test, and the recursive spectral bisection with
+!! connectivity-preserving fallbacks. Faithful to genmap.f.
+module gm_rsb
+  use, intrinsic :: iso_fortran_env, only: dp => real64, i4 => int32, i8 => int64, &
+       error_unit
+  implicit none
+  private
+  public :: rsb_partition
+
+  integer, parameter :: MLANC = 100  ! Krylov dimension for the Fiedler Lanczos
+  logical :: dbg = .false.           ! GENMAP_DEBUG diagnostic prints
+
+contains
+
+  !> Partition elements 1..nelv into `nparts` parts via recursive spectral
+  !! bisection. cell(nv,nelv) holds the (periodic-merged, compressed) vertex ids
+  !! of each element; nrnk = number of distinct vertex ids. part(1:nelv) receives
+  !! 0-based partition ids.
+  subroutine rsb_partition(cell, nv, nelv, nrnk, nparts, part)
+    integer(i4), intent(in) :: cell(nv, nelv)
+    integer, intent(in) :: nv, nelv, nrnk, nparts
+    integer(i4), intent(out) :: part(nelv)
+    integer(i4), allocatable :: loc(:)
+    integer :: i, elen
+    character(len=8) :: dbgs
+    call get_environment_variable('GENMAP_DEBUG', dbgs, elen)
+    dbg = (elen > 0)
+    allocate(loc(nelv))
+    do i = 1, nelv
+       loc(i) = i
+    end do
+    part = 0
+    call rsb_rec(loc, nelv, nparts, 0, cell, nv, nelv, nrnk, part)
+    deallocate(loc)
+  end subroutine rsb_partition
+
+  !> Recursively bisect the element subset loc(1:n) into q parts, numbering them
+  !! base .. base+q-1.
+  recursive subroutine rsb_rec(loc, n, q, base, cell, nv, nelv, nrnk, part)
+    integer(i4), intent(inout) :: loc(n)
+    integer, intent(in) :: n, q, base, nv, nelv, nrnk
+    integer(i4), intent(in) :: cell(nv, nelv)
+    integer(i4), intent(inout) :: part(nelv)
+    integer :: q1, q2, n1, i
+    if (q <= 1 .or. n == 0) then
+       do i = 1, n
+          part(loc(i)) = base
+       end do
+       return
+    end if
+    q1 = q / 2
+    q2 = q - q1
+    ! proportional target so all final parts differ by <= 1 element
+    n1 = nint(real(n, dp) * real(q1, dp) / real(q, dp))
+    if (n1 < 1) n1 = 1
+    if (n1 > n - 1) n1 = n - 1
+    ! bisect: reorder loc(1:n) so the first n1 form one side, the rest the other
+    call bisect(loc, n, n1, cell, nv, nelv, nrnk)
+    call rsb_rec(loc(1),    n1,     q1, base,      cell, nv, nelv, nrnk, part)
+    call rsb_rec(loc(n1+1), n - n1, q2, base + q1, cell, nv, nelv, nrnk, part)
+  end subroutine rsb_rec
+
+  !> Reorder loc(1:n) so loc(1:n1) is one half and loc(n1+1:n) the other, using
+  !! spectral bisection. It computes the KWANT lowest spectral modes of the
+  !! subset dual-graph Laplacian and, for each, forms the balanced split at rank
+  !! n1 and measures the resulting edge cut; it keeps the lowest-cut split, giving
+  !! preference to splits whose two halves are both connected. If none is
+  !! connected it region-grows the best split to restore connectivity. Trying the
+  !! few lowest modes (not just the single Fiedler vector) makes the bisection
+  !! robust on meshes with a degenerate/near-degenerate Fiedler space (cylinders,
+  !! symmetric boxes) as well as high-aspect-ratio/periodic meshes.
+  subroutine bisect(loc, n, n1, cell, nv, nelv, nrnk)
+    integer(i4), intent(inout) :: loc(n)
+    integer, intent(in) :: n, n1, nv, nelv, nrnk
+    integer(i4), intent(in) :: cell(nv, nelv)
+    integer(i4), allocatable :: ia(:), ja(:)
+    real(dp), allocatable :: va(:), fk(:,:)
+    integer(i4), allocatable :: perm(:), side(:), bside(:), tmp(:)
+    integer :: i, c, kwant, kgot
+    real(dp) :: cut, score, bscore, bcut
+    logical :: okconn, bconn
+
+    if (n <= 2) return   ! loc order is fine; first n1 vs rest
+
+    call build_dual(loc, n, cell, nv, nelv, nrnk, ia, ja, va)
+
+    kwant = min(4, n - 1)
+    allocate(fk(n, kwant), perm(n), side(n), bside(n), tmp(n))
+    call fiedler_k(ia, ja, va, n, kwant, fk, kgot)
+
+    bscore = huge(1.0_dp); bcut = 0.0_dp; bconn = .false.; bside = 2
+    do c = 1, max(kgot, 1)
+       call rsort(fk(1, c), perm, n)
+       side = 2
+       do i = 1, n1
+          side(perm(i)) = 1
+       end do
+       cut = split_cut(side, ia, ja, va, n)
+       okconn = conn_side(side, 1, n, ia, ja) .and. conn_side(side, 2, n, ia, ja)
+       ! prefer connected splits, then lowest cut
+       score = cut
+       if (.not. okconn) score = cut + 1.0e12_dp
+       if (score < bscore) then
+          bscore = score; bcut = cut; bside = side; bconn = okconn
+       end if
+    end do
+
+    if (.not. bconn) then
+       call region_grow(n, n1, bside, ia, ja)   ! guarantee connectivity
+    end if
+    ! (print bcut, never bscore: the +1e12 disconnected penalty would overflow
+    ! a default integer)
+    if (dbg) write(error_unit,'(a,i0,a,i0,a,l1,a,i0)') &
+         '   [dbg] bisect n=', n, ' n1=', n1, ' connected=', bconn, &
+         ' cut=', int(bcut, i8)
+
+    call apply_side(loc, n, bside, tmp)
+
+    deallocate(ia, ja, va, fk, perm, side, bside, tmp)
+  end subroutine bisect
+
+  !> Weighted edge cut of a bipartition `side` (1/2) over the CSR graph (ia,ja,va);
+  !! sums -va (the shared-vertex weight) over off-diagonal edges that cross, /2.
+  function split_cut(side, ia, ja, va, n) result(cut)
+    integer, intent(in) :: n
+    integer(i4), intent(in) :: side(n), ia(0:n), ja(:)
+    real(dp), intent(in) :: va(:)
+    real(dp) :: cut
+    integer :: i, j, jc
+    cut = 0.0_dp
+    do i = 1, n
+       do j = int(ia(i-1)) + 1, int(ia(i))
+          jc = ja(j)
+          if (jc /= i .and. side(jc) /= side(i)) cut = cut - va(j)
+       end do
+    end do
+    cut = cut * 0.5_dp
+  end function split_cut
+
+  !> Rearrange loc so all side==1 come first (in original relative order), then
+  !! side==2. Two-pass stable partition via scratch tmp(n).
+  subroutine apply_side(loc, n, side, tmp)
+    integer(i4), intent(inout) :: loc(n)
+    integer, intent(in) :: n
+    integer(i4), intent(in) :: side(n)
+    integer(i4), intent(inout) :: tmp(n)
+    integer :: i, k
+    k = 0
+    do i = 1, n
+       if (side(i) == 1) then
+          k = k + 1; tmp(k) = loc(i)
+       end if
+    end do
+    do i = 1, n
+       if (side(i) == 2) then
+          k = k + 1; tmp(k) = loc(i)
+       end if
+    end do
+    loc = tmp
+  end subroutine apply_side
+
+  !> Build the dual-graph Laplacian (CSR: ia(0:n), ja, va) for the subset
+  !! loc(1:n). Off-diagonal va = -(number of shared vertices); diagonal va =
+  !! +sum of shared-vertex counts to neighbours -- the weighted graph Laplacian,
+  !! exactly Nek5000 genmap's c2c weighting.
+  subroutine build_dual(loc, n, cell, nv, nelv, nrnk, ia, ja, va)
+    integer(i4), intent(in) :: loc(n)
+    integer, intent(in) :: n, nv, nelv, nrnk
+    integer(i4), intent(in) :: cell(nv, nelv)
+    integer(i4), allocatable, intent(out) :: ia(:), ja(:)
+    real(dp), allocatable, intent(out) :: va(:)
+    integer(i4), allocatable :: v2c_cnt(:), v2c_ptr(:), v2c(:)
+    integer(i4), allocatable :: touched(:), wcnt(:), nbr(:)
+    integer :: i, k, e, vtx, jj, j0, j1, ne, nnz, deg, off, nb
+    integer(i4) :: rowsum
+
+    ! --- vertex -> element (local) CSR over the subset ---
+    allocate(v2c_cnt(nrnk)); v2c_cnt = 0
+    do i = 1, n
+       e = loc(i)
+       do k = 1, nv
+          vtx = cell(k, e)
+          v2c_cnt(vtx) = v2c_cnt(vtx) + 1
+       end do
+    end do
+    allocate(v2c_ptr(nrnk + 1))
+    v2c_ptr(1) = 1
+    do i = 1, nrnk
+       v2c_ptr(i + 1) = v2c_ptr(i) + v2c_cnt(i)
+    end do
+    allocate(v2c(v2c_ptr(nrnk + 1) - 1))
+    v2c_cnt = 0
+    do i = 1, n
+       e = loc(i)
+       do k = 1, nv
+          vtx = cell(k, e)
+          v2c(v2c_ptr(vtx) + v2c_cnt(vtx)) = int(i, i4)   ! store LOCAL index
+          v2c_cnt(vtx) = v2c_cnt(vtx) + 1
+       end do
+    end do
+
+    ! --- accumulate adjacency; two passes (count, then fill) ---
+    allocate(touched(n)); touched = 0
+    allocate(wcnt(n)); wcnt = 0
+    allocate(nbr(n))
+    allocate(ia(0:n))
+    ia(0) = 0
+    nnz = 0
+    ! pass 1: count degree (incl. self) per row
+    do i = 1, n
+       e = loc(i)
+       nb = 0
+       do k = 1, nv
+          vtx = cell(k, e)
+          j0 = v2c_ptr(vtx); j1 = v2c_ptr(vtx + 1) - 1
+          do jj = j0, j1
+             if (touched(v2c(jj)) /= i) then
+                touched(v2c(jj)) = i
+                nb = nb + 1
+             end if
+          end do
+       end do
+       nnz = nnz + nb
+       ia(i) = nnz
+    end do
+    allocate(ja(nnz), va(nnz))
+    ! pass 2: fill neighbours + shared-vertex weights
+    touched = 0
+    do i = 1, n
+       e = loc(i)
+       off = int(ia(i-1))
+       deg = 0
+       do k = 1, nv
+          vtx = cell(k, e)
+          j0 = v2c_ptr(vtx); j1 = v2c_ptr(vtx + 1) - 1
+          do jj = j0, j1
+             ne = v2c(jj)
+             if (touched(ne) /= i) then
+                touched(ne) = i
+                deg = deg + 1
+                nbr(deg) = int(ne, i4)
+                wcnt(ne) = 1
+             else
+                wcnt(ne) = wcnt(ne) + 1
+             end if
+          end do
+       end do
+       rowsum = 0
+       do k = 1, deg
+          ne = nbr(k)
+          ja(off + k) = int(ne, i4)
+          if (ne == i) then
+             va(off + k) = 0.0_dp        ! placeholder; set to rowsum below
+          else
+             rowsum = rowsum + wcnt(ne)
+             va(off + k) = -real(wcnt(ne), dp)
+          end if
+       end do
+       ! set the diagonal entry to +rowsum
+       do k = 1, deg
+          if (ja(off + k) == i) va(off + k) = real(rowsum, dp)
+       end do
+    end do
+
+    deallocate(v2c_cnt, v2c_ptr, v2c, touched, wcnt, nbr)
+  end subroutine build_dual
+
+  !> The KWANT lowest non-trivial eigenvectors (Ritz vectors) of the graph
+  !! Laplacian (ia,ja,va) into columns of F(n,KWANT); kgot returns how many were
+  !! produced. Uses a Lanczos iteration with FULL reorthogonalisation that
+  !! deflates the constant null vector each step (ortho1) -- genmap's Lanczos ->
+  !! spectral idea, but numerically robust (plain Lanczos loses orthogonality and
+  !! under-resolves the low modes on hard spectra). The smallest mode is the
+  !! Fiedler vector; the caller picks the lowest-cut split among the KWANT modes.
+  subroutine fiedler_k(ia, ja, va, n, kwant, F, kgot)
+    integer(i4), intent(in) :: ia(0:n), ja(:)
+    real(dp), intent(in) :: va(:)
+    integer, intent(in) :: n, kwant
+    real(dp), intent(out) :: F(n, kwant)
+    integer, intent(out) :: kgot
+    real(dp), allocatable :: qv(:,:), alpha(:), bet(:), w(:), f0(:)
+    real(dp), allocatable :: dd(:), ee(:), zz(:,:)
+    integer(i4), allocatable :: ord(:)
+    real(dp) :: nrm, s, bk
+    integer :: m, i, j, k, mm, c, idum
+    integer(i8) :: hh
+
+    m = min(MLANC, n - 1)
+    allocate(qv(n, m + 1), alpha(m), bet(m), w(n), f0(n))
+
+    ! Deterministic generic start with components along every eigenmode (a fixed
+    ! integer hash -> [-0.5,0.5]), so Lanczos resolves the low modes regardless
+    ! of how the elements are ordered in the file.
+    do i = 1, n
+       hh = iand(int(i, i8) * 2654435761_i8, 2147483647_i8)
+       hh = iand(ieor(hh, ishft(hh, -15)), 1048575_i8)
+       f0(i) = real(hh, dp) / 1048575.0_dp - 0.5_dp
+    end do
+    call ortho1(f0, n)
+    nrm = sqrt(dot(f0, f0, n))
+    if (nrm <= 0.0_dp) then
+       do i = 1, n
+          f0(i) = real(i, dp)
+       end do
+       call ortho1(f0, n); nrm = sqrt(dot(f0, f0, n))
+    end if
+    do i = 1, n
+       qv(i, 1) = f0(i) / nrm
+    end do
+
+    mm = m
+    do k = 1, m
+       call ax(w, qv(1, k), ia, ja, va, n)
+       call ortho1(w, n)                          ! stay orthogonal to 1 (null space)
+       alpha(k) = dot(w, qv(1, k), n)
+       if (k == 1) then
+          do i = 1, n
+             w(i) = w(i) - alpha(k) * qv(i, k)
+          end do
+       else
+          do i = 1, n
+             w(i) = w(i) - alpha(k) * qv(i, k) - bet(k-1) * qv(i, k-1)
+          end do
+       end if
+       do j = 1, k                                ! full reorthogonalisation
+          s = dot(w, qv(1, j), n)
+          do i = 1, n
+             w(i) = w(i) - s * qv(i, j)
+          end do
+       end do
+       bk = sqrt(dot(w, w, n))
+       if (bk <= 1.0e-12_dp) then
+          mm = k; exit
+       end if
+       bet(k) = bk
+       do i = 1, n
+          qv(i, k+1) = w(i) / bk
+       end do
+    end do
+
+    allocate(dd(mm), ee(mm), zz(mm, mm), ord(mm))
+    call tql2_eig(alpha, bet, dd, ee, zz, mm, idum)   ! all eigenpairs of T
+    call rsort(dd, ord, mm)                            ! ord(1) = smallest eigenvalue
+    kgot = min(kwant, mm)
+    do c = 1, kgot
+       do i = 1, n
+          F(i, c) = 0.0_dp
+       end do
+       do k = 1, mm
+          s = zz(k, ord(c))
+          do i = 1, n
+             F(i, c) = F(i, c) + qv(i, k) * s
+          end do
+       end do
+    end do
+    deallocate(qv, alpha, bet, w, f0, dd, ee, zz, ord)
+  end subroutine fiedler_k
+
+  !> y = L x, L the graph Laplacian in CSR (diagonal stored explicitly in va).
+  subroutine ax(y, x, ia, ja, va, n)
+    integer, intent(in) :: n
+    real(dp), intent(out) :: y(n)
+    real(dp), intent(in) :: x(n), va(:)
+    integer(i4), intent(in) :: ia(0:n), ja(:)
+    integer :: i, j
+    do i = 1, n
+       y(i) = 0.0_dp
+       do j = int(ia(i-1)) + 1, int(ia(i))
+          y(i) = y(i) + va(j) * x(ja(j))
+       end do
+    end do
+  end subroutine ax
+
+  !> Symmetric tridiagonal QL with implicit shifts (Numerical Recipes / genmap
+  !! calcvec). diag(1:m), upper(1:m-1) input; eigenvalues in d, eigenvectors in
+  !! columns of z; imin = index of the smallest eigenvalue. Eigenvectors are
+  !! orthonormalised as in genmap.
+  subroutine tql2_eig(diag, upper, d, e, z, n, imin)
+    integer, intent(in) :: n
+    real(dp), intent(in) :: diag(*), upper(*)
+    real(dp), intent(inout) :: d(n), e(n), z(n, n)
+    integer, intent(out) :: imin
+    integer :: i, k, l, m, iter
+    real(dp) :: dd, g, r, s, c, p, f, b, dmin, sc, enorm
+    do i = 1, n
+       d(i) = diag(i)
+    end do
+    do i = 1, n - 1
+       e(i) = upper(i)
+    end do
+    e(n) = 0.0_dp
+    z = 0.0_dp
+    do i = 1, n
+       z(i, i) = 1.0_dp
+    end do
+    do l = 1, n
+       iter = 0
+1      continue
+       do m = l, n - 1
+          dd = abs(d(m)) + abs(d(m + 1))
+          if (abs(e(m)) + dd == dd) go to 2
+       end do
+       m = n
+2      continue
+       if (m /= l) then
+          if (iter == 30) then
+             write(error_unit,*) 'genmap_light: tql2 too many iterations'
+             exit
+          end if
+          iter = iter + 1
+          g = (d(l + 1) - d(l)) / (2.0_dp * e(l))
+          r = sqrt(g**2 + 1.0_dp)
+          g = d(m) - d(l) + e(l) / (g + sign(r, g))
+          s = 1.0_dp; c = 1.0_dp; p = 0.0_dp
+          do i = m - 1, l, -1
+             f = s * e(i)
+             b = c * e(i)
+             if (abs(f) >= abs(g)) then
+                c = g / f
+                r = sqrt(c**2 + 1.0_dp)
+                e(i + 1) = f * r
+                s = 1.0_dp / r
+                c = c * s
+             else
+                s = f / g
+                r = sqrt(s**2 + 1.0_dp)
+                e(i + 1) = g * r
+                c = 1.0_dp / r
+                s = s * c
+             end if
+             g = d(i + 1) - p
+             r = (d(i) - g) * s + 2.0_dp * c * b
+             p = s * r
+             d(i + 1) = g + p
+             g = c * r - b
+             do k = 1, n
+                f = z(k, i + 1)
+                z(k, i + 1) = s * z(k, i) + c * f
+                z(k, i) = c * z(k, i) - s * f
+             end do
+          end do
+          d(l) = d(l) - p
+          e(l) = g
+          e(m) = 0.0_dp
+          go to 1
+       end if
+    end do
+    ! smallest eigenvalue
+    imin = 1
+    dmin = d(1)
+    do i = 1, n
+       if (d(i) < dmin) then
+          dmin = d(i); imin = i
+       end if
+    end do
+    ! orthonormalise eigenvectors (genmap: scale each column by 1/||.||)
+    do k = 1, n
+       enorm = sqrt(abs(dot(z(1, k), z(1, k), n)))
+       if (enorm /= 0.0_dp) then
+          sc = 1.0_dp / enorm
+          do i = 1, n
+             z(i, k) = z(i, k) * sc
+          end do
+       end if
+    end do
+  end subroutine tql2_eig
+
+  subroutine ortho1(p, n)
+    integer, intent(in) :: n
+    real(dp), intent(inout) :: p(n)
+    real(dp) :: s
+    integer :: i
+    s = 0.0_dp
+    do i = 1, n
+       s = s + p(i)
+    end do
+    s = s / real(n, dp)
+    do i = 1, n
+       p(i) = p(i) - s
+    end do
+  end subroutine ortho1
+
+  pure function dot(x, y, n) result(s)
+    integer, intent(in) :: n
+    real(dp), intent(in) :: x(n), y(n)
+    real(dp) :: s
+    integer :: i
+    s = 0.0_dp
+    do i = 1, n
+       s = s + x(i) * y(i)
+    end do
+  end function dot
+
+  !> Heap sort of real key a(1:n) ascending; returns permutation perm so that
+  !! a(perm(1)) <= a(perm(2)) <= ...  (stable enough; ties keep heap order).
+  subroutine rsort(a, perm, n)
+    integer, intent(in) :: n
+    real(dp), intent(in) :: a(n)
+    integer(i4), intent(out) :: perm(n)
+    integer :: i, l, ir, indx, j
+    real(dp) :: q
+    do i = 1, n
+       perm(i) = int(i, i4)
+    end do
+    if (n <= 1) return
+    l = n / 2 + 1
+    ir = n
+    do
+       if (l > 1) then
+          l = l - 1
+          indx = perm(l)
+          q = a(indx)
+       else
+          indx = perm(ir)
+          q = a(indx)
+          perm(ir) = perm(1)
+          ir = ir - 1
+          if (ir == 1) then
+             perm(1) = indx
+             return
+          end if
+       end if
+       i = l
+       j = l + l
+       do while (j <= ir)
+          if (j < ir) then
+             if (a(perm(j)) < a(perm(j + 1))) j = j + 1
+          end if
+          if (q < a(perm(j))) then
+             perm(i) = perm(j)
+             i = j
+             j = j + j
+          else
+             j = ir + 1
+          end if
+       end do
+       perm(i) = indx
+    end do
+  end subroutine rsort
+
+  !> DFS connectivity of the subgraph induced by {i : side(i)==s}, over local
+  !! indices with adjacency (ia,ja). Empty set counts as connected.
+  function conn_side(side, s, n, ia, ja) result(ok)
+    integer, intent(in) :: s, n
+    integer(i4), intent(in) :: side(n), ia(0:n), ja(:)
+    logical :: ok
+    integer(i4), allocatable :: stack(:), seen(:)
+    integer :: i, top, cur, j, cnt, total, start
+    allocate(stack(n), seen(n)); seen = 0
+    total = 0; start = 0
+    do i = 1, n
+       if (side(i) == s) then
+          total = total + 1
+          if (start == 0) start = i
+       end if
+    end do
+    if (total == 0) then
+       ok = .true.; deallocate(stack, seen); return
+    end if
+    top = 1; stack(1) = int(start, i4); seen(start) = 1; cnt = 1
+    do while (top > 0)
+       cur = stack(top); top = top - 1
+       do j = int(ia(cur-1)) + 1, int(ia(cur))
+          i = ja(j)
+          if (i >= 1 .and. i <= n) then
+             if (side(i) == s .and. seen(i) == 0) then
+                seen(i) = 1; cnt = cnt + 1
+                top = top + 1; stack(top) = int(i, i4)
+             end if
+          end if
+       end do
+    end do
+    ok = (cnt == total)
+    deallocate(stack, seen)
+  end function conn_side
+
+  !> Region-growing fallback bisection: grow side 1 by BFS over the dual graph
+  !! from a fixed seed until it reaches n1 elements; everything not reached is
+  !! side 2. This guarantees a connected side 1 at the exact target size (side 2
+  !! is the complement and may itself be disconnected) -- genmap's growth
+  !! strategy in simplified form. If the input subgraph is disconnected and the
+  !! BFS runs dry early, side 1 is topped up deterministically.
+  subroutine region_grow(n, n1, side, ia, ja)
+    integer, intent(in) :: n, n1
+    integer(i4), intent(in) :: ia(0:n), ja(:)
+    integer(i4), intent(inout) :: side(n)
+    integer(i4), allocatable :: q(:)
+    integer :: head, tail, cur, j, i, c1
+    ! seed 1 = local index 1; seed 2 = the farthest-labelled index (n)
+    allocate(q(n))
+    side = 0
+    side(1) = 1
+    c1 = 1
+    head = 1; tail = 1; q(1) = 1_i4
+    do while (head <= tail .and. c1 < n1)
+       cur = q(head); head = head + 1
+       do j = int(ia(cur-1)) + 1, int(ia(cur))
+          i = ja(j)
+          if (i >= 1 .and. i <= n) then
+             if (side(i) == 0) then
+                side(i) = 1; c1 = c1 + 1
+                tail = tail + 1; q(tail) = int(i, i4)
+                if (c1 >= n1) exit
+             end if
+          end if
+       end do
+    end do
+    ! any element not reached (still 0) goes to side 2
+    do i = 1, n
+       if (side(i) == 0) side(i) = 2
+    end do
+    ! if side 1 fell short (disconnected input), top it up with lowest-index
+    ! side-2 elements to hit the exact target n1
+    if (c1 < n1) then
+       do i = 1, n
+          if (c1 >= n1) exit
+          if (side(i) == 2) then
+             side(i) = 1; c1 = c1 + 1
+          end if
+       end do
+    end if
+    deallocate(q)
+  end subroutine region_grow
+
+end module gm_rsb
+
+
+program genmap_light
+  use, intrinsic :: iso_fortran_env, only: dp => real64, i4 => int32, i8 => int64, &
+       error_unit
+  use gm_hash, only: imap_t
+  use gm_rsb, only: rsb_partition
+  implicit none
+
+  ! Neko facet (1..6) corners in nmsh vertex indices (= face_nodes composed with
+  ! the nmsh->mesh read swap [1,2,4,3,5,6,8,7]); same table validated byte-exact
+  ! for periodic glb_pt_ids in rea2nbin_light / mesh_checker_light.
+  integer(i4), parameter :: FACE_RE2(4,6) = reshape((/ &
+       1,5,8,4,   2,6,7,3,   1,2,6,5,   4,3,7,8,   1,2,3,4,   5,6,7,8 /), (/4,6/))
+
+  character(len=1024) :: fin, fout, argbuf
+  integer :: uin, uout, ios, i, k, argc, nparts
+  integer(i4) :: nelv, gdim, elid, nz, ncur, ztype
+  integer(i4) :: ze, zf, zpe, zpf, g1, g2, g3, g4
+  integer(i4), allocatable :: elid_of_pos(:), pos_of_elid(:)
+  integer(i4), allocatable :: ev(:,:)          ! (8,nelv) original nmsh point ids
+  real(dp), allocatable :: cx(:,:), cy(:,:), cz(:,:)  ! (8,nelv) coords
+  integer(i4), allocatable :: cell(:,:)        ! (8,nelv) merged+compressed vtx ids
+  integer(i4), allocatable :: part(:), newid(:), pos_of_newid(:)
+  integer(i4), allocatable :: blk(:)           ! partition prefix offsets
+  ! zone storage
+  integer(i4), allocatable :: pz_e(:), pz_f(:), pz_pe(:), pz_pf(:), pz_g(:,:)
+  integer(i4), allocatable :: lz_e(:), lz_f(:), lz_lab(:)
+  integer(i4), allocatable :: xz(:,:)          ! legacy zone types, raw 9-int records
+  integer :: npz, nlz, nxz
+  ! curve storage
+  integer(i4), allocatable :: cu_e(:), cu_type(:,:)
+  real(dp), allocatable :: cu_data(:,:,:)
+  integer :: ncu
+  type(imap_t) :: rm, comp
+  integer(i4) :: nrnk, nextid, vid, mid
+  real(dp) :: xyz(3)
+  integer(i8) :: cut, edges
+
+  argc = command_argument_count()
+  if (argc < 2) then
+     write(*,*) 'Usage: genmap_light mesh.nmsh nparts [out.nmsh]'
+     write(*,*) '  Partition a Neko .nmsh into <nparts> parts by recursive'
+     write(*,*) '  spectral bisection (Nek5000 genmap algorithm) and write a'
+     write(*,*) '  reordered .nmsh whose elements are grouped per partition'
+     write(*,*) '  (a linear read then reproduces the partition, like prepart).'
+     stop 1
+  end if
+  call get_command_argument(1, fin)
+  call get_command_argument(2, argbuf)
+  read(argbuf, *, iostat=ios) nparts
+  if (ios /= 0 .or. nparts < 1) then
+     write(error_unit,*) 'Error: nparts must be a positive integer'; stop 1
+  end if
+  if (argc >= 3) then
+     call get_command_argument(3, fout)
+  else
+     block
+       integer :: islash, idot
+       islash = scan(trim(fin), '/', back=.true.)   ! 0 if no directory part
+       idot   = scan(trim(fin), '.', back=.true.)
+       if (idot > islash) then                       ! a real extension to strip
+          fout = trim(fin(1:idot-1)) // '_' // trim(adjustl(argbuf)) // '.nmsh'
+       else                                          ! no extension (or '.' only in dir)
+          fout = trim(fin) // '_' // trim(adjustl(argbuf)) // '.nmsh'
+       end if
+     end block
+  end if
+
+  write(*,'(a)') ''
+  write(*,'(a)') '     _  __  ____  __ __  ____'
+  write(*,'(a)') '    / |/ / / __/ / //_/ / __ \'
+  write(*,'(a)') '   /    / / _/  / ,<   / /_/ /'
+  write(*,'(a)') '  /_/|_/ /___/ /_/|_|  \____/   genmap_light  (spectral partitioner)'
+  write(*,'(a)') ''
+  write(*,'(a,a)')    '  input     : ', trim(fin)
+  write(*,'(a,a)')    '  output    : ', trim(fout)
+  write(*,'(a,i0)')   '  nparts    : ', nparts
+
+  ! ---- read header + elements ----
+  open(newunit=uin, file=trim(fin), access='stream', form='unformatted', &
+       status='old', action='read', iostat=ios)
+  if (ios /= 0) then
+     write(error_unit,*) 'Error: cannot open ', trim(fin); stop 1
+  end if
+  read(uin, iostat=ios) nelv, gdim; call chk_read(ios)
+  if (gdim /= 3) then
+     write(error_unit,*) 'Error: genmap_light supports 3D (hex) meshes only (gdim=', &
+          gdim, ').'; stop 1
+  end if
+  if (nparts > nelv) then
+     write(error_unit,*) 'Error: nparts (', nparts, ') > number of elements (', &
+          nelv, ').'; stop 1
+  end if
+  write(*,'(a,i0,a)') '  mesh      : ', nelv, ' hex elements'
+
+  allocate(ev(8, nelv), cx(8, nelv), cy(8, nelv), cz(8, nelv))
+  allocate(elid_of_pos(nelv), pos_of_elid(nelv))
+  write(*,'(a)') '  [1/5] reading elements ...'
+  do i = 1, nelv
+     read(uin, iostat=ios) elid; call chk_read(ios)
+     elid_of_pos(i) = elid
+     do k = 1, 8
+        read(uin, iostat=ios) ev(k, i), xyz(1), xyz(2), xyz(3); call chk_read(ios)
+        cx(k, i) = xyz(1); cy(k, i) = xyz(2); cz(k, i) = xyz(3)
+     end do
+  end do
+  pos_of_elid = 0
+  do i = 1, nelv
+     if (elid_of_pos(i) < 1 .or. elid_of_pos(i) > nelv) then
+        write(error_unit,*) 'Error: element id out of [1,nelv]: ', elid_of_pos(i); stop 1
+     end if
+     pos_of_elid(elid_of_pos(i)) = int(i, i4)
+  end do
+  do i = 1, nelv                 ! element ids must be a permutation of 1..nelv
+     if (pos_of_elid(i) == 0) then
+        write(error_unit,*) 'Error: element ids are not a permutation of 1..nelv', &
+             ' (duplicate or missing id ', i, ').'; stop 1
+     end if
+  end do
+
+  ! ---- read zones ----
+  write(*,'(a)') '  [2/5] reading zones and curves ...'
+  read(uin, iostat=ios) nz; call chk_read(ios)
+  allocate(pz_e(nz), pz_f(nz), pz_pe(nz), pz_pf(nz), pz_g(4, nz))
+  allocate(lz_e(nz), lz_f(nz), lz_lab(nz), xz(9, max(nz, 1)))
+  npz = 0; nlz = 0; nxz = 0
+  call rm%init(max(1024_i8, int(nelv, i8)))
+  do i = 1, nz
+     read(uin, iostat=ios) ze, zf, zpe, zpf, g1, g2, g3, g4, ztype; call chk_read(ios)
+     if (ze < 1 .or. ze > nelv .or. zf < 1 .or. zf > 6) cycle
+     if (ztype == 5) then
+        npz = npz + 1
+        pz_e(npz) = ze; pz_f(npz) = zf; pz_pe(npz) = zpe; pz_pf(npz) = zpf
+        pz_g(1, npz) = g1; pz_g(2, npz) = g2; pz_g(3, npz) = g3; pz_g(4, npz) = g4
+        ! periodic point merge, exactly as mesh_checker_light / Neko on read
+        block
+          integer :: pos
+          pos = pos_of_elid(ze)
+          call rm%set(ev(FACE_RE2(1,zf), pos), g1)
+          call rm%set(ev(FACE_RE2(2,zf), pos), g2)
+          call rm%set(ev(FACE_RE2(3,zf), pos), g3)
+          call rm%set(ev(FACE_RE2(4,zf), pos), g4)
+        end block
+     else if (ztype == 7) then
+        nlz = nlz + 1
+        lz_e(nlz) = ze; lz_f(nlz) = zf; lz_lab(nlz) = zpf
+     else
+        ! legacy zone types (e.g. type 1/2 in older meshes): carry through
+        ! verbatim, renumbering only the element id at write time
+        nxz = nxz + 1
+        xz(:, nxz) = (/ ze, zf, zpe, zpf, g1, g2, g3, g4, ztype /)
+     end if
+  end do
+  if (nxz > 0) then
+     write(*,'(a,i0,a)') '        note: carrying ', nxz, &
+          ' zone records of legacy types through (element ids renumbered)'
+  end if
+
+  ! ---- read curves ----
+  read(uin, iostat=ios) ncur; call chk_read(ios)
+  ncu = ncur
+  if (ncu > 0) then
+     allocate(cu_e(ncu), cu_type(12, ncu), cu_data(5, 12, ncu))
+     do i = 1, ncu
+        read(uin, iostat=ios) cu_e(i), cu_data(:, :, i), cu_type(:, i); call chk_read(ios)
+        if (cu_e(i) < 1 .or. cu_e(i) > nelv) then
+           write(error_unit,*) 'Error: curve element id out of [1,nelv]: ', cu_e(i); stop 1
+        end if
+     end do
+  end if
+  close(uin)
+
+  ! ---- build cell(): apply periodic merge, then compress to 1..nrnk ----
+  write(*,'(a)') '  [3/5] building element dual graph ...'
+  allocate(cell(8, nelv))
+  call comp%init(max(1024_i8, int(nelv, i8)))
+  nextid = 0
+  do i = 1, nelv
+     do k = 1, 8
+        vid = rm%getor(ev(k, i), ev(k, i))     ! merged id (identity if not periodic)
+        mid = comp%intern(vid, nextid)         ! dense 1..nrnk
+        cell(k, i) = mid
+     end do
+  end do
+  nrnk = nextid
+
+  ! ---- recursive spectral bisection ----
+  write(*,'(a,i0,a)') '  [4/5] recursive spectral bisection into ', nparts, ' parts ...'
+  allocate(part(nelv))
+  call rsb_partition(cell, 8, nelv, nrnk, nparts, part)
+
+  ! edge-cut diagnostic (on the merged dual graph)
+  call count_cut(cell, 8, nelv, nrnk, part, cut, edges)
+  write(*,'(a,i0,a,i0,a,f7.3,a)') '        edge cut: ', cut, ' / ', edges, &
+       ' shared-vertex links cut (', 100.0_dp*real(cut,dp)/real(max(edges,1_i8),dp), '%)'
+
+  ! ---- reorder (prepart style): contiguous per-partition blocks ----
+  write(*,'(a)') '  [5/5] renumbering and writing reordered mesh ...'
+  allocate(blk(0:nparts))
+  blk = 0
+  do i = 1, nelv
+     blk(part(i) + 1) = blk(part(i) + 1) + 1
+  end do
+  do i = 1, nparts
+     blk(i) = blk(i) + blk(i - 1)          ! exclusive prefix sum -> block starts
+  end do
+  allocate(newid(nelv), pos_of_newid(nelv))
+  block
+    integer(i4) :: cnt(0:nparts-1)
+    integer :: r
+    cnt = 0
+    do i = 1, nelv
+       r = part(i)
+       cnt(r) = cnt(r) + 1
+       newid(i) = blk(r) + cnt(r)           ! 1-based new global id
+       pos_of_newid(newid(i)) = int(i, i4)
+    end do
+  end block
+
+  ! ---- write output nmsh ----
+  open(newunit=uout, file=trim(fout), access='stream', form='unformatted', &
+       status='replace', action='write')
+  write(uout) nelv, gdim
+  do i = 1, nelv
+     block
+       integer :: pos
+       pos = pos_of_newid(i)
+       write(uout) int(i, i4)               ! el_idx = new contiguous global id
+       do k = 1, 8
+          write(uout) ev(k, pos), cx(k, pos), cy(k, pos), cz(k, pos)
+       end do
+     end block
+  end do
+
+  ! zones: type-5 (periodic) first, then type-7 (labeled), matching Neko's
+  ! writer, then any legacy zone types carried through
+  write(uout) int(npz + nlz + nxz, i4)
+  do i = 1, npz
+     block
+       integer(i4) :: enew, penew
+       enew = newid(pos_of_elid(pz_e(i)))
+       if (pz_pe(i) >= 1 .and. pz_pe(i) <= nelv) then
+          penew = newid(pos_of_elid(pz_pe(i)))
+       else
+          penew = pz_pe(i)
+       end if
+       write(uout) enew, pz_f(i), penew, pz_pf(i), &
+            pz_g(1,i), pz_g(2,i), pz_g(3,i), pz_g(4,i), 5_i4
+     end block
+  end do
+  do i = 1, nlz
+     write(uout) newid(pos_of_elid(lz_e(i))), lz_f(i), 0_i4, lz_lab(i), &
+          0_i4, 0_i4, 0_i4, 0_i4, 7_i4
+  end do
+  do i = 1, nxz
+     write(uout) newid(pos_of_elid(xz(1, i))), xz(2:9, i)
+  end do
+
+  ! curves: first-class -- remap element id, carry curve_data/type verbatim
+  write(uout) int(ncu, i4)
+  do i = 1, ncu
+     write(uout) newid(pos_of_elid(cu_e(i))), cu_data(:, :, i), cu_type(:, i)
+  end do
+  close(uout)
+
+  write(*,'(a,a)') '  done -> ', trim(fout)
+
+  call rm%free(); call comp%free()
+
+contains
+
+  !> Abort cleanly if the .nmsh is truncated (reads happen before any output
+  !! file is opened, so nothing partial is left behind).
+  subroutine chk_read(ios_)
+    integer, intent(in) :: ios_
+    if (ios_ == 0) return
+    write(error_unit,*) 'Error: truncated or corrupt .nmsh file (unexpected ', &
+         'end of data)'
+    stop 1
+  end subroutine chk_read
+
+
+  !> Weighted edge cut of the partition on the merged dual graph. Edge weight =
+  !! number of shared vertices between two elements; `edges` is the total weight,
+  !! `cut` the weight crossing partition boundaries. Computed by, for each vertex,
+  !! counting element pairs that share it (a face-pair shares 4 vertices -> weight
+  !! 4, matching genmap's connectivity weighting).
+  subroutine count_cut(cell, nv, nelv, nrnk, part, cut, edges)
+    integer(i4), intent(in) :: cell(nv, nelv), part(nelv)
+    integer, intent(in) :: nv, nelv, nrnk
+    integer(i8), intent(out) :: cut, edges
+    integer(i4), allocatable :: cptr(:), ccnt(:), clist(:)
+    integer :: i, k, vtx, a, b, j0, j1, ea, eb
+    allocate(ccnt(nrnk)); ccnt = 0
+    do i = 1, nelv
+       do k = 1, nv
+          ccnt(cell(k, i)) = ccnt(cell(k, i)) + 1
+       end do
+    end do
+    allocate(cptr(nrnk + 1)); cptr(1) = 1
+    do i = 1, nrnk
+       cptr(i + 1) = cptr(i) + ccnt(i)
+    end do
+    allocate(clist(cptr(nrnk + 1) - 1)); ccnt = 0
+    do i = 1, nelv
+       do k = 1, nv
+          vtx = cell(k, i)
+          clist(cptr(vtx) + ccnt(vtx)) = int(i, i4)
+          ccnt(vtx) = ccnt(vtx) + 1
+       end do
+    end do
+    cut = 0_i8; edges = 0_i8
+    do vtx = 1, nrnk
+       j0 = cptr(vtx); j1 = cptr(vtx + 1) - 1
+       do a = j0, j1
+          ea = clist(a)
+          do b = a + 1, j1
+             eb = clist(b)
+             if (ea == eb) cycle       ! skip an element sharing a merged vertex
+                                       ! with itself (degenerate periodic/thin mesh)
+             edges = edges + 1_i8
+             if (part(ea) /= part(eb)) cut = cut + 1_i8
+          end do
+       end do
+    end do
+    deallocate(ccnt, cptr, clist)
+  end subroutine count_cut
+
+end program genmap_light

--- a/contrib/genmap_light/genmap_light.f90
+++ b/contrib/genmap_light/genmap_light.f90
@@ -78,8 +78,8 @@ module gm_hash
      integer(i8) :: cap = 0, mask = 0, n = 0
    contains
      procedure :: init => im_init
-     procedure :: set  => im_set      !< insert/overwrite key -> val
-     procedure :: getor => im_getor   !< val if present, else the supplied default
+     procedure :: set => im_set !< insert/overwrite key -> val
+     procedure :: getor => im_getor !< val if present, else the supplied default
      procedure :: intern => im_intern !< map key to a dense 1..n id, assigning on first sight
      procedure :: free => im_free
   end type imap_t
@@ -205,8 +205,8 @@ module gm_rsb
   private
   public :: rsb_partition
 
-  integer, parameter :: MLANC = 100  ! Krylov dimension for the Fiedler Lanczos
-  logical :: dbg = .false.           ! GENMAP_DEBUG diagnostic prints
+  integer, parameter :: MLANC = 100 ! Krylov dimension for the Fiedler Lanczos
+  logical :: dbg = .false. ! GENMAP_DEBUG diagnostic prints
 
 contains
 
@@ -254,7 +254,7 @@ contains
     if (n1 > n - 1) n1 = n - 1
     ! bisect: reorder loc(1:n) so the first n1 form one side, the rest the other
     call bisect(loc, n, n1, cell, nv, nelv, nrnk)
-    call rsb_rec(loc(1),    n1,     q1, base,      cell, nv, nelv, nrnk, part)
+    call rsb_rec(loc(1), n1, q1, base, cell, nv, nelv, nrnk, part)
     call rsb_rec(loc(n1+1), n - n1, q2, base + q1, cell, nv, nelv, nrnk, part)
   end subroutine rsb_rec
 
@@ -278,7 +278,7 @@ contains
     real(dp) :: cut, score, bscore, bcut
     logical :: okconn, bconn
 
-    if (n <= 2) return   ! loc order is fine; first n1 vs rest
+    if (n <= 2) return ! loc order is fine; first n1 vs rest
 
     call build_dual(loc, n, cell, nv, nelv, nrnk, ia, ja, va)
 
@@ -304,7 +304,7 @@ contains
     end do
 
     if (.not. bconn) then
-       call region_grow(n, n1, bside, ia, ja)   ! guarantee connectivity
+       call region_grow(n, n1, bside, ia, ja) ! guarantee connectivity
     end if
     ! (print bcut, never bscore: the +1e12 disconnected penalty would overflow
     ! a default integer)
@@ -392,7 +392,7 @@ contains
        e = loc(i)
        do k = 1, nv
           vtx = cell(k, e)
-          v2c(v2c_ptr(vtx) + v2c_cnt(vtx)) = int(i, i4)   ! store LOCAL index
+          v2c(v2c_ptr(vtx) + v2c_cnt(vtx)) = int(i, i4) ! store LOCAL index
           v2c_cnt(vtx) = v2c_cnt(vtx) + 1
        end do
     end do
@@ -448,7 +448,7 @@ contains
           ne = nbr(k)
           ja(off + k) = int(ne, i4)
           if (ne == i) then
-             va(off + k) = 0.0_dp        ! placeholder; set to rowsum below
+             va(off + k) = 0.0_dp ! placeholder; set to rowsum below
           else
              rowsum = rowsum + wcnt(ne)
              va(off + k) = -real(wcnt(ne), dp)
@@ -509,7 +509,7 @@ contains
     mm = m
     do k = 1, m
        call ax(w, qv(1, k), ia, ja, va, n)
-       call ortho1(w, n)                          ! stay orthogonal to 1 (null space)
+       call ortho1(w, n) ! stay orthogonal to 1 (null space)
        alpha(k) = dot(w, qv(1, k), n)
        if (k == 1) then
           do i = 1, n
@@ -520,7 +520,7 @@ contains
              w(i) = w(i) - alpha(k) * qv(i, k) - bet(k-1) * qv(i, k-1)
           end do
        end if
-       do j = 1, k                                ! full reorthogonalisation
+       do j = 1, k ! full reorthogonalisation
           s = dot(w, qv(1, j), n)
           do i = 1, n
              w(i) = w(i) - s * qv(i, j)
@@ -537,8 +537,8 @@ contains
     end do
 
     allocate(dd(mm), ee(mm), zz(mm, mm), ord(mm))
-    call tql2_eig(alpha, bet, dd, ee, zz, mm, idum)   ! all eigenpairs of T
-    call rsort(dd, ord, mm)                            ! ord(1) = smallest eigenvalue
+    call tql2_eig(alpha, bet, dd, ee, zz, mm, idum) ! all eigenpairs of T
+    call rsort(dd, ord, mm) ! ord(1) = smallest eigenvalue
     kgot = min(kwant, mm)
     do c = 1, kgot
        do i = 1, n
@@ -834,22 +834,22 @@ program genmap_light
   ! the nmsh->mesh read swap [1,2,4,3,5,6,8,7]); same table validated byte-exact
   ! for periodic glb_pt_ids in rea2nbin_light / mesh_checker_light.
   integer(i4), parameter :: FACE_RE2(4,6) = reshape((/ &
-       1,5,8,4,   2,6,7,3,   1,2,6,5,   4,3,7,8,   1,2,3,4,   5,6,7,8 /), (/4,6/))
+       1,5,8,4, 2,6,7,3, 1,2,6,5, 4,3,7,8, 1,2,3,4, 5,6,7,8 /), (/4,6/))
 
   character(len=1024) :: fin, fout, argbuf
   integer :: uin, uout, ios, i, k, argc, nparts
   integer(i4) :: nelv, gdim, elid, nz, ncur, ztype
   integer(i4) :: ze, zf, zpe, zpf, g1, g2, g3, g4
   integer(i4), allocatable :: elid_of_pos(:), pos_of_elid(:)
-  integer(i4), allocatable :: ev(:,:)          ! (8,nelv) original nmsh point ids
-  real(dp), allocatable :: cx(:,:), cy(:,:), cz(:,:)  ! (8,nelv) coords
-  integer(i4), allocatable :: cell(:,:)        ! (8,nelv) merged+compressed vtx ids
+  integer(i4), allocatable :: ev(:,:) ! (8,nelv) original nmsh point ids
+  real(dp), allocatable :: cx(:,:), cy(:,:), cz(:,:) ! (8,nelv) coords
+  integer(i4), allocatable :: cell(:,:) ! (8,nelv) merged+compressed vtx ids
   integer(i4), allocatable :: part(:), newid(:), pos_of_newid(:)
-  integer(i4), allocatable :: blk(:)           ! partition prefix offsets
+  integer(i4), allocatable :: blk(:) ! partition prefix offsets
   ! zone storage
   integer(i4), allocatable :: pz_e(:), pz_f(:), pz_pe(:), pz_pf(:), pz_g(:,:)
   integer(i4), allocatable :: lz_e(:), lz_f(:), lz_lab(:)
-  integer(i4), allocatable :: xz(:,:)          ! legacy zone types, raw 9-int records
+  integer(i4), allocatable :: xz(:,:) ! legacy zone types, raw 9-int records
   integer :: npz, nlz, nxz
   ! curve storage
   integer(i4), allocatable :: cu_e(:), cu_type(:,:)
@@ -880,11 +880,11 @@ program genmap_light
   else
      block
        integer :: islash, idot
-       islash = scan(trim(fin), '/', back=.true.)   ! 0 if no directory part
-       idot   = scan(trim(fin), '.', back=.true.)
-       if (idot > islash) then                       ! a real extension to strip
+       islash = scan(trim(fin), '/', back=.true.) ! 0 if no directory part
+       idot = scan(trim(fin), '.', back=.true.)
+       if (idot > islash) then ! a real extension to strip
           fout = trim(fin(1:idot-1)) // '_' // trim(adjustl(argbuf)) // '.nmsh'
-       else                                          ! no extension (or '.' only in dir)
+       else ! no extension (or '.' only in dir)
           fout = trim(fin) // '_' // trim(adjustl(argbuf)) // '.nmsh'
        end if
      end block
@@ -896,9 +896,9 @@ program genmap_light
   write(*,'(a)') '   /    / / _/  / ,<   / /_/ /'
   write(*,'(a)') '  /_/|_/ /___/ /_/|_|  \____/   genmap_light  (spectral partitioner)'
   write(*,'(a)') ''
-  write(*,'(a,a)')    '  input     : ', trim(fin)
-  write(*,'(a,a)')    '  output    : ', trim(fout)
-  write(*,'(a,i0)')   '  nparts    : ', nparts
+  write(*,'(a,a)') '  input     : ', trim(fin)
+  write(*,'(a,a)') '  output    : ', trim(fout)
+  write(*,'(a,i0)') '  nparts    : ', nparts
 
   ! ---- read header + elements ----
   open(newunit=uin, file=trim(fin), access='stream', form='unformatted', &
@@ -935,7 +935,7 @@ program genmap_light
      end if
      pos_of_elid(elid_of_pos(i)) = int(i, i4)
   end do
-  do i = 1, nelv                 ! element ids must be a permutation of 1..nelv
+  do i = 1, nelv ! element ids must be a permutation of 1..nelv
      if (pos_of_elid(i) == 0) then
         write(error_unit,*) 'Error: element ids are not a permutation of 1..nelv', &
              ' (duplicate or missing id ', i, ').'; stop 1
@@ -1001,8 +1001,8 @@ program genmap_light
   nextid = 0
   do i = 1, nelv
      do k = 1, 8
-        vid = rm%getor(ev(k, i), ev(k, i))     ! merged id (identity if not periodic)
-        mid = comp%intern(vid, nextid)         ! dense 1..nrnk
+        vid = rm%getor(ev(k, i), ev(k, i)) ! merged id (identity if not periodic)
+        mid = comp%intern(vid, nextid) ! dense 1..nrnk
         cell(k, i) = mid
      end do
   end do
@@ -1026,7 +1026,7 @@ program genmap_light
      blk(part(i) + 1) = blk(part(i) + 1) + 1
   end do
   do i = 1, nparts
-     blk(i) = blk(i) + blk(i - 1)          ! exclusive prefix sum -> block starts
+     blk(i) = blk(i) + blk(i - 1) ! exclusive prefix sum -> block starts
   end do
   allocate(newid(nelv), pos_of_newid(nelv))
   block
@@ -1036,7 +1036,7 @@ program genmap_light
     do i = 1, nelv
        r = part(i)
        cnt(r) = cnt(r) + 1
-       newid(i) = blk(r) + cnt(r)           ! 1-based new global id
+       newid(i) = blk(r) + cnt(r) ! 1-based new global id
        pos_of_newid(newid(i)) = int(i, i4)
     end do
   end block
@@ -1049,7 +1049,7 @@ program genmap_light
      block
        integer :: pos
        pos = pos_of_newid(i)
-       write(uout) int(i, i4)               ! el_idx = new contiguous global id
+       write(uout) int(i, i4) ! el_idx = new contiguous global id
        do k = 1, 8
           write(uout) ev(k, pos), cx(k, pos), cy(k, pos), cz(k, pos)
        end do
@@ -1140,8 +1140,8 @@ contains
           ea = clist(a)
           do b = a + 1, j1
              eb = clist(b)
-             if (ea == eb) cycle       ! skip an element sharing a merged vertex
-                                       ! with itself (degenerate periodic/thin mesh)
+             if (ea == eb) cycle ! skip an element sharing a merged vertex
+             ! with itself (degenerate periodic/thin mesh)
              edges = edges + 1_i8
              if (part(ea) /= part(eb)) cut = cut + 1_i8
           end do

--- a/contrib/genmap_light/genmap_light.md
+++ b/contrib/genmap_light/genmap_light.md
@@ -1,0 +1,178 @@
+```text
+     _  __  ____  __ __  ____
+    / |/ / / __/ / //_/ / __ \
+   /    / / _/  / ,<   / /_/ /
+  /_/|_/ /___/ /_/|_|  \____/
+```
+
+# genmap_light
+
+A standalone, CPU-only **spectral-bisection mesh partitioner** for Neko `.nmsh`
+files — a lightweight reimplementation of Nek5000's `genmap` that reads an
+`.nmsh`, partitions it into `nparts` parts, and writes a reordered `.nmsh` whose
+elements are grouped into contiguous per-partition blocks, exactly like
+`contrib/prepart` (so a later *linear* read reproduces the partition). Curves and
+zones are first-class.
+
+Needs only a Fortran compiler (no MPI, no Neko library, no ParMETIS):
+
+```sh
+make                                          # gfortran -O2 -o genmap_light genmap_light.f90
+./genmap_light mesh.nmsh 8                     # -> mesh_8.nmsh (8 parts)
+./genmap_light mesh.nmsh 16 out.nmsh
+make check                                     # partition + reorder validation vs a SciPy oracle
+```
+
+Usage mirrors `prepart`:
+
+```
+genmap_light mesh.nmsh nparts [out.nmsh]
+```
+
+`nparts` is any positive integer (need not be a power of two); the default output
+is `<base>_<nparts>.nmsh`.
+
+> `make check` reads meshes from a Neko checkout and needs `numpy`+`scipy`, so it
+> expects this folder inside a Neko source tree (`../../examples`, `../../tests`);
+> otherwise pass the tree explicitly:
+> `python3 validate_genmap.py ./genmap_light /path/to/neko [nparts]`.
+> Partitioning your own mesh needs no Neko tree and no Python.
+
+## Why it exists
+
+Neko partitions meshes with **ParMETIS** (via `prepart`, and the runtime load
+balancer). ParMETIS is excellent, but it is an external MPI library you have to
+build and link. Nek5000's `genmap` uses a lighter-weight, self-contained
+algorithm — **recursive spectral bisection (RSB)** using the Fiedler vector of
+the element graph — that is often nearly as good and needs no dependencies.
+`genmap_light` brings that algorithm to Neko's `.nmsh` format as a small
+standalone tool.
+
+Like the other `*_light` tools it does **no Neko initialisation** and links
+nothing, so it runs anywhere with just a Fortran compiler — in particular you do
+not need a separate CPU build of a GPU-configured Neko, and you do not need
+ParMETIS/MPI available just to (re)partition a mesh offline.
+
+> **Tested, but please check your own case.** The partition quality is
+> cross-checked against an independent SciPy exact-Fiedler eigensolver and the
+> reorder is checked to be a pure permutation (geometry, curves and zones
+> preserved) across the meshes shipped with Neko (see [Validation](#validation)).
+> It remains your responsibility to confirm the result is correct for *your* mesh
+> — `make check` on a case you trust first.
+
+## The algorithm (faithful to genmap)
+
+1. **Element dual graph.** Each element is a graph node; two elements are
+   connected if they share one or more vertices, with **edge weight = number of
+   shared vertices** (face-neighbours share 4, edge-neighbours 2, corner-
+   neighbours 1) — exactly Nek5000 genmap's `c2c` weighting. This becomes the
+   weighted graph Laplacian `L` (`L_ii = Σ weights`, `L_ij = −weight`).
+   Point ids come straight from the `.nmsh`; **periodic** facets are merged first
+   using the stored `glb_pt_ids` (the same merge Neko applies on read), so
+   periodic neighbours are graph-adjacent.
+2. **Low spectral modes.** The few lowest non-trivial eigenvectors of `L`
+   (the Fiedler vector and the next few) — computed by a Lanczos iteration on `L`
+   that deflates the constant null vector, just as genmap does. `genmap_light`
+   uses **full reorthogonalisation** and a generic (all-mode) start, which is more
+   robust than genmap's plain Lanczos: plain Lanczos loses orthogonality and can
+   under-resolve the low modes on high-aspect-ratio or periodic meshes and then
+   bisect along the wrong one.
+3. **Bisection (best of the low modes).** For each of those lowest modes, sort
+   the elements by the mode value, split at the balance point, and measure the
+   resulting edge cut; keep the **lowest-cut** split, preferring splits whose two
+   halves are both connected (a DFS check). If none is connected, a
+   region-growing (BFS) bisection restores connectivity (genmap's
+   connectivity-preserving strategy). Trying the few lowest modes — not just the
+   single Fiedler vector — makes the bisection robust on meshes with a
+   degenerate/near-degenerate Fiedler space (cylinders, symmetric boxes), where
+   the specific eigenvector chosen determines the cut.
+4. **Recurse** on each half until `nparts` parts remain. Non-power-of-two
+   `nparts` is handled by splitting the target part-count proportionally, so all
+   final parts differ by at most one element.
+5. **Reorder + write** (the `prepart` contract): number the parts' elements into
+   contiguous blocks, write a new `.nmsh` with `el_idx` renumbered `1..nelv`,
+   point ids and coordinates **unchanged**, and every curve and zone carried
+   through with its element reference remapped. A later linear read on `nparts`
+   ranks then lands each part on its rank.
+
+**Curves are first-class.** Every curve record is carried through: the element id
+is remapped, and the geometric payload (`curve_data(5,12)`, `curve_type(12)`) is
+copied **verbatim** — coordinates are never transformed, curvature never dropped.
+Periodic (type-5) zones keep their `glb_pt_ids` verbatim (those reference point
+ids, which the reorder does not change) with only the element references
+remapped; labeled (type-7) zones keep their label.
+
+## Validation
+
+`validate_genmap.py` runs genmap_light on every 3D mesh in a Neko tree and checks
+two things.
+
+**1. The reorder is correct (the prepart contract).** For every mesh the output
+is a **pure permutation** of the input — element geometry, all curve payloads,
+and all zone records are preserved as multisets — with `el_idx` renumbered to a
+contiguous `1..nelv` and the elements grouped into contiguous per-partition
+blocks, so a linear read reproduces the partition. Curves and periodic/labeled
+zones are verified carried through with only element references remapped.
+
+**2. The partition is good.** It rebuilds the same weighted dual-graph Laplacian
+and computes an **independent recursive spectral bisection with SciPy's exact
+eigensolver** (`scipy.sparse.linalg.eigsh`), then compares genmap_light's
+weighted edge cut and balance against that oracle and against a naive linear
+split. genmap_light's cut matches the exact-Fiedler oracle closely (often equal
+or better, thanks to the connectivity-preserving fallback) and is far below the
+linear baseline where spectral partitioning helps, with balance exact
+(part sizes differ by ≤ 1).
+
+Representative results (`nparts = 8`; weighted shared-vertex edge cut):
+
+| mesh | nelv | genmap_light | SciPy exact-Fiedler | linear |
+|---|--:|--:|--:|--:|
+| `turb_pipe` (curved+periodic) | 36480 | **49100** | 50336 | 199120 |
+| `tgv/32768` (3× periodic) | 32768 | **111181** | 101954 | 131072 |
+| `turb_channel` | 5832 | **25886** | 26624 | 41216 |
+| `cyl_boundary_layer` | 6939 | **13376** | 13448 | 29262 |
+| `cylinder` | 1824 | **6192** | 6192 | 8088 |
+| `hemi` | 2042 | **4900** | 4960 | 24380 |
+| `poisson/16384` | 16384 | **36456** | 31868 | 111132 |
+
+Across all 42 shipped 3D meshes the reorder is a pure permutation of the input,
+balance is exact (part sizes differ by ≤ 1), and the cut is at or near the exact
+spectral optimum (often below it, thanks to the best-of-modes choice). Against a
+naive linear split the cut is typically 1.2–5× lower, up to ~9× on stretched
+meshes, and equal only where the file order is already optimal (extruded,
+1-D-like boxes).
+
+## Scope / limitations
+
+- **3D hex meshes** (genmap's common case). 2D (`gdim=2`) exits with a clear
+  error.
+- **Serial / offline tool** (like `prepart`): it loads the whole mesh, so peak
+  memory is roughly 2 kB per element (element records + the weighted dual graph
+  + the Lanczos vectors) — small next to a solver run, but it is not itself
+  distributed. Practical up to meshes of tens of millions of elements; the CSR
+  dual-graph index is 32-bit, as in genmap.
+- **Partition quality vs ParMETIS.** RSB gives a good, low-cut partition but
+  ParMETIS's multilevel k-way method can still edge it out on some meshes; use
+  `prepart` when you have ParMETIS and want the last few percent. genmap_light is
+  the dependency-free option.
+- **Python sibling.** `prepart_light` (shipped alongside) implements the same
+  reorder contract in Python with three backends (spectral / METIS / geometric);
+  it is usually faster and, with `pymetis`, gives the best cut. Use
+  `genmap_light` when a Fortran compiler is all you have, `prepart_light` when
+  Python with NumPy/SciPy is available.
+- **Determinism.** The Fiedler start is a fixed deterministic hash, so a given
+  mesh + `nparts` always yields the same output.
+- **Diagnostics.** Setting the `GENMAP_DEBUG` environment variable prints one
+  line per bisection to stderr (subset size, split point, connectivity, cut).
+- **Legacy zone types.** Zone records of types other than 5/7 (found in some
+  older meshes) are carried through verbatim with the element id renumbered.
+- The only non-geometric fields that differ from a `prepart` run are ordering and
+  the labeled-zone `p_e`/`glb_pt_ids` that Neko leaves uninitialised (written as
+  deterministic zeros here); the reader ignores them.
+
+## Files
+
+- `genmap_light.f90` — the partitioner (hash + RSB numerics modules + program).
+- `validate_genmap.py` — the SciPy-oracle + permutation/curve/zone harness
+  (`make check`; needs `numpy`+`scipy`).
+- `Makefile` — `make`, `make check`, `make clean`.

--- a/contrib/genmap_light/validate_genmap.py
+++ b/contrib/genmap_light/validate_genmap.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, The Neko Authors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#
+#   * Neither the name of the authors nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#     _  __  ____  __ __  ____
+#    / |/ / / __/ / //_/ / __ \
+#   /    / / _/  / ,<   / /_/ /
+#  /_/|_/ /___/ /_/|_|  \____/
+#
+"""Validation for genmap_light across 3D meshes in the Neko tree.
+
+For each mesh it:
+  1. Runs genmap_light to produce a reordered .nmsh, and checks the reorder is
+     CORRECT: the output is a pure permutation of the input (element geometry,
+     curves, and zones preserved), el_idx is contiguous 1..nelv, and the elements
+     form contiguous per-partition blocks so a linear read reproduces the
+     partition (exactly the prepart contract).
+  2. Rebuilds the SAME merged dual-graph Laplacian (edge weight = number of
+     shared vertices, periodic facets merged via glb_pt_ids) and computes an
+     INDEPENDENT recursive spectral bisection using SciPy's exact eigensolver.
+     It then compares genmap_light's weighted edge cut and balance against the
+     SciPy oracle and against a naive linear split -- confirming the Lanczos
+     Fiedler vector matches the true spectral partition (cut within a small
+     factor of the exact eigensolver, and far below the linear baseline on
+     meshes where spectral partitioning helps).
+
+Usage:  python3 validate_genmap.py [path/to/genmap_light] [neko_root] [nparts]
+"""
+import struct, subprocess, glob, os, sys, tempfile, collections, math
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg as spla
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+EXE  = sys.argv[1] if len(sys.argv) > 1 else os.path.join(HERE, 'genmap_light')
+NEKO = sys.argv[2] if len(sys.argv) > 2 else os.path.abspath(os.path.join(HERE, '..', '..'))
+NPARTS = int(sys.argv[3]) if len(sys.argv) > 3 else 8
+
+FACE = [(1,5,8,4),(2,6,7,3),(1,2,6,5),(4,3,7,8),(1,2,3,4),(5,6,7,8)]  # 1-based nmsh vtx
+
+
+def readmesh(path):
+    d = open(path, 'rb').read()
+    nelv, gdim = struct.unpack('<ii', d[:8])
+    if gdim != 3:
+        return None
+    off = 8
+    vidx = np.empty((nelv, 8), dtype=np.int64)
+    geo = []          # per element: tuple of 8 (vidx,x,y,z) for permutation check
+    elids = np.empty(nelv, dtype=np.int64)
+    for e in range(nelv):
+        elids[e] = struct.unpack('<i', d[off:off+4])[0]; off += 4
+        g = []
+        for k in range(8):
+            vi = struct.unpack('<i', d[off:off+4])[0]
+            xyz = struct.unpack('<3d', d[off+4:off+28]); off += 28
+            vidx[e, k] = vi
+            g.append((vi,) + xyz)
+        geo.append(tuple(g))
+    nz = struct.unpack('<i', d[off:off+4])[0]; off += 4
+    zones = [struct.unpack('<9i', d[off+i*36:off+i*36+36]) for i in range(nz)]
+    off += nz * 36
+    nc = struct.unpack('<i', d[off:off+4])[0]; off += 4
+    curves = []
+    for i in range(nc):
+        e = struct.unpack('<i', d[off:off+4])[0]
+        cd = d[off+4:off+484]        # raw bytes of curve_data
+        ct = d[off+484:off+532]      # raw bytes of curve_type
+        curves.append((e, cd, ct)); off += 532
+    return dict(nelv=nelv, gdim=gdim, vidx=vidx, geo=geo, elids=elids,
+                zones=zones, curves=curves)
+
+
+def merged_cell(m):
+    """Apply the periodic glb_pt_ids merge and compress point ids to 0..nrnk-1.
+    Returns an (nelv,8) int array of compressed vertex ids."""
+    nelv = m['nelv']; vidx = m['vidx'].copy()
+    pos_of_elid = {int(e): i for i, e in enumerate(m['elids'])}
+    remap = {}
+    for z in m['zones']:
+        e, f, pe, pf, g1, g2, g3, g4, zt = z
+        if zt == 5:
+            pos = pos_of_elid[e]
+            g = (g1, g2, g3, g4)
+            for k in range(4):
+                raw = int(vidx[pos, FACE[f-1][k]-1])
+                remap[raw] = min(remap.get(raw, g[k]), g[k])
+    # apply remap
+    if remap:
+        for e in range(nelv):
+            for k in range(8):
+                v = int(vidx[e, k])
+                if v in remap:
+                    vidx[e, k] = remap[v]
+    # compress
+    uniq = {}
+    cell = np.empty((nelv, 8), dtype=np.int64)
+    nid = 0
+    for e in range(nelv):
+        for k in range(8):
+            v = int(vidx[e, k])
+            c = uniq.get(v)
+            if c is None:
+                c = nid; uniq[v] = nid; nid += 1
+            cell[e, k] = c
+    return cell, nid
+
+
+def dual_laplacian(cell, nrnk):
+    """Weighted element dual-graph Laplacian; weight = # shared vertices."""
+    nelv = cell.shape[0]
+    # vertex -> elements
+    v2c = collections.defaultdict(list)
+    for e in range(nelv):
+        for k in range(8):
+            v2c[int(cell[e, k])].append(e)
+    w = collections.Counter()
+    for v, els in v2c.items():
+        for a in range(len(els)):
+            for b in range(a+1, len(els)):
+                ea, eb = els[a], els[b]
+                if ea != eb:
+                    key = (ea, eb) if ea < eb else (eb, ea)
+                    w[key] += 1
+    rows = []; cols = []; data = []
+    deg = np.zeros(nelv)
+    for (a, b), wt in w.items():
+        rows += [a, b]; cols += [b, a]; data += [-float(wt), -float(wt)]
+        deg[a] += wt; deg[b] += wt
+    for i in range(nelv):
+        rows.append(i); cols.append(i); data.append(deg[i])
+    L = sp.csr_matrix((data, (rows, cols)), shape=(nelv, nelv))
+    return L, w
+
+
+def weighted_cut(w, part):
+    cut = 0
+    for (a, b), wt in w.items():
+        if part[a] != part[b]:
+            cut += wt
+    total = sum(w.values())
+    return cut, total
+
+
+def fiedler_vector(idx, L):
+    """Exact Fiedler vector of the subgraph induced by node set idx. Dense for
+    small n; sparse shift-invert eigsh near 0 for larger n (the Laplacian's
+    smallest eigenvalue is 0, so we shift just below it)."""
+    idx = np.asarray(idx)
+    n = len(idx)
+    sub = L[idx][:, idx].tocsr()
+    # rebuild the sub-graph Laplacian from the induced adjacency
+    A = -sub.copy()
+    A.setdiag(0.0); A.eliminate_zeros()
+    d = np.asarray(A.sum(axis=1)).ravel()
+    Ls = sp.diags(d) - A
+    if n <= 1500:
+        vals, vecs = np.linalg.eigh(Ls.toarray())
+        return vecs[:, 1]
+    # sparse: two smallest eigenpairs via shift-invert near 0
+    try:
+        v0 = np.random.default_rng(12345).standard_normal(n)
+        vals, vecs = spla.eigsh(Ls.tocsc(), k=2, sigma=-1e-6, which='LM', v0=v0)
+        o = np.argsort(vals)
+        return vecs[:, o[1]]
+    except Exception:
+        v0 = np.random.default_rng(12345).standard_normal(n)
+        vals, vecs = spla.eigsh(Ls, k=2, which='SA', maxiter=5000, tol=1e-6,
+                                v0=v0)
+        o = np.argsort(vals)
+        return vecs[:, o[1]]
+
+
+def scipy_rsb(L, nelv, nparts):
+    part = np.zeros(nelv, dtype=int)
+
+    def rec(idx, q, base):
+        idx = np.asarray(idx)
+        if q <= 1 or len(idx) == 0:
+            for i in idx:
+                part[i] = base
+            return
+        q1 = q // 2; q2 = q - q1
+        n1 = nint(len(idx) * q1 / q)
+        n1 = max(1, min(len(idx)-1, n1))
+        if len(idx) <= 2:
+            order = np.arange(len(idx))
+        else:
+            f = fiedler_vector(idx, L)
+            order = np.argsort(f, kind='stable')
+        left = idx[order[:n1]]; right = idx[order[n1:]]
+        rec(left, q1, base)
+        rec(right, q2, base + q1)
+
+    rec(np.arange(nelv), nparts, 0)
+    return part
+
+
+def genmap_partition(m, exe, nparts, tmp):
+    """Run genmap_light and derive the partition it produced from the output's
+    contiguous per-partition block structure, mapped back to input elements."""
+    out = os.path.join(tmp, 'out.nmsh')
+    r = subprocess.run([exe, m['path'], str(nparts), out],
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        raise RuntimeError('genmap_light failed: ' + r.stderr[:200])
+    o = readmesh(out)
+    # map output element -> input element by identical geometry tuple
+    in_of_geo = {}
+    for e, g in enumerate(m['geo']):
+        in_of_geo.setdefault(g, []).append(e)
+    perm_ok = True
+    part = np.empty(m['nelv'], dtype=int)
+    nelv = m['nelv']
+    # contiguous per-partition blocks: sizes from proportional recursion
+    # derive block id of each OUTPUT position, then attribute to input element
+    # compute block boundaries the same way the tool does (proportional RSB)
+    bounds = part_block_bounds(nelv, nparts)
+    blkid = np.empty(nelv, dtype=int)
+    for b in range(nparts):
+        blkid[bounds[b]:bounds[b+1]] = b
+    used = collections.Counter()
+    for j in range(nelv):
+        g = o['geo'][j]
+        cand = in_of_geo.get(g)
+        if not cand:
+            perm_ok = False; break
+        ie = cand[used[g] % len(cand)]; used[g] += 1
+        part[ie] = blkid[j]
+    return part, o, perm_ok, r.stdout
+
+
+def nint(x):
+    """Fortran NINT: round half AWAY from zero (not Python's banker's round()).
+    Must match genmap_light's rsb_rec target-size arithmetic exactly."""
+    return int(math.floor(x + 0.5)) if x >= 0 else -int(math.floor(-x + 0.5))
+
+
+def part_block_bounds(nelv, nparts):
+    """Reproduce the tool's contiguous block sizes from proportional recursive
+    bisection (must match genmap_light's rsb_rec exactly, incl. NINT rounding)."""
+    sizes = [0]*nparts
+    def rec(n, q, base):
+        if q <= 1:
+            sizes[base] = n; return
+        q1 = q//2; q2 = q-q1
+        n1 = nint(n*q1/q)
+        n1 = max(1, min(n-1, n1))
+        rec(n1, q1, base); rec(n-n1, q2, base+q1)
+    rec(nelv, nparts, 0)
+    bounds = [0]
+    for s in sizes:
+        bounds.append(bounds[-1]+s)
+    return bounds
+
+
+def check_output_valid(m, o, nparts):
+    """Reorder correctness: permutation, contiguity, curves & zones carried."""
+    res = {}
+    res['nelv'] = (o['nelv'] == m['nelv'])
+    res['contiguous_elid'] = (list(o['elids']) == list(range(1, o['nelv']+1)))
+    res['geom_permutation'] = (collections.Counter(m['geo']) ==
+                               collections.Counter(o['geo']))
+    # curves: payload multiset identical (ids remapped)
+    res['curves_carried'] = (
+        collections.Counter((c[1], c[2]) for c in m['curves']) ==
+        collections.Counter((c[1], c[2]) for c in o['curves']))
+    # zones: type-5 glb_pt_ids + f + p_f multiset identical; type-7 (f,label)
+    def zkey5(z):  # (f, p_f, glb_pt_ids) -- independent of element renumber
+        return (z[1], z[3], z[4], z[5], z[6], z[7])
+    in5 = collections.Counter(zkey5(z) for z in m['zones'] if z[8] == 5)
+    ou5 = collections.Counter(zkey5(z) for z in o['zones'] if z[8] == 5)
+    in7 = collections.Counter((z[1], z[3]) for z in m['zones'] if z[8] == 7)
+    ou7 = collections.Counter((z[1], z[3]) for z in o['zones'] if z[8] == 7)
+    res['zones_carried'] = (in5 == ou5 and in7 == ou7)
+    return res
+
+
+def main():
+    if not os.path.exists(EXE):
+        print('error: genmap_light not found at', EXE, '(build it first)'); return 1
+    paths = sorted(glob.glob(os.path.join(NEKO, 'examples', '**', '*.nmsh'), recursive=True) +
+                   glob.glob(os.path.join(NEKO, 'tests', '**', '*.nmsh'), recursive=True))
+    print('genmap_light validation  (nparts = %d)\n' % NPARTS)
+    print('%-42s %7s %6s %8s %8s %8s %6s %s' %
+          ('mesh', 'nelv', 'bal', 'cut_gm', 'cut_sp', 'cut_lin', 'ok', 'notes'))
+    allok = True
+    n_tested = 0
+    for path in paths:
+        m = readmesh(path)
+        if m is None:
+            continue
+        nelv = m['nelv']
+        if nelv < NPARTS or nelv > 60000:     # keep the exact eigensolver tractable
+            continue
+        m['path'] = path
+        n_tested += 1
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                part, o, perm_ok, out = genmap_partition(m, EXE, NPARTS, tmp)
+            except Exception as ex:
+                print('%-42s  RUN FAIL: %s' % (os.path.relpath(path, NEKO), ex))
+                allok = False; continue
+            valid = check_output_valid(m, o, NPARTS)
+        cell, nrnk = merged_cell(m)
+        L, w = dual_laplacian(cell, nrnk)
+        cut_gm, total = weighted_cut(w, part)
+        # scipy oracle
+        sp_part = scipy_rsb(L, nelv, NPARTS)
+        cut_sp, _ = weighted_cut(w, sp_part)
+        # linear baseline
+        bounds = part_block_bounds(nelv, NPARTS)
+        lin = np.empty(nelv, dtype=int)
+        for b in range(NPARTS):
+            lin[bounds[b]:bounds[b+1]] = b
+        cut_lin, _ = weighted_cut(w, lin)
+        # balance = max part / min part
+        sizes = np.bincount(part, minlength=NPARTS)
+        bal = sizes.max() / max(sizes.min(), 1)
+        # genmap_light's cut should be within ~1.5x of the exact spectral cut
+        cut_ok = (cut_gm <= max(1.5 * cut_sp, cut_sp + 0.02 * total) + 1)
+        bal_ok = (sizes.max() - sizes.min() <= 1)
+        vok = all(valid.values()) and perm_ok
+        ok = vok and cut_ok and bal_ok
+        allok = allok and ok
+        notes = '' if ok else ('valid=%s cut_ok=%s bal_ok=%s' %
+                               (valid, cut_ok, bal_ok))
+        print('%-42s %7d %6.2f %8d %8d %8d %6s %s' %
+              (os.path.relpath(path, NEKO), nelv, bal, cut_gm, cut_sp, cut_lin,
+               'OK' if ok else 'FAIL', notes))
+    print('\nmeshes tested: %d' % n_tested)
+    print('cut_gm = genmap_light, cut_sp = SciPy exact-Fiedler RSB, cut_lin = linear split')
+    print('checks: pure permutation + contiguous el_idx + curves/zones carried +')
+    print('        balance (max-min<=1) + cut within 1.5x of exact spectral cut.')
+    print('\nRESULT:', 'PASS' if allok and n_tested > 0 else
+          ('FAIL' if n_tested else 'NO MESHES FOUND'))
+    return 0 if (allok and n_tested > 0) else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/contrib/genmeshbox_light/genmeshbox_light.f90
+++ b/contrib/genmeshbox_light/genmeshbox_light.f90
@@ -78,10 +78,10 @@ program genmeshbox_light
   ! Neko facet (1..6) corners as nmsh vertex slots (1..8); the table validated
   ! byte-exact for periodic ids in rea2nbin_light.
   integer, parameter :: FCORN(4,6) = reshape((/ &
-       1,5,8,4,   2,6,7,3,   1,2,6,5,   4,3,7,8,   1,2,3,4,   5,6,7,8 /), (/4,6/))
+       1,5,8,4, 2,6,7,3, 1,2,6,5, 4,3,7,8, 1,2,3,4, 5,6,7,8 /), (/4,6/))
   ! nmsh vertex slot (1..8) -> (ix,iy,iz) corner of the reference cube
   integer, parameter :: SIJK(3,8) = reshape((/ &
-       0,0,0,  1,0,0,  1,1,0,  0,1,0,  0,0,1,  1,0,1,  1,1,1,  0,1,1 /), (/3,8/))
+       0,0,0, 1,0,0, 1,1,0, 0,1,0, 0,0,1, 1,0,1, 1,1,1, 0,1,1 /), (/3,8/))
 
   character(len=1024) :: arg, fout
   real(dp) :: x0, x1, y0, y1, z0, z1
@@ -89,8 +89,8 @@ program genmeshbox_light
   integer(i8) :: nel
   logical :: px, py, pz, direct
   character(len=1024) :: dxf, dyf, dzf
-  character(len=1024), allocatable :: av(:)         ! positional args (flags removed)
-  real(dp), allocatable :: gx(:), gy(:), gz(:)     ! grid-line coords (0..nx etc.)
+  character(len=1024), allocatable :: av(:) ! positional args (flags removed)
+  real(dp), allocatable :: gx(:), gy(:), gz(:) ! grid-line coords (0..nx etc.)
   integer(i4) :: vid, elid
   real(dp) :: xx, yy, zz
   integer(i8) :: nzones, nper, nlab
@@ -135,7 +135,7 @@ program genmeshbox_light
   if (na >= 15) then
      dxf = av(13); dyf = av(14); dzf = av(15)
   end if
-  if (na == 10 .or. na == 13 .or. na == 16) fout = av(na)  ! trailing output name
+  if (na == 10 .or. na == 13 .or. na == 16) fout = av(na) ! trailing output name
 
   if (nx < 1 .or. ny < 1 .or. nz < 1) then
      write(error_unit,*) 'Error: nelx/nely/nelz must all be >= 1 (got ', &
@@ -169,7 +169,7 @@ program genmeshbox_light
   if (i /= 0) then
      write(error_unit,*) 'Error: cannot open output file ', trim(fout); stop 1
   end if
-  write(uout) int(nel, i4), 3_i4                    ! header: nelv, gdim
+  write(uout) int(nel, i4), 3_i4 ! header: nelv, gdim
 
   ! ---- elements: genmeshbox loop order (ez outer, ey, ex inner) ----
   write(*,'(a,i0,a)') '  [1/2] writing ', nel, ' elements ...'
@@ -204,8 +204,8 @@ program genmeshbox_light
 
   ! periodic zones first, in genmeshbox marking order (x faces 1,2; y 3,4; z 5,6)
   if (px) then
-     call emit_dir_periodic(uout, 1)               ! x-low  (facet 1)
-     call emit_dir_periodic(uout, 2)               ! x-high (facet 2)
+     call emit_dir_periodic(uout, 1) ! x-low  (facet 1)
+     call emit_dir_periodic(uout, 2) ! x-high (facet 2)
   end if
   if (py) then
      call emit_dir_periodic(uout, 3)
@@ -225,7 +225,7 @@ program genmeshbox_light
      call emit_dir_labeled(uout, lbl)
   end do
 
-  write(uout) 0_i4                                   ! ncurves
+  write(uout) 0_i4 ! ncurves
   close(uout)
 
   write(*,'(a,i0,a,i0,a,i0,a,i0)') 'genmeshbox_light: ', nx, 'x', ny, 'x', nz, &
@@ -302,7 +302,7 @@ contains
     pf = opp_facet(face)
     ! marking order per direction (see genmeshbox.f90 zone loops)
     select case (face)
-    case (1, 2)                                     ! x: do e_y; do e_z
+    case (1, 2) ! x: do e_y; do e_z
        do a = 0, ny-1
           do b = 0, nz-1
              e_ey = a; e_ez = b
@@ -312,7 +312,7 @@ contains
              call wrec(u, face, e_ex, e_ey, e_ez, pf, p_ex, p_ey, p_ez)
           end do
        end do
-    case (3, 4)                                     ! y: do e_x; do e_z
+    case (3, 4) ! y: do e_x; do e_z
        do a = 0, nx-1
           do b = 0, nz-1
              e_ex = a; e_ez = b
@@ -322,7 +322,7 @@ contains
              call wrec(u, face, e_ex, e_ey, e_ez, pf, p_ex, p_ey, p_ez)
           end do
        end do
-    case (5, 6)                                     ! z: do e_x; do e_y
+    case (5, 6) ! z: do e_x; do e_y
        do a = 0, nx-1
           do b = 0, ny-1
              e_ex = a; e_ey = b
@@ -447,7 +447,7 @@ contains
              g(k+1) = a0 + ((a1 - a0) / real(n, dp)) * real(k, dp)
           end do
        else
-          g(:) = fv(:)                               ! exact grid values, verbatim
+          g(:) = fv(:) ! exact grid values, verbatim
        end if
     else
        allocate(ellen(n))

--- a/contrib/genmeshbox_light/genmeshbox_light.f90
+++ b/contrib/genmeshbox_light/genmeshbox_light.f90
@@ -1,0 +1,470 @@
+! Copyright (c) 2026, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!     _  __  ____  __ __  ____
+!    / |/ / / __/ / //_/ / __ \
+!   /    / / _/  / ,<   / /_/ /
+!  /_/|_/ /___/ /_/|_|  \____/
+!
+!> genmeshbox_light -- a lightweight, CPU-only box-mesh generator for Neko.
+!!
+!! Neko's `contrib/genmeshbox` builds a full `mesh_t` using Neko's
+!! general-purpose, production hash tables. Those are robust and reused across the
+!! code, but they are sized generously and store polymorphic keys, so they need a
+!! lot of memory for a large mesh. This tool is a lightweight, CPU-only
+!! reimplementation of just the piece needed: it writes the `.nmsh` for a box mesh
+!! by streaming the records directly, using plain typed arrays and no Neko
+!! initialisation. Every point id and vertex is a closed-form function of the grid
+!! indices, so it needs only O(1) memory beyond the three 1-D coordinate arrays,
+!! giving the same mesh in a small fraction of the memory.
+!!
+!! Because it does not link Neko, it needs only a Fortran compiler (no MPI, no
+!! Neko library) and runs anywhere -- in particular you do not need a separate
+!! CPU build of Neko. The `contrib` tools are CPU-only, so on a Neko configured
+!! for GPUs you would otherwise have to rebuild it for CPU just to generate a box;
+!! this sidesteps that entirely.
+!!
+!! Output is byte-identical to genmeshbox except in the labeled-zone `p_e` and
+!! `glb_pt_ids` fields, which genmeshbox leaves unset; this tool writes
+!! deterministic zeros there instead.
+!!
+!! Usage matches genmeshbox:
+!!   genmeshbox_light x0 x1 y0 y1 z0 z1 nelx nely nelz \
+!!       [periodic_x periodic_y periodic_z] [dist_x dist_y dist_z] [out.nmsh]
+!! periodic_* are .true./.false.; dist_* are 'uniform' or a CSV file of the nel+1
+!! grid coordinates, read exactly as Neko does: a single line of comma/space
+!! separated values, OR a header line followed by the values (when the file has
+!! more than one line, the first line is treated as a header). Default out =
+!! box.nmsh.
+!!
+!! Tested byte-for-byte against every genmeshbox box shipped with Neko and a
+!! freshly-built current genmeshbox, but it remains your responsibility to confirm
+!! the result is correct for your own box -- run `make check` on a case you trust
+!! first. See genmeshbox_light.md for the memory model, validation, and scope.
+program genmeshbox_light
+  use, intrinsic :: iso_fortran_env, only: dp => real64, i4 => int32, i8 => int64, &
+       error_unit
+  implicit none
+
+  ! Neko facet (1..6) corners as nmsh vertex slots (1..8); the table validated
+  ! byte-exact for periodic ids in rea2nbin_light.
+  integer, parameter :: FCORN(4,6) = reshape((/ &
+       1,5,8,4,   2,6,7,3,   1,2,6,5,   4,3,7,8,   1,2,3,4,   5,6,7,8 /), (/4,6/))
+  ! nmsh vertex slot (1..8) -> (ix,iy,iz) corner of the reference cube
+  integer, parameter :: SIJK(3,8) = reshape((/ &
+       0,0,0,  1,0,0,  1,1,0,  0,1,0,  0,0,1,  1,0,1,  1,1,1,  0,1,1 /), (/3,8/))
+
+  character(len=1024) :: arg, fout
+  real(dp) :: x0, x1, y0, y1, z0, z1
+  integer :: nx, ny, nz, argc, uout, ex, ey, ez, s, lbl, na, i
+  integer(i8) :: nel
+  logical :: px, py, pz, direct
+  character(len=1024) :: dxf, dyf, dzf
+  character(len=1024), allocatable :: av(:)         ! positional args (flags removed)
+  real(dp), allocatable :: gx(:), gy(:), gz(:)     ! grid-line coords (0..nx etc.)
+  integer(i4) :: vid, elid
+  real(dp) :: xx, yy, zz
+  integer(i8) :: nzones, nper, nlab
+
+  ! collect args, pulling out the --direct flag (may appear anywhere)
+  argc = command_argument_count()
+  allocate(av(max(1, argc))); na = 0; direct = .false.
+  do i = 1, argc
+     call get_command_argument(i, arg)
+     if (trim(arg) == '--direct') then
+        direct = .true.
+     else
+        na = na + 1; av(na) = arg
+     end if
+  end do
+  if (na < 9) then
+     write(*,*) 'Usage: genmeshbox_light x0 x1 y0 y1 z0 z1 nelx nely nelz \'
+     write(*,*) '   [px py pz (.true./.false.)] [dist_x dist_y dist_z] [out.nmsh] [--direct]'
+     write(*,*) 'px/py/pz: periodic in that direction. dist_*: "uniform" or a text file'
+     write(*,*) 'of nel+1 grid coordinates. --direct: use x0+k*(x1-x0)/n coordinates'
+     write(*,*) '(pre-2024 genmeshbox / exact grid values) instead of the default'
+     write(*,*) 'cumulative-sum coordinates the current genmeshbox produces.'
+     stop 1
+  end if
+  ! valid positional counts: 9 (basic), 12 (+periodic flags), 15 (+dist files),
+  ! each optionally followed by a trailing output name (10, 13, 16)
+  if (.not. (na == 9 .or. na == 10 .or. na == 12 .or. na == 13 .or. &
+       na == 15 .or. na == 16)) then
+     write(error_unit,*) 'Error: invalid number of positional arguments (', na, ')'
+     write(error_unit,*) 'Valid: 9, 12 or 15 positional arguments, optionally'
+     write(error_unit,*) 'followed by an output filename (10, 13, 16).'
+     stop 1
+  end if
+  call parse_dp(av(1), x0); call parse_dp(av(2), x1); call parse_dp(av(3), y0)
+  call parse_dp(av(4), y1); call parse_dp(av(5), z0); call parse_dp(av(6), z1)
+  call parse_i4(av(7), nx); call parse_i4(av(8), ny); call parse_i4(av(9), nz)
+  px = .false.; py = .false.; pz = .false.
+  dxf = 'uniform'; dyf = 'uniform'; dzf = 'uniform'; fout = 'box.nmsh'
+  if (na >= 12) then
+     call parse_lg(av(10), px); call parse_lg(av(11), py); call parse_lg(av(12), pz)
+  end if
+  if (na >= 15) then
+     dxf = av(13); dyf = av(14); dzf = av(15)
+  end if
+  if (na == 10 .or. na == 13 .or. na == 16) fout = av(na)  ! trailing output name
+
+  if (nx < 1 .or. ny < 1 .or. nz < 1) then
+     write(error_unit,*) 'Error: nelx/nely/nelz must all be >= 1 (got ', &
+          nx, ny, nz, ')'
+     stop 1
+  end if
+  if (int(nx, i8) * int(ny, i8) * int(nz, i8) > int(huge(1_i4), i8) .or. &
+      (int(nx, i8) + 1_i8) * (int(ny, i8) + 1_i8) * (int(nz, i8) + 1_i8) > &
+      int(huge(1_i4), i8)) then
+     write(error_unit,*) 'Error: mesh too large -- element/point counts must ', &
+          'fit 32-bit .nmsh ids'
+     stop 1
+  end if
+
+  write(*,'(a)') ''
+  write(*,'(a)') '     _  __  ____  __ __  ____'
+  write(*,'(a)') '    / |/ / / __/ / //_/ / __ \'
+  write(*,'(a)') '   /    / / _/  / ,<   / /_/ /'
+  write(*,'(a)') '  /_/|_/ /___/ /_/|_|  \____/   genmeshbox_light'
+  write(*,'(a)') ''
+
+  nel = int(nx, i8) * int(ny, i8) * int(nz, i8)
+
+  ! grid-line coordinates in each direction (indices 0..n -> array 1..n+1)
+  call build_axis(nx, x0, x1, dxf, direct, gx)
+  call build_axis(ny, y0, y1, dyf, direct, gy)
+  call build_axis(nz, z0, z1, dzf, direct, gz)
+
+  open(newunit=uout, file=trim(fout), access='stream', form='unformatted', &
+       status='replace', action='write', iostat=i)
+  if (i /= 0) then
+     write(error_unit,*) 'Error: cannot open output file ', trim(fout); stop 1
+  end if
+  write(uout) int(nel, i4), 3_i4                    ! header: nelv, gdim
+
+  ! ---- elements: genmeshbox loop order (ez outer, ey, ex inner) ----
+  write(*,'(a,i0,a)') '  [1/2] writing ', nel, ' elements ...'
+  elid = 0
+  do ez = 0, nz-1
+     do ey = 0, ny-1
+        do ex = 0, nx-1
+           elid = elid + 1
+           write(uout) elid
+           do s = 1, 8
+              vid = pt_id(ex + SIJK(1,s), ey + SIJK(2,s), ez + SIJK(3,s))
+              xx = gx(ex + SIJK(1,s) + 1)
+              yy = gy(ey + SIJK(2,s) + 1)
+              zz = gz(ez + SIJK(3,s) + 1)
+              write(uout) vid, xx, yy, zz
+           end do
+        end do
+     end do
+  end do
+
+  ! ---- zones ----
+  write(*,'(a)') '  [2/2] writing zones ...'
+  nper = 0; nlab = 0
+  if (px) nper = nper + 2_i8 * ny * nz
+  if (py) nper = nper + 2_i8 * nx * nz
+  if (pz) nper = nper + 2_i8 * nx * ny
+  if (.not. px) nlab = nlab + 2_i8 * ny * nz
+  if (.not. py) nlab = nlab + 2_i8 * nx * nz
+  if (.not. pz) nlab = nlab + 2_i8 * nx * ny
+  nzones = nper + nlab
+  write(uout) int(nzones, i4)
+
+  ! periodic zones first, in genmeshbox marking order (x faces 1,2; y 3,4; z 5,6)
+  if (px) then
+     call emit_dir_periodic(uout, 1)               ! x-low  (facet 1)
+     call emit_dir_periodic(uout, 2)               ! x-high (facet 2)
+  end if
+  if (py) then
+     call emit_dir_periodic(uout, 3)
+     call emit_dir_periodic(uout, 4)
+  end if
+  if (pz) then
+     call emit_dir_periodic(uout, 5)
+     call emit_dir_periodic(uout, 6)
+  end if
+
+  ! labeled zones, by label ascending (1..6); a face is labeled iff its
+  ! direction is not periodic.
+  do lbl = 1, 6
+     if (lbl <= 2 .and. px) cycle
+     if (lbl >= 3 .and. lbl <= 4 .and. py) cycle
+     if (lbl >= 5 .and. pz) cycle
+     call emit_dir_labeled(uout, lbl)
+  end do
+
+  write(uout) 0_i4                                   ! ncurves
+  close(uout)
+
+  write(*,'(a,i0,a,i0,a,i0,a,i0)') 'genmeshbox_light: ', nx, 'x', ny, 'x', nz, &
+       ' = ', int(nel, i4)
+  write(*,'(a,i0,a,i0,a)') 'Wrote ', nper, ' periodic + ', nlab, ' labeled zone facets'
+  write(*,'(a,a)') 'Done. Wrote ', trim(fout)
+
+contains
+
+  !> Parse helpers: clean one-line diagnostics instead of runtime backtraces.
+  subroutine parse_dp(s, v)
+    character(len=*), intent(in) :: s
+    real(dp), intent(out) :: v
+    integer :: ios_
+    read(s, *, iostat=ios_) v
+    if (ios_ /= 0) then
+       write(error_unit,*) 'Error: cannot parse "', trim(s), '" as a real number'
+       stop 1
+    end if
+  end subroutine parse_dp
+
+  subroutine parse_i4(s, v)
+    character(len=*), intent(in) :: s
+    integer, intent(out) :: v
+    integer :: ios_
+    read(s, *, iostat=ios_) v
+    if (ios_ /= 0) then
+       write(error_unit,*) 'Error: cannot parse "', trim(s), '" as an integer'
+       stop 1
+    end if
+  end subroutine parse_i4
+
+  subroutine parse_lg(s, v)
+    character(len=*), intent(in) :: s
+    logical, intent(out) :: v
+    integer :: ios_
+    read(s, *, iostat=ios_) v
+    if (ios_ /= 0) then
+       write(error_unit,*) 'Error: cannot parse "', trim(s), &
+            '" as a logical (.true./.false.)'
+       stop 1
+    end if
+  end subroutine parse_lg
+
+
+  !> Raw lexicographic point id of grid node (px,py,pz), px in [0,nx] etc.
+  pure integer(i4) function pt_id(a, b, c)
+    integer, intent(in) :: a, b, c
+    pt_id = int(1_i8 + a + int(b, i8)*(nx+1) + int(c, i8)*(nx+1)*(ny+1), i4)
+  end function pt_id
+
+  !> Periodic-merged id: wrap the high boundary of each periodic direction to 0
+  !! (min-id merge), then take the lexicographic id -- matches create_periodic_ids.
+  pure integer(i4) function merged_id(a, b, c)
+    integer, intent(in) :: a, b, c
+    integer :: ra, rb, rc
+    ra = a; rb = b; rc = c
+    if (px .and. a == nx) ra = 0
+    if (py .and. b == ny) rb = 0
+    if (pz .and. c == nz) rc = 0
+    merged_id = pt_id(ra, rb, rc)
+  end function merged_id
+
+  !> Global element id from grid element indices (ex,ey,ez), 0-based.
+  pure integer(i4) function el_id(a, b, c)
+    integer, intent(in) :: a, b, c
+    el_id = int(1_i8 + a + int(b, i8)*nx + int(c, i8)*nx*ny, i4)
+  end function el_id
+
+  !> Emit periodic zone records for face @a face (1..6), in genmeshbox marking order.
+  subroutine emit_dir_periodic(u, face)
+    integer, intent(in) :: u, face
+    integer :: a, b, e_ex, e_ey, e_ez, pf, p_ex, p_ey, p_ez
+    pf = opp_facet(face)
+    ! marking order per direction (see genmeshbox.f90 zone loops)
+    select case (face)
+    case (1, 2)                                     ! x: do e_y; do e_z
+       do a = 0, ny-1
+          do b = 0, nz-1
+             e_ey = a; e_ez = b
+             e_ex = merge(0, nx-1, face == 1)
+             p_ex = merge(nx-1, 0, face == 1)
+             p_ey = e_ey; p_ez = e_ez
+             call wrec(u, face, e_ex, e_ey, e_ez, pf, p_ex, p_ey, p_ez)
+          end do
+       end do
+    case (3, 4)                                     ! y: do e_x; do e_z
+       do a = 0, nx-1
+          do b = 0, nz-1
+             e_ex = a; e_ez = b
+             e_ey = merge(0, ny-1, face == 3)
+             p_ey = merge(ny-1, 0, face == 3)
+             p_ex = e_ex; p_ez = e_ez
+             call wrec(u, face, e_ex, e_ey, e_ez, pf, p_ex, p_ey, p_ez)
+          end do
+       end do
+    case (5, 6)                                     ! z: do e_x; do e_y
+       do a = 0, nx-1
+          do b = 0, ny-1
+             e_ex = a; e_ey = b
+             e_ez = merge(0, nz-1, face == 5)
+             p_ez = merge(nz-1, 0, face == 5)
+             p_ex = e_ex; p_ey = e_ey
+             call wrec(u, face, e_ex, e_ey, e_ez, pf, p_ex, p_ey, p_ez)
+          end do
+       end do
+    end select
+  end subroutine emit_dir_periodic
+
+  !> Write one periodic zone record (merged glb_pt_ids of the facet corners).
+  subroutine wrec(u, face, e_ex, e_ey, e_ez, pf, p_ex, p_ey, p_ez)
+    integer, intent(in) :: u, face, e_ex, e_ey, e_ez, pf, p_ex, p_ey, p_ez
+    integer(i4) :: gp(4)
+    integer :: k, sl
+    do k = 1, 4
+       sl = FCORN(k, face)
+       gp(k) = merged_id(e_ex + SIJK(1,sl), e_ey + SIJK(2,sl), e_ez + SIJK(3,sl))
+    end do
+    ! nmsh_zone_t: e, f, p_e, p_f, glb_pt_ids(4), type=5
+    write(u) el_id(e_ex, e_ey, e_ez), face, el_id(p_ex, p_ey, p_ez), pf, &
+         gp(1), gp(2), gp(3), gp(4), 5_i4
+  end subroutine wrec
+
+  !> Emit labeled zone records for face @a face (label = face), marking order.
+  !! p_e/glb_pt_ids are written 0 (Neko leaves them uninitialised).
+  subroutine emit_dir_labeled(u, face)
+    integer, intent(in) :: u, face
+    integer :: a, b, e_ex, e_ey, e_ez
+    select case (face)
+    case (1, 2)
+       do a = 0, ny-1
+          do b = 0, nz-1
+             e_ex = merge(0, nx-1, face == 1)
+             write(u) el_id(e_ex, a, b), face, 0_i4, face, 0_i4, 0_i4, 0_i4, 0_i4, 7_i4
+          end do
+       end do
+    case (3, 4)
+       do a = 0, nx-1
+          do b = 0, nz-1
+             e_ey = merge(0, ny-1, face == 3)
+             write(u) el_id(a, e_ey, b), face, 0_i4, face, 0_i4, 0_i4, 0_i4, 0_i4, 7_i4
+          end do
+       end do
+    case (5, 6)
+       do a = 0, nx-1
+          do b = 0, ny-1
+             e_ez = merge(0, nz-1, face == 5)
+             write(u) el_id(a, b, e_ez), face, 0_i4, face, 0_i4, 0_i4, 0_i4, 0_i4, 7_i4
+          end do
+       end do
+    end select
+  end subroutine emit_dir_labeled
+
+  pure integer function opp_facet(f)
+    integer, intent(in) :: f
+    select case (f)
+    case (1); opp_facet = 2
+    case (2); opp_facet = 1
+    case (3); opp_facet = 4
+    case (4); opp_facet = 3
+    case (5); opp_facet = 6
+    case (6); opp_facet = 5
+    end select
+  end function opp_facet
+
+  !> Grid-line coordinates in one direction (n+1 values, indices 0..n).
+  !!
+  !! Default (accumulate) reproduces the CURRENT genmeshbox EXACTLY: element
+  !! lengths are formed, then coordinates built by cumulative summation from a0
+  !! (`cumm(1)=a0; cumm(k+1)=cumm(k)+el_len(k)`); for a distribution file the
+  !! element lengths are the successive differences of its n+1 values.
+  !!
+  !! `--direct` uses the closed form `a0 + k*(a1-a0)/n` (what genmeshbox produced
+  !! before the 2024 cumulative-sum change, and what every shipped example box
+  !! stores), and takes distribution-file values verbatim as the grid lines.
+  subroutine build_axis(n, a0, a1, fname, direct, g)
+    integer, intent(in) :: n
+    real(dp), intent(in) :: a0, a1
+    character(len=*), intent(in) :: fname
+    logical, intent(in) :: direct
+    real(dp), allocatable, intent(out) :: g(:)
+    real(dp), allocatable :: ellen(:), fv(:)
+    integer :: k, u, ios, nlines, ios2
+    character(len=256) :: hdr
+    allocate(g(n+1))
+    if (trim(fname) /= 'uniform') then
+       allocate(fv(n+1))
+       open(newunit=u, file=trim(fname), status='old', action='read', iostat=ios)
+       if (ios /= 0) then
+          write(error_unit,*) 'Error: cannot open distribution file ', trim(fname); stop 1
+       end if
+       ! Match Neko's csv reader (csv_file_read_vector): count the records, and if
+       ! the file has more than one line assume the first is a header and skip it,
+       ! then list-directed read the n+1 grid values (commas/spaces/newlines all
+       ! act as separators). A single-line CSV carries no header. This is exactly
+       ! what genmeshbox does, so a distribution file that works with genmeshbox
+       ! works here and produces the same grid.
+       nlines = 0
+       do
+          read(u, *, iostat=ios2)
+          if (ios2 /= 0) exit
+          nlines = nlines + 1
+       end do
+       rewind(u)
+       if (nlines > 1) read(u, '(A)', iostat=ios2) hdr
+       read(u, *, iostat=ios) fv(1:n+1)
+       if (ios /= 0) then
+          write(error_unit,*) 'Error: expected ', n+1, ' grid values in ', trim(fname), &
+               ' (Neko treats the first line as a header when the file has >1 line)'
+          stop 1
+       end if
+       close(u)
+    end if
+    if (direct) then
+       if (trim(fname) == 'uniform') then
+          ! el_len formed first, then multiplied by k (the rounding order that
+          ! reproduces the shipped example boxes exactly).
+          do k = 0, n
+             g(k+1) = a0 + ((a1 - a0) / real(n, dp)) * real(k, dp)
+          end do
+       else
+          g(:) = fv(:)                               ! exact grid values, verbatim
+       end if
+    else
+       allocate(ellen(n))
+       if (trim(fname) == 'uniform') then
+          ellen(:) = (a1 - a0) / real(n, dp)
+       else
+          do k = 1, n
+             ellen(k) = fv(k+1) - fv(k)
+          end do
+       end if
+       g(1) = a0
+       do k = 1, n
+          g(k+1) = g(k) + ellen(k)
+       end do
+       deallocate(ellen)
+    end if
+    if (allocated(fv)) deallocate(fv)
+  end subroutine build_axis
+
+end program genmeshbox_light

--- a/contrib/genmeshbox_light/genmeshbox_light.md
+++ b/contrib/genmeshbox_light/genmeshbox_light.md
@@ -1,0 +1,159 @@
+```text
+     _  __  ____  __ __  ____
+    / |/ / / __/ / //_/ / __ \
+   /    / / _/  / ,<   / /_/ /
+  /_/|_/ /___/ /_/|_|  \____/
+```
+
+# genmeshbox_light
+
+A standalone, **O(1)-memory** box-mesh generator for Neko — a lightweight,
+CPU-only alternative to `contrib/genmeshbox` that writes the `.nmsh` by
+**streaming**, without ever building a `mesh_t`.
+
+Needs only a Fortran compiler (no MPI, no Neko library):
+
+```sh
+make                                        # gfortran -O2 -o genmeshbox_light genmeshbox_light.f90
+./genmeshbox_light 0 1 0 1 0 1 8 8 8 .true. .true. .false.
+make check                                  # byte-exactness vs every genmeshbox box in Neko
+```
+
+> `make check` reads the boxes shipped with Neko, so it expects this folder to
+> live inside a Neko source checkout (e.g. dropped into `contrib/`, so
+> `../../examples` and `../../tests` resolve). To run it from elsewhere, point the
+> validator at your Neko tree directly:
+> `python3 validate_gmb.py ./genmeshbox_light /path/to/neko`. Generating a box
+> (`./genmeshbox_light ...`) needs no Neko tree at all.
+
+The command line follows `genmeshbox`, with two additions — an optional
+trailing output filename and the `--direct` flag:
+
+```
+genmeshbox_light x0 x1 y0 y1 z0 z1 nelx nely nelz \
+    [px py pz] [dist_x dist_y dist_z] [out.nmsh] [--direct]
+```
+
+`px/py/pz` (`.true./.false.`) make that direction periodic; `dist_*` is `uniform`
+or a CSV file of the `nel+1` grid coordinates, read **exactly as Neko reads it**:
+either a single line of comma/space-separated values, or a header line followed
+by the values (when the file has more than one line, Neko treats the first line
+as a header and skips it). A distribution file that works with `genmeshbox` works
+here and yields the same grid. Default output is `box.nmsh`. `--direct` is
+explained under *Coordinates* below.
+
+## Why it exists
+
+Neko's `contrib/genmeshbox` assembles the box as a full `mesh_t` and writes it
+out. That goes through Neko's general-purpose, production hash tables — the same
+robust, well-tested structures used throughout the solver. They're sized
+generously and store polymorphic keys, which is the right trade-off inside Neko,
+but it means a lot of memory for a large box when every point id and vertex
+coordinate is really just a closed-form function of the grid indices.
+
+`genmeshbox_light` is a lightweight reimplementation of just the box generator.
+It computes each point id and coordinate directly, streams the records to disk,
+and does **no Neko initialisation** — so it produces the same `.nmsh` in a tiny
+fraction of the memory (a few kilobytes of working set regardless of box size).
+
+A couple of nice side effects of not linking Neko:
+
+- **No GPU rebuild needed.** The `contrib` tools are CPU-only. If your Neko is
+  configured for GPUs, you'd normally have to rebuild it for CPU just to run
+  them. `genmeshbox_light` needs only a Fortran compiler, so that step goes away.
+- **Runs anywhere** — a login node, a laptop, a small VM — since there's no MPI
+  and no Neko library to carry along.
+
+> **Tested, but please check your own case.** This tool is validated
+> byte-for-byte against every genmeshbox-produced box shipped with Neko and
+> head-to-head against a freshly-built current `genmeshbox` (see
+> [Validation](#validation)). It is still your responsibility to make sure the
+> result is correct for *your* box — `make check` on a case you trust before
+> relying on it.
+
+## What `genmeshbox_light` does instead
+
+For a box, *everything* is a closed form of the grid indices, so no mesh, no hash
+tables, and no dedup are needed:
+
+- **Point ids** are lexicographic: `id = 1 + ix + iy·(nx+1) + iz·(nx+1)(ny+1)`.
+- **Element records** are streamed in genmeshbox's loop order (`ez` outer … `ex`
+  inner), each with the 8 corner ids/coordinates in the standard vertex order.
+- **Periodic zones** carry the *merged* point ids, computed by wrapping each
+  periodic direction's high boundary to its low one (`px == nx → 0`) — the exact
+  min-id result of `create_periodic_ids`, in closed form.
+- **Labeled zones** get the label in `p_f`; their `p_e`/`glb_pt_ids` are written
+  zero (Neko leaves those uninitialised — stale heap).
+
+Memory is just the three 1-D coordinate arrays (`nx+ny+nz+3` doubles) plus a
+streaming write buffer — a few kilobytes for a 75M box.
+
+| | `genmeshbox` (75e6 box) | `genmeshbox_light` (75e6 box) |
+|---|--:|--:|
+| Dominant structures | general polymorphic mesh/connectivity tables + points | three 1-D coord arrays |
+| Peak memory | large (needs a big-memory node) | **~a few KB** |
+
+## Coordinates — `--direct` vs the default
+
+genmeshbox builds the 1-D grid line coordinates by **cumulative summation**
+(`cumm(1)=x0; cumm(k+1)=cumm(k)+el_len`, with `el_len=(x1-x0)/n`), together with
+the distribution-file support added in **Sep 2024**. This *drifts*: for
+`x0=0, x1=4, n=18`, grid line 6 is `1.3333333333333335` and the last line is
+`4.000000000000001` (not exactly `4.0`). `genmeshbox_light`'s **default reproduces
+that cumulative-sum arithmetic exactly** (identical operations, order and types →
+identical bits) — **verified byte-for-byte against the real, freshly-built current
+genmeshbox** (see Validation).
+
+Every box **shipped in the Neko examples predates that change** and instead stores
+`x0 + ((x1-x0)/n)·k` (element length formed once, multiplied by `k`, landing on
+exact values like `2.0`). Pass `--direct` to reproduce those; with a distribution
+file, `--direct` uses the file's values verbatim as the grid lines.
+
+## Validation
+
+`validate_gmb.py` regenerates every genmeshbox-produced box in the Neko tree
+(detected by the lexicographic point-id scheme — benchmark boxes from other
+generators, which number points sequentially per element, are skipped) and
+byte-compares. It feeds the exact grid lines as `--direct` distribution files, so
+the check is independent of the coordinate-formula detail and exercises the part
+that actually matters — element ordering, point ids, and the zone / periodic-merge
+logic.
+
+Result: **9 / 9 byte-exact** — header, every element record, and every periodic
+(type-5) zone identical; labeled (type-7) zones differ **only** in the
+`p_e`/`glb_pt_ids` fields Neko leaves uninitialised (the tool writes zeros).
+
+Corpus covers **1, 2 and 3 periodic directions**: `lid`/`lid2d`/`recycling`
+(z), `rayleigh_benard` (xy), `turb_channel`/`TS_channel` (xz),
+`euler_1d_sod` (yz), `advecting_cone`/`euler_2d_smooth` (xyz) — up to
+`euler_2d_smooth` at 10 000 elements.
+
+**Head-to-head against the real tool (definitive).** The current `genmeshbox` was
+built from source and run on three cases; `genmeshbox_light` (default arithmetic)
+matched its output **byte-for-byte** — header, all element records, all periodic
+zones, and total file size — with the only differences being the uninitialised
+labeled-zone fields:
+
+| case | args | result |
+|---|---|---|
+| 18³, 1-periodic | `0 4 -1 1 0 1.5 18 18 18 .false. .true. .false.` | **byte-exact** (the accumulate-drift case) |
+| 8³, 3-periodic | `0 1 0 1 0 1 8 8 8 .true. .true. .true.` | **byte-exact** |
+| 5×5×1, 2-periodic | `0 4.5 0 4.5 0 1 5 5 1 .true. .true. .false.` | **byte-exact** |
+
+The 18³ case is the one where accumulate (`1.333…35`) and the closed form
+(`1.333…33`) diverge — the default matches the accumulating original exactly.
+
+## Scope / limitations
+
+- **3D hex boxes** (genmeshbox's purpose). Non-uniform grids via a distribution
+  file are supported (uniform or per-direction).
+- Byte-identical to the **current** genmeshbox by default (cumulative-sum
+  coordinates); `--direct` reproduces pre-2024 / shipped-example boxes.
+- The only bytes that can differ from genmeshbox are the labeled-zone
+  `p_e`/`glb_pt_ids` that Neko writes from uninitialised memory.
+
+## Files
+
+- `genmeshbox_light.f90` — the generator (single program).
+- `validate_gmb.py` — the byte-exactness harness (`make check`).
+- `Makefile` — `make`, `make check`, `make clean`.

--- a/contrib/genmeshbox_light/validate_gmb.py
+++ b/contrib/genmeshbox_light/validate_gmb.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, The Neko Authors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#
+#   * Neither the name of the authors nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#     _  __  ____  __ __  ____
+#    / |/ / / __/ / //_/ / __ \
+#   /    / / _/  / ,<   / /_/ /
+#  /_/|_/ /___/ /_/|_|  \____/
+#
+"""Byte-exactness validation for genmeshbox_light against every genmeshbox-made
+box mesh shipped in the Neko tree.
+
+For each candidate `.nmsh` we detect whether it is a uniform tensor-product box
+(distinct x/y/z coordinates, uniform spacing, nelv = nx*ny*nz, genmeshbox element
+ordering), infer its parameters and per-direction periodicity (from the presence
+of type-5 zones on each face pair), regenerate it with genmeshbox_light, and
+byte-compare:
+
+  * header + every element record   -> must be byte-identical
+  * periodic (type-5) zone records  -> must be byte-identical (incl. merged ids)
+  * labeled (type-7) zone records   -> identical except p_e / glb_pt_ids, which
+                                       Neko's writer leaves UNINITIALISED (stale
+                                       heap); the tool writes deterministic zeros
+
+Shipped box files often carry trailing dead bytes after the valid structure (a
+non-truncating writer artifact, exactly like turb_pipe); the harness compares the
+structured records by offset and ignores that tail.
+
+Usage:  python3 validate_gmb.py [path/to/genmeshbox_light] [neko_root]
+"""
+import struct, subprocess, glob, os, sys, tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+EXE  = sys.argv[1] if len(sys.argv) > 1 else os.path.join(HERE, 'genmeshbox_light')
+NEKO = sys.argv[2] if len(sys.argv) > 2 else os.path.abspath(os.path.join(HERE, '..', '..'))
+
+
+def read_box(path):
+    d = open(path, 'rb').read()
+    nelv, gdim = struct.unpack('<ii', d[:8])
+    if gdim != 3:
+        return None
+    off = 8
+    elems = []
+    xs, ys, zs = set(), set(), set()
+    for _ in range(nelv):
+        struct.unpack('<i', d[off:off + 4]); off += 4
+        vs = []
+        for _ in range(8):
+            vi = struct.unpack('<i', d[off:off + 4])[0]
+            xyz = struct.unpack('<3d', d[off + 4:off + 28]); off += 28
+            vs.append((vi, xyz)); xs.add(xyz[0]); ys.add(xyz[1]); zs.add(xyz[2])
+        elems.append(vs)
+    nz = struct.unpack('<i', d[off:off + 4])[0]; off += 4
+    zbase = off
+    faces = set()
+    for i in range(nz):
+        z = struct.unpack('<9i', d[off + i * 36:off + i * 36 + 36])
+        if z[8] == 5:
+            faces.add(z[1])
+    off += nz * 36
+    ncurves = struct.unpack('<i', d[off:off + 4])[0]
+    return dict(d=d, nelv=nelv, elems=elems, xs=sorted(xs), ys=sorted(ys),
+                zs=sorted(zs), nz=nz, zbase=zbase, ncurves=ncurves,
+                valid_end=off + 4, per_faces=faces)
+
+
+def is_uniform(vals):
+    if len(vals) < 2:
+        return False
+    d0 = vals[1] - vals[0]
+    if d0 <= 0:
+        return False
+    return all(abs((vals[k + 1] - vals[k]) - d0) < 1e-9 * max(1.0, abs(d0)) for k in range(len(vals) - 1))
+
+
+def check(path, tmp):
+    b = read_box(path)
+    if b is None:
+        return None
+    nx, ny, nz = len(b['xs']) - 1, len(b['ys']) - 1, len(b['zs']) - 1
+    if nx < 1 or ny < 1 or nz < 1 or nx * ny * nz != b['nelv']:
+        return None                      # not a tensor-product box
+    if b['ncurves'] != 0:
+        return None
+    # Is this genmeshbox output? Its point ids follow the lexicographic scheme
+    # id = 1 + ix + iy*(nx+1) + iz*(nx+1)*(ny+1); other generators (nekbone/tgv/
+    # poisson benchmark meshes) number points sequentially per element instead.
+    def gid(ix, iy, iz):
+        return 1 + ix + iy * (nx + 1) + iz * (nx + 1) * (ny + 1)
+    exp1 = [gid(0,0,0), gid(1,0,0), gid(1,1,0), gid(0,1,0),
+            gid(0,0,1), gid(1,0,1), gid(1,1,1), gid(0,1,1)]
+    if [vi for vi, _ in b['elems'][0]] != exp1:
+        return None                      # different generator -> not a genmeshbox box
+    px = (1 in b['per_faces'] or 2 in b['per_faces'])
+    py = (3 in b['per_faces'] or 4 in b['per_faces'])
+    pz = (5 in b['per_faces'] or 6 in b['per_faces'])
+    x0, x1 = b['xs'][0], b['xs'][-1]; y0, y1 = b['ys'][0], b['ys'][-1]
+    z0, z1 = b['zs'][0], b['zs'][-1]
+    outp = os.path.join(tmp, 'g.nmsh')
+    # The exact command-line x0/x1 (and rounding order) that made each shipped box
+    # can't be recovered from the mesh, so feed the EXACT grid lines as dist files
+    # with --direct (verbatim). This validates the ordering / point ids / zone /
+    # periodic-merge logic byte-exact, independent of the coordinate-formula detail.
+    # Write single-line CSV distribution files (comma-separated, no header) -- the
+    # format genmeshbox and the tool read identically (Neko's csv reader skips a
+    # header only when the file has more than one line). A separate test below
+    # exercises the header-skip path explicitly.
+    dx = os.path.join(tmp, 'dx.csv'); dy = os.path.join(tmp, 'dy.csv'); dz = os.path.join(tmp, 'dz.csv')
+    open(dx, 'w').write(','.join(repr(v) for v in b['xs']))
+    open(dy, 'w').write(','.join(repr(v) for v in b['ys']))
+    open(dz, 'w').write(','.join(repr(v) for v in b['zs']))
+    args = [EXE, repr(x0), repr(x1), repr(y0), repr(y1), repr(z0), repr(z1),
+            str(nx), str(ny), str(nz),
+            str(px).lower(), str(py).lower(), str(pz).lower(), dx, dy, dz, outp, '--direct']
+    p = subprocess.run(args, capture_output=True, text=True)
+    if p.returncode != 0:
+        return (path, 'RUN FAIL: ' + (p.stderr.strip()[:80]))
+    ref = b['d']; out = open(outp, 'rb').read()
+    e1 = 8 + b['nelv'] * 228
+    elem_ok = (ref[:e1] == out[:e1])
+    # zones by type
+    per_ok = lab_only_uninit = True
+    z0off = e1 + 4
+    for i in range(b['nz']):
+        r = struct.unpack('<9i', ref[z0off + i * 36:z0off + i * 36 + 36])
+        o = struct.unpack('<9i', out[z0off + i * 36:z0off + i * 36 + 36])
+        if r[8] == 5 and r != o:
+            per_ok = False
+        if r[8] == 7:
+            # allowed to differ only in p_e (idx 2) and glb_pt_ids (idx 4..7)
+            for k in (0, 1, 3, 8):
+                if r[k] != o[k]:
+                    lab_only_uninit = False
+    ncur_ok = (out[e1 + 4 + b['nz'] * 36:e1 + 8 + b['nz'] * 36] ==
+               ref[e1 + 4 + b['nz'] * 36:e1 + 8 + b['nz'] * 36])
+    size_ok = (len(out) == b['valid_end'])          # tool writes no trailing tail
+    ok = elem_ok and per_ok and lab_only_uninit and ncur_ok and size_ok
+    return (path, nx, ny, nz, (px, py, pz), b['nz'], elem_ok, per_ok,
+            lab_only_uninit, size_ok, ok)
+
+
+def csv_header_test(tmp):
+    """The distribution file follows Neko's csv reader: a single-line CSV has no
+    header, but a file with >1 line has its first line treated as a header and
+    skipped. Confirm all three layouts that must agree produce the SAME box:
+    single-line CSV, header + one-value-per-line, header + CSV values."""
+    xs = [0.0, 0.3, 0.55, 0.8, 1.0]          # nx = 4, non-uniform
+    base = None
+    layouts = {
+        'single-line CSV        ': ','.join(repr(v) for v in xs),
+        'header + one-per-line  ': 'xcoord\n' + '\n'.join(repr(v) for v in xs),
+        'header + CSV values    ': 'x\n' + ','.join(repr(v) for v in xs),
+    }
+    allok = True
+    print('csv distribution-file header handling (Neko-compatible):')
+    for name, text in layouts.items():
+        dx = os.path.join(tmp, 'h.csv'); open(dx, 'w').write(text)
+        outp = os.path.join(tmp, 'h.nmsh')
+        args = [EXE, '0', '1', '0', '1', '0', '1', '4', '1', '1',
+                'false', 'false', 'false', dx, 'uniform', 'uniform', outp, '--direct']
+        p = subprocess.run(args, capture_output=True, text=True)
+        ok = (p.returncode == 0)
+        data = open(outp, 'rb').read() if ok else b''
+        if base is None and ok:
+            base = data
+        same = ok and data == base
+        allok = allok and same
+        print('  %s -> %s' % (name, 'OK (same box)' if same else 'FAIL: ' + p.stderr.strip()[:60]))
+    return allok
+
+
+def main():
+    if not os.path.exists(EXE):
+        print('error: genmeshbox_light not found at', EXE); return 1
+    paths = sorted(glob.glob(os.path.join(NEKO, 'examples', '**', '*.nmsh'), recursive=True) +
+                   glob.glob(os.path.join(NEKO, 'tests', '**', '*.nmsh'), recursive=True))
+    print('%-46s %10s %8s %8s %6s %5s' %
+          ('box mesh', 'grid', 'periodic', 'elem=', 'zones', 'ok'))
+    n = nok = 0
+    allok = True
+    with tempfile.TemporaryDirectory() as tmp:
+        for path in paths:
+            r = check(path, tmp)
+            if r is None:
+                continue                 # not a genmeshbox-style box; skip
+            if len(r) == 2:              # the tool crashed/errored on a box
+                print('%-46s  %s' % (os.path.relpath(r[0], NEKO), r[1]))
+                allok = False
+                n += 1
+                continue
+            (p, nx, ny, nz, per, nzc, elem_ok, per_ok, lab_ok, size_ok, ok) = r
+            n += 1; nok += ok; allok = allok and ok
+            print('%-46s %10s %8s %8s %6d %5s' %
+                  (os.path.relpath(p, NEKO), '%dx%dx%d' % (nx, ny, nz),
+                   ''.join('xyz'[i] for i in range(3) if per[i]) or '-',
+                   elem_ok, nzc, 'OK' if ok else 'FAIL'))
+            if not ok:
+                print('     elem=%s per=%s lab_only_uninit=%s size=%s' %
+                      (elem_ok, per_ok, lab_ok, size_ok))
+    print('\ngenmeshbox boxes tested : %d  (others use a different point numbering' % n)
+    print('                          -> not genmeshbox output, skipped)')
+    print('byte-exact              : %d / %d  (header + every element record and every' % (nok, n))
+    print('                          periodic/type-5 zone identical; type-7 labeled zones')
+    print('                          differ only in Neko-uninitialised p_e/glb_pt_ids)')
+    print()
+    with tempfile.TemporaryDirectory() as tmp:
+        hdr_ok = csv_header_test(tmp)
+    allok = allok and hdr_ok
+    print('\nRESULT:', 'PASS' if allok and n > 0 else ('FAIL' if n else 'NO BOXES FOUND'))
+    return 0 if (allok and n > 0 and hdr_ok) else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/contrib/mesh_checker_light/mesh_checker_light.f90
+++ b/contrib/mesh_checker_light/mesh_checker_light.f90
@@ -1,0 +1,857 @@
+! Copyright (c) 2026, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!     _  __  ____  __ __  ____
+!    / |/ / / __/ / //_/ / __ \
+!   /    / / _/  / ,<   / /_/ /
+!  /_/|_/ /___/ /_/|_|  \____/
+!
+!> mesh_checker_light -- a lightweight, CPU-only diagnostics tool for Neko `.nmsh`
+!! meshes.
+!!
+!! Neko's `contrib/mesh_checker` builds a full `mesh_t` using Neko's
+!! general-purpose, production hash tables. Those are robust and reused across the
+!! code, but they are sized generously and store polymorphic keys, so they need a
+!! lot of memory for a large mesh. This tool is a lightweight, CPU-only
+!! reimplementation of just the checks that are needed, using plain typed integer
+!! arrays (a face hash and an edge hash keyed on the nmsh point ids) and no Neko
+!! initialisation. Periodic facet-pairs are merged via the record's glb_pt_ids
+!! exactly as Neko does on read, so the face/edge counts match glb_mfcs/glb_meds.
+!! It gives the same result in a small fraction of the memory.
+!!
+!! Because it does not link Neko, it needs only a Fortran compiler (no MPI, no
+!! Neko library) and runs anywhere -- in particular you do not need a separate
+!! CPU build of Neko. The `contrib` tools are CPU-only, so on a Neko configured
+!! for GPUs you would otherwise have to rebuild it for CPU just to run them; this
+!! sidesteps that entirely.
+!!
+!! Reports, exactly like `mesh_checker`: element / point / face / edge counts,
+!! bounding box, number of periodic faces, labeled-zone face counts, and -- the
+!! key diagnostic -- the number of UNLABELED EXTERNAL faces (an external face
+!! that is neither a labeled zone nor periodic; must be 0 for a valid mesh).
+!! Exits non-zero if any unlabeled external face is found (as `mesh_checker` does).
+!! Two optional checks are available: `--jacobian` (a streaming negative/zero
+!! Jacobian scan, exact for straight-sided elements) and `--write-zone-indices`
+!! (writes a field file marking boundary faces by zone index). 3D (hex) meshes
+!! only.
+!!
+!! Tested against every 3D mesh shipped with Neko (cross-checked field for field
+!! against an independent recomputation), but it remains your responsibility to
+!! confirm the result is correct for your own mesh -- run `make check`, or
+!! cross-check a real `mesh_checker` run, on a case you trust first. See
+!! mesh_checker_light.md for the memory model, validation, and scope.
+module mc_hash
+  use, intrinsic :: iso_fortran_env, only: i4 => int32, i8 => int64, i1 => int8
+  implicit none
+  private
+  public :: fhash_t, ehash_t, rmap_t
+
+  !> Small remap of a raw nmsh point id -> its merged (periodic) point id.
+  !! An id that is absent maps to itself (identity). This reproduces Neko's
+  !! `apply_periodic_facet`, which overwrites a periodic facet's corner ids with
+  !! the record's `glb_pt_ids` on read, before the face/edge tables are built.
+  type :: rmap_t
+     integer(i4), allocatable :: key(:), val(:)
+     integer(i8) :: cap = 0, mask = 0, n = 0
+   contains
+     procedure :: init => r_init
+     procedure :: set  => r_set
+     procedure :: get  => r_get
+     procedure :: free => r_free
+  end type rmap_t
+
+  !> Hash of unique faces: key = 4 sorted point ids; tracks an occurrence count
+  !! (capped at 2 -- external = seen once, internal = seen twice).
+  type :: fhash_t
+     integer(i4), allocatable :: k1(:), k2(:), k3(:), k4(:)
+     integer(i1), allocatable :: cnt(:)
+     integer(i8) :: cap = 0, mask = 0, n = 0
+   contains
+     procedure :: init => f_init
+     procedure :: add  => f_add
+     procedure :: cnt_of => f_cnt_of
+     procedure :: free => f_free
+  end type fhash_t
+
+  !> Hash of unique edges: key = 2 sorted point ids (membership only).
+  type :: ehash_t
+     integer(i4), allocatable :: k1(:), k2(:)
+     integer(i8) :: cap = 0, mask = 0, n = 0
+   contains
+     procedure :: init => e_init
+     procedure :: add  => e_add
+     procedure :: free => e_free
+  end type ehash_t
+
+contains
+
+  pure function mix4(a, b, c, d) result(h)
+    integer(i4), intent(in) :: a, b, c, d
+    integer(i8) :: h
+    h = int(a, i8)
+    h = ieor(h, ishft(h, -33)) * (-49064778989728563_i8)
+    h = ieor(h, int(b, i8))
+    h = ieor(h, ishft(h, -29)) * (-4417276706812531889_i8)
+    h = ieor(h, int(c, i8))
+    h = ieor(h, ishft(h, -32)) * (-49064778989728563_i8)
+    h = ieor(h, int(d, i8))
+    h = ieor(h, ishft(h, -32))
+  end function mix4
+
+  ! -------- face hash --------
+  subroutine f_init(this, cap0)
+    class(fhash_t), intent(inout) :: this
+    integer(i8), intent(in) :: cap0
+    integer(i8) :: c
+    c = 1024
+    do while (c < cap0)
+       c = ishft(c, 1)
+    end do
+    this%cap = c; this%mask = c - 1; this%n = 0
+    allocate(this%k1(0:c-1), this%k2(0:c-1), this%k3(0:c-1), this%k4(0:c-1))
+    allocate(this%cnt(0:c-1))
+    this%k1 = 0; this%cnt = 0_i1
+  end subroutine f_init
+
+  !> Insert a face (its 4 point ids, in any order) and bump its count.
+  subroutine f_add(this, a, b, c, d)
+    class(fhash_t), intent(inout) :: this
+    integer(i4), intent(in) :: a, b, c, d
+    integer(i4) :: s(4), t
+    integer(i8) :: h
+    s = (/ a, b, c, d /)
+    ! sort4 ascending (5 compare-swaps)
+    if (s(1) > s(2)) then; t = s(1); s(1) = s(2); s(2) = t; end if
+    if (s(3) > s(4)) then; t = s(3); s(3) = s(4); s(4) = t; end if
+    if (s(1) > s(3)) then; t = s(1); s(1) = s(3); s(3) = t; end if
+    if (s(2) > s(4)) then; t = s(2); s(2) = s(4); s(4) = t; end if
+    if (s(2) > s(3)) then; t = s(2); s(2) = s(3); s(3) = t; end if
+    if (int(this%n, i8) * 3_i8 > this%cap * 2_i8) call f_grow(this)
+    h = iand(mix4(s(1), s(2), s(3), s(4)), this%mask)
+    do
+       if (this%k1(h) == 0) then
+          this%k1(h) = s(1); this%k2(h) = s(2)
+          this%k3(h) = s(3); this%k4(h) = s(4)
+          this%cnt(h) = 1_i1; this%n = this%n + 1; return
+       else if (this%k1(h) == s(1) .and. this%k2(h) == s(2) .and. &
+                this%k3(h) == s(3) .and. this%k4(h) == s(4)) then
+          if (this%cnt(h) < 2_i1) this%cnt(h) = this%cnt(h) + 1_i1
+          return
+       end if
+       h = iand(h + 1_i8, this%mask)
+    end do
+  end subroutine f_add
+
+  !> Occurrence count of a face (0 if absent).
+  function f_cnt_of(this, a, b, c, d) result(cnt)
+    class(fhash_t), intent(in) :: this
+    integer(i4), intent(in) :: a, b, c, d
+    integer(i4) :: s(4), t, cnt
+    integer(i8) :: h
+    s = (/ a, b, c, d /)
+    if (s(1) > s(2)) then; t = s(1); s(1) = s(2); s(2) = t; end if
+    if (s(3) > s(4)) then; t = s(3); s(3) = s(4); s(4) = t; end if
+    if (s(1) > s(3)) then; t = s(1); s(1) = s(3); s(3) = t; end if
+    if (s(2) > s(4)) then; t = s(2); s(2) = s(4); s(4) = t; end if
+    if (s(2) > s(3)) then; t = s(2); s(2) = s(3); s(3) = t; end if
+    h = iand(mix4(s(1), s(2), s(3), s(4)), this%mask)
+    do
+       if (this%k1(h) == 0) then
+          cnt = 0; return
+       else if (this%k1(h) == s(1) .and. this%k2(h) == s(2) .and. &
+                this%k3(h) == s(3) .and. this%k4(h) == s(4)) then
+          cnt = int(this%cnt(h), i4); return
+       end if
+       h = iand(h + 1_i8, this%mask)
+    end do
+  end function f_cnt_of
+
+  subroutine f_grow(this)
+    class(fhash_t), intent(inout) :: this
+    integer(i4), allocatable :: o1(:), o2(:), o3(:), o4(:)
+    integer(i1), allocatable :: oc(:)
+    integer(i8) :: i, h, oldcap
+    oldcap = this%cap
+    call move_alloc(this%k1, o1); call move_alloc(this%k2, o2)
+    call move_alloc(this%k3, o3); call move_alloc(this%k4, o4)
+    call move_alloc(this%cnt, oc)
+    this%cap = ishft(this%cap, 1); this%mask = this%cap - 1
+    allocate(this%k1(0:this%cap-1), this%k2(0:this%cap-1), &
+             this%k3(0:this%cap-1), this%k4(0:this%cap-1))
+    allocate(this%cnt(0:this%cap-1)); this%k1 = 0; this%cnt = 0_i1
+    do i = 0, oldcap - 1
+       if (o1(i) /= 0) then
+          h = iand(mix4(o1(i), o2(i), o3(i), o4(i)), this%mask)
+          do while (this%k1(h) /= 0)
+             h = iand(h + 1_i8, this%mask)
+          end do
+          this%k1(h) = o1(i); this%k2(h) = o2(i)
+          this%k3(h) = o3(i); this%k4(h) = o4(i); this%cnt(h) = oc(i)
+       end if
+    end do
+    deallocate(o1, o2, o3, o4, oc)
+  end subroutine f_grow
+
+  subroutine f_free(this)
+    class(fhash_t), intent(inout) :: this
+    if (allocated(this%k1)) deallocate(this%k1, this%k2, this%k3, this%k4, this%cnt)
+    this%cap = 0; this%mask = 0; this%n = 0
+  end subroutine f_free
+
+  ! -------- edge hash --------
+  subroutine e_init(this, cap0)
+    class(ehash_t), intent(inout) :: this
+    integer(i8), intent(in) :: cap0
+    integer(i8) :: c
+    c = 1024
+    do while (c < cap0)
+       c = ishft(c, 1)
+    end do
+    this%cap = c; this%mask = c - 1; this%n = 0
+    allocate(this%k1(0:c-1), this%k2(0:c-1)); this%k1 = 0
+  end subroutine e_init
+
+  subroutine e_add(this, a, b)
+    class(ehash_t), intent(inout) :: this
+    integer(i4), intent(in) :: a, b
+    integer(i4) :: lo, hi
+    integer(i8) :: h
+    lo = min(a, b); hi = max(a, b)
+    if (int(this%n, i8) * 3_i8 > this%cap * 2_i8) call e_grow(this)
+    h = iand(mix4(lo, hi, 0, 0), this%mask)
+    do
+       if (this%k1(h) == 0) then
+          this%k1(h) = lo; this%k2(h) = hi; this%n = this%n + 1; return
+       else if (this%k1(h) == lo .and. this%k2(h) == hi) then
+          return
+       end if
+       h = iand(h + 1_i8, this%mask)
+    end do
+  end subroutine e_add
+
+  subroutine e_grow(this)
+    class(ehash_t), intent(inout) :: this
+    integer(i4), allocatable :: o1(:), o2(:)
+    integer(i8) :: i, h, oldcap
+    oldcap = this%cap
+    call move_alloc(this%k1, o1); call move_alloc(this%k2, o2)
+    this%cap = ishft(this%cap, 1); this%mask = this%cap - 1
+    allocate(this%k1(0:this%cap-1), this%k2(0:this%cap-1)); this%k1 = 0
+    do i = 0, oldcap - 1
+       if (o1(i) /= 0) then
+          h = iand(mix4(o1(i), o2(i), 0, 0), this%mask)
+          do while (this%k1(h) /= 0)
+             h = iand(h + 1_i8, this%mask)
+          end do
+          this%k1(h) = o1(i); this%k2(h) = o2(i)
+       end if
+    end do
+    deallocate(o1, o2)
+  end subroutine e_grow
+
+  subroutine e_free(this)
+    class(ehash_t), intent(inout) :: this
+    if (allocated(this%k1)) deallocate(this%k1, this%k2)
+    this%cap = 0; this%mask = 0; this%n = 0
+  end subroutine e_free
+
+  ! -------- periodic point-id remap --------
+  subroutine r_init(this, cap0)
+    class(rmap_t), intent(inout) :: this
+    integer(i8), intent(in) :: cap0
+    integer(i8) :: c
+    c = 1024
+    do while (c < cap0)
+       c = ishft(c, 1)
+    end do
+    this%cap = c; this%mask = c - 1; this%n = 0
+    allocate(this%key(0:c-1), this%val(0:c-1)); this%key = 0
+  end subroutine r_init
+
+  !> Record raw id `k` -> merged id `v`. If `k` is already mapped, keep the
+  !! smaller target (Neko merges to the minimum id); consistent records agree.
+  subroutine r_set(this, k, v)
+    class(rmap_t), intent(inout) :: this
+    integer(i4), intent(in) :: k, v
+    integer(i8) :: h
+    if (this%cap == 0) call r_init(this, 1024_i8)
+    if (this%n * 3_i8 > this%cap * 2_i8) call r_grow(this)
+    h = iand(mix4(k, 0, 0, 0), this%mask)
+    do
+       if (this%key(h) == 0) then
+          this%key(h) = k; this%val(h) = v; this%n = this%n + 1; return
+       else if (this%key(h) == k) then
+          if (v < this%val(h)) this%val(h) = v
+          return
+       end if
+       h = iand(h + 1_i8, this%mask)
+    end do
+  end subroutine r_set
+
+  !> Merged id of `k` (returns `k` itself if it is not a periodic point).
+  function r_get(this, k) result(v)
+    class(rmap_t), intent(in) :: this
+    integer(i4), intent(in) :: k
+    integer(i4) :: v
+    integer(i8) :: h
+    if (this%cap == 0) then; v = k; return; end if
+    h = iand(mix4(k, 0, 0, 0), this%mask)
+    do
+       if (this%key(h) == 0) then
+          v = k; return
+       else if (this%key(h) == k) then
+          v = this%val(h); return
+       end if
+       h = iand(h + 1_i8, this%mask)
+    end do
+  end function r_get
+
+  subroutine r_grow(this)
+    class(rmap_t), intent(inout) :: this
+    integer(i4), allocatable :: ok(:), ov(:)
+    integer(i8) :: i, h, oldcap
+    oldcap = this%cap
+    call move_alloc(this%key, ok); call move_alloc(this%val, ov)
+    this%cap = ishft(this%cap, 1); this%mask = this%cap - 1
+    allocate(this%key(0:this%cap-1), this%val(0:this%cap-1)); this%key = 0
+    do i = 0, oldcap - 1
+       if (ok(i) /= 0) then
+          h = iand(mix4(ok(i), 0, 0, 0), this%mask)
+          do while (this%key(h) /= 0)
+             h = iand(h + 1_i8, this%mask)
+          end do
+          this%key(h) = ok(i); this%val(h) = ov(i)
+       end if
+    end do
+    deallocate(ok, ov)
+  end subroutine r_grow
+
+  subroutine r_free(this)
+    class(rmap_t), intent(inout) :: this
+    if (allocated(this%key)) deallocate(this%key, this%val)
+    this%cap = 0; this%mask = 0; this%n = 0
+  end subroutine r_free
+
+end module mc_hash
+
+
+!> Straight-sided hex geometry helpers (trilinear map at the 3-point GLL nodes
+!! r,s,t in {-1,0,1}). Exact for non-curved elements -- for those it reproduces
+!! mesh_checker's dofmap geometry and Jacobian, because a trilinear field lies
+!! inside the lx=3 (quadratic) tensor space, so the spectral derivative is exact.
+!! Curve records ('C'/'m') are NOT deformed here (see the tool's scope note).
+module mc_geom
+  use, intrinsic :: iso_fortran_env, only: dp => real64
+  implicit none
+  private
+  public :: hex_min_jac, hex_gll_xyz, GLL3
+
+  real(dp), parameter :: GLL3(3) = (/ -1.0_dp, 0.0_dp, 1.0_dp /)
+  ! reference-cube corner coords for nmsh/re2 vertex order v1..v8
+  real(dp), parameter :: RC(8) = (/ -1, 1, 1,-1,-1, 1, 1,-1 /)
+  real(dp), parameter :: SC(8) = (/ -1,-1, 1, 1,-1,-1, 1, 1 /)
+  real(dp), parameter :: TC(8) = (/ -1,-1,-1,-1, 1, 1, 1, 1 /)
+
+contains
+
+  !> Minimum Jacobian determinant of the trilinear map over the 27 GLL points.
+  !! <= 0 flags an inverted/degenerate (tangled) element.
+  function hex_min_jac(cx, cy, cz) result(jmin)
+    real(dp), intent(in) :: cx(8), cy(8), cz(8)
+    real(dp) :: jmin, r, s, t, dr, ds, dt
+    real(dp) :: xr, xs, xt, yr, ys, yt, zr, zs, zt, jac
+    integer :: ir, is, it, k
+    jmin = huge(1.0_dp)
+    do it = 1, 3
+       t = GLL3(it)
+       do is = 1, 3
+          s = GLL3(is)
+          do ir = 1, 3
+             r = GLL3(ir)
+             xr = 0; xs = 0; xt = 0; yr = 0; ys = 0; yt = 0; zr = 0; zs = 0; zt = 0
+             do k = 1, 8
+                dr = 0.125_dp * RC(k) * (1 + s*SC(k)) * (1 + t*TC(k))
+                ds = 0.125_dp * SC(k) * (1 + r*RC(k)) * (1 + t*TC(k))
+                dt = 0.125_dp * TC(k) * (1 + r*RC(k)) * (1 + s*SC(k))
+                xr = xr + dr*cx(k); xs = xs + ds*cx(k); xt = xt + dt*cx(k)
+                yr = yr + dr*cy(k); ys = ys + ds*cy(k); yt = yt + dt*cy(k)
+                zr = zr + dr*cz(k); zs = zs + ds*cz(k); zt = zt + dt*cz(k)
+             end do
+             jac = xr*(ys*zt - yt*zs) - xs*(yr*zt - yt*zr) + xt*(yr*zs - ys*zr)
+             if (jac < jmin) jmin = jac
+          end do
+       end do
+    end do
+  end function hex_min_jac
+
+  !> The 27 GLL-point coordinates of the trilinear map, in nek fld order
+  !! (k outer, j, i inner -> index = i + 3*(j-1) + 9*(k-1)).
+  subroutine hex_gll_xyz(cx, cy, cz, gx, gy, gz)
+    real(dp), intent(in) :: cx(8), cy(8), cz(8)
+    real(dp), intent(out) :: gx(27), gy(27), gz(27)
+    real(dp) :: r, s, t, nshp
+    integer :: ir, is, it, k, idx
+    idx = 0
+    do it = 1, 3
+       t = GLL3(it)
+       do is = 1, 3
+          s = GLL3(is)
+          do ir = 1, 3
+             r = GLL3(ir); idx = idx + 1
+             gx(idx) = 0; gy(idx) = 0; gz(idx) = 0
+             do k = 1, 8
+                nshp = 0.125_dp * (1 + r*RC(k)) * (1 + s*SC(k)) * (1 + t*TC(k))
+                gx(idx) = gx(idx) + nshp*cx(k)
+                gy(idx) = gy(idx) + nshp*cy(k)
+                gz(idx) = gz(idx) + nshp*cz(k)
+             end do
+          end do
+       end do
+    end do
+  end subroutine hex_gll_xyz
+
+end module mc_geom
+
+
+program mesh_checker_light
+  use, intrinsic :: iso_fortran_env, only: dp => real64, sp => real32, &
+       i4 => int32, i8 => int64, i1 => int8, error_unit
+  use mc_hash, only: fhash_t, ehash_t, rmap_t
+  use mc_geom, only: hex_min_jac, hex_gll_xyz
+  implicit none
+
+  ! Neko facet (1..6) corners in nmsh vertex indices (= face_nodes composed with
+  ! the nmsh->mesh read swap [1,2,4,3,5,6,8,7]); same table validated byte-exact
+  ! for periodic glb_pt_ids in rea2nbin_light.
+  integer(i4), parameter :: FACE_RE2(4,6) = reshape((/ &
+       1,5,8,4,   2,6,7,3,   1,2,6,5,   4,3,7,8,   1,2,3,4,   5,6,7,8 /), (/4,6/))
+  ! The 12 hex edges in nmsh vertex indices (edge_nodes composed with the swap).
+  integer(i4), parameter :: EDGE_RE2(2,12) = reshape((/ &
+       1,2,  3,4,  5,6,  7,8,  1,4,  2,3,  5,8,  6,7,  1,5,  2,6,  4,8,  3,7 /), (/2,12/))
+
+  character(len=1024) :: fin
+  character(len=64) :: argbuf
+  integer :: uin, ios, i, f, argc
+  integer :: iphase, nphase                    ! user-facing progress counters
+  integer(i4) :: nelv, gdim, elid, vidx(8), nz, ztype, zlabel
+  integer(i4) :: ze, zf
+  integer(i4) :: max_vidx, periodic_size, n_unlabeled
+  integer(i4), allocatable :: elid_of_pos(:), pos_of_elid(:)
+  integer(i4), allocatable :: ev(:,:)          ! (8,nelv): the 8 nmsh point ids per element
+  integer(i1), allocatable :: ftype(:,:)       ! (6,nelv): 0 none, 1 labeled, 2 periodic
+  integer(i1), allocatable :: flabel(:,:)      ! (6,nelv): labeled-zone index 1..20 or 0
+  integer(i4) :: labeled_cnt(20)
+  real(dp) :: xyz(3), lo(3), hi(3)
+  real(dp) :: cx8(8), cy8(8), cz8(8), jmin
+  integer(i8) :: cnt
+  integer(i4) :: n_neg_jac, first_bad
+  real(dp) :: min_jac
+  logical :: do_jac, do_zone
+  type(fhash_t) :: fh
+  type(ehash_t) :: eh
+  type(rmap_t) :: rm
+  logical :: failed
+
+  argc = command_argument_count()
+  if (argc < 1) then
+     write(*,*) 'Usage: mesh_checker_light mesh.nmsh [--jacobian] [--write-zone-indices]'
+     write(*,*) '  --jacobian            : also check for negative/zero Jacobians'
+     write(*,*) '                          (streaming; exact for straight-sided elements).'
+     write(*,*) '  --write-zone-indices  : also write zone_indices.fld (boundary faces'
+     write(*,*) '                          marked by zone index) -- streamed, low memory.'
+     write(*,*) '  Reports mesh size, bounding box, periodic/labeled zones, and'
+     write(*,*) '  the number of unlabeled external faces (0 for a valid mesh).'
+     stop 1
+  end if
+  call get_command_argument(1, fin)
+  do_jac = .false.; do_zone = .false.
+  do i = 2, argc
+     call get_command_argument(i, argbuf)
+     select case (trim(argbuf))
+     case ('--jacobian');            do_jac = .true.
+     case ('--write-zone-indices');  do_zone = .true.; do_jac = .true.
+     case default
+        write(error_unit,*) 'Unknown option: ', trim(argbuf); stop 1
+     end select
+  end do
+
+  nphase = 3
+  if (do_zone) nphase = 4
+  iphase = 0
+
+  write(*,'(a)') ''
+  write(*,'(a)') '     _  __  ____  __ __  ____'
+  write(*,'(a)') '    / |/ / / __/ / //_/ / __ \'
+  write(*,'(a)') '   /    / / _/  / ,<   / /_/ /'
+  write(*,'(a)') '  /_/|_/ /___/ /_/|_|  \____/   mesh_checker_light'
+  write(*,'(a)') ''
+
+  open(newunit=uin, file=trim(fin), access='stream', form='unformatted', &
+       status='old', action='read', iostat=ios)
+  if (ios /= 0) then
+     write(error_unit,*) 'Error: cannot open ', trim(fin); stop 1
+  end if
+  read(uin, iostat=ios) nelv, gdim
+  if (ios /= 0) then
+     write(error_unit,*) 'Error: ', trim(fin), ' is not a Neko .nmsh file ', &
+          '(short header)'; stop 1
+  end if
+  if (gdim /= 3) then
+     write(error_unit,*) 'Error: mesh_checker_light supports 3D meshes only (gdim=', &
+          gdim, '). Use the full mesh_checker for 2D.'; stop 1
+  end if
+
+  allocate(ftype(6, nelv)); ftype = 0_i1
+  if (do_zone) then
+     allocate(flabel(6, nelv)); flabel = 0_i1
+  end if
+  allocate(elid_of_pos(nelv), pos_of_elid(nelv))
+  labeled_cnt = 0; max_vidx = 0; periodic_size = 0; n_unlabeled = 0; failed = .false.
+  n_neg_jac = 0; first_bad = 0; min_jac = huge(1.0_dp)
+  lo = huge(1.0_dp); hi = -huge(1.0_dp)
+  call fh%init(max(1024_i8, int(nelv, i8)))     ! merged unique faces, grown on demand
+  call eh%init(max(1024_i8, int(nelv, i8)))
+  allocate(ev(8, nelv))
+
+  ! ---- pass 1 (streaming): elements -> connectivity, bbox, Jacobians ----
+  ! The face/edge tables are NOT built here: for a periodic mesh, Neko's
+  ! mesh_checker reports the counts AFTER merging periodic point ids
+  ! (glb_mfcs/glb_meds), so we must first read the zones (which carry the merged
+  ! glb_pt_ids) before we can hash faces/edges. We stash the connectivity in `ev`
+  ! and hash it once the periodic remap is known.
+  iphase = iphase + 1
+  if (do_jac) then
+     write(*,'(a,i0,a,i0,a)') '  [', iphase, '/', nphase, &
+          '] reading elements (bounding box, connectivity, Jacobians) ...'
+  else
+     write(*,'(a,i0,a,i0,a)') '  [', iphase, '/', nphase, &
+          '] reading elements (bounding box, connectivity) ...'
+  end if
+  do i = 1, nelv
+     read(uin, iostat=ios) elid
+     if (ios /= 0) then
+        write(error_unit,*) 'Error: truncated element section (element ', i, &
+             ' of ', nelv, ')'; stop 1
+     end if
+     do f = 1, 8
+        read(uin, iostat=ios) vidx(f), xyz(1), xyz(2), xyz(3)
+        if (ios /= 0) then
+           write(error_unit,*) 'Error: truncated element section (element ', i, &
+                ' of ', nelv, ')'; stop 1
+        end if
+        lo = min(lo, xyz); hi = max(hi, xyz)
+        if (vidx(f) > max_vidx) max_vidx = vidx(f)
+        cx8(f) = xyz(1); cy8(f) = xyz(2); cz8(f) = xyz(3)
+     end do
+     elid_of_pos(i) = elid
+     ev(:, i) = vidx
+     if (do_jac) then
+        jmin = hex_min_jac(cx8, cy8, cz8)
+        if (jmin < min_jac) min_jac = jmin
+        if (jmin <= 0.0_dp) then
+           n_neg_jac = n_neg_jac + 1
+           if (first_bad == 0) first_bad = i
+        end if
+     end if
+  end do
+
+  ! inverse element-id map (nmsh zone %e is a global element id)
+  pos_of_elid = 0
+  do i = 1, nelv
+     if (elid_of_pos(i) < 1 .or. elid_of_pos(i) > nelv) then
+        write(error_unit,*) 'Error: element id out of [1,nelv]: ', elid_of_pos(i); stop 1
+     end if
+     pos_of_elid(elid_of_pos(i)) = i
+  end do
+  do i = 1, nelv                 ! element ids must be a permutation of 1..nelv
+     if (pos_of_elid(i) == 0) then
+        write(error_unit,*) 'Error: element ids are not a permutation of ', &
+             '1..nelv (duplicate or missing id ', i, ')'; stop 1
+     end if
+  end do
+
+  ! ---- zones: mark labeled (type 7) and periodic (type 5) facets ----
+  iphase = iphase + 1
+  write(*,'(a,i0,a,i0,a)') '  [', iphase, '/', nphase, &
+       '] reading and marking boundary zones ...'
+  block
+    integer(i4) :: zpe, zpf, g1, g2, g3, g4, pos
+    read(uin, iostat=ios) nz
+    if (ios /= 0) then
+       write(error_unit,*) 'Error: truncated file (missing zone count)'; stop 1
+    end if
+    do i = 1, nz
+       ! nmsh_zone_t: e, f, p_e, p_f, glb_pt_ids(4), type   (9 x i4)
+       read(uin, iostat=ios) ze, zf, zpe, zpf, g1, g2, g3, g4, ztype
+       if (ios /= 0) then
+          write(error_unit,*) 'Error: truncated zone section (record ', i, &
+               ' of ', nz, ')'; stop 1
+       end if
+       if (ze < 1 .or. ze > nelv .or. zf < 1 .or. zf > 6) cycle
+       pos = pos_of_elid(ze)
+       if (ztype == 5) then
+          periodic_size = periodic_size + 1
+          ftype(zf, pos) = 2_i1
+          ! Record the periodic point merge exactly as Neko's apply_periodic_facet
+          ! does: corner k of facet zf (nmsh slot FACE_RE2(k,zf)) takes the merged
+          ! id glb_pt_ids(k). The file stores glb_pt_ids in that same face_nodes
+          ! order (see mesh_reset_periodic_ids/hex_facet_order).
+          call rm%set(ev(FACE_RE2(1,zf), pos), g1)
+          call rm%set(ev(FACE_RE2(2,zf), pos), g2)
+          call rm%set(ev(FACE_RE2(3,zf), pos), g3)
+          call rm%set(ev(FACE_RE2(4,zf), pos), g4)
+       else if (ztype == 7) then
+          zlabel = zpf                       ! label lives in the p_f field
+          if (zlabel >= 1 .and. zlabel <= 20) labeled_cnt(zlabel) = labeled_cnt(zlabel) + 1
+          ftype(zf, pos) = 1_i1
+          if (do_zone .and. zlabel >= 1 .and. zlabel <= 20) flabel(zf, pos) = int(zlabel, i1)
+       end if
+    end do
+  end block
+  close(uin)
+
+  ! ---- apply the periodic merge to the stored connectivity (once) ----
+  ! After this, every point carries its merged id, so a periodic facet-pair
+  ! collapses to a single shared (internal) face/edge -- reproducing the
+  ! glb_mfcs/glb_meds that Neko's mesh_checker reports.
+  if (rm%n > 0) then
+     do i = 1, nelv
+        do f = 1, 8
+           ev(f, i) = rm%get(ev(f, i))
+        end do
+     end do
+  end if
+
+  ! ---- build the (merged) face/edge tables and scan unlabeled external faces ----
+  ! An external face appears exactly once across the mesh (merged face count == 1);
+  ! a periodic facet-pair now shares one internal face (count == 2), so it is
+  ! excluded automatically. Unlabeled external = external AND facet not labeled.
+  iphase = iphase + 1
+  write(*,'(a,i0,a,i0,a)') '  [', iphase, '/', nphase, &
+       '] building face/edge tables and scanning unlabeled external faces ...'
+  do i = 1, nelv
+     do f = 1, 6
+        call fh%add(ev(FACE_RE2(1,f),i), ev(FACE_RE2(2,f),i), &
+                    ev(FACE_RE2(3,f),i), ev(FACE_RE2(4,f),i))
+     end do
+     do f = 1, 12
+        call eh%add(ev(EDGE_RE2(1,f),i), ev(EDGE_RE2(2,f),i))
+     end do
+  end do
+  do i = 1, nelv
+     do f = 1, 6
+        cnt = int(fh%cnt_of(ev(FACE_RE2(1,f),i), ev(FACE_RE2(2,f),i), &
+                            ev(FACE_RE2(3,f),i), ev(FACE_RE2(4,f),i)), i8)
+        if (cnt == 1 .and. ftype(f, i) == 0_i1) n_unlabeled = n_unlabeled + 1
+     end do
+  end do
+
+  ! ---- report (mirrors mesh_checker) ----
+  write(*,*) ''
+  write(*,*) '--------------Size-------------'
+  write(*,'(A,I0)') ' Number of elements: ', nelv
+  write(*,'(A,I0)') ' Number of points:   ', max_vidx
+  write(*,'(A,I0)') ' Number of faces:    ', fh%n
+  write(*,'(A,I0)') ' Number of edges:    ', eh%n
+  write(*,*) 'Bounding box:'
+  write(*,'(A,2(g14.6,1X))') '    x', lo(1), hi(1)
+  write(*,'(A,2(g14.6,1X))') '    y', lo(2), hi(2)
+  write(*,'(A,2(g14.6,1X))') '    z', lo(3), hi(3)
+  write(*,*) ''
+  write(*,*) '--------------Zones------------'
+  write(*,'(A,I0)') ' Number of periodic faces: ', periodic_size
+  write(*,*) ''
+  write(*,*) 'Labeled zones: '
+  do i = 1, 20
+     if (labeled_cnt(i) > 0) &
+          write(*,'(A,I2,A,I0,A)') '    Zone ', i, ': ', labeled_cnt(i), ' faces'
+  end do
+
+  if (do_jac) then
+     write(*,*) ''
+     write(*,*) '------------Jacobian----------'
+     write(*,'(A,g14.6)') ' Min Jacobian (straight-sided): ', min_jac
+     if (n_neg_jac > 0) then
+        failed = .true.
+        write(*,'(A,I0,A,I0,A)') ' Error: Found ', n_neg_jac, &
+             ' element(s) with a negative/zero Jacobian (first at element ', first_bad, ').'
+     else
+        write(*,*) ' No negative/zero Jacobians.'
+     end if
+  end if
+
+  if (n_unlabeled > 0) then
+     failed = .true.
+     write(*,'(A,I0,A)') ' Error: Found ', n_unlabeled, ' unlabeled external faces.'
+  end if
+
+  if (do_zone) then
+     iphase = iphase + 1
+     write(*,'(a,i0,a,i0,a)') '  [', iphase, '/', nphase, &
+          '] writing zone_indices.fld ...'
+     call write_zone_indices_fld(trim(fin), nelv, flabel)
+  end if
+
+  write(*,*) 'Done'
+  call fh%free(); call eh%free(); call rm%free()
+  deallocate(ftype, elid_of_pos, pos_of_elid)
+  if (allocated(ev)) deallocate(ev)
+  if (allocated(flabel)) deallocate(flabel)
+
+  if (failed) then
+     write(error_unit,*) 'Mesh check failed with one or several errors.'
+     stop 1
+  end if
+
+contains
+
+  !> Write zone_indices.fld -- a single-precision Neko/NEKTON field file with the
+  !! mesh (straight-sided trilinear geometry at the 3x3x3 GLL nodes) and one
+  !! scalar field: the labeled-zone index at each GLL point (a point on a labeled
+  !! facet takes that zone's index; the highest index wins where facets meet; 0
+  !! in the interior). Streamed element-by-element -- O(1) memory, no dofmap.
+  !! Geometry is straight-sided (curve records are not deformed); the zone labels
+  !! -- the point of the file -- are exact. Also writes the .nek5000 companion.
+  subroutine write_zone_indices_fld(meshfile, nel, flab)
+    character(len=*), intent(in) :: meshfile
+    integer(i4), intent(in) :: nel
+    integer(i1), intent(in) :: flab(:,:)
+    integer :: u, uf, kk, e, ff
+    integer(i4) :: eidx
+    real(sp) :: gx(27), gy(27), gz(27), sc(27), bb(6), test_pattern
+    real(sp), allocatable :: scmn(:), scmx(:)
+    real(dp) :: c8x(8), c8y(8), c8z(8), gdx(27), gdy(27), gdz(27)
+    character(len=132) :: hdr
+
+    write(hdr, 1) 4, 3, 3, 3, nel, nel, 0.0_dp, 1, 1, 1, 'XS01      '
+1   format('#std', 1x, i1, 1x, i2, 1x, i2, 1x, i2, 1x, i10, 1x, i10, &
+         1x, e20.13, 1x, i9, 1x, i6, 1x, i6, 1x, a10)
+
+    open(newunit=u, file='zone_indices.fld', access='stream', form='unformatted', &
+         status='replace', action='write')
+    write(u) hdr
+    test_pattern = 6.54321_sp
+    write(u) test_pattern
+    do e = 1, nel                                    ! element global-id list
+       eidx = e; write(u) eidx
+    end do
+
+    ! mesh block: for each element, gx(1:27), gy(1:27), gz(1:27) (single prec)
+    open(newunit=uf, file=meshfile, access='stream', form='unformatted', &
+         status='old', action='read')
+    read(uf) eidx, eidx                              ! skip nelv, gdim
+    do e = 1, nel
+       call read_corners(uf, c8x, c8y, c8z)
+       call hex_gll_xyz(c8x, c8y, c8z, gdx, gdy, gdz)
+       gx = real(gdx, sp); gy = real(gdy, sp); gz = real(gdz, sp)
+       write(u) gx, gy, gz
+    end do
+    close(uf)
+
+    ! scalar block: labeled-zone index at each of the 27 GLL points
+    allocate(scmn(nel), scmx(nel))
+    do e = 1, nel
+       do kk = 1, 27
+          sc(kk) = 0.0_sp
+       end do
+       do ff = 1, 6
+          if (flab(ff, e) /= 0_i1) call mark_facet_points(sc, ff, real(flab(ff, e), sp))
+       end do
+       write(u) sc
+       scmn(e) = minval(sc); scmx(e) = maxval(sc)
+    end do
+
+    ! per-element bounding-box metadata (min/max of x, y, z), single precision
+    open(newunit=uf, file=meshfile, access='stream', form='unformatted', &
+         status='old', action='read')
+    read(uf) eidx, eidx
+    do e = 1, nel
+       call read_corners(uf, c8x, c8y, c8z)
+       call hex_gll_xyz(c8x, c8y, c8z, gdx, gdy, gdz)
+       bb(1) = real(minval(gdx), sp); bb(2) = real(maxval(gdx), sp)
+       bb(3) = real(minval(gdy), sp); bb(4) = real(maxval(gdy), sp)
+       bb(5) = real(minval(gdz), sp); bb(6) = real(maxval(gdz), sp)
+       write(u) bb
+    end do
+    close(uf)
+
+    ! per-element (min, max) metadata for the scalar field: Neko's fld writer
+    ! appends this block after the geometry bounding boxes (see
+    ! fld_file_write_metadata_scalar in src/io/fld_file.f90), so match it
+    do e = 1, nel
+       write(u) scmn(e), scmx(e)
+    end do
+    deallocate(scmn, scmx)
+    close(u)
+
+    ! ParaView companion
+    open(newunit=uf, file='zone_indices.nek5000', status='replace', action='write')
+    write(uf, '(A)') 'filetemplate: zone_indices.fld'
+    write(uf, '(A)') 'firsttimestep: 1'
+    write(uf, '(A)') 'numtimesteps: 1'
+    close(uf)
+    write(*,*) 'Wrote zone_indices.fld (+ .nek5000 companion)'
+  end subroutine write_zone_indices_fld
+
+  !> Read one nmsh hex element (el_idx + 8*(v_idx,x,y,z)); return the 8 corners.
+  subroutine read_corners(u, c8x, c8y, c8z)
+    integer, intent(in) :: u
+    real(dp), intent(out) :: c8x(8), c8y(8), c8z(8)
+    integer(i4) :: eidx, vi
+    integer :: j
+    read(u) eidx
+    do j = 1, 8
+       read(u) vi, c8x(j), c8y(j), c8z(j)
+    end do
+  end subroutine read_corners
+
+  !> Set the 9 GLL points lying on facet @a ff to value @a v (max-wins).
+  subroutine mark_facet_points(sc, ff, v)
+    real(sp), intent(inout) :: sc(27)
+    integer, intent(in) :: ff
+    real(sp), intent(in) :: v
+    integer :: ir, is, it, idx
+    logical :: on
+    do it = 1, 3
+       do is = 1, 3
+          do ir = 1, 3
+             idx = ir + 3*(is-1) + 9*(it-1)
+             on = (ff == 1 .and. ir == 1) .or. (ff == 2 .and. ir == 3) .or. &
+                  (ff == 3 .and. is == 1) .or. (ff == 4 .and. is == 3) .or. &
+                  (ff == 5 .and. it == 1) .or. (ff == 6 .and. it == 3)
+             if (on .and. v > sc(idx)) sc(idx) = v
+          end do
+       end do
+    end do
+  end subroutine mark_facet_points
+
+end program mesh_checker_light

--- a/contrib/mesh_checker_light/mesh_checker_light.f90
+++ b/contrib/mesh_checker_light/mesh_checker_light.f90
@@ -84,8 +84,8 @@ module mc_hash
      integer(i8) :: cap = 0, mask = 0, n = 0
    contains
      procedure :: init => r_init
-     procedure :: set  => r_set
-     procedure :: get  => r_get
+     procedure :: set => r_set
+     procedure :: get => r_get
      procedure :: free => r_free
   end type rmap_t
 
@@ -97,7 +97,7 @@ module mc_hash
      integer(i8) :: cap = 0, mask = 0, n = 0
    contains
      procedure :: init => f_init
-     procedure :: add  => f_add
+     procedure :: add => f_add
      procedure :: cnt_of => f_cnt_of
      procedure :: free => f_free
   end type fhash_t
@@ -108,7 +108,7 @@ module mc_hash
      integer(i8) :: cap = 0, mask = 0, n = 0
    contains
      procedure :: init => e_init
-     procedure :: add  => e_add
+     procedure :: add => e_add
      procedure :: free => e_free
   end type ehash_t
 
@@ -453,22 +453,22 @@ program mesh_checker_light
   ! the nmsh->mesh read swap [1,2,4,3,5,6,8,7]); same table validated byte-exact
   ! for periodic glb_pt_ids in rea2nbin_light.
   integer(i4), parameter :: FACE_RE2(4,6) = reshape((/ &
-       1,5,8,4,   2,6,7,3,   1,2,6,5,   4,3,7,8,   1,2,3,4,   5,6,7,8 /), (/4,6/))
+       1,5,8,4, 2,6,7,3, 1,2,6,5, 4,3,7,8, 1,2,3,4, 5,6,7,8 /), (/4,6/))
   ! The 12 hex edges in nmsh vertex indices (edge_nodes composed with the swap).
   integer(i4), parameter :: EDGE_RE2(2,12) = reshape((/ &
-       1,2,  3,4,  5,6,  7,8,  1,4,  2,3,  5,8,  6,7,  1,5,  2,6,  4,8,  3,7 /), (/2,12/))
+       1,2, 3,4, 5,6, 7,8, 1,4, 2,3, 5,8, 6,7, 1,5, 2,6, 4,8, 3,7 /), (/2,12/))
 
   character(len=1024) :: fin
   character(len=64) :: argbuf
   integer :: uin, ios, i, f, argc
-  integer :: iphase, nphase                    ! user-facing progress counters
+  integer :: iphase, nphase ! user-facing progress counters
   integer(i4) :: nelv, gdim, elid, vidx(8), nz, ztype, zlabel
   integer(i4) :: ze, zf
   integer(i4) :: max_vidx, periodic_size, n_unlabeled
   integer(i4), allocatable :: elid_of_pos(:), pos_of_elid(:)
-  integer(i4), allocatable :: ev(:,:)          ! (8,nelv): the 8 nmsh point ids per element
-  integer(i1), allocatable :: ftype(:,:)       ! (6,nelv): 0 none, 1 labeled, 2 periodic
-  integer(i1), allocatable :: flabel(:,:)      ! (6,nelv): labeled-zone index 1..20 or 0
+  integer(i4), allocatable :: ev(:,:) ! (8,nelv): the 8 nmsh point ids per element
+  integer(i1), allocatable :: ftype(:,:) ! (6,nelv): 0 none, 1 labeled, 2 periodic
+  integer(i1), allocatable :: flabel(:,:) ! (6,nelv): labeled-zone index 1..20 or 0
   integer(i4) :: labeled_cnt(20)
   real(dp) :: xyz(3), lo(3), hi(3)
   real(dp) :: cx8(8), cy8(8), cz8(8), jmin
@@ -497,8 +497,8 @@ program mesh_checker_light
   do i = 2, argc
      call get_command_argument(i, argbuf)
      select case (trim(argbuf))
-     case ('--jacobian');            do_jac = .true.
-     case ('--write-zone-indices');  do_zone = .true.; do_jac = .true.
+     case ('--jacobian'); do_jac = .true.
+     case ('--write-zone-indices'); do_zone = .true.; do_jac = .true.
      case default
         write(error_unit,*) 'Unknown option: ', trim(argbuf); stop 1
      end select
@@ -538,7 +538,7 @@ program mesh_checker_light
   labeled_cnt = 0; max_vidx = 0; periodic_size = 0; n_unlabeled = 0; failed = .false.
   n_neg_jac = 0; first_bad = 0; min_jac = huge(1.0_dp)
   lo = huge(1.0_dp); hi = -huge(1.0_dp)
-  call fh%init(max(1024_i8, int(nelv, i8)))     ! merged unique faces, grown on demand
+  call fh%init(max(1024_i8, int(nelv, i8))) ! merged unique faces, grown on demand
   call eh%init(max(1024_i8, int(nelv, i8)))
   allocate(ev(8, nelv))
 
@@ -592,7 +592,7 @@ program mesh_checker_light
      end if
      pos_of_elid(elid_of_pos(i)) = i
   end do
-  do i = 1, nelv                 ! element ids must be a permutation of 1..nelv
+  do i = 1, nelv ! element ids must be a permutation of 1..nelv
      if (pos_of_elid(i) == 0) then
         write(error_unit,*) 'Error: element ids are not a permutation of ', &
              '1..nelv (duplicate or missing id ', i, ')'; stop 1
@@ -630,7 +630,7 @@ program mesh_checker_light
           call rm%set(ev(FACE_RE2(3,zf), pos), g3)
           call rm%set(ev(FACE_RE2(4,zf), pos), g4)
        else if (ztype == 7) then
-          zlabel = zpf                       ! label lives in the p_f field
+          zlabel = zpf ! label lives in the p_f field
           if (zlabel >= 1 .and. zlabel <= 20) labeled_cnt(zlabel) = labeled_cnt(zlabel) + 1
           ftype(zf, pos) = 1_i1
           if (do_zone .and. zlabel >= 1 .and. zlabel <= 20) flabel(zf, pos) = int(zlabel, i1)
@@ -761,14 +761,14 @@ contains
     write(u) hdr
     test_pattern = 6.54321_sp
     write(u) test_pattern
-    do e = 1, nel                                    ! element global-id list
+    do e = 1, nel ! element global-id list
        eidx = e; write(u) eidx
     end do
 
     ! mesh block: for each element, gx(1:27), gy(1:27), gz(1:27) (single prec)
     open(newunit=uf, file=meshfile, access='stream', form='unformatted', &
          status='old', action='read')
-    read(uf) eidx, eidx                              ! skip nelv, gdim
+    read(uf) eidx, eidx ! skip nelv, gdim
     do e = 1, nel
        call read_corners(uf, c8x, c8y, c8z)
        call hex_gll_xyz(c8x, c8y, c8z, gdx, gdy, gdz)

--- a/contrib/mesh_checker_light/mesh_checker_light.md
+++ b/contrib/mesh_checker_light/mesh_checker_light.md
@@ -1,0 +1,189 @@
+```text
+     _  __  ____  __ __  ____
+    / |/ / / __/ / //_/ / __ \
+   /    / / _/  / ,<   / /_/ /
+  /_/|_/ /___/ /_/|_|  \____/
+```
+
+# mesh_checker_light
+
+A standalone, low-memory diagnostics tool for Neko `.nmsh` meshes — a lightweight,
+CPU-only alternative to the **default** checks of `contrib/mesh_checker`.
+
+Needs only a Fortran compiler (no MPI, no Neko library):
+
+```sh
+make                                   # gfortran -O2 -o mesh_checker_light mesh_checker_light.f90
+./mesh_checker_light mesh.nmsh
+./mesh_checker_light mesh.nmsh --jacobian              # + negative/zero Jacobian check
+./mesh_checker_light mesh.nmsh --write-zone-indices    # + write zone_indices.fld (implies --jacobian)
+make check                             # cross-check vs independent Python on every 3D mesh
+```
+
+> `make check` reads the meshes shipped with Neko, so it expects this folder to
+> live inside a Neko source checkout (e.g. dropped into `contrib/`, so
+> `../../examples` and `../../tests` resolve). To run it from elsewhere, point the
+> validator at your Neko tree directly:
+> `python3 validate_mc.py ./mesh_checker_light /path/to/neko`. Checking your own
+> mesh (`./mesh_checker_light mesh.nmsh`) needs no Neko tree at all.
+
+It reports — exactly like `mesh_checker` — the element / point / face / edge
+counts, the bounding box, the number of periodic faces, the labeled-zone face
+counts, and the key diagnostic: the number of **unlabeled external faces** (an
+external face that is neither a labeled zone nor periodic — must be `0` for a
+mesh whose boundaries are fully specified). It exits non-zero if any are found.
+With `--jacobian` it also flags **negative/zero Jacobians** (inverted/tangled
+elements); with `--write-zone-indices` it also writes the `zone_indices.fld`
+visualization field. Both are **streamed element-by-element** — O(1) extra memory,
+no `dofmap`/`coef`.
+
+## Why it exists
+
+Neko's `contrib/mesh_checker` reads the `.nmsh` into a full `mesh_t` with
+connectivity generation on, because it needs the face/edge neighbour information
+for the unlabeled-face check and a `dofmap` for the bounding box. Building that
+goes through Neko's general-purpose, production hash tables — the same robust,
+well-tested structures reused all over the code base. They're sized generously
+and store polymorphic keys, which is exactly what you want inside the solver, but
+it means a lot of memory per element when all you want is a quick sanity check of
+a large mesh.
+
+`mesh_checker_light` is a lightweight reimplementation of just those checks. It
+works directly from the deduplicated point ids already stored in the `.nmsh`,
+builds a couple of small typed integer hashes instead of the general tables, and
+does **no Neko initialisation** — giving the same answers in a small fraction of
+the memory.
+
+One practical note: `mesh_checker` is MPI-parallel, so its footprint divides
+across ranks — with enough ranks per-rank memory is fine. The awkward case is
+running a quick check on **one or a few ranks** for a very large mesh, where
+you'd otherwise have to spin up a big MPI job just to confirm the boundaries are
+labeled. That's the gap this fills: a **serial** check of a large mesh on a
+single node.
+
+A couple of nice side effects of not linking Neko:
+
+- **No GPU rebuild needed.** The `contrib` tools are CPU-only. If your Neko is
+  configured for GPUs, you'd normally have to rebuild it for CPU just to run
+  them. `mesh_checker_light` needs only a Fortran compiler, so that step goes
+  away.
+- **Runs anywhere** — a login node, a laptop, a small VM — since there's no MPI
+  and no Neko library to carry along.
+
+> **Tested, but please check your own case.** This tool is cross-checked field
+> for field against an independent Python recomputation on every 3D mesh shipped
+> with Neko, plus topological-identity and broken-mesh tests (see
+> [Validation](#validation)). It is still your responsibility to make sure the
+> result is correct for *your* mesh — `make check`, or cross-check against a real
+> `mesh_checker` run, on a case you trust before relying on it.
+
+## What `mesh_checker_light` does instead
+
+The mesh's `.nmsh` already stores the deduplicated point ids (`v_idx`), so no
+point table is needed. The tool reads the element connectivity (8 ids per
+element), applies the periodic merge, and builds just **two small typed integer
+hashes** (structure-of-arrays, no polymorphism, no per-entry heap):
+
+- a **face hash** keyed by the 4 sorted `v_idx` of each facet, tracking an
+  occurrence count (external = seen once, internal = seen twice) — `~17 B/slot`;
+- an **edge hash** keyed by the 2 sorted `v_idx` of each edge (membership only).
+
+Faces/edges are extracted with the **same `FACE_RE2` corner table validated
+byte-exact for periodic ids in `rea2nbin_light`** (Neko's `face_nodes`/`edge_nodes`
+composed with the nmsh→mesh vertex swap). Zones are read straight from the `.nmsh`
+to mark labeled/periodic facets; an external face whose facet is unmarked is an
+unlabeled external face.
+
+**Periodic merge.** Neko's `mesh_checker` reports the face/edge counts *after*
+merging periodic point ids: on read, `apply_periodic_facet` overwrites each
+periodic facet's corner ids with the record's `glb_pt_ids` before the
+connectivity tables are built, so a periodic facet-pair collapses to a single
+shared face and `glb_mfcs`/`glb_meds` count it once. This tool does exactly the
+same — it applies the stored `glb_pt_ids` as a point-id remap before hashing — so
+its `Number of faces`/`Number of edges` match `glb_mfcs`/`glb_meds` on periodic
+meshes (channels, pipes, TGV, …), not just the raw per-facet totals. (The stored
+`glb_pt_ids` are in `face_nodes` order, matching `FACE_RE2`; see
+`mesh_reset_periodic_ids`/`hex_facet_order`.)
+
+| | `mesh_checker` (75e6 hex, 1 rank) | `mesh_checker_light` (75e6 hex) |
+|---|--:|--:|
+| Dominant structures | general polymorphic point/connectivity tables + curve/zone scratch + dofmap | one face hash + one edge hash |
+| Peak memory (default) | large (needs a big-memory node when run serially) | modest — a small multiple of the mesh's point data |
+
+The `--jacobian` and `--write-zone-indices` options stay cheap because both are
+streamed element-by-element (O(1) extra memory) rather than materialising a
+`coef`/`dofmap`.
+
+## Validation
+
+There is no bundled reference output for `mesh_checker` (it needs the full Neko
+build to run), so `validate_mc.py` validates several independent ways, across every
+3D `.nmsh` in the tree (43 meshes):
+
+1. **Independent recomputation.** It recomputes *every* reported quantity — points,
+   faces, edges, periodic count, per-label counts, unlabeled-external count — in
+   Python straight from the raw nmsh bytes, **applying the same periodic
+   `glb_pt_ids` merge Neko applies on read**, and checks the tool matches **field
+   for field**. Result: **43 / 43, exact.** (For the periodic meshes the merged
+   `Number of faces`/`Number of edges` equal Neko's `glb_mfcs`/`glb_meds` — e.g.
+   `cylinder` 5712 / 5952, `turb_channel` 17820 / 18144 — not the larger raw
+   per-facet totals.)
+2. **Topological identity (ground truth, independent of the tool).** Any correct
+   *merged* face dedup must satisfy `2·(#faces) − (#external) = 6·nelv` (each
+   internal face shared by 2 elements, each external by 1); and a fully-periodic
+   mesh is a closed 3-torus, so `#faces = #edges = 3·nelv` exactly. Both hold on
+   every non-degenerate mesh (e.g. `tgv/512`: 1536 faces = 1536 edges = 3·512;
+   `turb_pipe`: `2·111720 − 4560 = 218880 = 6·36480`). Only the correct periodic
+   merge — right `glb_pt_ids` ordering — satisfies these; the raw unmerged counts
+   do not. (A single-element-thick periodic slab such as `euler_1d_sod` collapses
+   each cross-section to a point; Neko produces those degenerate counts too, so
+   the identity is skipped there while the field-for-field check still holds.)
+3. **The diagnostic actually fires.** Stripping turb_pipe's labeled wall zone
+   (4560 faces) makes the tool report **exactly 4560** unlabeled external faces and
+   exit 1 — it detects precisely the newly-exposed boundary.
+4. **Jacobian.** A correctly-oriented unit cube (`jac = +0.125`) is not flagged; a
+   mirrored one (`jac = −0.125`) is flagged. No shipped mesh has a negative Jacobian.
+5. **Zone-index field.** `zone_indices.fld` is written, parsed back, and its scalar
+   field is checked to equal the mesh's per-GLL-point zone label everywhere (0
+   mismatches; header/`test_pattern`/section byte-offsets all consistent).
+
+The exit code is `0` iff there are no unlabeled external faces. Several shipped
+benchmark meshes (`poisson/`, `nekbone/` boxes, some cylinders) carry **no
+mesh-level BCs at all**, so their entire open surface is unlabeled external — the
+tool flags them (e.g. a 128-element box → its full 160-face surface), exactly as
+the real `mesh_checker` would.
+
+> If you have a real `mesh_checker` run for one of your meshes, cross-checking its
+> `Number of faces/edges` against this tool is a nice extra confirmation of the
+> `glb_mfcs`/`glb_meds` semantics — the same way the real pipe `.nmsh` nailed down
+> `rea2nbin_light`.
+
+## Scope / limitations
+
+- **3D hex meshes** (the common case). 2D meshes exit with a clear error (the full
+  `mesh_checker` handles 2D via a separate path).
+- **Straight-sided geometry** for `--jacobian` and `--write-zone-indices`. Both use
+  the trilinear map at the GLL nodes, which is **exact for non-curved elements** (a
+  trilinear field is inside the lx=3 space, so it equals `mesh_checker`'s dofmap
+  geometry and Jacobian there). For **curved** (`'C'`/`'m'`) elements the curve
+  deformation is *not* applied, so: the Jacobian is a valid **corner-geometry**
+  inversion check but won't match `mesh_checker`'s exact GLL Jacobian; and the
+  `zone_indices.fld` renders element edges as straight (the **zone labels — the
+  point of the file — are exact**, only the drawn geometry is faceted). Full
+  curve-aware geometry would be a natural extension.
+- **Jacobian severity.** `--jacobian` flags **negative *or* zero** Jacobians and
+  exits non-zero (a hard check). Neko's `mesh_checker` is slightly
+  more lenient — it *warns* on strictly-negative Jacobians only (`jac < 0`) and
+  does not fail. So a perfectly degenerate (exactly-zero-Jacobian) element is
+  flagged here but not by `mesh_checker`; the verdict for genuinely inverted
+  (`jac < 0`) elements is identical.
+- The size counts match `mesh_checker`'s **serial** output; because the merged
+  unique faces/edges/points are partition-independent, they also equal its
+  parallel **global** counts (`glb_mfcs`/`glb_meds`/`glb_mpts`).
+
+## Files
+
+- `mesh_checker_light.f90` — the tool (hash + geometry modules + program).
+- `validate_mc.py` — the independent cross-check, broken-mesh, Jacobian and
+  zone-index-`.fld` harness (`make check`).
+- `Makefile` — `make`, `make check`, `make clean`.

--- a/contrib/mesh_checker_light/validate_mc.py
+++ b/contrib/mesh_checker_light/validate_mc.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, The Neko Authors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#
+#   * Neither the name of the authors nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#     _  __  ____  __ __  ____
+#    / |/ / / __/ / //_/ / __ \
+#   /    / / _/  / ,<   / /_/ /
+#  /_/|_/ /___/ /_/|_|  \____/
+#
+"""Validation for mesh_checker_light across every 3D .nmsh in the Neko tree.
+
+There is no bundled reference output for mesh_checker (it needs the full Neko
+build to run), so this harness independently recomputes -- in Python, from the
+raw nmsh bytes -- every quantity mesh_checker_light reports, cross-checks the
+tool's stdout against it, and verifies the topological identity that any correct
+face dedup must satisfy:
+
+    2 * (#faces) - (#external faces) == 6 * nelv          (each internal face is
+    shared by exactly 2 elements, each external face by 1; 6 facets per hex)
+
+and that every external face of a VALID mesh is either labeled or periodic
+(i.e. #unlabeled-external == 0). It also confirms the tool's exit code (0 for a
+valid mesh). A separate broken-mesh test strips a labeled zone and
+checks the tool then detects exactly the newly-exposed faces.
+
+Usage:  python3 validate_mc.py [path/to/mesh_checker_light] [neko_root]
+"""
+import struct, subprocess, glob, os, sys, re
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+EXE  = sys.argv[1] if len(sys.argv) > 1 else os.path.join(HERE, 'mesh_checker_light')
+NEKO = sys.argv[2] if len(sys.argv) > 2 else os.path.abspath(os.path.join(HERE, '..', '..'))
+
+FACE = [(1,5,8,4),(2,6,7,3),(1,2,6,5),(4,3,7,8),(1,2,3,4),(5,6,7,8)]   # nmsh-vtx, 1-based
+EDGE = [(1,2),(3,4),(5,6),(7,8),(1,4),(2,3),(5,8),(6,7),(1,5),(2,6),(4,8),(3,7)]
+
+
+def compute(path):
+    d = open(path, 'rb').read()
+    nelv, gdim = struct.unpack('<ii', d[:8])
+    if gdim != 3:
+        return None
+    off = 8
+    elems = []          # list of 8 v_idx (nmsh order)
+    maxv = 0
+    for _ in range(nelv):
+        struct.unpack('<i', d[off:off+4]); off += 4      # el_idx (identity)
+        v = []
+        for _ in range(8):
+            vi = struct.unpack('<i', d[off:off+4])[0]
+            off += 28                                    # v_idx + 3 dp
+            v.append(vi); maxv = max(maxv, vi)
+        elems.append(v)
+    nz = struct.unpack('<i', d[off:off+4])[0]; off += 4
+    marked = {}         # (e_pos_1based, facet_1based) -> 'L' or 'P'
+    periodic = 0
+    labeled = {}
+    remap = {}          # raw point id -> merged (periodic) id, exactly like Neko
+    for _ in range(nz):
+        z = struct.unpack('<9i', d[off:off+36]); off += 36
+        e, f, ztype, plabel = z[0], z[1], z[8], z[3]
+        if ztype == 5:
+            periodic += 1; marked[(e, f)] = 'P'
+            # Reproduce apply_periodic_facet: corner k of facet f (nmsh slot
+            # FACE[f][k]) takes the record's glb_pt_ids(k). The file stores those
+            # in the same face_nodes order (mesh_reset_periodic_ids/hex_facet_order).
+            g = z[4:8]
+            for k in range(4):
+                raw = elems[e-1][FACE[f-1][k]-1]
+                remap[raw] = min(remap.get(raw, g[k]), g[k])
+        elif ztype == 7:
+            labeled[plabel] = labeled.get(plabel, 0) + 1; marked[(e, f)] = 'L'
+
+    def rm(x):
+        return remap.get(x, x)
+
+    # Neko's mesh_checker reports the counts AFTER the periodic merge
+    # (glb_mfcs / glb_meds), so faces/edges are hashed on the MERGED ids.
+    fcnt = {}           # sorted 4-tuple of merged ids -> (count, first (e,f))
+    for e in range(nelv):
+        for fi, fc in enumerate(FACE):
+            key = tuple(sorted(rm(elems[e][c-1]) for c in fc))
+            if key in fcnt:
+                fcnt[key] = (fcnt[key][0] + 1, fcnt[key][1])
+            else:
+                fcnt[key] = (1, (e + 1, fi + 1))
+    edges = set()
+    for e in range(nelv):
+        for ec in EDGE:
+            edges.add(tuple(sorted(rm(elems[e][c-1]) for c in ec)))
+    external = [ef for (cnt, ef) in fcnt.values() if cnt == 1]
+    unlabeled = sum(1 for ef in external if ef not in marked)
+    # A mesh that is a single element thick in a periodic direction collapses each
+    # cross-section to one point, so some element loses distinct corners after the
+    # merge. Neko produces exactly these collapsed counts too (same apply path), but
+    # the non-degenerate topological identities below no longer apply -- flag it.
+    degenerate = any(len(set(rm(elems[e][c-1]) for c in range(1, 9))) < 8
+                     for e in range(nelv))
+    return dict(nelv=nelv, points=maxv, faces=len(fcnt), edges=len(edges),
+                periodic=periodic, labeled=labeled, n_external=len(external),
+                unlabeled=unlabeled, degenerate=degenerate)
+
+
+def parse_tool(out):
+    g = {}
+    for pat, key in [(r'Number of elements:\s*(\d+)', 'nelv'),
+                     (r'Number of points:\s*(\d+)', 'points'),
+                     (r'Number of faces:\s*(\d+)', 'faces'),
+                     (r'Number of edges:\s*(\d+)', 'edges'),
+                     (r'Number of periodic faces:\s*(\d+)', 'periodic')]:
+        m = re.search(pat, out)
+        if m:
+            g[key] = int(m.group(1))
+    g['labeled'] = {int(a): int(b) for a, b in re.findall(r'Zone\s+(\d+):\s*(\d+)\s*faces', out)}
+    m = re.search(r'Found\s+(\d+)\s+unlabeled external faces', out)
+    g['unlabeled'] = int(m.group(1)) if m else 0
+    return g
+
+
+def broken_mesh_test(exe, neko):
+    """Strip the labeled wall zone from turb_pipe and confirm the tool detects
+    exactly the newly-exposed faces (the whole diagnostic point of the tool)."""
+    import tempfile
+    src = os.path.join(neko, 'examples', 'turb_pipe', 'turb_pipe.nmsh')
+    if not os.path.exists(src):
+        print('  (skip: turb_pipe.nmsh not found)'); return True
+    d = open(src, 'rb').read()
+    nelv = struct.unpack('<i', d[:4])[0]
+    off = 8 + nelv * 228
+    nz = struct.unpack('<i', d[off:off+4])[0]; zbase = off + 4
+    zones = [d[zbase+i*36:zbase+i*36+36] for i in range(nz)]
+    tail = d[zbase+nz*36:]
+    kept = [z for z in zones if struct.unpack('<9i', z)[8] != 7]
+    dropped_faces = sum(1 for z in zones if struct.unpack('<9i', z)[8] == 7)
+    new = d[:off] + struct.pack('<i', len(kept)) + b''.join(kept) + tail
+    with tempfile.TemporaryDirectory() as t:
+        b = os.path.join(t, 'broken.nmsh'); open(b, 'wb').write(new)
+        p = subprocess.run([exe, b], capture_output=True, text=True)
+    m = re.search(r'Found\s+(\d+)\s+unlabeled', p.stdout)
+    got = int(m.group(1)) if m else 0
+    ok = (got == dropped_faces and p.returncode == 1)
+    print('broken-mesh test (strip turb_pipe wall zone = %d faces):' % dropped_faces)
+    print('  tool detected %d unlabeled external faces, exit %d -> %s' %
+          (got, p.returncode, 'PASS' if ok else 'FAIL'))
+    return ok
+
+
+def jacobian_test(exe):
+    """A correctly-oriented unit cube (jac>0, not flagged) and a mirrored one
+    (jac<0, must be flagged) confirm the negative-Jacobian detector."""
+    import tempfile
+    good = [(0,0,0),(1,0,0),(1,1,0),(0,1,0),(0,0,1),(1,0,1),(1,1,1),(0,1,1)]
+    mirror = [(-x, y, z) for (x, y, z) in good]
+
+    def make(path, corners):
+        with open(path, 'wb') as f:
+            f.write(struct.pack('<ii', 1, 3)); f.write(struct.pack('<i', 1))
+            for j in range(8):
+                f.write(struct.pack('<i', j + 1)); f.write(struct.pack('<3d', *corners[j]))
+            f.write(struct.pack('<i', 0)); f.write(struct.pack('<i', 0))
+
+    ok = True
+    with tempfile.TemporaryDirectory() as t:
+        for name, c, want_flag in [('good cube', good, False), ('mirrored cube', mirror, True)]:
+            p = os.path.join(t, 'm.nmsh'); make(p, c)
+            r = subprocess.run([exe, p, '--jacobian'], capture_output=True, text=True)
+            flagged = ('negative/zero Jacobian (first' in r.stdout)
+            good_case = (flagged == want_flag)
+            ok = ok and good_case
+            print('  %-16s flagged=%-5s (want %s) -> %s' %
+                  (name, flagged, want_flag, 'OK' if good_case else 'FAIL'))
+    return ok
+
+
+def fld_test(exe, neko):
+    """Write zone_indices.fld for the cylinder, parse it back, and confirm the
+    scalar field equals the mesh's per-GLL-point zone label everywhere."""
+    import tempfile
+    mesh = os.path.join(neko, 'examples', 'cylinder', 'cylinder.nmsh')
+    if not os.path.exists(mesh):
+        print('  (skip: cylinder.nmsh not found)'); return True
+    exe = os.path.abspath(exe)
+    cwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as t:
+        os.chdir(t)
+        try:
+            subprocess.run([exe, mesh, '--write-zone-indices'], capture_output=True, text=True)
+            d = open('zone_indices.fld', 'rb').read()
+        finally:
+            os.chdir(cwd)
+    hdr = d[:132].split(); off = 132
+    lx, nelv = int(hdr[2]), int(hdr[5]); lxyz = lx**3
+    tp = struct.unpack('<f', d[off:off+4])[0]; off += 4
+    off += 4 * nelv                                    # idx
+    off += 4 * nelv * 3 * lxyz                          # mesh block
+    scal = struct.unpack('<%df' % (nelv * lxyz), d[off:off+4*nelv*lxyz]); off += 4*nelv*lxyz
+    off += 4 * nelv * 6                                 # geometry bb metadata
+    off += 4 * nelv * 2                                 # scalar min/max metadata
+    struct_ok = (off == len(d) and abs(tp - 6.54321) < 1e-4)
+    # expected labels from the mesh
+    m = open(mesh, 'rb').read(); mn = struct.unpack('<i', m[:4])[0]
+    mo = 8 + mn * 228; nz = struct.unpack('<i', m[mo:mo+4])[0]; mo += 4
+
+    def facet_pts(ff):
+        out = []
+        for it in range(3):
+            for js in range(3):
+                for ir in range(3):
+                    on = ((ff==1 and ir==0) or (ff==2 and ir==2) or (ff==3 and js==0) or
+                          (ff==4 and js==2) or (ff==5 and it==0) or (ff==6 and it==2))
+                    if on:
+                        out.append(ir + 3*js + 9*it)
+        return out
+
+    exp = {}
+    for i in range(nz):
+        z = struct.unpack('<9i', m[mo+i*36:mo+i*36+36])
+        if z[8] == 7:
+            e, ff, lbl = z[0]-1, z[1], z[3]
+            for pt in facet_pts(ff):
+                exp[(e, pt)] = max(exp.get((e, pt), 0), lbl)
+    bad = sum(1 for e in range(mn) for pt in range(27)
+              if round(scal[e*27+pt]) != exp.get((e, pt), 0))
+    ok = struct_ok and bad == 0
+    print('  .fld struct ok=%s ; zone-index field mismatches=%d -> %s' %
+          (struct_ok, bad, 'OK' if ok else 'FAIL'))
+    return ok
+
+
+def main():
+    if not os.path.exists(EXE):
+        print('error: mesh_checker_light not found at', EXE, '(build it first)'); return 1
+    paths = sorted(glob.glob(os.path.join(NEKO, 'examples', '**', '*.nmsh'), recursive=True) +
+                   glob.glob(os.path.join(NEKO, 'tests', '**', '*.nmsh'), recursive=True))
+    print('%-46s %8s %8s %8s %6s %6s %5s' %
+          ('mesh', 'nelv', 'faces', 'edges', 'per', 'unlab', 'ok'))
+    n = nok = 0
+    allok = True
+    for path in paths:
+        ref = compute(path)
+        if ref is None:
+            continue
+        p = subprocess.run([EXE, path], capture_output=True, text=True)
+        got = parse_tool(p.stdout)
+        # (1) tool output must equal the independent Python computation, field by field
+        fields_ok = all(got.get(k) == ref[k] for k in ('nelv', 'points', 'faces', 'edges', 'periodic', 'unlabeled'))
+        lbl_ok = (got['labeled'] == ref['labeled'])
+        # (2) topological identity any correct MERGED face dedup must satisfy:
+        #     each internal face is shared by 2 elements, each external by 1.
+        #     (Skipped for degenerate single-element-thick collapsed meshes, which
+        #     Neko reproduces identically -- there the tool==python check carries it.)
+        euler_ok = ref['degenerate'] or \
+            (2 * ref['faces'] - ref['n_external'] == 6 * ref['nelv'])
+        # (2b) a non-degenerate mesh with no external faces is a closed 3-torus
+        #      (fully periodic): then #faces == #edges == 3*nelv exactly. Hard
+        #      ground truth that ONLY the correct periodic merge (right glb_pt_ids
+        #      ordering) satisfies -- the raw, unmerged counts do not.
+        torus_ok = True
+        if ref['n_external'] == 0 and not ref['degenerate']:
+            torus_ok = (ref['faces'] == 3 * ref['nelv'] and ref['edges'] == 3 * ref['nelv'])
+        # (3) exit code reflects the diagnostic (0 iff no unlabeled external faces)
+        exit_ok = (p.returncode == (1 if ref['unlabeled'] > 0 else 0))
+        ok = fields_ok and lbl_ok and euler_ok and torus_ok and exit_ok
+        n += 1; nok += ok; allok = allok and ok
+        note = '' if ref['unlabeled'] == 0 else '(no-BC mesh: whole surface unlabeled)'
+        print('%-46s %8d %8d %8d %6d %6d %-4s %s' %
+              (os.path.relpath(path, NEKO), ref['nelv'], ref['faces'], ref['edges'],
+               ref['periodic'], ref['unlabeled'], 'OK' if ok else 'FAIL', note))
+        if not ok:
+            print('     tool=%s ref=%s euler=%s exit=%d' %
+                  (got, {k: ref[k] for k in ('nelv','points','faces','edges','periodic','labeled','unlabeled')},
+                   euler_ok, p.returncode))
+    print('\n3D meshes tested            : %d' % n)
+    print('tool==python + Euler + exit : %d / %d' % (nok, n))
+    print('  (independent Python recomputation matches the tool on every field;')
+    print('   2F-B=6*nelv holds; exit code = 0 iff 0 unlabeled external faces.')
+    print('   Meshes with unlabeled>0 are benchmark boxes/cylinders that carry no')
+    print('   mesh-level BCs -- the tool correctly flags their whole open surface,')
+    print('   exactly as the real mesh_checker would.)')
+    print()
+    brk = broken_mesh_test(EXE, NEKO)
+    print('\njacobian test (good vs mirrored/inverted cube):')
+    jac = jacobian_test(EXE)
+    print('\nzone-index .fld test:')
+    fld = fld_test(EXE, NEKO)
+    allok = allok and brk and jac and fld
+    print('\nRESULT:', 'PASS' if allok else 'FAIL')
+    return 0 if allok else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/contrib/prepart_light/prepart_light.md
+++ b/contrib/prepart_light/prepart_light.md
@@ -1,0 +1,178 @@
+```text
+     _  __  ____  __ __  ____
+    / |/ / / __/ / //_/ / __ \
+   /    / / _/  / ,<   / /_/ /
+  /_/|_/ /___/ /_/|_|  \____/
+```
+
+# prepart_light
+
+A lightweight, CPU-only **mesh partitioner** for Neko `.nmsh` files, in pure
+scientific Python — it reads an `.nmsh`, partitions it into `nparts` parts, and
+writes a reordered `.nmsh` whose elements are grouped into contiguous
+per-partition blocks, exactly like `contrib/prepart` (a later *linear* read
+reproduces the partition). Curves and zones are first-class. No MPI, no ParMETIS
+build, no Fortran compiler — just Python.
+
+```sh
+pip install numpy scipy                        # required
+pip install pymetis                            # optional: --backend metis
+pip install pyamg                              # optional: faster spectral on large meshes
+
+./prepart_light.py mesh.nmsh 8                 # -> mesh_8.nmsh (spectral, default)
+./prepart_light.py mesh.nmsh 64 --metis        # multilevel k-way (best cut)
+./prepart_light.py mesh.nmsh 1024 --geometric --no-stats   # near-instant fast path
+make check                                     # validation across a Neko tree
+```
+
+Usage mirrors `prepart`:
+
+```
+prepart_light.py mesh.nmsh nparts [out.nmsh] [--backend spectral|metis|geometric] [--no-stats]
+```
+
+`nparts` is any positive integer; the default output is `<base>_<nparts>.nmsh`.
+
+> `make check` reads meshes from a Neko checkout, so it expects this folder
+> inside a Neko source tree (`../../examples`, `../../tests`); otherwise:
+> `python3 validate_prepart.py /path/to/neko [nparts]`. Partitioning your own
+> mesh needs no Neko tree.
+
+## Why it exists — and why Python
+
+Neko partitions meshes with **ParMETIS** (via `prepart` and the runtime load
+balancer) — excellent, but an external MPI library you must build and link.
+`prepart_light` is the dependency-light offline alternative: on most systems
+`python + numpy/scipy` is *more* readily available than a Fortran compiler or a
+ParMETIS build, and this is preprocessing — run once, cache the result.
+
+The performance case for Python here is real, not hand-waving: the element dual
+graph is built as a single **compiled sparse matrix product** `A = E·Eᵀ`
+(`E` = element×vertex incidence; `A[i,j]` = number of shared vertices — exactly
+the weighted dual graph Nek5000's `genmap` uses), and the partitioners are
+compiled library code (ARPACK/LOBPCG, METIS). Measured on a 1M-element box into
+16 parts, against the Fortran spectral tool from this same tool family:
+
+| backend | time (1M box, 16 parts) | weighted edge cut |
+|---|--:|--:|
+| Fortran spectral (genmap_light) | 76 s | 3.95 % |
+| `--backend metis` | **16.5 s** | **2.96 %** |
+| `--backend geometric` | **4.5 s** (2.6 s with `--no-stats`) | 2.86 % |
+| `--backend spectral` (default) | comparable to Fortran | ≈ Fortran |
+
+Extrapolated to a 75M-element mesh: **minutes** with `--geometric`
+(sort-dominated, no graph), **~20 min** with `--metis` (the ~2×10⁹-edge dual
+graph costs ~25 GB — a single fat node, feasible). The dual-graph build itself
+is ~1.3 s per million elements.
+
+> **Tested, but please check your own case.** All three backends are validated
+> across the meshes shipped with Neko (see [Validation](#validation)), but it
+> remains your responsibility to confirm the result is correct for *your* mesh —
+> `make check`, or run the validator on a case you trust, first.
+
+## The three backends
+
+All partition the **same weighted element dual graph** (edge weight = number of
+shared vertices; **periodic facets are merged** through the stored `glb_pt_ids`
+so periodic neighbours are graph-adjacent), and are scored by the same weighted
+edge cut:
+
+- **`spectral` (default; numpy/scipy only).** Recursive spectral bisection —
+  Nek5000 `genmap`'s algorithm with a robust eigensolver. Per bisection it takes
+  the few lowest non-trivial eigenvectors of the sub-graph Laplacian (dense for
+  tiny subsets; shift-invert Lanczos for medium; pyamg-preconditioned LOBPCG for
+  large subsets when `pyamg` is installed), forms the balanced split for each
+  mode, and keeps the lowest-cut split that leaves both halves connected (BFS
+  region-growing fallback otherwise). Parts differ by ≤ 1 element. Above ~50 k
+  elements per subset it uses pyamg-preconditioned LOBPCG (with `pyamg`,
+  `tgv/262144` partitions in ~22 s); without `pyamg` it falls back to
+  shift-invert with a printed warning — fine to ~10⁵ elements, slow beyond
+  (use `--metis` or `--geometric` there).
+- **`metis` (needs `pip install pymetis`).** Multilevel k-way METIS on the same
+  weighted graph, so it minimises the same objective. Usually the best cut and
+  much faster than spectral. Balance follows METIS's semantics: the **largest**
+  part stays within METIS's ~3 % tolerance of the ideal size (plus ±1 element of
+  integer granularity on tiny parts) — e.g. 25 elements into 8 parts gives
+  `[3,3,3,3,3,3,3,4]`. Spectral/geometric instead guarantee max−min ≤ 1. When
+  `nparts` approaches `nelv` (tiny mean part size) k-way METIS can collapse
+  parts; the tool detects this, retries with METIS recursive bisection, and
+  errors out loudly rather than ever writing fewer parts than requested.
+- **`geometric` (numpy only, no graph).** Recursive coordinate bisection on
+  element centroids: split along the longest bounding-box axis at the balanced
+  point, recurse. O(n log n), near-instant at any size; with `--no-stats` the
+  dual graph is never built at all. **Caveat:** centroids know nothing of
+  periodic wrap-around, so on strongly periodic meshes the cut can be worse than
+  the graph-based backends (in practice it is often surprisingly good — 5.10 %
+  cut on the periodic turbulent pipe, on par with the graph-based backends
+  there).
+
+Determinism: all three are deterministic — fixed eigensolver starting vectors
+plus an eigenvector sign convention (spectral), deterministic METIS defaults,
+and stable sorts (geometric). Same input + nparts ⇒ byte-identical output.
+
+## What the reorder does (the prepart contract)
+
+Elements are renumbered into contiguous per-partition blocks (`el_idx` becomes
+`1..nelv` in file order); point ids and coordinates are **never changed**. Every
+**curve record** is carried through with its element reference renumbered and
+the geometric payload (`curve_data(5,12)`, `curve_type(12)`) copied verbatim.
+**Periodic (type-5) zones** keep `f`/`p_f`/`glb_pt_ids` verbatim (those
+reference point ids, which don't change) with `e`/`p_e` renumbered; **labeled
+(type-7) zones** keep their label (`p_f`), with the `p_e`/`glb_pt_ids` fields
+Neko leaves uninitialised written as deterministic zeros. Zone records of
+**other (legacy) types** — e.g. the type-1/2 zones in older meshes such as the
+shipped poisson/nekbone boxes, which Neko's current reader ignores — are carried
+through verbatim with only the element id renumbered (with a note printed).
+A linear read on `nparts` ranks then lands each part on its rank.
+
+The reader validates section framing (truncated zone/curve sections, implausible
+zone types, out-of-range curve element ids all abort with a clear error before
+anything is written) and tolerates the trailing bytes some real meshes carry
+past the curve section (an MPI-IO no-truncate artifact; Neko ignores them too).
+
+I/O is numpy-vectorized (packed structured dtypes matching the 228/36/532-byte
+nmsh records; one `fromfile`/`tofile` per section), so reading + writing a
+1M-element mesh takes ~2 s.
+
+## Validation
+
+`validate_prepart.py` runs every (mesh × backend) combination across a Neko tree
+and checks, independently of the tool's internals:
+
+1. **Pure permutation** — the output's element payloads are exactly a
+   permutation of the input's; `el_idx` contiguous `1..nelv`.
+2. **Curves carried and bound** — every curve payload survives byte-verbatim
+   *and* is attached to the geometrically identical element (matched by the
+   element's vertex ids + coordinates), not merely preserved as a multiset.
+3. **Zones carried and bound** — periodic zones keep `f`/`p_f`/`glb_pt_ids` on
+   the geometrically identical element; labeled zones keep their label/binding.
+4. **Contiguous blocks** — the file order equals the stable
+   partition-grouped order (the prepart contract).
+5. **Balance** — parts within ≤ 1 element (spectral/geometric) or METIS's
+   tolerance; plus a weighted-cut report vs a naive linear split.
+
+Additionally, every reordered output re-reads with `mesh_checker_light` giving
+byte-identical element/point/face/edge/periodic/labeled-zone counts to the
+input — confirming periodic fusion and topology survive the reorder.
+
+## Scope / limitations
+
+- **3D hex meshes** (as `prepart`). 2D (`gdim=2`) exits with a clear error.
+- **Serial / offline** (like `prepart`): the whole mesh is loaded. Memory is
+  dominated by the element records (~230 B/element) plus, for the graph-based
+  backends, the weighted dual graph (~24 GB at 75M; `--geometric --no-stats`
+  skips it entirely).
+- **Requires numpy + scipy**; `pymetis`/`pyamg` optional. If you cannot have
+  Python at all, the Fortran sibling (`genmap_light`, gfortran-only) covers the
+  spectral tier.
+- For production-scale *parallel* partitioning within a running solve, Neko's
+  ParMETIS load balancer / `prepart` remains the tool of choice; this is the
+  offline, dependency-light complement.
+
+## Files
+
+- `prepart_light.py` — the partitioner (single file; spectral / metis /
+  geometric backends).
+- `validate_prepart.py` — the permutation/binding/blocks/balance harness
+  (`make check`).
+- `Makefile` — `make check`, `make clean`.

--- a/contrib/prepart_light/prepart_light.py
+++ b/contrib/prepart_light/prepart_light.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, The Neko Authors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#
+#   * Neither the name of the authors nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#     _  __  ____  __ __  ____
+#    / |/ / / __/ / //_/ / __ \
+#   /    / / _/  / ,<   / /_/ /
+#  /_/|_/ /___/ /_/|_|  \____/
+#
+"""prepart_light -- a lightweight, CPU-only mesh partitioner for Neko `.nmsh`
+files, in pure scientific Python (numpy/scipy).
+
+Like Neko's `contrib/prepart` it reads an `.nmsh`, partitions it into `nparts`
+parts, and writes a reordered `.nmsh` whose elements are grouped into contiguous
+per-partition blocks, so a later *linear* read reproduces the partition. Curves
+and zones are first-class: every curve record and every periodic/labeled zone is
+carried through with only its element reference renumbered; point ids and
+coordinates are never changed. It does no Neko initialisation and needs no MPI,
+no ParMETIS build, and no Fortran compiler -- just Python with numpy/scipy.
+
+Three partitioning backends (all share the same weighted element dual graph:
+edge weight = number of shared vertices, with periodic facets merged through the
+stored glb_pt_ids so periodic neighbours are graph-adjacent):
+
+  --backend spectral   (default) recursive spectral bisection: the few lowest
+                       eigenvectors of the dual-graph Laplacian per bisection,
+                       best-of-modes balanced split with a connectivity check
+                       and BFS region-growing fallback. Deterministic. This is
+                       Nek5000 genmap's algorithm with a robust eigensolver
+                       (scipy shift-invert Lanczos; pyamg-preconditioned LOBPCG
+                       on large sub-problems when pyamg is installed).
+  --backend metis      multilevel k-way via pymetis (pip install pymetis).
+                       Fed the same weighted dual graph, so it minimises the
+                       same edge-cut objective; usually the best cut.
+  --backend geometric  recursive coordinate bisection on element centroids:
+                       no graph, no eigensolve, near-instant even on very large
+                       meshes. Ignores periodic wrap-around (a known quality
+                       trade-off on periodic meshes).
+
+Usage:
+  prepart_light.py mesh.nmsh nparts [out.nmsh] [--backend spectral|metis|geometric]
+
+Default output is <base>_<nparts>.nmsh (the prepart convention).
+
+Tested against the meshes shipped with Neko and cross-checked between backends,
+but it remains your responsibility to confirm the result is correct for your own
+mesh -- run the bundled validator on a case you trust first. See
+prepart_light.md for the algorithm, validation, and scope. 3D hex meshes only.
+"""
+
+import argparse
+import sys
+import time
+
+import numpy as np
+import scipy.sparse as sp
+from scipy.sparse.csgraph import connected_components, breadth_first_order
+
+# ---------------------------------------------------------------------------
+# nmsh binary layout (packed little-endian records; see nmsh format reference)
+# ---------------------------------------------------------------------------
+EL_DT = np.dtype([('id', '<i4'),
+                  ('v', [('idx', '<i4'), ('xyz', '<f8', (3,))], (8,))])   # 228 B
+ZONE_DT = np.dtype([('e', '<i4'), ('f', '<i4'), ('p_e', '<i4'), ('p_f', '<i4'),
+                    ('g', '<i4', (4,)), ('t', '<i4')])                     # 36 B
+CURVE_DT = np.dtype([('e', '<i4'), ('data', '<f8', (12, 5)),
+                     ('type', '<i4', (12,))])                              # 532 B
+assert EL_DT.itemsize == 228 and ZONE_DT.itemsize == 36 and CURVE_DT.itemsize == 532
+
+# Neko facet (1..6) corners as nmsh vertex slots (0-based here) -- face_nodes
+# composed with the nmsh->mesh read swap [1,2,4,3,5,6,8,7]; the same table
+# validated byte-exact for periodic glb_pt_ids in the sibling *_light tools.
+FACE_RE2 = np.array([[1, 5, 8, 4], [2, 6, 7, 3], [1, 2, 6, 5],
+                     [4, 3, 7, 8], [1, 2, 3, 4], [5, 6, 7, 8]], dtype=np.int64) - 1
+
+BANNER = r"""
+     _  __  ____  __ __  ____
+    / |/ / / __/ / //_/ / __ \
+   /    / / _/  / ,<   / /_/ /
+  /_/|_/ /___/ /_/|_|  \____/   prepart_light  (mesh partitioner)
+"""
+
+
+def log(msg):
+    print(msg, flush=True)
+
+
+# ---------------------------------------------------------------------------
+# I/O
+# ---------------------------------------------------------------------------
+def read_nmsh(path):
+    def count(f, what):
+        a = np.fromfile(f, dtype='<i4', count=1)
+        if a.size != 1:
+            sys.exit('Error: truncated file (missing %s count)' % what)
+        n = int(a[0])
+        if n < 0:
+            sys.exit('Error: negative %s count (%d) -- corrupt file?' % (what, n))
+        return n
+
+    try:
+        f = open(path, 'rb')
+    except OSError as ex:
+        sys.exit('Error: cannot open %s (%s)' % (path, ex.strerror))
+    with f:
+        hdr = np.fromfile(f, dtype='<i4', count=2)
+        if hdr.size != 2:
+            sys.exit('Error: %s is not a Neko .nmsh file (short header)' % path)
+        nelv, gdim = int(hdr[0]), int(hdr[1])
+        if gdim != 3:
+            sys.exit('Error: prepart_light supports 3D (hex) meshes only '
+                     '(gdim=%d).' % gdim)
+        elems = np.fromfile(f, dtype=EL_DT, count=nelv)
+        if elems.size != nelv:
+            sys.exit('Error: truncated element section (%d of %d records)'
+                     % (elems.size, nelv))
+        nz = count(f, 'zone')
+        zones = np.fromfile(f, dtype=ZONE_DT, count=nz)
+        if zones.size != nz:
+            sys.exit('Error: truncated zone section (%d of %d records)'
+                     % (zones.size, nz))
+        nc = count(f, 'curve')
+        curves = np.fromfile(f, dtype=CURVE_DT, count=nc)
+        if curves.size != nc:
+            sys.exit('Error: truncated curve section (%d of %d records)'
+                     % (curves.size, nc))
+        # NOTE: bytes may remain past the curve section (an MPI-IO no-truncate
+        # artifact seen in real meshes, e.g. turb_pipe); Neko's reader ignores
+        # them and so do we.
+    # semantic sanity -- catches mis-framed sections that happen to parse
+    # (valid Neko zone types are 1..7; 5=periodic, 7=labeled, 1..4 legacy)
+    if zones.size and ((zones['t'] < 1) | (zones['t'] > 7)).any():
+        sys.exit('Error: zone record with implausible type (valid: 1..7) -- '
+                 'corrupt or mis-framed zone section?')
+    if curves.size and ((curves['e'] < 1) | (curves['e'] > nelv)).any():
+        sys.exit('Error: curve element id out of [1,nelv] -- corrupt or '
+                 'mis-framed curve section?')
+    return nelv, elems, zones, curves
+
+
+def write_nmsh(path, elems_out, zones5, zones7, zones_other, curves_out):
+    nelv = elems_out.shape[0]
+    nz = zones5.shape[0] + zones7.shape[0] + zones_other.shape[0]
+    try:
+        f = open(path, 'wb')
+    except OSError as ex:
+        sys.exit('Error: cannot write %s (%s)' % (path, ex.strerror))
+    with f:
+        np.array([nelv, 3], dtype='<i4').tofile(f)
+        elems_out.tofile(f)
+        np.array([nz], dtype='<i4').tofile(f)
+        zones5.tofile(f)          # periodic (type 5) first, then labeled --
+        zones7.tofile(f)          # the order Neko's own writer uses --
+        zones_other.tofile(f)     # then any legacy zone types, carried through
+        np.array([curves_out.shape[0]], dtype='<i4').tofile(f)
+        curves_out.tofile(f)
+
+
+# ---------------------------------------------------------------------------
+# Dual graph (periodic-merged, shared-vertex weighted)
+# ---------------------------------------------------------------------------
+def merged_cell(nelv, elems, zones):
+    """Apply the periodic glb_pt_ids merge (exactly what Neko's reader does via
+    apply_periodic_facet) and compress point ids to 0..nrnk-1. Returns the
+    (nelv, 8) compressed connectivity and pos_of_elid (0-based)."""
+    elids = elems['id'].astype(np.int64)
+    if elids.min() < 1 or elids.max() > nelv:
+        sys.exit('Error: element id out of [1,nelv]')
+    pos_of_elid = np.full(nelv + 1, -1, dtype=np.int64)
+    pos_of_elid[elids] = np.arange(nelv)
+    if (pos_of_elid[1:] < 0).any():
+        sys.exit('Error: element ids are not a permutation of 1..nelv')
+
+    vidx = elems['v']['idx'].astype(np.int64)          # (nelv, 8)
+    z5 = zones[zones['t'] == 5]
+    if z5.size:
+        ok = (z5['e'] >= 1) & (z5['e'] <= nelv) & (z5['f'] >= 1) & (z5['f'] <= 6)
+        z5 = z5[ok]
+    if z5.size:
+        # Merge over the set of ids actually present (memory O(#unique ids)),
+        # not a dense table sized by max id -- sparse/large ids stay cheap.
+        uniq = np.unique(vidx)                                # sorted
+        merge = uniq.copy()                                   # identity default
+        pos = pos_of_elid[z5['e'].astype(np.int64)]
+        slots = FACE_RE2[z5['f'].astype(np.int64) - 1]        # (nz5, 4)
+        raw = vidx[pos[:, None], slots]                       # (nz5, 4)
+        ridx = np.searchsorted(uniq, raw.ravel())
+        np.minimum.at(merge, ridx, z5['g'].astype(np.int64).ravel())
+        vidx = merge[np.searchsorted(uniq, vidx.ravel())].reshape(nelv, 8)
+
+    _, cell = np.unique(vidx.ravel(), return_inverse=True)
+    return cell.reshape(nelv, 8), pos_of_elid
+
+
+def dual_graph(cell):
+    """Weighted element dual graph A = E.Ep^T with the diagonal removed:
+    A[i,j] = number of shared (merged) vertices between elements i and j."""
+    nelv = cell.shape[0]
+    npts = int(cell.max()) + 1
+    rows = np.repeat(np.arange(nelv, dtype=np.int64), 8)
+    E = sp.csr_matrix((np.ones(nelv * 8), (rows, cell.ravel())),
+                      shape=(nelv, npts))
+    A = (E @ E.T).tocsr()
+    A.setdiag(0)
+    A.eliminate_zeros()
+    return A
+
+
+def weighted_cut(A, part):
+    C = A.tocoo()
+    mask = part[C.row] != part[C.col]
+    return float(C.data[mask].sum()) / 2.0, float(C.data.sum()) / 2.0
+
+
+def nint(x):
+    """Fortran NINT (round half away from zero) -- same proportional-split
+    arithmetic as the Fortran genmap_light, so block models agree."""
+    return int(np.floor(x + 0.5)) if x >= 0 else -int(np.floor(-x + 0.5))
+
+
+# ---------------------------------------------------------------------------
+# Backend: spectral (recursive spectral bisection, best of the low modes)
+# ---------------------------------------------------------------------------
+def _low_modes(subA, n, kmodes, rng_seed=12345):
+    """The kmodes lowest non-trivial eigenvectors of the sub-graph Laplacian.
+    Dense for small n; shift-invert Lanczos for medium; pyamg-preconditioned
+    LOBPCG for large (falls back to shift-invert if pyamg is missing)."""
+    from scipy.sparse.csgraph import laplacian
+    L = laplacian(subA).tocsr()
+    k = min(kmodes + 1, n - 1)          # +1 for the trivial constant mode
+    if n <= 800:
+        vals, vecs = np.linalg.eigh(L.toarray())
+        return vecs[:, 1:1 + kmodes]
+    v0 = np.random.default_rng(rng_seed).standard_normal(n)
+    if n > 50_000:
+        # shift-invert LU on a large 3D dual graph suffers fill-in explosion;
+        # AMG-preconditioned LOBPCG is the scalable path (needs pyamg).
+        try:
+            import pyamg
+            from scipy.sparse.linalg import lobpcg
+            ml = pyamg.smoothed_aggregation_solver(L.tocsr().astype(np.float64))
+            M = ml.aspreconditioner()
+            X0 = np.random.default_rng(rng_seed).standard_normal((n, k))
+            X0[:, 0] = 1.0
+            vals, vecs = lobpcg(L, X0, M=M, largest=False, tol=1e-6,
+                                maxiter=200)
+            order = np.argsort(vals)
+            return vecs[:, order[1:1 + kmodes]]
+        except ImportError:
+            log('  note: pyamg not installed -- falling back to shift-invert '
+                'Lanczos on a %d-element subset (may be slow; pip install '
+                'pyamg, or use --backend metis/geometric)' % n)
+        except Exception as ex:
+            log('  note: pyamg/LOBPCG failed on a %d-element subset (%s) -- '
+                'falling back to shift-invert Lanczos' % (n, ex))
+    from scipy.sparse.linalg import eigsh
+    vals, vecs = eigsh(L.tocsc(), k=k, sigma=-1e-6, which='LM', v0=v0)
+    order = np.argsort(vals)
+    return vecs[:, order[1:1 + kmodes]]
+
+
+def _split_connected(subA, side):
+    for s in (0, 1):
+        idx = np.flatnonzero(side == s)
+        if idx.size == 0:
+            continue
+        ncomp, _ = connected_components(subA[idx][:, idx], directed=False)
+        if ncomp > 1:
+            return False
+    return True
+
+
+def _region_grow(subA, n, n1):
+    """BFS from node 0 until n1 nodes are claimed; guarantees a connected first
+    half on a connected subgraph. Top up deterministically if disconnected."""
+    order = breadth_first_order(subA, 0, directed=False,
+                                return_predecessors=False)
+    side = np.ones(n, dtype=np.int8)
+    take = order[:min(n1, order.size)]
+    side[take] = 0
+    short = n1 - take.size
+    if short > 0:
+        rest = np.flatnonzero(side == 1)[:short]
+        side[rest] = 0
+    return side
+
+
+def spectral_partition(A, nelv, nparts, kmodes=4):
+    part = np.zeros(nelv, dtype=np.int64)
+
+    def rec(idx, q, base):
+        n = idx.size
+        if q <= 1 or n == 0:
+            part[idx] = base
+            return
+        q1 = q // 2
+        n1 = max(1, min(n - 1, nint(n * q1 / q)))
+        if n <= 2:
+            left, right = idx[:n1], idx[n1:]
+        else:
+            subA = A[idx][:, idx].tocsr()
+            F = _low_modes(subA, n, min(kmodes, n - 1))
+            best = None
+            for c in range(F.shape[1]):
+                f = F[:, c]
+                j = int(np.argmax(np.abs(f)))
+                if f[j] < 0:
+                    f = -f                              # sign convention
+                order = np.argsort(f, kind='stable')
+                side = np.ones(n, dtype=np.int8)
+                side[order[:n1]] = 0
+                C = subA.tocoo()
+                cut = float(C.data[side[C.row] != side[C.col]].sum()) / 2
+                conn = _split_connected(subA, side)
+                score = cut if conn else cut + 1e12     # prefer connected
+                if best is None or score < best[0]:
+                    best = (score, side, conn)
+            side = best[1]
+            if not best[2]:
+                side = _region_grow(subA, n, n1)
+            left = idx[side == 0]
+            right = idx[side == 1]
+        rec(left, q1, base)
+        rec(right, q - q1, base + q1)
+
+    rec(np.arange(nelv, dtype=np.int64), nparts, 0)
+    return part
+
+
+# ---------------------------------------------------------------------------
+# Backend: metis (multilevel k-way, same weighted graph)
+# ---------------------------------------------------------------------------
+def metis_partition(A, nelv, nparts):
+    try:
+        import pymetis
+    except ImportError:
+        sys.exit('Error: --backend metis needs pymetis (pip install pymetis)')
+    if nparts == 1:
+        return np.zeros(nelv, dtype=np.int64)
+    Ai = A.tocsr()
+    if Ai.nnz >= 2**31:
+        sys.exit('Error: dual graph too large for METIS 32-bit indices '
+                 '(%d edges); use --backend geometric' % Ai.nnz)
+    xadj = Ai.indptr.astype(np.int32)
+    adjncy = Ai.indices.astype(np.int32)
+    eweights = np.rint(Ai.data).astype(np.int32)
+
+    def _part(recursive=False):
+        try:                                  # pymetis >= 2025.2
+            adj = pymetis.CSRAdjacency(adj_starts=xadj, adjacent=adjncy)
+            return pymetis.part_graph(nparts, adjacency=adj,
+                                      eweights=eweights, recursive=recursive)
+        except (AttributeError, TypeError):   # older pymetis
+            return pymetis.part_graph(nparts, xadj=xadj, adjncy=adjncy,
+                                      eweights=eweights, recursive=recursive)
+
+    _, membership = _part()
+    part = np.asarray(membership, dtype=np.int64)
+    if np.unique(part).size < nparts:
+        # k-way METIS can collapse parts when the mean part size gets tiny
+        # (nparts a large fraction of nelv); recursive bisection handles that.
+        log('  note: k-way METIS returned %d non-empty parts; '
+            'retrying with recursive bisection' % np.unique(part).size)
+        _, membership = _part(recursive=True)
+        part = np.asarray(membership, dtype=np.int64)
+    if np.unique(part).size < nparts:
+        sys.exit('Error: METIS produced only %d non-empty parts of %d '
+                 'requested; use --backend spectral or geometric for this '
+                 'nparts/nelv ratio.' % (np.unique(part).size, nparts))
+    return part
+
+
+# ---------------------------------------------------------------------------
+# Backend: geometric (recursive coordinate bisection on centroids)
+# ---------------------------------------------------------------------------
+def geometric_partition(elems, nelv, nparts):
+    cent = elems['v']['xyz'].mean(axis=1)               # (nelv, 3)
+    part = np.zeros(nelv, dtype=np.int64)
+
+    def rec(idx, q, base):
+        n = idx.size
+        if q <= 1 or n == 0:
+            part[idx] = base
+            return
+        q1 = q // 2
+        n1 = max(1, min(n - 1, nint(n * q1 / q)))
+        c = cent[idx]
+        axis = int(np.argmax(c.max(axis=0) - c.min(axis=0)))
+        order = np.argsort(c[:, axis], kind='stable')
+        rec(idx[order[:n1]], q1, base)
+        rec(idx[order[n1:]], q - q1, base + q1)
+
+    rec(np.arange(nelv, dtype=np.int64), nparts, 0)
+    return part
+
+
+# ---------------------------------------------------------------------------
+# Reorder + write (the prepart contract)
+# ---------------------------------------------------------------------------
+def reorder_and_write(path, nelv, elems, zones, curves, part, pos_of_elid):
+    # stable sort by partition: contiguous blocks, original order within a part
+    order = np.argsort(part, kind='stable')             # new position -> old pos
+    newid_of_pos = np.empty(nelv, dtype=np.int64)       # old pos -> new 1-based id
+    newid_of_pos[order] = np.arange(1, nelv + 1)
+
+    elems_out = elems[order].copy()
+    elems_out['id'] = np.arange(1, nelv + 1, dtype=np.int32)
+
+    def remap_el(ids):
+        ids = ids.astype(np.int64)
+        ok = (ids >= 1) & (ids <= nelv)
+        out = ids.copy()
+        out[ok] = newid_of_pos[pos_of_elid[ids[ok]]]
+        return out.astype(np.int32)
+
+    z5 = zones[zones['t'] == 5].copy()
+    z7 = zones[zones['t'] == 7].copy()
+    zx = zones[(zones['t'] != 5) & (zones['t'] != 7)].copy()
+    if z5.size:
+        z5['e'] = remap_el(z5['e'])
+        z5['p_e'] = remap_el(z5['p_e'])
+    if z7.size:
+        z7['e'] = remap_el(z7['e'])
+        z7['p_e'] = 0                                   # Neko leaves these unset;
+        z7['g'] = 0                                     # write deterministic zeros
+    if zx.size:
+        # Legacy zone types (e.g. type 1/2 in older meshes: poisson, nekbone).
+        # Neko's current reader ignores them, but they are part of the file --
+        # carry them through verbatim with only the element id renumbered.
+        log('  note: carrying %d zone records of other types %s through '
+            '(element ids renumbered, payload verbatim)'
+            % (zx.shape[0], sorted(set(int(t) for t in zx['t']))))
+        zx['e'] = remap_el(zx['e'])
+    curves_out = curves.copy()
+    if curves_out.size:
+        curves_out['e'] = remap_el(curves_out['e'])
+
+    write_nmsh(path, elems_out, z5, z7, zx, curves_out)
+
+
+# ---------------------------------------------------------------------------
+def main():
+    ap = argparse.ArgumentParser(
+        prog='prepart_light.py',
+        description='Partition a Neko .nmsh and write a reordered .nmsh whose '
+                    'linear read reproduces the partition (like prepart).')
+    ap.add_argument('mesh', help='input .nmsh')
+    ap.add_argument('nparts', type=int, help='number of partitions')
+    ap.add_argument('out', nargs='?', default=None,
+                    help='output .nmsh (default <base>_<nparts>.nmsh)')
+    ap.add_argument('--backend', choices=('spectral', 'metis', 'geometric'),
+                    default='spectral')
+    ap.add_argument('--metis', dest='backend', action='store_const',
+                    const='metis', help='shorthand for --backend metis')
+    ap.add_argument('--geometric', dest='backend', action='store_const',
+                    const='geometric', help='shorthand for --backend geometric')
+    ap.add_argument('--no-stats', action='store_true',
+                    help='skip the edge-cut report (avoids building the dual '
+                         'graph for --backend geometric on very large meshes)')
+    args = ap.parse_args()
+
+    if args.nparts < 1:
+        sys.exit('Error: nparts must be a positive integer')
+    if args.out is None:
+        base = args.mesh
+        i = base.rfind('.')
+        j = base.rfind('/')
+        base = base[:i] if i > j else base
+        args.out = '%s_%d.nmsh' % (base, args.nparts)
+
+    log(BANNER)
+    log('  input     : %s' % args.mesh)
+    log('  output    : %s' % args.out)
+    log('  nparts    : %d' % args.nparts)
+    log('  backend   : %s' % args.backend)
+
+    t0 = time.time()
+    log('  [1/4] reading mesh ...')
+    nelv, elems, zones, curves = read_nmsh(args.mesh)
+    log('        %d hex elements, %d zones, %d curved elements'
+        % (nelv, zones.shape[0], curves.shape[0]))
+    if args.nparts > nelv:
+        sys.exit('Error: nparts (%d) > number of elements (%d)'
+                 % (args.nparts, nelv))
+
+    cell, pos_of_elid = merged_cell(nelv, elems, zones)
+
+    need_graph = (args.backend in ('spectral', 'metis')) or not args.no_stats
+    A = None
+    if need_graph:
+        log('  [2/4] building element dual graph (periodic-merged) ...')
+        A = dual_graph(cell)
+    else:
+        log('  [2/4] skipping dual graph (--no-stats, geometric backend)')
+
+    log('  [3/4] partitioning (%s) ...' % args.backend)
+    if args.backend == 'spectral':
+        part = spectral_partition(A, nelv, args.nparts)
+    elif args.backend == 'metis':
+        part = metis_partition(A, nelv, args.nparts)
+    else:
+        part = geometric_partition(elems, nelv, args.nparts)
+
+    sizes = np.bincount(part, minlength=args.nparts)
+    log('        part sizes: min %d / max %d' % (sizes.min(), sizes.max()))
+    if A is not None and not args.no_stats:
+        cut, total = weighted_cut(A, part)
+        log('        edge cut: %d / %d shared-vertex links cut (%7.3f%%)'
+            % (cut, total, 100.0 * cut / max(total, 1.0)))
+
+    log('  [4/4] renumbering and writing reordered mesh ...')
+    reorder_and_write(args.out, nelv, elems, zones, curves, part, pos_of_elid)
+    log('  done -> %s   (%.1f s)' % (args.out, time.time() - t0))
+
+
+if __name__ == '__main__':
+    main()

--- a/contrib/prepart_light/validate_prepart.py
+++ b/contrib/prepart_light/validate_prepart.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, The Neko Authors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#
+#   * Neither the name of the authors nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#     _  __  ____  __ __  ____
+#    / |/ / / __/ / //_/ / __ \
+#   /    / / _/  / ,<   / /_/ /
+#  /_/|_/ /___/ /_/|_|  \____/
+#
+"""Validation for prepart_light across the 3D meshes in a Neko tree.
+
+For each mesh x backend it runs prepart_light.py and checks, independently of
+the tool's internals:
+
+  1. PURE PERMUTATION -- the output's element payloads (vertex ids + coords) are
+     exactly a permutation of the input's; el_idx is contiguous 1..nelv.
+  2. CURVES CARRIED + BOUND -- every curve payload survives verbatim and is
+     attached to the *geometrically identical* element (matched by the element's
+     8 (id,x,y,z) tuples), not merely preserved as a multiset.
+  3. ZONES CARRIED + BOUND -- every periodic (type-5) zone keeps f/p_f/glb_pt_ids
+     and lands on the geometrically identical element; labeled (type-7) zones
+     keep their label and binding.
+  4. CONTIGUOUS BLOCKS -- elements appear grouped by partition (derived by
+     re-running the backend in-process), i.e. a linear read reproduces the
+     partition (the prepart contract).
+  5. BALANCE + CUT -- part sizes differ by <= 1 (spectral/geometric; METIS is
+     allowed its ~3% imbalance tolerance) and the weighted edge cut is reported
+     against a naive linear split.
+
+Usage:  python3 validate_prepart.py [neko_root] [nparts]
+"""
+import collections
+import glob
+import os
+import subprocess
+import sys
+import tempfile
+
+import numpy as np
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import prepart_light as pl                                     # noqa: E402
+
+NEKO = sys.argv[1] if len(sys.argv) > 1 else os.path.abspath(
+    os.path.join(HERE, '..', '..'))
+NPARTS = int(sys.argv[2]) if len(sys.argv) > 2 else 8
+BACKENDS = (sys.argv[3].split(',') if len(sys.argv) > 3
+            else ['spectral', 'metis', 'geometric'])
+SPECTRAL_MAX = 40000        # keep the (slowest) spectral backend tractable
+ANY_MAX = 300000
+
+
+def el_keys(elems):
+    """Hashable per-element geometry keys (the 228-byte payload minus el_idx)."""
+    return [e['v'].tobytes() for e in elems]
+
+
+def check_mesh(path, backend, nparts):
+    nelv, elems, zones, curves = pl.read_nmsh(path)
+    with tempfile.TemporaryDirectory() as tmp:
+        out = os.path.join(tmp, 'out.nmsh')
+        r = subprocess.run([sys.executable,
+                            os.path.join(HERE, 'prepart_light.py'),
+                            path, str(nparts), out, '--backend', backend],
+                           capture_output=True, text=True)
+        if r.returncode != 0:
+            return dict(fail='RUN: ' + r.stderr.strip()[:100])
+        nelv2, elems2, zones2, curves2 = pl.read_nmsh(out)
+
+    res = {}
+    res['contig'] = (nelv2 == nelv and
+                     np.array_equal(elems2['id'], np.arange(1, nelv + 1)))
+    ki, ko = el_keys(elems), el_keys(elems2)
+    res['perm'] = collections.Counter(ki) == collections.Counter(ko)
+
+    # geometry-binding maps: element key -> positions
+    pos_in = collections.defaultdict(list)
+    for p, k in enumerate(ki):
+        pos_in[k].append(p)
+    pos_out = collections.defaultdict(list)
+    for p, k in enumerate(ko):
+        pos_out[k].append(p)
+
+    pos_of_elid_in = np.full(nelv + 1, -1, dtype=np.int64)
+    pos_of_elid_in[elems['id'].astype(np.int64)] = np.arange(nelv)
+
+    # curves: payload verbatim + bound to the geometrically identical element
+    ok = True
+    for c_in in curves:
+        p_in = pos_of_elid_in[int(c_in['e'])]
+        k = ki[p_in]
+        match = False
+        for c_out in curves2:
+            if (c_out['data'].tobytes() == c_in['data'].tobytes() and
+                    c_out['type'].tobytes() == c_in['type'].tobytes()):
+                p_out = int(c_out['e']) - 1              # output ids contiguous
+                if ko[p_out] == k:
+                    match = True
+                    break
+        if not match:
+            ok = False
+            break
+    res['curves'] = ok and (curves2.shape[0] == curves.shape[0])
+
+    # zones: binding by (element geometry key, f) with payload carried
+    def zone_sig(zs, keys, pos_of, out_side):
+        sig = collections.Counter()
+        for z in zs:
+            e = int(z['e'])
+            if not (1 <= e <= nelv):
+                sig[('oor', bytes(z.tobytes()))] += 1   # passed through verbatim
+                continue
+            p = (e - 1) if out_side else int(pos_of[e])
+            if z['t'] == 5:
+                sig[(5, keys[p], int(z['f']), int(z['p_f']),
+                     z['g'].tobytes())] += 1
+            elif z['t'] == 7:
+                sig[(7, keys[p], int(z['f']), int(z['p_f']))] += 1
+            else:
+                # legacy types: whole payload (minus e) verbatim + binding
+                sig[(int(z['t']), keys[p], int(z['f']), int(z['p_e']),
+                     int(z['p_f']), z['g'].tobytes())] += 1
+        return sig
+    si = zone_sig(zones, ki, pos_of_elid_in, False)
+    so = zone_sig(zones2, ko, None, True)
+    res['zones'] = (si == so)
+
+    # contiguous blocks: recompute the partition in-process and compare
+    cell, pos_of_elid = pl.merged_cell(nelv, elems, zones)
+    A = pl.dual_graph(cell)
+    if backend == 'spectral':
+        part = pl.spectral_partition(A, nelv, nparts)
+    elif backend == 'metis':
+        part = pl.metis_partition(A, nelv, nparts)
+    else:
+        part = pl.geometric_partition(elems, nelv, nparts)
+    order = np.argsort(part, kind='stable')
+    expect = el_keys(elems[order])
+    res['blocks'] = (expect == ko)
+
+    sizes = np.bincount(part, minlength=nparts)
+    if backend == 'metis':
+        # METIS balances the LARGEST part against the ideal size within its
+        # ufactor tolerance (~3%); with tiny parts integer granularity adds +-1.
+        # max/min is the wrong metric there (a [3,...,3,4] split of 25 into 8 is
+        # optimal yet max/min = 1.33). What matters for solver load is the max.
+        ideal = nelv / nparts
+        res['balance'] = sizes.max() <= np.ceil(1.03 * ideal) + 1
+    else:
+        res['balance'] = (sizes.max() - sizes.min()) <= 1
+    cut, total = pl.weighted_cut(A, part)
+    lin = np.repeat(np.arange(nparts),
+                    np.diff(np.linspace(0, nelv, nparts + 1).astype(int)))
+    cut_lin, _ = pl.weighted_cut(A, lin[:nelv])
+    res['cut'] = cut
+    res['cut_lin'] = cut_lin
+    res['nelv'] = nelv
+    return res
+
+
+def main():
+    paths = sorted(
+        glob.glob(os.path.join(NEKO, 'examples', '**', '*.nmsh'),
+                  recursive=True) +
+        glob.glob(os.path.join(NEKO, 'tests', '**', '*.nmsh'), recursive=True))
+    print('prepart_light validation  (nparts = %d)\n' % NPARTS)
+    print('%-42s %-9s %7s %9s %9s %5s' %
+          ('mesh', 'backend', 'nelv', 'cut', 'cut_lin', 'ok'))
+    allok = True
+    n = 0
+    for path in paths:
+        try:
+            nelv, _, _, _ = pl.read_nmsh(path)
+        except SystemExit:
+            continue
+        if nelv < NPARTS or nelv > ANY_MAX:
+            continue
+        for backend in BACKENDS:
+            if backend == 'spectral' and nelv > SPECTRAL_MAX:
+                continue
+            r = check_mesh(path, backend, NPARTS)
+            n += 1
+            if 'fail' in r:
+                print('%-42s %-9s  FAIL %s' %
+                      (os.path.relpath(path, NEKO), backend, r['fail']))
+                allok = False
+                continue
+            checks = ('contig', 'perm', 'curves', 'zones', 'blocks', 'balance')
+            ok = all(r[c] for c in checks)
+            allok = allok and ok
+            note = '' if ok else str({c: r[c] for c in checks if not r[c]})
+            print('%-42s %-9s %7d %9d %9d %5s %s' %
+                  (os.path.relpath(path, NEKO), backend, r['nelv'],
+                   r['cut'], r['cut_lin'], 'OK' if ok else 'FAIL', note))
+    print('\nmesh x backend combinations tested: %d' % n)
+    print('checks: permutation + contiguous el_idx + curve/zone payloads bound')
+    print('        to the geometrically identical elements + contiguous blocks')
+    print('        + balance.')
+    print('\nRESULT:', 'PASS' if allok and n > 0 else
+          ('FAIL' if n else 'NO MESHES FOUND'))
+    return 0 if (allok and n > 0) else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/contrib/rea2nbin_light/rea2nbin_light.f90
+++ b/contrib/rea2nbin_light/rea2nbin_light.f90
@@ -70,9 +70,9 @@ module coord_hash
      integer(i8) :: mask = 0
      integer(i4) :: n = 0
    contains
-     procedure :: init  => ch_init
+     procedure :: init => ch_init
      procedure :: get_or_add => ch_get_or_add
-     procedure :: free  => ch_free
+     procedure :: free => ch_free
   end type coord_hash_t
 contains
 
@@ -113,9 +113,9 @@ contains
           this%n = this%n + 1
           this%kx(s) = x; this%ky(s) = y; this%kz(s) = z
           this%id(s) = this%n; idx = this%n; is_new = .true.; return
-       ! exact REAL(dp) equality is intentional (-Wcompare-reals): coordinates are
-       ! copied from the file, never computed, and Neko's own point dedup
-       ! (htable_pt_t) also compares them bit-exactly
+          ! exact REAL(dp) equality is intentional (-Wcompare-reals): coordinates are
+          ! copied from the file, never computed, and Neko's own point dedup
+          ! (htable_pt_t) also compares them bit-exactly
        else if (this%kx(s) == x .and. this%ky(s) == y .and. this%kz(s) == z) then
           idx = this%id(s); is_new = .false.; return
        end if
@@ -163,13 +163,13 @@ program rea2nbin_light
   integer(i4), parameter :: FACET_MAP(6) = (/3, 2, 4, 1, 5, 6/)
   ! the 4 corners of each Neko facet (facet_order), in re2-vertex indices
   integer(i4), parameter :: FACE_RE2(4,6) = reshape((/ &
-       1,5,8,4,   2,6,7,3,   1,2,6,5,   4,3,7,8,   1,2,3,4,   5,6,7,8 /), (/4,6/))
+       1,5,8,4, 2,6,7,3, 1,2,6,5, 4,3,7,8, 1,2,3,4, 5,6,7,8 /), (/4,6/))
   integer(i4), parameter :: MAXZ = 20
-  real(dp) :: PTOL = 1.0e-7_dp   ! periodic match tol; overridable via NEKO_PERIODIC_TOL
+  real(dp) :: PTOL = 1.0e-7_dp ! periodic match tol; overridable via NEKO_PERIODIC_TOL
 
   character(len=1024) :: fin, fout
-  character(len=80)   :: hdr
-  character(len=5)    :: ver
+  character(len=80) :: hdr
+  character(len=5) :: ver
   integer(i4) :: nel, ndim, nelv, nbc4
   logical :: v2
   real(sp) :: endian
@@ -246,10 +246,10 @@ program rea2nbin_light
      write(error_unit,*) 'Error: this tool supports 3D (hex) meshes only'; stop 1
   end if
 
-  write(*,'(a,a)')            '  input     : ', trim(fin)
-  write(*,'(a,a)')            '  output    : ', trim(fout)
-  write(*,'(a,i0,a,a,a)')     '  mesh      : ', nelv, ' hex elements  (format ', ver, ')'
-  write(*,'(a)')              '  [1/3] reading elements and de-duplicating points ...'
+  write(*,'(a,a)') '  input     : ', trim(fin)
+  write(*,'(a,a)') '  output    : ', trim(fout)
+  write(*,'(a,i0,a,a,a)') '  mesh      : ', nelv, ' hex elements  (format ', ver, ')'
+  write(*,'(a)') '  [1/3] reading elements and de-duplicating points ...'
 
   call ch%init(max(1024_i8, int(nelv, i8) * 2_i8))
   allocate(elem_vid(8, nelv))
@@ -286,8 +286,8 @@ program rea2nbin_light
      end do
   end do
 
-  write(*,'(a,i0,a)')        '        ', ch%n, ' unique points'
-  write(*,'(a)')             '  [2/3] reading curves and boundary conditions ...'
+  write(*,'(a,i0,a)') '        ', ch%n, ' unique points'
+  write(*,'(a)') '  [2/3] reading curves and boundary conditions ...'
 
   ! ---- tail: re2 curves + re2 BCs -> nmsh periodic & labeled zones ----
   block
@@ -300,7 +300,7 @@ program rea2nbin_light
     character(len=8) :: bt
     ! curved-element records (stored compactly, re-emitted per element)
     integer(i4), allocatable :: rc_el(:), rc_ed(:), rc_ty(:)
-    real(dp),    allocatable :: rc_d(:,:)
+    real(dp), allocatable :: rc_d(:,:)
     integer(i4), allocatable :: ccnt(:), order(:)
     integer(i4) :: ncurves, acc, cc, cur_e, idx
     real(dp) :: cbuf(5,12)
@@ -443,8 +443,8 @@ program rea2nbin_light
                     'Error: periodic BC references out-of-range partner element/face'; stop 1
             end if
             npf = npf + 1
-            p_e(npf)  = el
-            p_f(npf)  = sym_facet
+            p_e(npf) = el
+            p_f(npf) = sym_facet
             p_pe(npf) = int(b_d1(ib))
             p_pf(npf) = FACET_MAP(int(b_d2(ib)))
          case ('E','e')
@@ -468,7 +468,7 @@ program rea2nbin_light
     end do
 
     ! ---- write zones: periodic first (type 5), then labeled (type 7) ----
-    write(*,'(a)')             '  [3/3] writing zones and curved-element records ...'
+    write(*,'(a)') '  [3/3] writing zones and curved-element records ...'
     nz = npf + nzl
     write(uout) nz
     do i = 1, npf
@@ -500,18 +500,18 @@ program rea2nbin_light
        do i = 1, nelv
           if (ccnt(i) > 0) ncurves = ncurves + 1
        end do
-       acc = 1                               ! prefix-sum counts -> start offsets
+       acc = 1 ! prefix-sum counts -> start offsets
        do i = 1, nelv
           cc = ccnt(i); ccnt(i) = acc; acc = acc + cc
        end do
-       allocate(order(ncurv))                ! stable bucket by element
+       allocate(order(ncurv)) ! stable bucket by element
        do k = 1, ncurv
           order(ccnt(rc_el(k))) = k
           ccnt(rc_el(k)) = ccnt(rc_el(k)) + 1
        end do
        write(uout) ncurves
        cur_e = -1
-       do idx = 1, ncurv                     ! walk records grouped by element
+       do idx = 1, ncurv ! walk records grouped by element
           k = order(idx)
           if (rc_el(k) /= cur_e) then
              if (cur_e > 0) write(uout) cur_e, cbuf, tbuf
@@ -524,7 +524,7 @@ program rea2nbin_light
        deallocate(ccnt, order)
     else
        ncurves = 0
-       write(uout) 0_i4                       ! ncurves
+       write(uout) 0_i4 ! ncurves
        if (curve_skip) write(*,'(a)') &
             '        note: unsupported curve type (s/e/other); mesh treated as '// &
             'non-curved (ncurves=0), as Neko also does'
@@ -610,7 +610,7 @@ contains
     integer(i4) :: ia, ja, id_i, id_j, m, match
     L = 0.0_dp
     do ia = 1, 4
-       id_i = evid(FACE_RE2(ia, f),  e)
+       id_i = evid(FACE_RE2(ia, f), e)
        id_j = evid(FACE_RE2(ia, pf), pe)
        L(1) = L(1) + (cx(id_i) - cx(id_j))
        L(2) = L(2) + (cy(id_i) - cy(id_j))

--- a/contrib/rea2nbin_light/rea2nbin_light.f90
+++ b/contrib/rea2nbin_light/rea2nbin_light.f90
@@ -1,0 +1,640 @@
+! Copyright (c) 2026, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!     _  __  ____  __ __  ____
+!    / |/ / / __/ / //_/ / __ \
+!   /    / / _/  / ,<   / /_/ /
+!  /_/|_/ /___/ /_/|_|  \____/
+!
+!> rea2nbin_light -- a lightweight, CPU-only re2 -> nmsh mesh converter.
+!!
+!! Neko's `contrib/rea2nbin` builds a full `mesh_t` using Neko's general-purpose,
+!! production hash tables. Those are robust and reused everywhere in the code, but
+!! they are sized generously and store polymorphic keys, so they need a lot of
+!! memory for a large mesh. This tool is a lightweight reimplementation of just the
+!! part needed for a serial re2 -> nmsh conversion: the point de-duplication and
+!! the record streaming, using plain typed arrays and no Neko initialisation. The
+!! result is the same `.nmsh`, produced in a small fraction of the memory.
+!!
+!! Because it does not link Neko, it needs only a Fortran compiler (no MPI, no
+!! Neko library) and runs anywhere -- in particular you do not need a separate
+!! CPU build of Neko. The `contrib` tools are CPU-only and serial, so on a Neko
+!! configured for GPUs you would otherwise have to rebuild it for CPU just to
+!! convert a mesh; this sidesteps that entirely.
+!!
+!! Supports labeled/named BCs, periodic BCs (any number of periodic directions:
+!! channel = 2, TGV/HIT = 3), and curved elements ('C' circle / 'm' midside
+!! records, passed through to nmsh curve records exactly as Neko does).
+!!
+!! Tested against the meshes shipped with Neko and a real wall-resolved pipe, but
+!! it remains your responsibility to confirm the result is correct for your own
+!! mesh -- run one of the `make check` suites on a case you trust first. See
+!! rea2nbin_light.md for the memory model, validation, and scope.
+module coord_hash
+  use, intrinsic :: iso_fortran_env, only: dp => real64, i4 => int32, i8 => int64
+  implicit none
+  private
+  type, public :: coord_hash_t
+     real(dp), allocatable :: kx(:), ky(:), kz(:)
+     integer(i4), allocatable :: id(:)
+     integer(i8) :: cap = 0
+     integer(i8) :: mask = 0
+     integer(i4) :: n = 0
+   contains
+     procedure :: init  => ch_init
+     procedure :: get_or_add => ch_get_or_add
+     procedure :: free  => ch_free
+  end type coord_hash_t
+contains
+
+  subroutine ch_init(this, init_cap)
+    class(coord_hash_t), intent(inout) :: this
+    integer(i8), intent(in) :: init_cap
+    integer(i8) :: c
+    c = 1024
+    do while (c < init_cap)
+       c = ishft(c, 1)
+    end do
+    this%cap = c; this%mask = c - 1; this%n = 0
+    allocate(this%kx(0:c-1), this%ky(0:c-1), this%kz(0:c-1))
+    allocate(this%id(0:c-1)); this%id = 0
+  end subroutine ch_init
+  pure function ch_hash(this, x, y, z) result(h)
+    class(coord_hash_t), intent(in) :: this
+    real(dp), intent(in) :: x, y, z
+    integer(i8) :: h, a, b, c
+    a = transfer(x, a); b = transfer(y, b); c = transfer(z, c)
+    h = ieor(a, ishft(a, -33)) * (-49064778989728563_i8)
+    h = ieor(h, b) + (-7046029254386353131_i8)
+    h = ieor(h, ishft(h, -29)) * (-4417276706812531889_i8)
+    h = ieor(h, c)
+    h = ieor(h, ishft(h, -32))
+    h = iand(h, this%mask)
+  end function ch_hash
+  subroutine ch_get_or_add(this, x, y, z, idx, is_new)
+    class(coord_hash_t), intent(inout) :: this
+    real(dp), intent(in) :: x, y, z
+    integer(i4), intent(out) :: idx
+    logical, intent(out) :: is_new
+    integer(i8) :: s
+    if (int(this%n, i8) * 3_i8 > this%cap * 2_i8) call ch_grow(this)
+    s = ch_hash(this, x, y, z)
+    do
+       if (this%id(s) == 0) then
+          this%n = this%n + 1
+          this%kx(s) = x; this%ky(s) = y; this%kz(s) = z
+          this%id(s) = this%n; idx = this%n; is_new = .true.; return
+       ! exact REAL(dp) equality is intentional (-Wcompare-reals): coordinates are
+       ! copied from the file, never computed, and Neko's own point dedup
+       ! (htable_pt_t) also compares them bit-exactly
+       else if (this%kx(s) == x .and. this%ky(s) == y .and. this%kz(s) == z) then
+          idx = this%id(s); is_new = .false.; return
+       end if
+       s = iand(s + 1_i8, this%mask)
+    end do
+  end subroutine ch_get_or_add
+  subroutine ch_grow(this)
+    class(coord_hash_t), intent(inout) :: this
+    real(dp), allocatable :: ox(:), oy(:), oz(:)
+    integer(i4), allocatable :: oid(:)
+    integer(i8) :: i, s, oldcap
+    oldcap = this%cap
+    call move_alloc(this%kx, ox); call move_alloc(this%ky, oy)
+    call move_alloc(this%kz, oz); call move_alloc(this%id, oid)
+    this%cap = ishft(this%cap, 1); this%mask = this%cap - 1
+    allocate(this%kx(0:this%cap-1), this%ky(0:this%cap-1), this%kz(0:this%cap-1))
+    allocate(this%id(0:this%cap-1)); this%id = 0
+    do i = 0, oldcap - 1
+       if (oid(i) /= 0) then
+          s = ch_hash(this, ox(i), oy(i), oz(i))
+          do while (this%id(s) /= 0)
+             s = iand(s + 1_i8, this%mask)
+          end do
+          this%kx(s) = ox(i); this%ky(s) = oy(i); this%kz(s) = oz(i)
+          this%id(s) = oid(i)
+       end if
+    end do
+    deallocate(ox, oy, oz, oid)
+  end subroutine ch_grow
+  subroutine ch_free(this)
+    class(coord_hash_t), intent(inout) :: this
+    if (allocated(this%kx)) deallocate(this%kx, this%ky, this%kz, this%id)
+    this%cap = 0; this%mask = 0; this%n = 0
+  end subroutine ch_free
+end module coord_hash
+
+
+program rea2nbin_light
+  use, intrinsic :: iso_fortran_env, only: dp => real64, sp => real32, &
+       i4 => int32, i8 => int64, error_unit
+  use coord_hash, only: coord_hash_t
+  implicit none
+
+  ! re2 face -> Neko symmetric facet
+  integer(i4), parameter :: FACET_MAP(6) = (/3, 2, 4, 1, 5, 6/)
+  ! the 4 corners of each Neko facet (facet_order), in re2-vertex indices
+  integer(i4), parameter :: FACE_RE2(4,6) = reshape((/ &
+       1,5,8,4,   2,6,7,3,   1,2,6,5,   4,3,7,8,   1,2,3,4,   5,6,7,8 /), (/4,6/))
+  integer(i4), parameter :: MAXZ = 20
+  real(dp) :: PTOL = 1.0e-7_dp   ! periodic match tol; overridable via NEKO_PERIODIC_TOL
+
+  character(len=1024) :: fin, fout
+  character(len=80)   :: hdr
+  character(len=5)    :: ver
+  integer(i4) :: nel, ndim, nelv, nbc4
+  logical :: v2
+  real(sp) :: endian
+  real(sp), parameter :: RE2_ENDIAN_TEST = 6.54321_sp
+  integer :: uin, uout, ios, i, j
+  type(coord_hash_t) :: ch
+  real(dp) :: rg, x8(8), y8(8), z8(8)
+  real(sp) :: rg4, x4(8), y4(8), z4(8)
+  integer(i4) :: vidx(8)
+  logical :: isnew
+  integer(i4) :: gdim_out
+  ! per-element vertex ids (re2 order) + id -> coordinate map (for periodic merge)
+  integer(i4), allocatable :: elem_vid(:,:)
+  real(dp), allocatable :: cx(:), cy(:), cz(:)
+  integer(i4) :: cap_id
+
+  write(*,'(a)') ''
+  write(*,'(a)') '     _  __  ____  __ __  ____'
+  write(*,'(a)') '    / |/ / / __/ / //_/ / __ \'
+  write(*,'(a)') '   /    / / _/  / ,<   / /_/ /'
+  write(*,'(a)') '  /_/|_/ /___/ /_/|_|  \____/   rea2nbin_light  (re2 -> nmsh)'
+  write(*,'(a)') ''
+
+  if (command_argument_count() < 1 .or. command_argument_count() > 2) then
+     write(*,*) 'Usage: rea2nbin_light <mesh.re2> [<mesh.nmsh>]'; stop 1
+  end if
+  call get_command_argument(1, fin)
+  if (command_argument_count() == 2) then
+     call get_command_argument(2, fout)
+  else
+     fout = fin(1:len_trim(fin)-3) // 'nmsh'
+  end if
+
+  ! Periodic match tolerance: honour NEKO_PERIODIC_TOL like Neko (default 1e-7).
+  block
+    character(len=255) :: tol_str
+    integer :: tol_len
+    integer :: tios
+    call get_environment_variable('NEKO_PERIODIC_TOL', tol_str, tol_len)
+    if (tol_len > len(tol_str)) then
+       write(error_unit,*) 'Error: NEKO_PERIODIC_TOL value too long'; stop 1
+    end if
+    if (tol_len > 0) then
+       read(tol_str(1:tol_len), *, iostat=tios) PTOL
+       if (tios /= 0 .or. PTOL <= 0.0_dp) then
+          write(error_unit,*) 'Error: invalid NEKO_PERIODIC_TOL value: ', &
+               tol_str(1:tol_len)
+          stop 1
+       end if
+    end if
+  end block
+
+  open(newunit=uin, file=trim(fin), access='stream', form='unformatted', &
+       status='old', action='read', iostat=ios)
+  if (ios /= 0) then
+     write(error_unit,*) 'Error: cannot open ', trim(fin); stop 1
+  end if
+  read(uin, iostat=ios) hdr; call chk_read(ios)
+  ver = hdr(1:5); v2 = .false.
+  if (ver == '#v004') then
+     read(hdr, '(a5,i16,i3,i16,i4)') ver, nel, ndim, nelv, nbc4; v2 = .true.
+  else if (ver == '#v002' .or. ver == '#v003') then
+     read(hdr, '(a5,i9,i3,i9)') ver, nel, ndim, nelv; v2 = .true.
+  else if (ver == '#v001') then
+     read(hdr, '(a5,i9,i3,i9)') ver, nel, ndim, nelv; v2 = .false.
+  else
+     write(error_unit,*) 'Error: unknown re2 version ', ver; stop 1
+  end if
+  read(uin, iostat=ios) endian; call chk_read(ios)
+  if (abs(endian - RE2_ENDIAN_TEST) > 1.0e-4_sp) then
+     write(error_unit,*) 'Error: byte-swapped re2 not supported'; stop 1
+  end if
+  if (ndim /= 3) then
+     write(error_unit,*) 'Error: this tool supports 3D (hex) meshes only'; stop 1
+  end if
+
+  write(*,'(a,a)')            '  input     : ', trim(fin)
+  write(*,'(a,a)')            '  output    : ', trim(fout)
+  write(*,'(a,i0,a,a,a)')     '  mesh      : ', nelv, ' hex elements  (format ', ver, ')'
+  write(*,'(a)')              '  [1/3] reading elements and de-duplicating points ...'
+
+  call ch%init(max(1024_i8, int(nelv, i8) * 2_i8))
+  allocate(elem_vid(8, nelv))
+  cap_id = max(1024, 2*nelv)
+  allocate(cx(cap_id), cy(cap_id), cz(cap_id))
+
+  open(newunit=uout, file=trim(fout), access='stream', form='unformatted', &
+       status='replace', action='write')
+  gdim_out = ndim
+  write(uout) nelv, gdim_out
+
+  ! Stream elements: read re2 record, dedup 8 vertices, write nmsh record,
+  ! and record per-element vertex ids + id->coordinate for periodic merging.
+  do i = 1, nelv
+     if (v2) then
+        read(uin, iostat=ios) rg, x8, y8, z8; call chk_read(ios)
+     else
+        read(uin, iostat=ios) rg4, x4, y4, z4; call chk_read(ios)
+        x8 = real(x4, dp); y8 = real(y4, dp); z8 = real(z4, dp)
+     end if
+     do j = 1, 8
+        call ch%get_or_add(x8(j), y8(j), z8(j), vidx(j), isnew)
+        elem_vid(j, i) = vidx(j)
+        if (isnew) then
+           if (vidx(j) > cap_id) call grow_coords(cx, cy, cz, cap_id)
+           cx(vidx(j)) = x8(j); cy(vidx(j)) = y8(j); cz(vidx(j)) = z8(j)
+        end if
+     end do
+     ! nmsh hex record: el_idx, then 8 x (v_idx, x, y, z). Vertex order is
+     ! identity w.r.t. re2 (the add_element swap and vcyc_to_sym cancel).
+     write(uout) i
+     do j = 1, 8
+        write(uout) vidx(j), x8(j), y8(j), z8(j)
+     end do
+  end do
+
+  write(*,'(a,i0,a)')        '        ', ch%n, ' unique points'
+  write(*,'(a)')             '  [2/3] reading curves and boundary conditions ...'
+
+  ! ---- tail: re2 curves + re2 BCs -> nmsh periodic & labeled zones ----
+  block
+    integer(i4) :: ncurv, nbcs, k, lbl, sym_facet, el, iface, nz
+    real(dp) :: rc_elem, rc_zone, rc_pt(5), t2, bc_elem, bc_face, bc_data(5)
+    real(sp) :: sc_pt(5), sbc_data(5)
+    integer(i4) :: ci4, ei4, fi4
+    character(len=8) :: btype8
+    character(len=4) :: btype4
+    character(len=8) :: bt
+    ! curved-element records (stored compactly, re-emitted per element)
+    integer(i4), allocatable :: rc_el(:), rc_ed(:), rc_ty(:)
+    real(dp),    allocatable :: rc_d(:,:)
+    integer(i4), allocatable :: ccnt(:), order(:)
+    integer(i4) :: ncurves, acc, cc, cur_e, idx
+    real(dp) :: cbuf(5,12)
+    integer(i4) :: tbuf(12)
+    logical :: curve_skip
+    ! labeled zones
+    integer(i4), allocatable :: z_e(:), z_f(:), z_lbl(:)
+    integer(i4) :: nzl, cap_z, cur_internal, user_off, named_map(6)
+    ! periodic facets
+    integer(i4), allocatable :: p_e(:), p_f(:), p_pe(:), p_pf(:)
+    integer(i4) :: npf, cap_p
+    ! merged point ids (in-place min, exactly like Neko's create_periodic_ids)
+    integer(i4), allocatable :: pid(:)
+    integer(i4) :: gpid(4), pass
+
+    if (v2) then
+       read(uin, iostat=ios) t2; call chk_read(ios); ncurv = int(t2)
+    else
+       read(uin, iostat=ios) ncurv; call chk_read(ios)
+    end if
+    ! Read curve records into compact arrays. Type mapping mirrors Neko's
+    ! re2_file_read_curve: 'C' (circle) -> 3, 'm' (midside) -> 4; 's'/'e' or any
+    ! other type make Neko treat the whole mesh as non-curved, so a single
+    ! unsupported record sets curve_skip and drops all curves (ncurves = 0).
+    curve_skip = .false.
+    if (ncurv > 0) then
+       allocate(rc_el(ncurv), rc_ed(ncurv), rc_ty(ncurv), rc_d(5, ncurv))
+       do k = 1, ncurv
+          if (v2) then
+             read(uin, iostat=ios) rc_elem, rc_zone, rc_pt, btype8; call chk_read(ios)
+             rc_el(k) = int(rc_elem); rc_ed(k) = int(rc_zone)
+             rc_d(1:5, k) = rc_pt; bt = btype8
+          else
+             read(uin, iostat=ios) ei4, ci4, sc_pt, btype4; call chk_read(ios)
+             rc_el(k) = ei4; rc_ed(k) = ci4
+             rc_d(1:5, k) = real(sc_pt, dp); bt = btype4
+          end if
+          if (rc_el(k) < 1 .or. rc_el(k) > nelv) then
+             write(error_unit,'(a,i0)') &
+                  'Error: curve record references element out of range: ', rc_el(k); stop 1
+          end if
+          if (rc_ed(k) < 1 .or. rc_ed(k) > 12) then
+             write(error_unit,'(a,i0)') &
+                  'Error: curve record edge index out of [1,12]: ', rc_ed(k); stop 1
+          end if
+          ! Neko decodes only the FIRST character (its chtemp is character(len=1)),
+          ! so match on bt(1:1) -- robust to NUL/junk-padded type fields too.
+          select case (bt(1:1))
+          case ('C')
+             rc_ty(k) = 3
+          case ('m')
+             rc_ty(k) = 4
+          case default
+             rc_ty(k) = 0; curve_skip = .true.
+          end select
+       end do
+    end if
+
+    if (v2) then
+       read(uin, iostat=ios) t2; call chk_read(ios); nbcs = int(t2)
+    else
+       read(uin, iostat=ios) nbcs; call chk_read(ios)
+    end if
+
+    cap_z = max(64, nbcs); cap_p = max(64, nbcs)
+    allocate(z_e(cap_z), z_f(cap_z), z_lbl(cap_z))
+    allocate(p_e(cap_p), p_f(cap_p), p_pe(cap_p), p_pf(cap_p))
+    nzl = 0; npf = 0; named_map = 0; cur_internal = 1; user_off = 0
+    allocate(pid(ch%n))
+    do i = 1, ch%n
+       pid(i) = i
+    end do
+
+    block
+      integer(i4), allocatable :: b_el(:), b_fc(:)
+      character(len=8), allocatable :: b_ty(:)
+      real(dp), allocatable :: b_d1(:), b_d2(:), b_d5(:)
+      integer(i4) :: ib
+      allocate(b_el(nbcs), b_fc(nbcs), b_ty(nbcs), b_d1(nbcs), b_d2(nbcs), b_d5(nbcs))
+      do ib = 1, nbcs
+         if (v2) then
+            read(uin, iostat=ios) bc_elem, bc_face, bc_data, btype8; call chk_read(ios)
+            b_el(ib) = int(bc_elem); b_fc(ib) = int(bc_face); b_ty(ib) = btype8
+            b_d1(ib) = bc_data(1); b_d2(ib) = bc_data(2); b_d5(ib) = bc_data(5)
+         else
+            read(uin, iostat=ios) ei4, fi4, sbc_data, btype4; call chk_read(ios)
+            b_el(ib) = ei4; b_fc(ib) = fi4; b_ty(ib) = btype4
+            b_d1(ib) = real(sbc_data(1),dp); b_d2(ib) = real(sbc_data(2),dp)
+            b_d5(ib) = real(sbc_data(5),dp)
+         end if
+         ! bounds (Neko neko_error's here; we stop cleanly rather than index OOB)
+         if (b_el(ib) < 1 .or. b_el(ib) > nelv) then
+            write(error_unit,'(a,i0)') &
+                 'Error: BC record references element out of range: ', b_el(ib); stop 1
+         end if
+         if (b_fc(ib) < 1 .or. b_fc(ib) > 6) then
+            write(error_unit,'(a,i0)') &
+                 'Error: BC record face out of [1,6]: ', b_fc(ib); stop 1
+         end if
+      end do
+
+      ! pass 1: MSH/EXO user labels (track the max user label)
+      do ib = 1, nbcs
+         bt = adjustl(b_ty(ib))
+         if (is_msh(bt)) user_off = max(user_off, int(b_d5(ib)))
+      end do
+      do ib = 1, nbcs
+         bt = adjustl(b_ty(ib))
+         if (is_msh(bt)) call add_zone(z_e, z_f, z_lbl, nzl, b_el(ib), &
+              FACET_MAP(b_fc(ib)), int(b_d5(ib)))
+      end do
+
+      ! pass 2: named BCs -> internal labels, and collect periodic facets
+      do ib = 1, nbcs
+         bt = adjustl(b_ty(ib)); el = b_el(ib); sym_facet = FACET_MAP(b_fc(ib))
+         select case (trim(bt))
+         case ('MSH','msh','EXO','exo')
+         case ('W')
+            call named_label(named_map, 1, cur_internal, user_off, lbl)
+            call add_zone(z_e, z_f, z_lbl, nzl, el, sym_facet, lbl)
+         case ('v','V')
+            call named_label(named_map, 2, cur_internal, user_off, lbl)
+            call add_zone(z_e, z_f, z_lbl, nzl, el, sym_facet, lbl)
+         case ('O','o')
+            call named_label(named_map, 3, cur_internal, user_off, lbl)
+            call add_zone(z_e, z_f, z_lbl, nzl, el, sym_facet, lbl)
+         case ('SYM','sym')
+            call named_label(named_map, 4, cur_internal, user_off, lbl)
+            call add_zone(z_e, z_f, z_lbl, nzl, el, sym_facet, lbl)
+         case ('ON','on')
+            call named_label(named_map, 5, cur_internal, user_off, lbl)
+            call add_zone(z_e, z_f, z_lbl, nzl, el, sym_facet, lbl)
+         case ('s','sl','sh','shl','S','SL','SH','SHL')
+            call named_label(named_map, 6, cur_internal, user_off, lbl)
+            call add_zone(z_e, z_f, z_lbl, nzl, el, sym_facet, lbl)
+         case ('P')
+            if (int(b_d1(ib)) < 1 .or. int(b_d1(ib)) > nelv .or. &
+                 int(b_d2(ib)) < 1 .or. int(b_d2(ib)) > 6) then
+               write(error_unit,'(a)') &
+                    'Error: periodic BC references out-of-range partner element/face'; stop 1
+            end if
+            npf = npf + 1
+            p_e(npf)  = el
+            p_f(npf)  = sym_facet
+            p_pe(npf) = int(b_d1(ib))
+            p_pf(npf) = FACET_MAP(int(b_d2(ib)))
+         case ('E','e')
+            ! internal element connectivity: skip
+         case default
+            ! blank / unknown: skip
+         end select
+      end do
+      deallocate(b_el, b_fc, b_ty, b_d1, b_d2, b_d5)
+    end block
+
+    ! ---- periodic merge: EXACT replica of Neko re2_file_read_bcs -- 3 sweeps
+    !      (do j=1,3) over the P facets, each doing id = min(id_i, id_j) in place.
+    !      Matching Neko's fixed 3 sweeps (not a full union-find) makes glb_pt_ids
+    !      byte-identical for any mesh, incl. pathological >3-hop merge chains. ----
+    do pass = 1, 3
+       do i = 1, npf
+          call merge_periodic_facet(pid, elem_vid, cx, cy, cz, &
+               p_e(i), p_f(i), p_pe(i), p_pf(i))
+       end do
+    end do
+
+    ! ---- write zones: periodic first (type 5), then labeled (type 7) ----
+    write(*,'(a)')             '  [3/3] writing zones and curved-element records ...'
+    nz = npf + nzl
+    write(uout) nz
+    do i = 1, npf
+       do j = 1, 4
+          gpid(j) = pid(elem_vid(FACE_RE2(j, p_f(i)), p_e(i)))
+       end do
+       ! nmsh_zone_t: e, f, p_e, p_f, glb_pt_ids(4), type
+       write(uout) p_e(i), p_f(i), p_pe(i), p_pf(i), &
+            gpid(1), gpid(2), gpid(3), gpid(4), 5_i4
+    end do
+    do lbl = 1, MAXZ
+       do k = 1, nzl
+          if (z_lbl(k) == lbl) then
+             el = z_e(k); iface = z_f(k)
+             write(uout) el, iface, 0_i4, lbl, 0_i4, 0_i4, 0_i4, 0_i4, 7_i4
+          end if
+       end do
+    end do
+    ! ---- curves: aggregate re2 curve records per element (edge -> slot in the
+    !      nmsh curve_data(5,12)/type(12) buffers) and write one nmsh curve
+    !      record per curved element, in ascending element order (as Neko's
+    !      writer does). A counting sort groups the records by element in O(n).
+    if (ncurv > 0 .and. .not. curve_skip) then
+       allocate(ccnt(nelv)); ccnt = 0
+       do k = 1, ncurv
+          ccnt(rc_el(k)) = ccnt(rc_el(k)) + 1
+       end do
+       ncurves = 0
+       do i = 1, nelv
+          if (ccnt(i) > 0) ncurves = ncurves + 1
+       end do
+       acc = 1                               ! prefix-sum counts -> start offsets
+       do i = 1, nelv
+          cc = ccnt(i); ccnt(i) = acc; acc = acc + cc
+       end do
+       allocate(order(ncurv))                ! stable bucket by element
+       do k = 1, ncurv
+          order(ccnt(rc_el(k))) = k
+          ccnt(rc_el(k)) = ccnt(rc_el(k)) + 1
+       end do
+       write(uout) ncurves
+       cur_e = -1
+       do idx = 1, ncurv                     ! walk records grouped by element
+          k = order(idx)
+          if (rc_el(k) /= cur_e) then
+             if (cur_e > 0) write(uout) cur_e, cbuf, tbuf
+             cbuf = 0.0_dp; tbuf = 0; cur_e = rc_el(k)
+          end if
+          cbuf(1:5, rc_ed(k)) = rc_d(1:5, k)
+          tbuf(rc_ed(k)) = rc_ty(k)
+       end do
+       if (cur_e > 0) write(uout) cur_e, cbuf, tbuf
+       deallocate(ccnt, order)
+    else
+       ncurves = 0
+       write(uout) 0_i4                       ! ncurves
+       if (curve_skip) write(*,'(a)') &
+            '        note: unsupported curve type (s/e/other); mesh treated as '// &
+            'non-curved (ncurves=0), as Neko also does'
+    end if
+    if (allocated(rc_el)) deallocate(rc_el, rc_ed, rc_ty, rc_d)
+
+    write(*,'(a,i0,a,i0,a,i0,a)') '        ', npf, ' periodic + ', nzl, &
+         ' labeled boundary facets, ', ncurves, ' curved elements'
+    deallocate(z_e, z_f, z_lbl, p_e, p_f, p_pe, p_pf, pid)
+  end block
+
+  close(uin); close(uout)
+  call ch%free()
+  deallocate(elem_vid, cx, cy, cz)
+  write(*,'(a)') ''
+  write(*,'(a,a)') '  done -> ', trim(fout)
+  write(*,'(a)') ''
+
+contains
+
+  !> Abort cleanly on a truncated/corrupt .re2, removing any partial output.
+  subroutine chk_read(ios_)
+    integer, intent(in) :: ios_
+    logical :: op
+    if (ios_ == 0) return
+    write(error_unit,*) 'Error: truncated or corrupt .re2 file (unexpected ', &
+         'end of data)'
+    inquire(unit=uout, opened=op)
+    if (op) close(uout, status='delete')
+    stop 1
+  end subroutine chk_read
+
+
+  logical function is_msh(bt)
+    character(len=*), intent(in) :: bt
+    is_msh = (trim(bt)=='MSH' .or. trim(bt)=='msh' .or. &
+              trim(bt)=='EXO' .or. trim(bt)=='exo')
+  end function is_msh
+
+  subroutine grow_coords(cx, cy, cz, cap)
+    real(dp), allocatable, intent(inout) :: cx(:), cy(:), cz(:)
+    integer(i4), intent(inout) :: cap
+    real(dp), allocatable :: t(:)
+    integer(i4) :: newcap
+    newcap = cap * 2
+    allocate(t(newcap)); t(1:cap) = cx; call move_alloc(t, cx)
+    allocate(t(newcap)); t(1:cap) = cy; call move_alloc(t, cy)
+    allocate(t(newcap)); t(1:cap) = cz; call move_alloc(t, cz)
+    cap = newcap
+  end subroutine grow_coords
+
+  subroutine add_zone(ze, zf, zl, n, e, f, lbl)
+    integer(i4), intent(inout) :: ze(:), zf(:), zl(:), n
+    integer(i4), intent(in) :: e, f, lbl
+    ! Neko aborts on labels outside [1, NEKO_MSH_MAX_ZLBLS=20]; match that rather
+    ! than silently dropping them (the writer loop only emits labels 1..MAXZ).
+    if (lbl < 1 .or. lbl > MAXZ) then
+       write(error_unit,'(a,i0)') 'Error: boundary label out of [1,20]: ', lbl; stop 1
+    end if
+    n = n + 1; ze(n) = e; zf(n) = f; zl(n) = lbl
+  end subroutine add_zone
+
+  subroutine named_label(nm, which, cur, off, lbl)
+    integer(i4), intent(inout) :: nm(6), cur
+    integer(i4), intent(in) :: which, off
+    integer(i4), intent(out) :: lbl
+    if (nm(which) == 0) then
+       nm(which) = cur; cur = cur + 1
+    end if
+    lbl = off + nm(which)
+  end subroutine named_label
+
+  !> Merge the ids of periodically-matching corners of facet (f,e) and (pf,pe),
+  !! a line-for-line replica of Neko mesh_create_periodic_ids: translation
+  !! L = mean facet offset; for each corner, the single partner matching within
+  !! PTOL gets id = min(id_i, id_j) set in place on both. Neko aborts if a corner
+  !! has 0 or >1 matches (a malformed periodic pairing); we do the same.
+  subroutine merge_periodic_facet(pid, evid, cx, cy, cz, e, f, pe, pf)
+    integer(i4), intent(inout) :: pid(:)
+    integer(i4), intent(in) :: evid(:,:), e, f, pe, pf
+    real(dp), intent(in) :: cx(:), cy(:), cz(:)
+    real(dp) :: L(3), a(3), b(3)
+    integer(i4) :: ia, ja, id_i, id_j, m, match
+    L = 0.0_dp
+    do ia = 1, 4
+       id_i = evid(FACE_RE2(ia, f),  e)
+       id_j = evid(FACE_RE2(ia, pf), pe)
+       L(1) = L(1) + (cx(id_i) - cx(id_j))
+       L(2) = L(2) + (cy(id_i) - cy(id_j))
+       L(3) = L(3) + (cz(id_i) - cz(id_j))
+    end do
+    L = L / 4.0_dp
+    do ia = 1, 4
+       id_i = evid(FACE_RE2(ia, f), e)
+       a = (/ cx(id_i), cy(id_i), cz(id_i) /)
+       match = 0
+       do ja = 1, 4
+          id_j = evid(FACE_RE2(ja, pf), pe)
+          b = (/ cx(id_j), cy(id_j), cz(id_j) /)
+          if (norm2(a - b - L) < PTOL) then
+             m = min(pid(id_i), pid(id_j))
+             pid(id_i) = m; pid(id_j) = m
+             match = match + 1
+          end if
+       end do
+       if (match /= 1) then
+          write(error_unit,'(a,i0,a)') 'Error: periodic facet corner has ', &
+               match, ' matches (expected 1); malformed periodic pairing'; stop 1
+       end if
+    end do
+  end subroutine merge_periodic_facet
+
+end program rea2nbin_light

--- a/contrib/rea2nbin_light/rea2nbin_light.md
+++ b/contrib/rea2nbin_light/rea2nbin_light.md
@@ -1,0 +1,281 @@
+```text
+     _  __  ____  __ __  ____
+    / |/ / / __/ / //_/ / __ \
+   /    / / _/  / ,<   / /_/ /
+  /_/|_/ /___/ /_/|_|  \____/
+```
+
+# rea2nbin_light
+
+A standalone, low-memory `re2 → nmsh` mesh converter — a lightweight, CPU-only
+alternative to Neko's `contrib/rea2nbin` for the common case of a **serial**
+conversion.
+
+Needs only a Fortran compiler (no MPI, no Neko library):
+
+```sh
+make                                   # gfortran -O2 -o rea2nbin_light rea2nbin_light.f90
+./rea2nbin_light mesh.re2 [mesh.nmsh]
+make check                             # byte-exactness vs examples/hemi (golden pair)
+make check-roundtrip                   # geometry+topology check vs every 3D mesh in Neko
+make check-periodic                    # periodic-BC identification vs every periodic mesh
+make check-curved                      # curved-element ('C'/'m') records vs every curved mesh
+make check-all                         # the four in-tree suites above
+make check-golden RE2=p.re2 NMSH=p.nmsh # TRUE oracle: byte-diff vs a REAL Neko .nmsh
+```
+
+> The `make check*` targets read the meshes shipped with Neko, so they expect
+> this folder to live inside a Neko source checkout (e.g. dropped into
+> `contrib/`, so `../../examples` resolves). To run them from elsewhere, point
+> the validator at your Neko tree directly, e.g.
+> `python3 validate_roundtrip.py ./rea2nbin_light /path/to/neko`. Converting your
+> own mesh (`./rea2nbin_light mesh.re2`) needs no Neko tree at all.
+
+## Why it exists
+
+Neko's `contrib/rea2nbin` reads the `.re2` into a full `mesh_t` and writes it
+out. Building that `mesh_t` goes through Neko's general-purpose, production hash
+tables — the same robust, well-tested structures reused all over the code base.
+They're sized generously and store polymorphic keys, which is exactly what you
+want for a solver, but it means a fair amount of memory per element when all you
+actually want is to convert a mesh once.
+
+`rea2nbin_light` is a lightweight reimplementation of just that conversion. It
+uses plain typed arrays instead of the general hash tables and does **no Neko
+initialisation**, so it produces the same `.nmsh` in a small fraction of the
+memory — comfortably converting meshes that would otherwise need a very large
+node.
+
+A couple of nice side effects of not linking Neko:
+
+- **No GPU rebuild needed.** The `contrib` tools are CPU-only. If your Neko is
+  configured for GPUs, you'd normally have to rebuild it for CPU just to run
+  them. `rea2nbin_light` needs only a Fortran compiler, so that whole step goes
+  away.
+- **Runs anywhere** — a login node, a laptop, a small VM — since there's no MPI
+  and no Neko library to carry along.
+
+> **Tested, but please check your own case.** This tool has been validated
+> against the meshes shipped with Neko and against a real, wall-resolved pipe
+> (see [Validation](#validation)), and it is byte-exact with the real
+> `rea2nbin` on those. It is nonetheless your responsibility to make sure the
+> result is correct for *your* mesh — run one of the checks below on a case you
+> trust before relying on it in production.
+
+## What `rea2nbin_light` does instead
+
+- A single **typed** open-addressing coordinate hash (structure-of-arrays:
+  `real(dp) kx/ky/kz`, `integer id`), **no polymorphism, no per-entry heap**,
+  sized to the number of *unique* points (~`nelv` for a hex mesh, not `8·nelv`)
+  and **grown on demand**. ~28 bytes per slot.
+- Elements are **streamed** straight from the re2 record to the nmsh record —
+  the mesh is never materialised.
+- **Periodic (`P`) BCs** are reproduced by a **line-for-line replica of Neko's
+  `mesh_create_periodic_ids`**: the same **fixed 3 sweeps** over the `P` facets
+  (Neko's `do j = 1, 3` in `re2_file_read_bcs`), each setting `id = min(id_i,
+  id_j)` in place on the coordinate-matched corner pairs, with Neko's
+  `match /= 1` abort guard. Using Neko's exact 3-sweep (rather than a full
+  union-find) makes the merged `glb_pt_ids` byte-identical for *any* mesh —
+  including pathological >3-hop merge chains — not just the ≤3-direction case.
+  This handles 1, 2 and 3 simultaneous periodic directions (channel, TGV/HIT, …);
+  see validation §3 and the real-pipe oracle §5.
+- **Curved elements** (`'C'` circle / `'m'` midside re2 curve records) are
+  **passed through** to nmsh curve records exactly as Neko does — essential for
+  curved geometry such as a pipe/cylinder wall, which the solver bends onto the
+  arcs in `dofmap_generate_xyz`. Records are stored compactly (not the dense
+  `5·12·nelv` array Neko allocates) and re-emitted one per curved element in
+  ascending element order via an O(n) counting sort; a single unsupported type
+  (`'s'`/`'e'`/other) makes Neko treat the mesh as non-curved, and the tool
+  matches that (writes `ncurves = 0`). See validation §4.
+
+Measured on `examples/hemi`: **2718 unique points** vs `8·2042 = 16336` vertex
+slots (true unique count ~1.33·nelv), confirming the `8·nelv` sizing is ~6×
+oversized before the general table rounds up.
+
+| | `rea2nbin` (75e6 hex) | `rea2nbin_light` (75e6 hex) |
+|---|--:|--:|
+| Dominant structures | general polymorphic point/connectivity tables + per-element stacks + dense `5·12·nelv` curve buffer | one `~2·uniq` typed coordinate hash + compact per-record curve store |
+| Peak memory | very large (needs a big-memory node) | **~10–15 GB** straight-sided; **+~5 GB** if fully curved |
+
+(The curve store is compact — one entry per re2 curve record (`~52 B`), not
+Neko's dense `5·12·nelv` (`528 B·nelv`, ~40 GB at 75e6) that exists whether or
+not an element is curved. So even a fully-curved 75e6 pipe stays well under
+~20 GB.)
+
+## Validation
+
+Reproduce everything with `make check-all`.
+
+### 1. Byte-exactness vs the golden pair (`examples/hemi/hemi.re2` → `hemi.nmsh`)
+
+`hemi` is the only `.re2` shipped with Neko, so it is the one true end-to-end
+reference. Converting it and comparing to the bundled `hemi.nmsh`:
+
+- **Element section (header + hex records, 465 584 B): byte-for-byte identical.**
+  The coordinate dedup, the first-appearance `v_idx` numbering, the (net-identity)
+  vertex ordering, and the packed binary layout all match Neko exactly.
+- **`nzones` (1232), `ncurves` (0), total file size, and every meaningful zone
+  field (`e`, `f`, `p_f`, `type`) match** position-by-position for all zones.
+- The **only** differing bytes (8587 / 509 944 = 1.68 %) are the `p_e` and
+  `glb_pt_ids` fields of labeled zones, which Neko's own writer leaves
+  uninitialised (`nmsh_file.f90` sets only `%e/%f/%p_f/%type` for `type = 7`
+  zones, so it writes stale heap into the file). Those bytes are ignored on read
+  and are not reproducible by construction; `rea2nbin_light` writes deterministic
+  zeros there, producing a *cleaner* but functionally identical file.
+
+### 2. Geometry + topology across every 3D mesh in the Neko tree (43 meshes)
+
+Since there is only one `.re2`, `validate_roundtrip.py` round-trips each shipped
+3D `.nmsh` instead: `nmsh → synthesize a .re2 → rea2nbin_light → nmsh'`, and
+checks the two invariants that define a correct mesh import. A bad import can only
+show up as **wrong coordinates** (geometry corrupted) or **wrong sharing** (two
+coincident vertices not merged, or distinct ones merged = topology corrupted).
+
+Corpus: 43 meshes, **25 → 262 144 elements** — cylinders, boxes, turbulent pipe,
+hemisphere, TGV, Poisson/nekbone stacks, lid, Rayleigh–Bénard, forward-facing
+step, and more.
+
+| Invariant | Result |
+|---|---|
+| **Coordinates bit-exact** (geometry) | **43 / 43** |
+| **Point dedup partition identical** (topology / sharing) | **43 / 43** |
+| `v_idx` *values* exact | 34 / 43 |
+| remaining 9 (`genmeshbox` boxes): id map is a clean **bijection** | verified |
+
+The 9 meshes whose `v_idx` *values* differ are all `genmeshbox`-generated boxes.
+Their `.nmsh` numbers points in lexicographic order because they were never made
+from a `.re2`; `rea2nbin_light` (like Neko's re2 reader) numbers points in
+first-appearance order. The two id sets are in exact one-to-one correspondence
+(a benign **relabeling**, not a topology change) — so the mesh is identical. Run
+the original `rea2nbin` on a box's `.re2` and it would produce the same
+first-appearance numbering, which is exactly why the tool is byte-exact against
+the genuine re2-derived reference (`hemi`).
+
+### 3. Periodic-BC identification across every periodic mesh in the tree (19 meshes)
+
+Periodicity is the one piece of information a `.nmsh` carries that isn't in the
+element records: Neko merges the point-ids of matched periodic facets
+(`mesh_create_periodic_ids`) and writes the *merged* ids into each periodic
+(type-5) zone's `glb_pt_ids`. `rea2nbin_light` must rebuild exactly that merge
+from the raw re2 `P` records. `validate_periodic.py` synthesizes the equivalent
+`.re2` (`P` records reconstructed from each mesh's periodic zones), runs the
+tool, and checks three things against the shipped `.nmsh`:
+
+| Check | What it proves | Result |
+|---|---|--:|
+| **Zone records** (`e`, `f`, `p_e`, `p_f`) match position-by-position | facets paired correctly | **19 / 19** |
+| **Merge partition** of physical coordinates identical | the *right* nodes are fused (numbering-independent) | **19 / 19** |
+| **One merged id per coordinate** in both files | no split/contradictory merges | **19 / 19** |
+
+Corpus: 19 periodic meshes covering all three multiplicities —
+**1 direction** (cylinders, `turb_pipe`, `rayleigh_benard`), **2 directions**
+(`TS_channel`, `turb_channel`), and **3 directions** (`tgv/512`, `tgv/32768`,
+`tgv/262144` — 24 576 periodic facets). The 3-sweep in-place min-id merge
+reproduces Neko's `mesh_create_periodic_ids` exactly on every one, so a channel
+(two periodic pairs) or a TGV/HIT box (three periodic pairs) converts identically
+to what Neko would build.
+
+### 4. Curved-element records across every curved mesh in the tree (11 meshes)
+
+Curve records are the geometry a straight-edged hex can't carry: Neko reads each
+re2 curve record (`elem`, `edge`, 5 values, type char) into
+`curve_data(5,12,elem)`/`curve_type(12,elem)`, writes one nmsh curve record per
+curved element, and later **bends the element faces onto them** in
+`dofmap_generate_xyz` — circle arcs for `'C'`, explicit midside nodes for `'m'`.
+Dropping them would flatten a pipe/cylinder wall into facets. `rea2nbin_light`
+passes them through. There is no shipped `.re2` with *supported* curves (`hemi`'s
+are `'s'`, which Neko itself drops), so `validate_curved.py` reconstructs the
+equivalent re2 curve records from each curved `.nmsh` and compares the tool's
+nmsh curve section to the reference, record by record:
+
+| Check | Result |
+|---|--:|
+| **curve record count** matches | **11 / 11** |
+| **element ids** match (ascending order) | **11 / 11** |
+| **`curve_data(5,12)` bit-exact** (all 60 doubles/record) | **11 / 11** |
+| **`type(12)` exact** | **11 / 11** |
+
+Corpus: 11 curved meshes — the cylinders, `cyl_boundary_layer`,
+`rayleigh_benard_cylinder` (100 % curved), and **`turb_pipe`** (36 480 elements,
+17 860 curved — the pipe case directly analogous to a wall-resolved DNS pipe).
+A separate synthetic test confirms the two paths the shipped meshes don't
+exercise: mixed `'C'`+`'m'` records on one element round-trip per-edge, and an
+`'s'` record correctly forces `ncurves = 0` (Neko-identical drop-all).
+
+### 5. True oracle — head-to-head vs a real Neko `.nmsh` (a genuine pipe)
+
+The §1–§4 harnesses synthesize their `.re2` from a `.nmsh`, so they could in
+principle share a blind spot with the tool. `validate_golden.py` removes that: it
+byte-diffs the tool's output against a **`.nmsh` produced by the real Neko
+`rea2nbin`**, section by section. Run on a genuine **Re_τ=550 pipe**
+(`P550…Nc2198_Nz5`, 10 990 elements = 2198 × 5; streamwise-periodic wall-resolved,
+all features at once):
+
+| Section | Differing bytes |
+|---|--:|
+| header | **0** |
+| elements (2.5 MB: dedup ids, vertex order, coords) | **0** |
+| **periodic (type-5) zones — incl. merged `glb_pt_ids`** | **0** |
+| **curves** (4.6 MB, 8640 curved elements) | **0** |
+| labeled (type-7) zone `p_e`/`glb_pt_ids` | 2621 (Neko-uninitialised heap) |
+
+**Total file size: identical. The only differing bytes are the type-7 labeled-zone
+`p_e`/`glb_pt_ids` fields that Neko's writer never initialises** (it leaves stale
+heap — values like `134239120` — while the tool writes deterministic `0`); the
+nmsh reader never reads those fields, so the meshes are functionally identical and
+the tool's output is the cleaner of the two. Point `make check-golden` at any real
+pair you have (`RE2=…  NMSH=…`).
+
+The converter has additionally been cross-checked by section-by-section source
+comparison against Neko's re2 reader and nmsh writer, plus deliberate
+break-attempt tests on malformed inputs. Verdict: **byte-exact on well-formed 3D
+`#v002` meshes, modulo the type-7 heap fields.**
+
+### Robustness
+
+Where the real `rea2nbin` calls `neko_error` and writes no file, the tool does
+the same rather than crash or silently emit a wrong mesh:
+
+- **Bounds guards** — curve/BC element `∉ [1,nelv]`, curve edge `∉ [1,12]`, BC
+  face `∉ [1,6]`, boundary label `∉ [1,20]`, or a periodic partner out of range
+  give a clean error and exit 1.
+- **Curve type** is decoded on the **first character only** (matching Neko's
+  `character(len=1)` field), so a NUL/junk-padded type field from a non-Nek5000
+  writer does not silently drop all curves.
+- **`NEKO_PERIODIC_TOL`** environment variable honoured (default `1e-7`), exactly
+  as Neko does.
+
+## Scope / limitations
+
+- **3D hex meshes** (the common case). **2D meshes are not handled** — the tool
+  exits with a clear error (the real `rea2nbin` *does* convert 2D quads; if you
+  need 2D, use it). Other element types are likewise out of scope.
+- **Curved elements** *are* supported: `'C'` (circle) and `'m'` (midside) re2
+  curve records are converted to nmsh curve records bit-exact (validation §4).
+  Only the two curve types Neko itself supports are handled; `'s'`/`'e'`/unknown
+  types make Neko drop all curves, and the tool matches that. (`hemi`'s 700 curve
+  records are `'s'`, so both it and the tool write `ncurves = 0` — which is why
+  the golden-pair byte-exactness in §1 still holds.)
+- **Periodic (`P`) BCs** *are* supported (exact 3-sweep min-id replica, 1/2/3
+  directions; validation §3, §5). Labeled/named BCs (`MSH`/`EXO`, `W`, `v/V`,
+  `O/o`, `SYM`, `ON`, `s*`) are fully ported, including Neko's user-label offset
+  and first-appearance ordering.
+- **Header versions**: `#v002`/`#v003` (double precision) are validated
+  end-to-end by the shipped suites. `#v001` (single precision, same layout) and
+  `#v004` (EXO, i16 element counts) parsing is implemented but not exercised by
+  the in-tree meshes — if you rely on either, validate a real pair once with
+  `make check-golden RE2=… NMSH=…`.
+
+For meshes within scope this is a validated, much lighter serial converter,
+byte-exact with the real `rea2nbin` (modulo the type-7 fields Neko leaves
+uninitialised). As always, confirm it on a case you trust before relying on it.
+
+## Files
+
+- `rea2nbin_light.f90` — the converter (module + program).
+- `validate_roundtrip.py` — the geometry+topology harness (`make check-roundtrip`).
+- `validate_periodic.py` — the periodic-BC harness (`make check-periodic`).
+- `validate_curved.py` — the curved-element harness (`make check-curved`).
+- `validate_golden.py` — the real-`.nmsh` byte-diff oracle (`make check-golden`).
+- `Makefile` — `make`, `make check`, `make check-roundtrip`, `make check-periodic`,
+  `make check-curved`, `make check-all`, `make check-golden`, `make clean`.

--- a/contrib/rea2nbin_light/validate_curved.py
+++ b/contrib/rea2nbin_light/validate_curved.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, The Neko Authors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#
+#   * Neither the name of the authors nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#     _  __  ____  __ __  ____
+#    / |/ / / __/ / //_/ / __ \
+#   /    / / _/  / ,<   / /_/ /
+#  /_/|_/ /___/ /_/|_|  \____/
+#
+"""Curved-element validation for rea2nbin_light across every curved mesh in Neko.
+
+Curve records are what re2 -> nmsh must carry through so the solver can bend
+element faces onto circular arcs ('C') or place explicit midside nodes ('m')
+in dofmap_generate_xyz. Neko reads each re2 curve record (elem, edge, 5 values,
+type char) into curve_data(5,12,elem)/curve_type(12,elem), then writes one nmsh
+curve record per curved element (e, curve_data(5,12), type(12)) in ascending
+element order. rea2nbin_light must reproduce that exactly.
+
+There is no shipped .re2 with supported ('C'/'m') curves -- hemi's are 's'
+(sphere), which Neko itself drops -- so for each curved .nmsh we reconstruct the
+equivalent .re2 curve records from the mesh's own nmsh curve section (edge e's
+5 values <-> re2 record point(1:5); nmsh type 3->'C', 4->'m'), run the tool, and
+compare the resulting nmsh curve section byte-for-byte against the reference.
+
+Note: a few shipped curved .nmsh (turb_pipe, cylinder) carry extra trailing
+bytes after their curve section that Neko's reader never reads (it consumes
+exactly ncurves records); this harness parses the structured curve records by
+offset, so that dead tail is correctly ignored.
+
+Usage:  python3 validate_curved.py [path/to/rea2nbin_light] [neko_root]
+"""
+import struct, subprocess, glob, os, sys, tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+EXE  = sys.argv[1] if len(sys.argv) > 1 else os.path.join(HERE, 'rea2nbin_light')
+NEKO = sys.argv[2] if len(sys.argv) > 2 else os.path.abspath(os.path.join(HERE, '..', '..'))
+
+TYPE_CHAR = {3: b'C', 4: b'm'}                          # nmsh curve type -> re2 char
+
+
+def read_mesh(path):
+    d = open(path, 'rb').read()
+    nelv, gdim = struct.unpack('<ii', d[:8])
+    if gdim != 3:
+        return None
+    off = 8
+    els = []
+    for _ in range(nelv):
+        el = struct.unpack('<i', d[off:off + 4])[0]; off += 4
+        vs = []
+        for _ in range(8):
+            vi = struct.unpack('<i', d[off:off + 4])[0]
+            xyz = struct.unpack('<3d', d[off + 4:off + 28]); off += 28
+            vs.append((vi, xyz))
+        els.append((el, vs))
+    nz = struct.unpack('<i', d[off:off + 4])[0]; off += 4
+    off += nz * 36
+    nc = struct.unpack('<i', d[off:off + 4])[0]; off += 4
+    curves = []                                          # (e, [60 doubles], [12 ints])
+    for _ in range(nc):
+        e = struct.unpack('<i', d[off:off + 4])[0]
+        cd = struct.unpack('<60d', d[off + 4:off + 484])
+        ty = struct.unpack('<12i', d[off + 484:off + 532])
+        off += 532
+        curves.append((e, cd, ty))
+    return nelv, els, curves
+
+
+def write_re2(path, nelv, els, curves):
+    hdr = '#v002%9d%3d%9d' % (nelv, 3, nelv); hdr = hdr + ' ' * (80 - len(hdr))
+    # explode nmsh per-element curve records into per-edge re2 curve records
+    re2curves = []                                       # (elem, edge, [5 dbl], char)
+    for (e, cd, ty) in curves:
+        for edge in range(12):
+            if ty[edge] != 0:
+                pts = cd[edge * 5:edge * 5 + 5]          # curve_data(5,12) col-major
+                re2curves.append((e, edge + 1, pts, TYPE_CHAR[ty[edge]]))
+    with open(path, 'wb') as f:
+        f.write(hdr.encode('ascii'))
+        f.write(struct.pack('<f', 6.54321))
+        for _, vs in els:
+            f.write(struct.pack('<d', 1.0))
+            for k in range(3):
+                f.write(struct.pack('<8d', *[vs[j][1][k] for j in range(8)]))
+        f.write(struct.pack('<d', float(len(re2curves))))          # ncurv
+        for (elem, edge, pts, ch) in re2curves:                    # v2 curve records
+            f.write(struct.pack('<d', float(elem)))
+            f.write(struct.pack('<d', float(edge)))
+            f.write(struct.pack('<5d', *pts))
+            f.write(ch + b' ' * 7)
+        f.write(struct.pack('<d', 0.0))                            # nbcs = 0
+
+
+def check(path, tmp):
+    r = read_mesh(path)
+    if r is None:
+        return None
+    nelv, els, curves = r
+    if not curves:
+        return None
+    re2 = os.path.join(tmp, 'c.re2'); out = os.path.join(tmp, 'c.nmsh')
+    write_re2(re2, nelv, els, curves)
+    p = subprocess.run([EXE, re2, out], capture_output=True, text=True)
+    if p.returncode != 0:
+        return (path, 'RUN FAIL: ' + p.stderr.strip()[:70])
+    _, _, curves2 = read_mesh(out)
+    same_n = (len(curves) == len(curves2))
+    # element ids + curve_data + type, record by record
+    e_ok = cd_ok = ty_ok = same_n
+    for a, b in zip(curves, curves2):
+        if a[0] != b[0]:
+            e_ok = False
+        if a[1] != b[1]:
+            cd_ok = False
+        if a[2] != b[2]:
+            ty_ok = False
+    types = sorted(set(t for _, _, ty in curves for t in ty if t))
+    return (path, len(curves), same_n, e_ok, cd_ok, ty_ok, types)
+
+
+def main():
+    if not os.path.exists(EXE):
+        print('error: rea2nbin_light not found at', EXE, '(build it first: make)')
+        return 1
+    paths = sorted(glob.glob(os.path.join(NEKO, 'examples', '**', '*.nmsh'), recursive=True) +
+                   glob.glob(os.path.join(NEKO, 'tests', '**', '*.nmsh'), recursive=True))
+    print('%-50s %8s %6s %6s %8s %6s %s' %
+          ('curved mesh', 'ncurve', 'count', 'elem', 'crv_data', 'type', 'types'))
+    ok = True; n = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        for path in paths:
+            r = check(path, tmp)
+            if r is None:
+                continue
+            if len(r) == 2:
+                print('%-50s %s' % (os.path.relpath(r[0], NEKO), r[1])); ok = False; continue
+            p, nc, sn, eo, co, to, types = r; n += 1
+            print('%-50s %8d %6s %6s %8s %6s %s' %
+                  (os.path.relpath(p, NEKO), nc, sn, eo, co, to, types))
+            if not (sn and eo and co and to):
+                ok = False
+    print('\ncurved meshes tested:', n, '  RESULT:',
+          'PASS (curve records reproduced bit-exact)' if ok else 'FAIL')
+    return 0 if ok else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/contrib/rea2nbin_light/validate_golden.py
+++ b/contrib/rea2nbin_light/validate_golden.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, The Neko Authors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#
+#   * Neither the name of the authors nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#     _  __  ____  __ __  ____
+#    / |/ / / __/ / //_/ / __ \
+#   /    / / _/  / ,<   / /_/ /
+#  /_/|_/ /___/ /_/|_|  \____/
+#
+"""True head-to-head oracle: rea2nbin_light vs a REAL Neko-produced .nmsh.
+
+The round-trip validators synthesize their .re2 from a .nmsh, so they can share a
+blind spot with the tool. This one does not: give it a genuine (.re2, .nmsh) pair
+where the .nmsh was produced by the real Neko rea2nbin, and it byte-diffs the
+tool's output against that reference, section by section, and classifies every
+differing byte. The ONLY differences that count as a PASS are in the type-7
+(labeled) zone p_e / glb_pt_ids fields, which Neko's writer leaves UNINITIALIZED
+(nondeterministic heap) and the tool writes as deterministic zeros -- fields the
+nmsh reader never reads. Anything else is a real discrepancy and fails.
+
+Usage:  python3 validate_golden.py <rea2nbin_light> <mesh.re2> <reference.nmsh>
+"""
+import sys, struct, subprocess, tempfile, os
+
+
+def sections(d):
+    nelv, gdim = struct.unpack('<ii', d[:8])
+    e1 = 8 + nelv * 228
+    nz = struct.unpack('<i', d[e1:e1 + 4])[0]; z0 = e1 + 4; z1 = z0 + nz * 36
+    nc = struct.unpack('<i', d[z1:z1 + 4])[0]; c0 = z1 + 4; c1 = c0 + nc * 532
+    return dict(nelv=nelv, gdim=gdim, e0=8, e1=e1, nz=nz, z0=z0, z1=z1,
+               nc=nc, c0=c0, c1=c1)
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(__doc__); return 2
+    exe, re2, ref_path = sys.argv[1:4]
+    ref = open(ref_path, 'rb').read()
+    with tempfile.TemporaryDirectory() as t:
+        out_path = os.path.join(t, 'out.nmsh')
+        p = subprocess.run([exe, re2, out_path], capture_output=True, text=True)
+        if p.returncode != 0:
+            print('tool FAILED:', (p.stderr or p.stdout).strip()[:200]); return 1
+        out = open(out_path, 'rb').read()
+
+    print('reference:', os.path.basename(ref_path))
+    print('sizes: reference=%d  light=%d  equal=%s' % (len(ref), len(out), len(ref) == len(out)))
+    if len(ref) != len(out):
+        print('SIZE MISMATCH -> structural difference (curves? zones?). FAIL'); return 1
+    s = sections(ref)
+    print('nelv=%d gdim=%d nzones=%d ncurves=%d' % (s['nelv'], s['gdim'], s['nz'], s['nc']))
+
+    dc = lambda lo, hi: sum(1 for k in range(lo, hi) if ref[k] != out[k])
+    hdr_d = dc(0, 8)
+    elem_d = dc(s['e0'] + 0, s['e1'])
+    nzint_d = dc(s['e1'], s['z0'])
+    curv_d = dc(s['c0'], s['c1'])
+    ncint_d = dc(s['z1'], s['c0'])
+
+    # zone diffs, split by type and field
+    FIELD = ['e', 'f', 'p_e', 'p_f', 'gp0', 'gp1', 'gp2', 'gp3', 'type']
+    benign = real = 0
+    per_type_field = {5: [0] * 9, 7: [0] * 9}
+    for i in range(s['nz']):
+        b = s['z0'] + i * 36
+        r = struct.unpack('<9i', ref[b:b + 36]); o = struct.unpack('<9i', out[b:b + 36])
+        zt = r[8]
+        for f in range(9):
+            if r[f] != o[f]:
+                per_type_field.setdefault(zt, [0] * 9)[f] += 1
+                # benign iff type-7 and field is p_e (2) or glb_pt_ids (4..7)
+                if zt == 7 and (f == 2 or 4 <= f <= 7):
+                    benign += 4   # 4 bytes per int32 field
+                else:
+                    real += 4
+
+    print('\n--- differing bytes by section ---')
+    print('  header        : %d' % hdr_d)
+    print('  elements      : %d / %d' % (elem_d, s['e1'] - s['e0']))
+    print('  nzones int    : %d' % nzint_d)
+    print('  zones         : %d  (benign type-7 uninit: %d, REAL: %d)' %
+          (benign + real, benign, real))
+    print('  ncurves int   : %d' % ncint_d)
+    print('  curves        : %d / %d' % (curv_d, s['c1'] - s['c0']))
+    print('\n  zone field-diff counts (records differing per field):')
+    print('    %-6s %s' % ('type', ' '.join('%5s' % f for f in FIELD)))
+    for zt in sorted(per_type_field):
+        print('    %-6d %s' % (zt, ' '.join('%5d' % c for c in per_type_field[zt])))
+
+    nonzone_real = hdr_d + elem_d + nzint_d + ncint_d + curv_d
+    ok = (nonzone_real == 0 and real == 0)
+    print('\nRESULT:', 'PASS (byte-exact modulo Neko-uninitialised type-7 zone fields)'
+          if ok else 'FAIL -- real discrepancy outside the known type-7 uninit fields')
+    return 0 if ok else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/contrib/rea2nbin_light/validate_periodic.py
+++ b/contrib/rea2nbin_light/validate_periodic.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, The Neko Authors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#
+#   * Neither the name of the authors nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#     _  __  ____  __ __  ____
+#    / |/ / / __/ / //_/ / __ \
+#   /    / / _/  / ,<   / /_/ /
+#  /_/|_/ /___/ /_/|_|  \____/
+#
+"""Periodic-BC validation for rea2nbin_light across every periodic 3D mesh in Neko.
+
+Neko encodes periodicity in two places in a .nmsh:
+  * the element records use *un-merged* dedup point ids (via reset_periodic_ids),
+  * each periodic (type-5) zone carries the *merged* point ids in glb_pt_ids,
+    which is what tells the solver "these two facets are the same nodes".
+
+rea2nbin_light must reproduce that merge from the raw re2 'P' BC records alone
+(a 3-pass coordinate-matched union-find, min-id as root -- exactly Neko's
+mesh_create_periodic_ids). There is no shipped .re2 with periodic BCs, so for
+each periodic .nmsh we synthesize the equivalent .re2 ('P' records rebuilt from
+the periodic zones via the neko-facet->re2-face map), run the tool, and check:
+
+  struct     : the periodic zone records (e, f, p_e, p_f) match position-by-position
+  partition  : the *merge partition* of physical coordinates is identical -- i.e.
+               grouping coordinates by their merged id yields the same set of
+               groups as the reference (numbering-independent: robust to any
+               relabeling of the merged ids)
+  consist    : every physical coordinate maps to exactly one merged id in both
+               the reference and the tool output (no split/contradictory merges)
+
+Usage:  python3 validate_periodic.py [path/to/rea2nbin_light] [neko_root]
+"""
+import struct, subprocess, glob, os, sys, tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+EXE  = sys.argv[1] if len(sys.argv) > 1 else os.path.join(HERE, 'rea2nbin_light')
+# default: this script lives in contrib/rea2nbin_light/, so neko root is ../../
+NEKO = sys.argv[2] if len(sys.argv) > 2 else os.path.abspath(os.path.join(HERE, '..', '..'))
+
+INV = {1: 4, 2: 2, 3: 1, 4: 3, 5: 5, 6: 6}                 # neko facet -> re2 face
+FACE_RE2 = {1: [1, 5, 8, 4], 2: [2, 6, 7, 3], 3: [1, 2, 6, 5],
+            4: [4, 3, 7, 8], 5: [1, 2, 3, 4], 6: [5, 6, 7, 8]}
+
+
+def read(path):
+    d = open(path, 'rb').read()
+    nelv, gdim = struct.unpack('<ii', d[:8])
+    if gdim != 3:
+        return None
+    off = 8; els = []
+    for _ in range(nelv):
+        el = struct.unpack('<i', d[off:off + 4])[0]; off += 4; vs = []
+        for _ in range(8):
+            vi = struct.unpack('<i', d[off:off + 4])[0]
+            xyz = struct.unpack('<3d', d[off + 4:off + 28]); off += 28
+            vs.append((vi, xyz))
+        els.append((el, vs))
+    nz = struct.unpack('<i', d[off:off + 4])[0]; off += 4
+    Z = [struct.unpack('<9i', d[off + i * 36:off + i * 36 + 36]) for i in range(nz)]
+    return nelv, els, Z
+
+
+def write_re2_periodic(path, nelv, els, per):
+    hdr = '#v002%9d%3d%9d' % (nelv, 3, nelv); hdr = hdr + ' ' * (80 - len(hdr))
+    with open(path, 'wb') as f:
+        f.write(hdr.encode()); f.write(struct.pack('<f', 6.54321))
+        for _, vs in els:
+            f.write(struct.pack('<d', 1.0))
+            for k in range(3):
+                f.write(struct.pack('<8d', *[vs[j][1][k] for j in range(8)]))
+        f.write(struct.pack('<d', 0.0))                    # ncurv = 0
+        f.write(struct.pack('<d', float(len(per))))        # nbcs
+        for (e, ff, pe, pf) in per:                        # 'P' records
+            ty = b'P' + b' ' * 7
+            f.write(struct.pack('<7d', float(e), float(INV[ff]),
+                                float(pe), float(INV[pf]), 0.0, 0.0, 0.0))
+            f.write(ty)
+
+
+def partition(els, Z):
+    # coord -> merged_id from periodic (type-5) zones; count contradictory assigns
+    c2m = {}; multi = 0
+    for z in Z:
+        if z[8] != 5:
+            continue
+        e, ff = z[0], z[1]; ids = z[4:8]
+        _, vs = els[e - 1]
+        for k in range(4):
+            coord = vs[FACE_RE2[ff][k] - 1][1]
+            if coord in c2m and c2m[coord] != ids[k]:
+                multi += 1
+            c2m[coord] = ids[k]
+    groups = {}
+    for coord, m in c2m.items():
+        groups.setdefault(m, set()).add(coord)
+    return frozenset(frozenset(g) for g in groups.values()), multi, len(c2m)
+
+
+def check(path, tmp):
+    r = read(path)
+    if r is None:
+        return None
+    nelv, els, Z = r
+    per = [(z[0], z[1], z[2], z[3]) for z in Z if z[8] == 5]
+    if not per:
+        return None
+    re2 = os.path.join(tmp, 'p.re2'); out = os.path.join(tmp, 'p.nmsh')
+    write_re2_periodic(re2, nelv, els, per)
+    p = subprocess.run([EXE, re2, out], capture_output=True, text=True)
+    if p.returncode != 0:
+        return (path, 'RUN FAIL: ' + p.stderr.strip()[:70])
+    _, els2, Z2 = read(out)
+    per2 = [(z[0], z[1], z[2], z[3]) for z in Z2 if z[8] == 5]
+    struct_ok = (per == per2)
+    part_o, mo, no = partition(els, Z); part_m, mm, nm = partition(els2, Z2)
+    return (path, len(per), struct_ok, (part_o == part_m), mo, mm, no)
+
+
+def main():
+    if not os.path.exists(EXE):
+        print('error: rea2nbin_light not found at', EXE, '(build it first: make)')
+        return 1
+    paths = sorted(glob.glob(os.path.join(NEKO, 'examples', '**', '*.nmsh'), recursive=True) +
+                   glob.glob(os.path.join(NEKO, 'tests', '**', '*.nmsh'), recursive=True))
+    print('%-48s %8s %8s %10s %8s' %
+          ('periodic mesh', '#per', 'struct', 'partition', 'consist'))
+    ok = True; n = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        for path in paths:
+            r = check(path, tmp)
+            if r is None:
+                continue
+            if len(r) == 2:
+                print('%-48s %s' % (os.path.relpath(r[0], NEKO), r[1])); ok = False; continue
+            p, npf, sk, pk, mo, mm, no = r; n += 1
+            cons = (mo == 0 and mm == 0)
+            print('%-48s %8d %8s %10s %8s' % (os.path.relpath(p, NEKO), npf, sk, pk, cons))
+            if not (sk and pk and cons):
+                ok = False
+    print('\nperiodic meshes tested:', n, '  RESULT:',
+          'PASS (periodic identification matches Neko)' if ok else 'FAIL')
+    return 0 if ok else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/contrib/rea2nbin_light/validate_roundtrip.py
+++ b/contrib/rea2nbin_light/validate_roundtrip.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, The Neko Authors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#
+#   * Neither the name of the authors nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#     _  __  ____  __ __  ____
+#    / |/ / / __/ / //_/ / __ \
+#   /    / / _/  / ,<   / /_/ /
+#  /_/|_/ /___/ /_/|_|  \____/
+#
+"""Round-trip validation for rea2nbin_light across every 3D .nmsh in the Neko tree.
+
+For each mesh:  nmsh  ->  synthesize a .re2  ->  rea2nbin_light  ->  nmsh'
+and check the two invariants that define a correct mesh import:
+  * coordinates are bit-exact          (geometry preserved)
+  * the point dedup partition matches   (topology: which vertices are shared)
+
+The point-id *values* additionally match exactly for meshes whose reference
+numbering follows the re2/rea2nbin first-appearance convention; genmeshbox-
+generated box meshes use a different (lexicographic) numbering, so their ids
+differ by a clean bijection (a benign relabeling, reported separately).
+
+Usage:  python3 validate_roundtrip.py [path/to/rea2nbin_light] [neko_root]
+"""
+import struct, subprocess, glob, os, sys, tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+EXE  = sys.argv[1] if len(sys.argv) > 1 else os.path.join(HERE, 'rea2nbin_light')
+# default: this script lives in contrib/rea2nbin_light/, so neko root is ../../
+NEKO = sys.argv[2] if len(sys.argv) > 2 else os.path.abspath(os.path.join(HERE, '..', '..'))
+
+
+def read_nmsh_elems(path):
+    d = open(path, 'rb').read()
+    nelv, gdim = struct.unpack('<ii', d[:8])
+    if gdim != 3:
+        return None
+    off = 8
+    els = []
+    for _ in range(nelv):
+        el = struct.unpack('<i', d[off:off + 4])[0]; off += 4
+        vs = []
+        for _ in range(8):
+            vi = struct.unpack('<i', d[off:off + 4])[0]
+            xyz = struct.unpack('<3d', d[off + 4:off + 28]); off += 28
+            vs.append((vi, xyz))
+        els.append((el, vs))
+    return nelv, els
+
+
+def write_re2(path, nelv, els):
+    hdr = '#v002%9d%3d%9d' % (nelv, 3, nelv)
+    hdr = hdr + ' ' * (80 - len(hdr))
+    with open(path, 'wb') as f:
+        f.write(hdr.encode('ascii'))
+        f.write(struct.pack('<f', 6.54321))            # endian test
+        for _, vs in els:
+            f.write(struct.pack('<d', 1.0))            # rgroup (unused)
+            for k in range(3):
+                f.write(struct.pack('<8d', *[vs[j][1][k] for j in range(8)]))
+        f.write(struct.pack('<d', 0.0))                # ncurv = 0
+        f.write(struct.pack('<d', 0.0))                # nbcs  = 0
+
+
+def check(path, tmp):
+    r = read_nmsh_elems(path)
+    if r is None:
+        return None
+    nelv, els = r
+    # is the reference itself a proper coordinate dedup?
+    c2i, i2c, ref_ok = {}, {}, True
+    for _, vs in els:
+        for vi, xyz in vs:
+            if xyz in c2i and c2i[xyz] != vi:
+                ref_ok = False
+            if vi in i2c and i2c[vi] != xyz:
+                ref_ok = False
+            c2i[xyz] = vi; i2c[vi] = xyz
+    re2 = os.path.join(tmp, 'rt.re2'); out = os.path.join(tmp, 'rt.nmsh')
+    write_re2(re2, nelv, els)
+    p = subprocess.run([EXE, re2, out], capture_output=True, text=True)
+    if p.returncode != 0:
+        return (path, nelv, 'RUN FAILED: ' + (p.stderr.strip()[:60] or 'nonzero exit'))
+    nelv2, els2 = read_nmsh_elems(out)
+    coords_ok = (nelv == nelv2)
+    vidx_exact, part_ok = True, True
+    lc2i, fmap, gmap = {}, {}, {}
+    for e in range(nelv):
+        for j in range(8):
+            if els[e][1][j][1] != els2[e][1][j][1]:
+                coords_ok = False
+            vi_ref, xyz = els[e][1][j][0], els2[e][1][j][1]
+            vi_out = els2[e][1][j][0]
+            if vi_ref != vi_out:
+                vidx_exact = False
+            if xyz in lc2i and lc2i[xyz] != vi_out:
+                part_ok = False
+            lc2i[xyz] = vi_out
+            # bijection between reference ids and light ids
+            if vi_ref in fmap and fmap[vi_ref] != vi_out:
+                part_ok = False
+            if vi_out in gmap and gmap[vi_out] != vi_ref:
+                part_ok = False
+            fmap[vi_ref] = vi_out; gmap[vi_out] = vi_ref
+    uniq = len(set(v for _, vs in els2 for v, _ in vs))
+    return (path, nelv, uniq, ref_ok, coords_ok, vidx_exact, part_ok)
+
+
+def main():
+    if not os.path.exists(EXE):
+        print('error: rea2nbin_light not found at', EXE, '(build it first: make)')
+        return 1
+    paths = sorted(glob.glob(os.path.join(NEKO, 'examples', '**', '*.nmsh'), recursive=True) +
+                   glob.glob(os.path.join(NEKO, 'tests', '**', '*.nmsh'), recursive=True))
+    print('%-52s %8s %8s  %-5s %-6s %-6s %-6s' %
+          ('mesh', 'nelv', 'uniqpts', 'refOK', 'coords', 'vidx=', 'part='))
+    n3d = n_coords = n_part = n_vidx = 0
+    ok = True
+    with tempfile.TemporaryDirectory() as tmp:
+        for path in paths:
+            r = check(path, tmp)
+            if r is None:
+                continue
+            if len(r) == 3:
+                print('%-52s %8d  %s' % (os.path.relpath(r[0], NEKO), r[1], r[2]))
+                ok = False; continue
+            p, nelv, uniq, refok, cok, vx, pk = r
+            n3d += 1; n_coords += cok; n_part += pk; n_vidx += vx
+            print('%-52s %8d %8d  %-5s %-6s %-6s %-6s' %
+                  (os.path.relpath(p, NEKO), nelv, uniq, refok, cok, vx, pk))
+            if not (cok and pk):
+                ok = False
+    print()
+    print('3D meshes tested          : %d' % n3d)
+    print('coordinates bit-exact     : %d / %d' % (n_coords, n3d))
+    print('topology (partition) exact: %d / %d' % (n_part, n3d))
+    print('v_idx values exact        : %d / %d  (rest: benign relabeling on genmeshbox meshes)' % (n_vidx, n3d))
+    print('\nRESULT:', 'PASS (geometry + topology preserved on all meshes)' if ok else 'FAIL')
+    return 0 if ok else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## What

This PR adds five standalone, CPU-only companions to the existing `contrib/`
tools, each in its own self-contained folder (tool + validation harness +
Makefile + doc), plus a top-level README with a dependency matrix:

| Tool | What it does | Needs |
|---|---|---|
| `rea2nbin_light` | Serial `.re2` → `.nmsh` converter, byte-exact with `rea2nbin`; periodic BCs and curved elements fully supported | gfortran |
| `genmeshbox_light` | O(1)-memory box-mesh generator, byte-exact with `genmeshbox`; streams the `.nmsh` without building a `mesh_t` | gfortran |
| `mesh_checker_light` | Low-memory `.nmsh` diagnostics: sizes (matching `glb_mfcs`/`glb_meds` incl. the periodic merge), BC zones, unlabeled external faces, `--jacobian`, `--write-zone-indices` | gfortran |
| `genmap_light` | Spectral-bisection mesh partitioner (Nek5000 `genmap` algorithm) that reorders the `.nmsh` like `prepart`; deterministic, dependency-free | gfortran |
| `prepart_light` | Mesh partitioner in scientific Python with three backends: spectral (default), METIS (`pip install pymetis`), and geometric RCB for very large meshes | python3 + numpy/scipy |

## Why

The existing `contrib` tools build a full `mesh_t` through Neko's
general-purpose data structures. Those are robust and reused everywhere, but on
large meshes (10⁷–10⁸ elements) the generously-sized polymorphic hash tables
and connectivity structures need hundreds of GB — for tasks (convert, check,
generate, partition) that only need to stream records. The recently merged
`lgenc` fix removes the unwanted connectivity build; these tools go further and
skip the `mesh_t` entirely: plain typed arrays, no Neko initialisation, the
same output in a small fraction of the memory.

Because they do not link Neko, they also need no Neko build at all — in
particular no separate CPU rebuild of a GPU-configured Neko (the `contrib`
tools are CPU-only), no MPI, and no ParMETIS for the partitioners.

## Validation

Each folder ships a validation harness (`make check`, designed to run from
`contrib/<tool>/` inside the source tree):

- **rea2nbin_light** — byte-exact against the bundled `hemi` golden pair and a
  real Neko-produced pipe mesh (the only differing bytes are the type-7 zone
  fields Neko's writer leaves uninitialised); round-trip geometry/topology
  43/43 meshes, periodic identification 19/19, curved records bit-exact 11/11.
- **genmeshbox_light** — 9/9 shipped boxes byte-exact, head-to-head byte-exact
  against a freshly built `genmeshbox`, Neko-compatible CSV distribution files.
- **mesh_checker_light** — all reported quantities match an independent
  recomputation on 43/43 meshes, including the periodic-merged face/edge counts
  (`glb_mfcs`/`glb_meds`); broken-mesh, Jacobian and `.fld`-layout tests.
- **genmap_light / prepart_light** — output verified to be a pure permutation
  of the input with curves and zones carried through (element references
  renumbered, payloads verbatim) and contiguous per-partition blocks, so a
  linear read reproduces the partition (the `prepart` contract); partition
  quality checked against an exact-eigensolver reference; exact balance;
  deterministic output.

All tools reject malformed/truncated inputs with clean one-line errors and
leave no partial output behind.

## Notes for reviewers

- Purely additive: no changes to any existing Neko source.
- All files carry the standard BSD-3 header (The Neko Authors).
- The four Fortran tools build with `gfortran -O2 -Wall` (warning-free); the
  Python tool targets python3 + numpy/scipy, with `pymetis`/`pyamg` optional.
- Each `.md` documents the algorithm, the validation evidence, and the scope /
  limitations (e.g. 3D hex only; `mesh_checker_light`'s Jacobian is exact for
  straight-sided elements), and notes that users should validate on a case they
  trust before relying on a tool in production.
