### PR TITLE
Add device reduction buffer type

### DIFF
--- a/src/.depends_device
+++ b/src/.depends_device
@@ -1,5 +1,5 @@
 device/hip/check.lo : device/hip/check.hip device/hip/check.h
-math/bcknd/device/hip/math.lo : math/bcknd/device/hip/math.hip math/bcknd/device/hip/math_kernel.h
+math/bcknd/device/hip/math.lo : math/bcknd/device/hip/math.hip math/bcknd/device/hip/math_kernel.h device/hip/buffer.lo
 math/bcknd/device/hip/mathops.lo : math/bcknd/device/hip/mathops.hip math/bcknd/device/hip/mathops_kernel.h
 math/bcknd/device/hip/opr_dudxyz.lo : math/bcknd/device/hip/opr_dudxyz.hip math/bcknd/device/hip/dudxyz_kernel.h
 math/bcknd/device/hip/opr_cdtp.lo : math/bcknd/device/hip/opr_cdtp.hip math/bcknd/device/hip/cdtp_kernel.h
@@ -53,7 +53,7 @@ krylov/bcknd/device/hip/cheby_aux.lo : krylov/bcknd/device/hip/cheby_aux.hip
 comm/bcknd/device/cuda/nvshmem.lo : comm/bcknd/device/cuda/nvshmem.cu comm/comm.h
 device/cuda/check.lo : device/cuda/check.cu device/cuda/check.h
 device/cuda/nvtx_wrapper.lo : device/cuda/nvtx_wrapper.cu
-math/bcknd/device/cuda/math.lo : math/bcknd/device/cuda/math.cu math/bcknd/device/cuda/math_kernel.h
+math/bcknd/device/cuda/math.lo : math/bcknd/device/cuda/math.cu math/bcknd/device/cuda/math_kernel.h device/cuda/buffer.lo
 math/bcknd/device/cuda/mathops.lo : math/bcknd/device/cuda/mathops.cu math/bcknd/device/cuda/mathops_kernel.h
 math/bcknd/device/cuda/opr_dudxyz.lo : math/bcknd/device/cuda/opr_dudxyz.cu math/bcknd/device/cuda/dudxyz_kernel.h
 math/bcknd/device/cuda/opr_cdtp.lo : math/bcknd/device/cuda/opr_cdtp.cu math/bcknd/device/cuda/cdtp_kernel.h
@@ -106,7 +106,7 @@ les/bcknd/device/cuda/wale_nut.lo : les/bcknd/device/cuda/wale_nut.cu les/bcknd/
 les/bcknd/device/cuda/deardorff_nut.lo : les/bcknd/device/cuda/deardorff_nut.cu les/bcknd/device/cuda/deardorff_nut_kernel.h
 device/opencl/check.lo : device/opencl/check.c device/opencl/check.h
 device/opencl/jit.lo : device/opencl/jit.c device/opencl/jit.h
-math/bcknd/device/opencl/math.lo : math/bcknd/device/opencl/math.c math/bcknd/device/opencl/math_kernel.cl.h
+math/bcknd/device/opencl/math.lo : math/bcknd/device/opencl/math.c math/bcknd/device/opencl/math_kernel.cl.h device/opencl/buffer.lo
 math/bcknd/device/opencl/schwarz.lo : math/bcknd/device/opencl/schwarz.c math/bcknd/device/opencl/schwarz_kernel.cl.h
 math/bcknd/device/opencl/tensor.lo : math/bcknd/device/opencl/tensor.c math/bcknd/device/opencl/tensor_kernel.cl.h
 math/bcknd/device/opencl/fdm.lo : math/bcknd/device/opencl/fdm.c math/bcknd/device/opencl/fdm_kernel.cl.h

--- a/src/.depends_device
+++ b/src/.depends_device
@@ -1,4 +1,5 @@
 device/hip/check.lo : device/hip/check.hip device/hip/check.h
+device/hip/buffer.lo : device/hip/buffer.hip device/hip/buffer.h
 math/bcknd/device/hip/math.lo : math/bcknd/device/hip/math.hip math/bcknd/device/hip/math_kernel.h device/hip/buffer.lo
 math/bcknd/device/hip/mathops.lo : math/bcknd/device/hip/mathops.hip math/bcknd/device/hip/mathops_kernel.h
 math/bcknd/device/hip/opr_dudxyz.lo : math/bcknd/device/hip/opr_dudxyz.hip math/bcknd/device/hip/dudxyz_kernel.h
@@ -8,7 +9,7 @@ math/bcknd/device/hip/opr_convect_scalar.lo : math/bcknd/device/hip/opr_convect_
 math/bcknd/device/hip/set_convect_rst.lo : math/bcknd/device/hip/set_convect_rst.hip math/bcknd/device/hip/set_convect_rst_kernel.h
 math/bcknd/device/hip/opr_opgrad.lo : math/bcknd/device/hip/opr_opgrad.hip math/bcknd/device/hip/opgrad_kernel.h
 math/bcknd/device/hip/opr_lambda2.lo : math/bcknd/device/hip/opr_lambda2.hip math/bcknd/device/hip/lambda2_kernel.h
-math/bcknd/device/hip/opr_cfl.lo : math/bcknd/device/hip/opr_cfl.hip math/bcknd/device/hip/cfl_kernel.h
+math/bcknd/device/hip/opr_cfl.lo : math/bcknd/device/hip/opr_cfl.hip math/bcknd/device/hip/cfl_kernel.h device/hip/buffer.lo
 math/bcknd/device/hip/opr_rotate_cyc.lo : math/bcknd/device/hip/opr_rotate_cyc.hip math/bcknd/device/hip/rotate_kernel.h
 math/bcknd/device/hip/ax_helm.lo : math/bcknd/device/hip/ax_helm.hip math/bcknd/device/hip/ax_helm_kernel.h
 math/bcknd/device/hip/ax_helm_full.lo : math/bcknd/device/hip/ax_helm_full.hip math/bcknd/device/hip/ax_helm_full_kernel.h
@@ -16,10 +17,10 @@ math/bcknd/device/hip/schwarz.lo : math/bcknd/device/hip/schwarz.hip math/bcknd/
 math/bcknd/device/hip/tensor.lo : math/bcknd/device/hip/tensor.hip math/bcknd/device/hip/tensor_kernel.h
 math/bcknd/device/hip/fdm.lo : math/bcknd/device/hip/fdm.hip math/bcknd/device/hip/fdm_kernel.h
 krylov/bcknd/device/hip/pc_jacobi.lo : krylov/bcknd/device/hip/pc_jacobi.hip
-krylov/bcknd/device/hip/pipecg_aux.lo : krylov/bcknd/device/hip/pipecg_aux.hip krylov/bcknd/device/hip/pipecg_kernel.h
-krylov/bcknd/device/hip/fusedcg_aux.lo : krylov/bcknd/device/hip/fusedcg_aux.hip krylov/bcknd/device/hip/fusedcg_kernel.h
-krylov/bcknd/device/hip/fusedcg_cpld_aux.lo : krylov/bcknd/device/hip/fusedcg_cpld_aux.hip krylov/bcknd/device/hip/fusedcg_cpld_kernel.h
-krylov/bcknd/device/hip/gmres_aux.lo : krylov/bcknd/device/hip/gmres_aux.hip krylov/bcknd/device/hip/gmres_kernel.h
+krylov/bcknd/device/hip/pipecg_aux.lo : krylov/bcknd/device/hip/pipecg_aux.hip krylov/bcknd/device/hip/pipecg_kernel.h device/hip/buffer.lo
+krylov/bcknd/device/hip/fusedcg_aux.lo : krylov/bcknd/device/hip/fusedcg_aux.hip krylov/bcknd/device/hip/fusedcg_kernel.h device/hip/buffer.lo
+krylov/bcknd/device/hip/fusedcg_cpld_aux.lo : krylov/bcknd/device/hip/fusedcg_cpld_aux.hip krylov/bcknd/device/hip/fusedcg_cpld_kernel.h device/hip/buffer.lo
+krylov/bcknd/device/hip/gmres_aux.lo : krylov/bcknd/device/hip/gmres_aux.hip krylov/bcknd/device/hip/gmres_kernel.h device/hip/buffer.lo
 gs/bcknd/device/hip/gs.lo : gs/bcknd/device/hip/gs.hip gs/bcknd/device/hip/gs_kernels.h
 bc/bcknd/device/hip/dirichlet.lo : bc/bcknd/device/hip/dirichlet.hip bc/bcknd/device/hip/dirichlet_kernel.h
 bc/bcknd/device/hip/inflow.lo : bc/bcknd/device/hip/inflow.hip bc/bcknd/device/hip/inflow_kernel.h
@@ -30,7 +31,7 @@ bc/bcknd/device/hip/inhom_dirichlet.lo : bc/bcknd/device/hip/inhom_dirichlet.hip
 bc/bcknd/device/hip/dong_outflow.lo : bc/bcknd/device/hip/dong_outflow.hip bc/bcknd/device/hip/dong_outflow_kernel.h
 bc/bcknd/device/hip/neumann.lo : bc/bcknd/device/hip/neumann.hip bc/bcknd/device/hip/neumann_kernel.h
 common/bcknd/device/hip/rhs_maker.lo : common/bcknd/device/hip/rhs_maker.hip common/bcknd/device/hip/sumab_kernel.h common/bcknd/device/hip/makeext_kernel.h common/bcknd/device/hip/makebdf_kernel.h common/bcknd/device/hip/makeoifs_kernel.h
-common/bcknd/device/hip/projection.lo : common/bcknd/device/hip/projection.hip common/bcknd/device/hip/projection_kernel.h
+common/bcknd/device/hip/projection.lo : common/bcknd/device/hip/projection.hip common/bcknd/device/hip/projection_kernel.h device/hip/buffer.lo
 common/bcknd/device/hip/gradient_jump_penalty.lo : common/bcknd/device/hip/gradient_jump_penalty.hip common/bcknd/device/hip/gradient_jump_penalty_kernel.h
 fluid/bcknd/device/hip/pnpn_res.lo : fluid/bcknd/device/hip/pnpn_res.hip fluid/bcknd/device/hip/vel_res_update_kernel.h fluid/bcknd/device/hip/prs_res_kernel.h
 fluid/bcknd/device/hip/compressible_res.lo : fluid/bcknd/device/hip/compressible_res.hip fluid/bcknd/device/hip/compressible_res_kernel.h
@@ -52,6 +53,7 @@ multigrid/bcknd/device/hip/amg_cheby.lo : multigrid/bcknd/device/hip/amg_cheby.h
 krylov/bcknd/device/hip/cheby_aux.lo : krylov/bcknd/device/hip/cheby_aux.hip
 comm/bcknd/device/cuda/nvshmem.lo : comm/bcknd/device/cuda/nvshmem.cu comm/comm.h
 device/cuda/check.lo : device/cuda/check.cu device/cuda/check.h
+device/cuda/buffer.lo : device/cuda/buffer.cu device/cuda/buffer.h
 device/cuda/nvtx_wrapper.lo : device/cuda/nvtx_wrapper.cu
 math/bcknd/device/cuda/math.lo : math/bcknd/device/cuda/math.cu math/bcknd/device/cuda/math_kernel.h device/cuda/buffer.lo
 math/bcknd/device/cuda/mathops.lo : math/bcknd/device/cuda/mathops.cu math/bcknd/device/cuda/mathops_kernel.h
@@ -62,7 +64,7 @@ math/bcknd/device/cuda/opr_convect_scalar.lo : math/bcknd/device/cuda/opr_convec
 math/bcknd/device/cuda/set_convect_rst.lo : math/bcknd/device/cuda/set_convect_rst.cu math/bcknd/device/cuda/set_convect_rst_kernel.h
 math/bcknd/device/cuda/opr_opgrad.lo : math/bcknd/device/cuda/opr_opgrad.cu math/bcknd/device/cuda/opgrad_kernel.h
 math/bcknd/device/cuda/opr_lambda2.lo : math/bcknd/device/cuda/opr_lambda2.cu math/bcknd/device/cuda/lambda2_kernel.h
-math/bcknd/device/cuda/opr_cfl.lo : math/bcknd/device/cuda/opr_cfl.cu math/bcknd/device/cuda/cfl_kernel.h
+math/bcknd/device/cuda/opr_cfl.lo : math/bcknd/device/cuda/opr_cfl.cu math/bcknd/device/cuda/cfl_kernel.h device/cuda/buffer.lo
 math/bcknd/device/cuda/opr_rotate_cyc.lo : math/bcknd/device/cuda/opr_rotate_cyc.cu math/bcknd/device/cuda/rotate_kernel.h
 math/bcknd/device/cuda/ax_helm.lo : math/bcknd/device/cuda/ax_helm.cu math/bcknd/device/cuda/ax_helm_kernel.h
 math/bcknd/device/cuda/ax_helm_full.lo : math/bcknd/device/cuda/ax_helm_full.cu math/bcknd/device/cuda/ax_helm_full_kernel.h
@@ -70,10 +72,10 @@ math/bcknd/device/cuda/schwarz.lo : math/bcknd/device/cuda/schwarz.cu math/bcknd
 math/bcknd/device/cuda/tensor.lo : math/bcknd/device/cuda/tensor.cu math/bcknd/device/cuda/tensor_kernel.h
 math/bcknd/device/cuda/fdm.lo : math/bcknd/device/cuda/fdm.cu math/bcknd/device/cuda/fdm_kernel.h
 krylov/bcknd/device/cuda/pc_jacobi.lo : krylov/bcknd/device/cuda/pc_jacobi.cu
-krylov/bcknd/device/cuda/pipecg_aux.lo : krylov/bcknd/device/cuda/pipecg_aux.cu krylov/bcknd/device/cuda/pipecg_kernel.h
-krylov/bcknd/device/cuda/fusedcg_aux.lo : krylov/bcknd/device/cuda/fusedcg_aux.cu krylov/bcknd/device/cuda/fusedcg_kernel.h
-krylov/bcknd/device/cuda/fusedcg_cpld_aux.lo : krylov/bcknd/device/cuda/fusedcg_cpld_aux.cu krylov/bcknd/device/cuda/fusedcg_cpld_kernel.h
-krylov/bcknd/device/cuda/gmres_aux.lo : krylov/bcknd/device/cuda/gmres_aux.cu krylov/bcknd/device/cuda/gmres_kernel.h
+krylov/bcknd/device/cuda/pipecg_aux.lo : krylov/bcknd/device/cuda/pipecg_aux.cu krylov/bcknd/device/cuda/pipecg_kernel.h device/cuda/buffer.lo
+krylov/bcknd/device/cuda/fusedcg_aux.lo : krylov/bcknd/device/cuda/fusedcg_aux.cu krylov/bcknd/device/cuda/fusedcg_kernel.h device/cuda/buffer.lo
+krylov/bcknd/device/cuda/fusedcg_cpld_aux.lo : krylov/bcknd/device/cuda/fusedcg_cpld_aux.cu krylov/bcknd/device/cuda/fusedcg_cpld_kernel.h device/cuda/buffer.lo
+krylov/bcknd/device/cuda/gmres_aux.lo : krylov/bcknd/device/cuda/gmres_aux.cu krylov/bcknd/device/cuda/gmres_kernel.h device/cuda/buffer.lo
 gs/bcknd/device/cuda/gs.lo : gs/bcknd/device/cuda/gs.cu gs/bcknd/device/cuda/gs_kernels.h
 gs/bcknd/device/cuda/gs_nvshmem.lo : gs/bcknd/device/cuda/gs_nvshmem.cu gs/bcknd/device/cuda/gs_kernels.h gs/bcknd/device/cuda/gs_nvshmem_kernels.h
 bc/bcknd/device/cuda/dirichlet.lo : bc/bcknd/device/cuda/dirichlet.cu bc/bcknd/device/cuda/dirichlet_kernel.h
@@ -85,7 +87,7 @@ bc/bcknd/device/cuda/neumann.lo : bc/bcknd/device/cuda/neumann.cu bc/bcknd/devic
 bc/bcknd/device/cuda/inhom_dirichlet.lo : bc/bcknd/device/cuda/inhom_dirichlet.cu bc/bcknd/device/cuda/inhom_dirichlet_kernel.h
 bc/bcknd/device/cuda/dong_outflow.lo : bc/bcknd/device/cuda/dong_outflow.cu bc/bcknd/device/cuda/dong_outflow_kernel.h
 common/bcknd/device/cuda/rhs_maker.lo : common/bcknd/device/cuda/rhs_maker.cu common/bcknd/device/cuda/sumab_kernel.h common/bcknd/device/cuda/makeext_kernel.h common/bcknd/device/cuda/makebdf_kernel.h common/bcknd/device/cuda/makeoifs_kernel.h
-common/bcknd/device/cuda/projection.lo : common/bcknd/device/cuda/projection.cu common/bcknd/device/cuda/projection_kernel.h
+common/bcknd/device/cuda/projection.lo : common/bcknd/device/cuda/projection.cu common/bcknd/device/cuda/projection_kernel.h device/cuda/buffer.lo
 fluid/bcknd/device/cuda/pnpn_res.lo : fluid/bcknd/device/cuda/pnpn_res.cu fluid/bcknd/device/cuda/vel_res_update_kernel.h fluid/bcknd/device/cuda/prs_res_kernel.h
 fluid/bcknd/device/cuda/compressible_res.lo : fluid/bcknd/device/cuda/compressible_res.cu fluid/bcknd/device/cuda/compressible_res_kernel.h
 fluid/bcknd/device/cuda/compressible_ops_compute_max_wave_speed.lo : fluid/bcknd/device/cuda/compressible_ops_compute_max_wave_speed.cu fluid/bcknd/device/cuda/compressible_ops_kernel.h
@@ -105,6 +107,7 @@ les/bcknd/device/cuda/sigma_nut.lo : les/bcknd/device/cuda/sigma_nut.cu les/bckn
 les/bcknd/device/cuda/wale_nut.lo : les/bcknd/device/cuda/wale_nut.cu les/bcknd/device/cuda/wale_nut_kernel.h
 les/bcknd/device/cuda/deardorff_nut.lo : les/bcknd/device/cuda/deardorff_nut.cu les/bcknd/device/cuda/deardorff_nut_kernel.h
 device/opencl/check.lo : device/opencl/check.c device/opencl/check.h
+device/opencl/buffer.lo : device/opencl/buffer.c device/opencl/buffer.h
 device/opencl/jit.lo : device/opencl/jit.c device/opencl/jit.h
 math/bcknd/device/opencl/math.lo : math/bcknd/device/opencl/math.c math/bcknd/device/opencl/math_kernel.cl.h device/opencl/buffer.lo
 math/bcknd/device/opencl/schwarz.lo : math/bcknd/device/opencl/schwarz.c math/bcknd/device/opencl/schwarz_kernel.cl.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -497,6 +497,7 @@ if ENABLE_HIP
 libneko_la_SOURCES += \
     ale/bcknd/device/hip/ale_kinematics.hip\
 	device/hip/check.hip\
+	device/hip/buffer.hip\
 	math/bcknd/device/hip/math.hip\
 	math/bcknd/device/hip/schwarz.hip\
 	math/bcknd/device/hip/tensor.hip\
@@ -563,6 +564,7 @@ if ENABLE_CUDA
 libneko_la_SOURCES += \
     ale/bcknd/device/cuda/ale_kinematics.cu\
 	device/cuda/check.cu\
+	device/cuda/buffer.cu\
 	device/cuda/nvtx_wrapper.cu\
 	math/bcknd/device/cuda/math.cu\
 	math/bcknd/device/cuda/schwarz.cu\
@@ -671,6 +673,7 @@ if ENABLE_OPENCL
 libneko_la_SOURCES += \
 	device/opencl/check.c\
 	device/opencl/jit.c\
+	device/opencl/buffer.c\
 	math/bcknd/device/opencl/math.c\
 	math/bcknd/device/opencl/schwarz.c\
 	math/bcknd/device/opencl/tensor.c\
@@ -1159,6 +1162,9 @@ EXTRA_DIST = \
 	device/opencl/check.h\
 	device/hip/check.h\
 	device/cuda/check.h\
+	device/cuda/buffer.h\
+	device/hip/buffer.h\
+	device/opencl/buffer.h\
 	comm/comm_nccl.h\
 	comm/comm.h\
 	common/neko_log.h

--- a/src/common/bcknd/device/cuda/projection.cu
+++ b/src/common/bcknd/device/cuda/projection.cu
@@ -34,16 +34,17 @@
 
 #include <device/device_config.h>
 #include <device/cuda/check.h>
+#include <device/cuda/buffer.h>
 
 #include "projection_kernel.h"
 #include <math/bcknd/device/cuda/math_kernel.h>
 
 
 /*
- * Reduction buffer
+ * Device-only reduction buffer, owned by the device layer and
+ * released on device teardown (cuda_buffer_free_all in cuda_finalize)
  */
-int proj_red_s = 0;
-real * proj_bufred_d = NULL;
+cuda_buffer_t proj_bufred = CUDA_BUFFER_INIT_DEV;
 
 extern "C" {
 
@@ -62,13 +63,8 @@ extern "C" {
     const dim3 glsc3_nthrds(pow2, nt, 1);
     const dim3 glsc3_nblcks(((*n)+nt - 1)/nt, 1, 1);
     const int glsc3_nb = ((*n) + nt - 1)/nt;
-    if((*j)*glsc3_nb>proj_red_s){
-      proj_red_s = (*j)*glsc3_nb;
-      if (proj_bufred_d != NULL) {
-	CUDA_CHECK(cudaFree(proj_bufred_d));
-      }
-      CUDA_CHECK(cudaMalloc(&proj_bufred_d, (*j)*glsc3_nb*sizeof(real)));
-    }
+    cuda_buffer_reserve(&proj_bufred, (*j)*glsc3_nb*sizeof(real));
+    real *proj_bufred_d = (real *) proj_bufred.dev;
 
     /* First glsc3_many call */
     glsc3_many_kernel<real>
@@ -137,13 +133,8 @@ extern "C" {
     const dim3 glsc3_nthrds(pow2, nt, 1);
     const dim3 glsc3_nblcks(((*n)+nt - 1)/nt, 1, 1);
     const int glsc3_nb = ((*n) + nt - 1)/nt;
-    if((*j)*glsc3_nb>proj_red_s){
-      proj_red_s = (*j)*glsc3_nb;
-      if (proj_bufred_d != NULL) {
-	CUDA_CHECK(cudaFree(proj_bufred_d));
-      }
-      CUDA_CHECK(cudaMalloc(&proj_bufred_d, (*j)*glsc3_nb*sizeof(real)));
-    }
+    cuda_buffer_reserve(&proj_bufred, (*j)*glsc3_nb*sizeof(real));
+    real *proj_bufred_d = (real *) proj_bufred.dev;
 
     /* First glsc3_many call */
     glsc3_many_kernel<real>

--- a/src/common/bcknd/device/hip/projection.hip
+++ b/src/common/bcknd/device/hip/projection.hip
@@ -35,16 +35,17 @@
 #include <hip/hip_runtime.h>
 #include <device/device_config.h>
 #include <device/hip/check.h>
+#include <device/hip/buffer.h>
 
 #include "projection_kernel.h"
 #include <math/bcknd/device/hip/math_kernel.h>
 
 
 /*
- * Reduction buffer
+ * Device-only reduction buffer, owned by the device layer and
+ * released on device teardown (hip_buffer_free_all in hip_finalize)
  */
-int proj_red_s = 0;
-real * proj_bufred_d = NULL;
+hip_buffer_t proj_bufred = HIP_BUFFER_INIT_DEV;
 
 extern "C" {
 
@@ -62,13 +63,8 @@ extern "C" {
     const dim3 glsc3_nthrds(pow2, nt, 1);
     const dim3 glsc3_nblcks(((*n)+nt - 1)/nt, 1, 1);
     const int glsc3_nb = ((*n) + nt - 1)/nt;
-    if((*j)*glsc3_nb>proj_red_s){
-      proj_red_s = (*j)*glsc3_nb;
-      if (proj_bufred_d != NULL) {
-	HIP_CHECK(hipFree(proj_bufred_d));
-      }
-      HIP_CHECK(hipMalloc(&proj_bufred_d, (*j)*glsc3_nb*sizeof(real)));
-    }
+    hip_buffer_reserve(&proj_bufred, (*j)*glsc3_nb*sizeof(real));
+    real *proj_bufred_d = (real *) proj_bufred.dev;
 
     /* First glsc3_many call */
     hipLaunchKernelGGL(HIP_KERNEL_NAME( glsc3_many_kernel<real> ),
@@ -135,13 +131,8 @@ extern "C" {
     const dim3 glsc3_nthrds(pow2, nt, 1);
     const dim3 glsc3_nblcks(((*n)+nt - 1)/nt, 1, 1);
     const int glsc3_nb = ((*n) + nt - 1)/nt;
-    if((*j)*glsc3_nb>proj_red_s){
-      proj_red_s = (*j)*glsc3_nb;
-      if (proj_bufred_d != NULL) {
-	HIP_CHECK(hipFree(proj_bufred_d));
-      }
-      HIP_CHECK(hipMalloc(&proj_bufred_d, (*j)*glsc3_nb*sizeof(real)));
-    }
+    hip_buffer_reserve(&proj_bufred, (*j)*glsc3_nb*sizeof(real));
+    real *proj_bufred_d = (real *) proj_bufred.dev;
 
     /* First glsc3_many call */
     hipLaunchKernelGGL(HIP_KERNEL_NAME( glsc3_many_kernel<real> ),

--- a/src/device/cuda/buffer.cu
+++ b/src/device/cuda/buffer.cu
@@ -52,8 +52,9 @@ extern "C" {
     if (size <= buf->size)
       return;
 
-    if (buf->host != NULL) {
-      CUDA_CHECK(cudaFreeHost(buf->host));
+    if (buf->dev != NULL) {
+      if (buf->host != NULL)
+        CUDA_CHECK(cudaFreeHost(buf->host));
 #ifdef HAVE_NVSHMEM
       if (buf->symm)
         nvshmem_free(buf->dev);
@@ -64,7 +65,8 @@ extern "C" {
 #endif
     }
 
-    CUDA_CHECK(cudaMallocHost(&buf->host, size));
+    if (!buf->dev_only)
+      CUDA_CHECK(cudaMallocHost(&buf->host, size));
 #ifdef HAVE_NVSHMEM
     if (buf->symm)
       buf->dev = nvshmem_malloc(size);
@@ -90,6 +92,8 @@ extern "C" {
       if (buf->host != NULL) {
         CUDA_CHECK(cudaFreeHost(buf->host));
         buf->host = NULL;
+      }
+      if (buf->dev != NULL) {
 #ifdef HAVE_NVSHMEM
         if (buf->symm)
           nvshmem_free(buf->dev);

--- a/src/device/cuda/buffer.cu
+++ b/src/device/cuda/buffer.cu
@@ -1,0 +1,111 @@
+/*
+ Copyright (c) 2026, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <device/device_config.h>
+#include <device/cuda/check.h>
+#include <device/cuda/buffer.h>
+
+#ifdef HAVE_NVSHMEM
+#include <nvshmem.h>
+#endif
+
+extern "C" {
+
+  /**
+   * Registry of all reserved device buffers
+   */
+  static cuda_buffer_t *buffer_registry = NULL;
+
+  void cuda_buffer_reserve(cuda_buffer_t *buf, size_t size) {
+
+    if (size <= buf->size)
+      return;
+
+    if (buf->host != NULL) {
+      CUDA_CHECK(cudaFreeHost(buf->host));
+#ifdef HAVE_NVSHMEM
+      if (buf->symm)
+        nvshmem_free(buf->dev);
+      else
+        CUDA_CHECK(cudaFree(buf->dev));
+#else
+      CUDA_CHECK(cudaFree(buf->dev));
+#endif
+    }
+
+    CUDA_CHECK(cudaMallocHost(&buf->host, size));
+#ifdef HAVE_NVSHMEM
+    if (buf->symm)
+      buf->dev = nvshmem_malloc(size);
+    else
+      CUDA_CHECK(cudaMalloc(&buf->dev, size));
+#else
+    CUDA_CHECK(cudaMalloc(&buf->dev, size));
+#endif
+    buf->size = size;
+
+    if (!buf->registered) {
+      buf->next = buffer_registry;
+      buffer_registry = buf;
+      buf->registered = 1;
+    }
+  }
+
+  void cuda_buffer_free_all(void) {
+    cuda_buffer_t *buf = buffer_registry;
+
+    while (buf != NULL) {
+      cuda_buffer_t *next = buf->next;
+      if (buf->host != NULL) {
+        CUDA_CHECK(cudaFreeHost(buf->host));
+        buf->host = NULL;
+#ifdef HAVE_NVSHMEM
+        if (buf->symm)
+          nvshmem_free(buf->dev);
+        else
+          CUDA_CHECK(cudaFree(buf->dev));
+#else
+        CUDA_CHECK(cudaFree(buf->dev));
+#endif
+        buf->dev = NULL;
+      }
+      buf->size = 0;
+      buf->registered = 0;
+      buf->next = NULL;
+      buf = next;
+    }
+    buffer_registry = NULL;
+  }
+
+}

--- a/src/device/cuda/buffer.h
+++ b/src/device/cuda/buffer.h
@@ -49,21 +49,24 @@ extern "C" {
  * demand after a subsequent device init
  */
 struct cuda_buffer {
-  void *host;               /**< Pinned host buffer */
+  void *host;               /**< Pinned host buffer (NULL if device-only) */
   void *dev;                /**< Device buffer */
   size_t size;              /**< Capacity in bytes */
   int symm;                 /**< Device buffer on NVSHMEM symmetric heap */
+  int dev_only;             /**< Device buffer only, no pinned host buffer */
   int registered;           /**< Buffer linked into the registry */
   struct cuda_buffer *next; /**< Registry link */
 };
 typedef struct cuda_buffer cuda_buffer_t;
 
-#define CUDA_BUFFER_INIT {NULL, NULL, 0, 0, 0, NULL}
-#define CUDA_BUFFER_INIT_SYMM {NULL, NULL, 0, 1, 0, NULL}
+#define CUDA_BUFFER_INIT {NULL, NULL, 0, 0, 0, 0, NULL}
+#define CUDA_BUFFER_INIT_SYMM {NULL, NULL, 0, 1, 0, 0, NULL}
+#define CUDA_BUFFER_INIT_DEV {NULL, NULL, 0, 0, 1, 0, NULL}
 
 /**
  * Ensure that a buffer holds at least @a size bytes on both the
- * host and the device side, growing it if necessary
+ * host and the device side (device side only for device-only
+ * buffers), growing it if necessary
  */
 void cuda_buffer_reserve(cuda_buffer_t *buf, size_t size);
 

--- a/src/device/cuda/buffer.h
+++ b/src/device/cuda/buffer.h
@@ -1,0 +1,79 @@
+#ifndef __CUDA_BUFFER_H
+#define __CUDA_BUFFER_H
+/*
+ Copyright (c) 2026, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Device buffer: a lazily grown pair of a pinned host buffer and a
+ * device buffer, owned by the device layer. A buffer is linked into
+ * a registry on its first reservation, and cuda_buffer_free_all()
+ * (called from cuda_finalize) releases all registered buffers and
+ * resets them to an empty state, from which they grow again on
+ * demand after a subsequent device init
+ */
+struct cuda_buffer {
+  void *host;               /**< Pinned host buffer */
+  void *dev;                /**< Device buffer */
+  size_t size;              /**< Capacity in bytes */
+  int symm;                 /**< Device buffer on NVSHMEM symmetric heap */
+  int registered;           /**< Buffer linked into the registry */
+  struct cuda_buffer *next; /**< Registry link */
+};
+typedef struct cuda_buffer cuda_buffer_t;
+
+#define CUDA_BUFFER_INIT {NULL, NULL, 0, 0, 0, NULL}
+#define CUDA_BUFFER_INIT_SYMM {NULL, NULL, 0, 1, 0, NULL}
+
+/**
+ * Ensure that a buffer holds at least @a size bytes on both the
+ * host and the device side, growing it if necessary
+ */
+void cuda_buffer_reserve(cuda_buffer_t *buf, size_t size);
+
+/**
+ * Free all registered buffers and reset them to an empty state
+ */
+void cuda_buffer_free_all(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CUDA_BUFFER_H */

--- a/src/device/cuda_intf.F90
+++ b/src/device/cuda_intf.F90
@@ -295,6 +295,7 @@ contains
   subroutine cuda_finalize(glb_cmd_queue, aux_cmd_queue)
     type(c_ptr), intent(inout) :: glb_cmd_queue
     type(c_ptr), intent(inout) :: aux_cmd_queue
+    integer :: ierr
 
     ! Release all device buffers held by the device layer
     call cuda_buffer_free_all()

--- a/src/device/cuda_intf.F90
+++ b/src/device/cuda_intf.F90
@@ -111,6 +111,10 @@ module cuda_intf
        implicit none
      end function cudaDeviceReset
 
+     subroutine cuda_buffer_free_all() &
+          bind(c, name = 'cuda_buffer_free_all')
+     end subroutine cuda_buffer_free_all
+
      integer(c_int) function cudaGetDeviceProperties(prop, device) &
           bind(c, name = 'cudaGetDeviceProperties')
        use, intrinsic :: iso_c_binding
@@ -291,7 +295,9 @@ contains
   subroutine cuda_finalize(glb_cmd_queue, aux_cmd_queue)
     type(c_ptr), intent(inout) :: glb_cmd_queue
     type(c_ptr), intent(inout) :: aux_cmd_queue
-    integer(c_int) :: ierr
+
+    ! Release all device buffers held by the device layer
+    call cuda_buffer_free_all()
 
     if (cudaStreamDestroy(glb_cmd_queue) .ne. cudaSuccess) then
        call neko_error('Error destroying main stream')

--- a/src/device/hip/buffer.h
+++ b/src/device/hip/buffer.h
@@ -1,0 +1,77 @@
+#ifndef __HIP_BUFFER_H
+#define __HIP_BUFFER_H
+/*
+ Copyright (c) 2026, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Device buffer: a lazily grown pair of a pinned host buffer and a
+ * device buffer, owned by the device layer. A buffer is linked into
+ * a registry on its first reservation, and hip_buffer_free_all()
+ * (called from hip_finalize) releases all registered buffers and
+ * resets them to an empty state, from which they grow again on
+ * demand after a subsequent device init
+ */
+struct hip_buffer {
+  void *host;              /**< Pinned host buffer */
+  void *dev;               /**< Device buffer */
+  size_t size;             /**< Capacity in bytes */
+  int registered;          /**< Buffer linked into the registry */
+  struct hip_buffer *next; /**< Registry link */
+};
+typedef struct hip_buffer hip_buffer_t;
+
+#define HIP_BUFFER_INIT {NULL, NULL, 0, 0, NULL}
+
+/**
+ * Ensure that a buffer holds at least @a size bytes on both the
+ * host and the device side, growing it if necessary
+ */
+void hip_buffer_reserve(hip_buffer_t *buf, size_t size);
+
+/**
+ * Free all registered buffers and reset them to an empty state
+ */
+void hip_buffer_free_all(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HIP_BUFFER_H */

--- a/src/device/hip/buffer.h
+++ b/src/device/hip/buffer.h
@@ -49,19 +49,22 @@ extern "C" {
  * demand after a subsequent device init
  */
 struct hip_buffer {
-  void *host;              /**< Pinned host buffer */
+  void *host;              /**< Pinned host buffer (NULL if device-only) */
   void *dev;               /**< Device buffer */
   size_t size;             /**< Capacity in bytes */
+  int dev_only;            /**< Device buffer only, no pinned host buffer */
   int registered;          /**< Buffer linked into the registry */
   struct hip_buffer *next; /**< Registry link */
 };
 typedef struct hip_buffer hip_buffer_t;
 
-#define HIP_BUFFER_INIT {NULL, NULL, 0, 0, NULL}
+#define HIP_BUFFER_INIT {NULL, NULL, 0, 0, 0, NULL}
+#define HIP_BUFFER_INIT_DEV {NULL, NULL, 0, 1, 0, NULL}
 
 /**
  * Ensure that a buffer holds at least @a size bytes on both the
- * host and the device side, growing it if necessary
+ * host and the device side (device side only for device-only
+ * buffers), growing it if necessary
  */
 void hip_buffer_reserve(hip_buffer_t *buf, size_t size);
 

--- a/src/device/hip/buffer.hip
+++ b/src/device/hip/buffer.hip
@@ -49,12 +49,14 @@ extern "C" {
     if (size <= buf->size)
       return;
 
-    if (buf->host != NULL) {
-      HIP_CHECK(hipHostFree(buf->host));
+    if (buf->dev != NULL) {
+      if (buf->host != NULL)
+        HIP_CHECK(hipHostFree(buf->host));
       HIP_CHECK(hipFree(buf->dev));
     }
 
-    HIP_CHECK(hipHostMalloc(&buf->host, size, hipHostMallocDefault));
+    if (!buf->dev_only)
+      HIP_CHECK(hipHostMalloc(&buf->host, size, hipHostMallocDefault));
     HIP_CHECK(hipMalloc(&buf->dev, size));
     buf->size = size;
 
@@ -73,6 +75,8 @@ extern "C" {
       if (buf->host != NULL) {
         HIP_CHECK(hipHostFree(buf->host));
         buf->host = NULL;
+      }
+      if (buf->dev != NULL) {
         HIP_CHECK(hipFree(buf->dev));
         buf->dev = NULL;
       }

--- a/src/device/hip/buffer.hip
+++ b/src/device/hip/buffer.hip
@@ -1,0 +1,87 @@
+/*
+ Copyright (c) 2026, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <hip/hip_runtime.h>
+#include <device/device_config.h>
+#include <device/hip/check.h>
+#include <device/hip/buffer.h>
+
+extern "C" {
+
+  /**
+   * Registry of all reserved device buffers
+   */
+  static hip_buffer_t *buffer_registry = NULL;
+
+  void hip_buffer_reserve(hip_buffer_t *buf, size_t size) {
+
+    if (size <= buf->size)
+      return;
+
+    if (buf->host != NULL) {
+      HIP_CHECK(hipHostFree(buf->host));
+      HIP_CHECK(hipFree(buf->dev));
+    }
+
+    HIP_CHECK(hipHostMalloc(&buf->host, size, hipHostMallocDefault));
+    HIP_CHECK(hipMalloc(&buf->dev, size));
+    buf->size = size;
+
+    if (!buf->registered) {
+      buf->next = buffer_registry;
+      buffer_registry = buf;
+      buf->registered = 1;
+    }
+  }
+
+  void hip_buffer_free_all(void) {
+    hip_buffer_t *buf = buffer_registry;
+
+    while (buf != NULL) {
+      hip_buffer_t *next = buf->next;
+      if (buf->host != NULL) {
+        HIP_CHECK(hipHostFree(buf->host));
+        buf->host = NULL;
+        HIP_CHECK(hipFree(buf->dev));
+        buf->dev = NULL;
+      }
+      buf->size = 0;
+      buf->registered = 0;
+      buf->next = NULL;
+      buf = next;
+    }
+    buffer_registry = NULL;
+  }
+
+}

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -267,6 +267,7 @@ contains
   subroutine hip_finalize(glb_cmd_queue, aux_cmd_queue)
     type(c_ptr), intent(inout) :: glb_cmd_queue
     type(c_ptr), intent(inout) :: aux_cmd_queue
+    integer :: ierr
 
     ! Release all device buffers held by the device layer
     call hip_buffer_free_all()

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -129,6 +129,10 @@ module hip_intf
        implicit none
      end function hipDeviceReset
 
+     subroutine hip_buffer_free_all() &
+          bind(c, name = 'hip_buffer_free_all')
+     end subroutine hip_buffer_free_all
+
      integer(c_int) function hipDeviceGetName(name, len, device) &
           bind(c, name = 'hipDeviceGetName')
        use, intrinsic :: iso_c_binding
@@ -263,7 +267,9 @@ contains
   subroutine hip_finalize(glb_cmd_queue, aux_cmd_queue)
     type(c_ptr), intent(inout) :: glb_cmd_queue
     type(c_ptr), intent(inout) :: aux_cmd_queue
-    integer(c_int) :: ierr
+
+    ! Release all device buffers held by the device layer
+    call hip_buffer_free_all()
 
     if (hipStreamDestroy(glb_cmd_queue) .ne. hipSuccess) then
        call neko_error('Error destroying main stream')

--- a/src/device/opencl/buffer.c
+++ b/src/device/opencl/buffer.c
@@ -1,0 +1,86 @@
+/*
+ Copyright (c) 2026, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stdlib.h>
+
+#include <device/device_config.h>
+#include <device/opencl/check.h>
+#include <device/opencl/buffer.h>
+
+/**
+ * Registry of all reserved device buffers
+ */
+static opencl_buffer_t *buffer_registry = NULL;
+
+void opencl_buffer_reserve(opencl_buffer_t *buf, size_t size) {
+  cl_int err;
+
+  if (size <= buf->size)
+    return;
+
+  if (buf->host != NULL) {
+    free(buf->host);
+    CL_CHECK(clReleaseMemObject(buf->dev));
+  }
+
+  buf->host = malloc(size);
+  buf->dev = clCreateBuffer(glb_ctx, CL_MEM_READ_WRITE, size, NULL, &err);
+  CL_CHECK(err);
+  buf->size = size;
+
+  if (!buf->registered) {
+    buf->next = buffer_registry;
+    buffer_registry = buf;
+    buf->registered = 1;
+  }
+}
+
+void opencl_buffer_free_all(void) {
+  opencl_buffer_t *buf = buffer_registry;
+
+  while (buf != NULL) {
+    opencl_buffer_t *next = buf->next;
+    if (buf->host != NULL) {
+      free(buf->host);
+      buf->host = NULL;
+      CL_CHECK(clReleaseMemObject(buf->dev));
+      buf->dev = NULL;
+    }
+    buf->size = 0;
+    buf->registered = 0;
+    buf->next = NULL;
+    buf = next;
+  }
+  buffer_registry = NULL;
+}

--- a/src/device/opencl/buffer.h
+++ b/src/device/opencl/buffer.h
@@ -1,0 +1,76 @@
+#ifndef __OPENCL_BUFFER_H
+#define __OPENCL_BUFFER_H
+/*
+ Copyright (c) 2026, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stddef.h>
+
+#ifdef __APPLE__
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
+
+/**
+ * Device buffer: a lazily grown pair of a host buffer and a device
+ * buffer, owned by the device layer. A buffer is linked into a
+ * registry on its first reservation, and opencl_buffer_free_all()
+ * (called from opencl_finalize before the context is released)
+ * releases all registered buffers and resets them to an empty
+ * state, from which they grow again on demand after a subsequent
+ * device init
+ */
+struct opencl_buffer {
+  void *host;                 /**< Host buffer */
+  cl_mem dev;                 /**< Device buffer */
+  size_t size;                /**< Capacity in bytes */
+  int registered;             /**< Buffer linked into the registry */
+  struct opencl_buffer *next; /**< Registry link */
+};
+typedef struct opencl_buffer opencl_buffer_t;
+
+#define OPENCL_BUFFER_INIT {NULL, NULL, 0, 0, NULL}
+
+/**
+ * Ensure that a buffer holds at least @a size bytes on both the
+ * host and the device side, growing it if necessary
+ */
+void opencl_buffer_reserve(opencl_buffer_t *buf, size_t size);
+
+/**
+ * Free all registered buffers and reset them to an empty state
+ */
+void opencl_buffer_free_all(void);
+
+#endif /* __OPENCL_BUFFER_H */

--- a/src/device/opencl_intf.F90
+++ b/src/device/opencl_intf.F90
@@ -353,6 +353,10 @@ module opencl_intf
        implicit none
        type(c_ptr), value :: cmd_queue
      end function clFinish
+
+     subroutine opencl_buffer_free_all() &
+          bind(c, name = 'opencl_buffer_free_all')
+     end subroutine opencl_buffer_free_all
   end interface
 
 contains
@@ -378,6 +382,8 @@ contains
     end if
 
     if (c_associated(glb_ctx)) then
+       ! Release all device buffers created against the old context
+       call opencl_buffer_free_all()
        if (clReleaseContext(glb_ctx) .ne. CL_SUCCESS) then
           call neko_error('Failed to release context')
        end if
@@ -420,6 +426,10 @@ contains
     type(c_ptr), intent(inout) :: glb_cmd_queue
     type(c_ptr), intent(inout) :: aux_cmd_queue
     type(c_ptr), intent(inout) :: prf_cmd_queue
+
+    ! Release all device buffers held by the device layer
+    ! (must precede the release of the context owning them)
+    call opencl_buffer_free_all()
 
     if (c_associated(glb_ctx)) then
        if (clReleaseContext(glb_ctx) .ne. CL_SUCCESS) then

--- a/src/krylov/bcknd/device/cuda/fusedcg_aux.cu
+++ b/src/krylov/bcknd/device/cuda/fusedcg_aux.cu
@@ -35,6 +35,7 @@
 #include "fusedcg_kernel.h"
 #include <device/device_config.h>
 #include <device/cuda/check.h>
+#include <device/cuda/buffer.h>
 
 #ifdef HAVE_NVSHMEM
 #include <nvshmem.h>
@@ -42,11 +43,10 @@
 #endif
 
 /**
- * @todo Make sure that this gets deleted at some point...
+ * Reduction buffer, owned by the device layer and released on device
+ * teardown (cuda_buffer_free_all in cuda_finalize)
  */
-real *fusedcg_buf = NULL;
-void *fusedcg_buf_d = NULL;
-int fusedcg_buf_len = 0;
+cuda_buffer_t fusedcg_redbuf = CUDA_BUFFER_INIT_SYMM;
 
 extern "C" {
 
@@ -92,25 +92,10 @@ extern "C" {
     const int nb = ((*n) + 1024 - 1)/ 1024;
     const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
-    if (fusedcg_buf != NULL && fusedcg_buf_len < nb) {
-      CUDA_CHECK(cudaFreeHost(fusedcg_buf));
-#ifdef HAVE_NVSHMEM
-      nvshmem_free(fusedcg_buf_d);
-#else
-      CUDA_CHECK(cudaFree(fusedcg_buf_d));
-#endif
-      fusedcg_buf = NULL;
-    }
-
-    if (fusedcg_buf == NULL){
-      CUDA_CHECK(cudaMallocHost(&fusedcg_buf, 2*sizeof(real)));
-#ifdef HAVE_NVSHMEM
-      fusedcg_buf_d = (real *) nvshmem_malloc(nb*sizeof(real));
-#else
-      CUDA_CHECK(cudaMalloc(&fusedcg_buf_d, nb*sizeof(real)));
-#endif
-      fusedcg_buf_len = nb;
-    }
+    /* nb + 1 to fit the two-element host staging area for any nb */
+    cuda_buffer_reserve(&fusedcg_redbuf, (nb + 1)*sizeof(real));
+    real *fusedcg_buf = (real *) fusedcg_redbuf.host;
+    real *fusedcg_buf_d = (real *) fusedcg_redbuf.dev;
 
     /* Store alpha(p_cur) in pinned memory */
     fusedcg_buf[1] = (*alpha);

--- a/src/krylov/bcknd/device/cuda/fusedcg_cpld_aux.cu
+++ b/src/krylov/bcknd/device/cuda/fusedcg_cpld_aux.cu
@@ -35,6 +35,7 @@
 #include "fusedcg_cpld_kernel.h"
 #include <device/device_config.h>
 #include <device/cuda/check.h>
+#include <device/cuda/buffer.h>
 
 #ifdef HAVE_NVSHMEM
 #include <nvshmem.h>
@@ -42,11 +43,10 @@
 #endif
 
 /**
- * @todo Make sure that this gets deleted at some point...
+ * Reduction buffer, owned by the device layer and released on device
+ * teardown (cuda_buffer_free_all in cuda_finalize)
  */
-real *fusedcg_cpld_buf = NULL;
-void *fusedcg_cpld_buf_d = NULL;
-int fusedcg_cpld_buf_len = 0;
+cuda_buffer_t fusedcg_cpld_redbuf = CUDA_BUFFER_INIT_SYMM;
 
 extern "C" {
 
@@ -111,25 +111,10 @@ extern "C" {
     const int nb = ((*n) + 1024 - 1)/ 1024;
     const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
-    if (fusedcg_cpld_buf != NULL && fusedcg_cpld_buf_len < nb) {
-      CUDA_CHECK(cudaFreeHost(fusedcg_cpld_buf));
-#ifdef HAVE_NVSHMEM
-      nvshmem_free(fusedcg_cpld_buf_d);
-#else
-      CUDA_CHECK(cudaFree(fusedcg_cpld_buf_d));
-#endif
-      fusedcg_cpld_buf = NULL;
-    }
-
-    if (fusedcg_cpld_buf == NULL){
-      CUDA_CHECK(cudaMallocHost(&fusedcg_cpld_buf, 2*sizeof(real)));
-#ifdef HAVE_NVSHMEM
-      fusedcg_cpld_buf_d = (real *) nvshmem_malloc(nb*sizeof(real));
-#else
-      CUDA_CHECK(cudaMalloc(&fusedcg_cpld_buf_d, nb*sizeof(real)));
-#endif
-      fusedcg_cpld_buf_len = nb;
-    }
+    /* nb + 1 to fit the two-element host staging area for any nb */
+    cuda_buffer_reserve(&fusedcg_cpld_redbuf, (nb + 1)*sizeof(real));
+    real *fusedcg_cpld_buf = (real *) fusedcg_cpld_redbuf.host;
+    real *fusedcg_cpld_buf_d = (real *) fusedcg_cpld_redbuf.dev;
 
     /* Store alpha(p_cur) in pinned memory */
     fusedcg_cpld_buf[1] = (*alpha);

--- a/src/krylov/bcknd/device/cuda/gmres_aux.cu
+++ b/src/krylov/bcknd/device/cuda/gmres_aux.cu
@@ -36,6 +36,7 @@
 #include "gmres_kernel.h"
 #include <device/device_config.h>
 #include <device/cuda/check.h>
+#include <device/cuda/buffer.h>
 
 #ifdef HAVE_NVSHMEM
 #include <nvshmem.h>
@@ -53,11 +54,10 @@ extern "C" {
 #endif
 
   /**
-   * @todo Make sure that this gets deleted at some point...
+   * Reduction buffer, owned by the device layer and released on
+   * device teardown (cuda_buffer_free_all in cuda_finalize)
    */
-  real * gmres_bf1 = NULL;
-  real * gmres_bfd1 = NULL;
-  int gmres_bf_len = 0;
+  cuda_buffer_t gmres_redbuf = CUDA_BUFFER_INIT_SYMM;
 
   real cuda_gmres_part2(void *w, void *v, void *h, void * mult, int *j, int *n) {
 
@@ -66,25 +66,9 @@ extern "C" {
     const int nb = ((*n) + 1024 - 1)/ 1024;
     const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
-    if (gmres_bf1 != NULL && gmres_bf_len < nb) {
-      CUDA_CHECK(cudaFreeHost(gmres_bf1));
-#ifdef HAVE_NVSHMEM
-      nvshmem_free(gmres_bfd1);
-#else
-      CUDA_CHECK(cudaFree(gmres_bfd1));
-#endif
-      gmres_bf1 = NULL;
-    }
-
-    if (gmres_bf1 == NULL){
-      CUDA_CHECK(cudaMallocHost(&gmres_bf1, nb*sizeof(real)));
-#ifdef HAVE_NVSHMEM
-      gmres_bfd1 = (real *) nvshmem_malloc(nb*sizeof(real));
-#else
-      CUDA_CHECK(cudaMalloc(&gmres_bfd1, nb*sizeof(real)));
-#endif
-      gmres_bf_len = nb;
-    }
+    cuda_buffer_reserve(&gmres_redbuf, nb*sizeof(real));
+    real *gmres_bf1 = (real *) gmres_redbuf.host;
+    real *gmres_bfd1 = (real *) gmres_redbuf.dev;
 
     gmres_part2_kernel<real>
       <<<nblcks, nthrds, 0, stream>>>((real *) w, (real **) v,

--- a/src/krylov/bcknd/device/cuda/pipecg_aux.cu
+++ b/src/krylov/bcknd/device/cuda/pipecg_aux.cu
@@ -35,15 +35,14 @@
 #include "pipecg_kernel.h"
 #include <device/device_config.h>
 #include <device/cuda/check.h>
+#include <device/cuda/buffer.h>
 
 /**
- * @todo Make sure that this gets deleted at some point...
+ * Reduction buffer, owned by the device layer and released on device
+ * teardown (cuda_buffer_free_all in cuda_finalize); the device side
+ * holds the three partial-reduction arrays back to back
  */
-real *buf = NULL;
-real *buf_d1 = NULL;
-real *buf_d2 = NULL;
-real *buf_d3 = NULL;
-int buf_len = 0;
+cuda_buffer_t pipecg_buf = CUDA_BUFFER_INIT;
 
 extern "C" {
   
@@ -73,21 +72,11 @@ extern "C" {
     const int nb = ((*n) + 1024 - 1)/ 1024;
     const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
-    if (buf != NULL && buf_len < nb) {
-      CUDA_CHECK(cudaFreeHost(buf));
-      CUDA_CHECK(cudaFree(buf_d1));
-      CUDA_CHECK(cudaFree(buf_d2));
-      CUDA_CHECK(cudaFree(buf_d3));
-      buf = NULL;
-    }
-
-    if (buf == NULL){
-      CUDA_CHECK(cudaMallocHost(&buf, 3*sizeof(real)));
-      CUDA_CHECK(cudaMalloc(&buf_d1, nb*sizeof(real)));
-      CUDA_CHECK(cudaMalloc(&buf_d2, nb*sizeof(real)));
-      CUDA_CHECK(cudaMalloc(&buf_d3, nb*sizeof(real)));
-      buf_len = nb;
-    }
+    cuda_buffer_reserve(&pipecg_buf, 3*nb*sizeof(real));
+    real *buf = (real *) pipecg_buf.host;
+    real *buf_d1 = (real *) pipecg_buf.dev;
+    real *buf_d2 = buf_d1 + nb;
+    real *buf_d3 = buf_d1 + 2*nb;
      
     pipecg_vecops_kernel<real>
       <<<nblcks, nthrds, 0, stream>>>((real *) p, (real *) q,

--- a/src/krylov/bcknd/device/hip/fusedcg_aux.hip
+++ b/src/krylov/bcknd/device/hip/fusedcg_aux.hip
@@ -36,13 +36,13 @@
 #include "fusedcg_kernel.h"
 #include <device/device_config.h>
 #include <device/hip/check.h>
+#include <device/hip/buffer.h>
 
 /**
- * @todo Make sure that this gets deleted at some point...
+ * Reduction buffer, owned by the device layer and released on device
+ * teardown (hip_buffer_free_all in hip_finalize)
  */
-real *fusedcg_buf = NULL;
-real *fusedcg_buf_d = NULL;
-int fusedcg_buf_len = 0;
+hip_buffer_t fusedcg_redbuf = HIP_BUFFER_INIT;
 
 extern "C" {
 
@@ -91,17 +91,10 @@ extern "C" {
     const int nb = ((*n) + 1024 - 1)/ 1024;
     const hipStream_t stream = (hipStream_t) glb_cmd_queue;
 
-    if (fusedcg_buf != NULL && fusedcg_buf_len < nb) {
-      HIP_CHECK(hipHostFree(fusedcg_buf));
-      HIP_CHECK(hipFree(fusedcg_buf_d));
-      fusedcg_buf = NULL;
-    }
-    
-    if (fusedcg_buf == NULL){
-      HIP_CHECK(hipHostMalloc(&fusedcg_buf, 2*sizeof(real)));
-      HIP_CHECK(hipMalloc(&fusedcg_buf_d, nb*sizeof(real)));
-      fusedcg_buf_len = nb;
-    }
+    /* nb + 1 to fit the two-element host staging area for any nb */
+    hip_buffer_reserve(&fusedcg_redbuf, (nb + 1)*sizeof(real));
+    real *fusedcg_buf = (real *) fusedcg_redbuf.host;
+    real *fusedcg_buf_d = (real *) fusedcg_redbuf.dev;
 
     /* Store alpha(p_cur) in pinned memory */
     fusedcg_buf[1] = (*alpha);

--- a/src/krylov/bcknd/device/hip/fusedcg_cpld_aux.hip
+++ b/src/krylov/bcknd/device/hip/fusedcg_cpld_aux.hip
@@ -34,14 +34,14 @@
 
 #include <device/device_config.h>
 #include <device/hip/check.h>
+#include <device/hip/buffer.h>
 #include "fusedcg_cpld_kernel.h"
 
 /**
- * @todo Make sure that this gets deleted at some point...
+ * Reduction buffer, owned by the device layer and released on device
+ * teardown (hip_buffer_free_all in hip_finalize)
  */
-real *fusedcg_cpld_buf = NULL;
-real *fusedcg_cpld_buf_d = NULL;
-int fusedcg_cpld_buf_len = 0;
+hip_buffer_t fusedcg_cpld_redbuf = HIP_BUFFER_INIT;
 
 extern "C" {
 
@@ -111,17 +111,10 @@ extern "C" {
     const int nb = ((*n) + 1024 - 1)/ 1024;
     const hipStream_t stream = (hipStream_t) glb_cmd_queue;
 
-    if (fusedcg_cpld_buf != NULL && fusedcg_cpld_buf_len < nb) {
-      HIP_CHECK(hipHostFree(fusedcg_cpld_buf));
-      HIP_CHECK(hipFree(fusedcg_cpld_buf_d));
-      fusedcg_cpld_buf = NULL;
-    }
-    
-    if (fusedcg_cpld_buf == NULL){
-      HIP_CHECK(hipHostMalloc(&fusedcg_cpld_buf, 2*sizeof(real)));
-      HIP_CHECK(hipMalloc(&fusedcg_cpld_buf_d, nb*sizeof(real)));
-      fusedcg_cpld_buf_len = nb;
-    }
+    /* nb + 1 to fit the two-element host staging area for any nb */
+    hip_buffer_reserve(&fusedcg_cpld_redbuf, (nb + 1)*sizeof(real));
+    real *fusedcg_cpld_buf = (real *) fusedcg_cpld_redbuf.host;
+    real *fusedcg_cpld_buf_d = (real *) fusedcg_cpld_redbuf.dev;
 
     /* Store alpha(p_cur) in pinned memory */
     fusedcg_cpld_buf[1] = (*alpha);

--- a/src/krylov/bcknd/device/hip/gmres_aux.hip
+++ b/src/krylov/bcknd/device/hip/gmres_aux.hip
@@ -37,6 +37,7 @@
 #include "gmres_kernel.h"
 #include <device/device_config.h>
 #include <device/hip/check.h>
+#include <device/hip/buffer.h>
 
 extern "C" {
 
@@ -49,11 +50,10 @@ extern "C" {
 #endif
 
   /**
-   * @todo Make sure that this gets deleted at some point...
+   * Reduction buffer, owned by the device layer and released on
+   * device teardown (hip_buffer_free_all in hip_finalize)
    */
-  real * gmres_bf1 = NULL;
-  real * gmres_bfd1 = NULL;
-  int gmres_bf_len = 0;  
+  hip_buffer_t gmres_redbuf = HIP_BUFFER_INIT;
 
   real hip_gmres_part2(void *w, void *v, void *h, void * mult, int *j, int *n) {
 	
@@ -61,17 +61,9 @@ extern "C" {
     const dim3 nblcks(((*n)+1024 - 1)/ 1024, 1, 1);
     const int nb = ((*n) + 1024 - 1)/ 1024;
     
-    if (gmres_bf1 != NULL && gmres_bf_len < nb) {
-      HIP_CHECK(hipHostFree(gmres_bf1));
-      HIP_CHECK(hipFree(gmres_bfd1));
-      gmres_bf1 = NULL;
-    }
-
-    if (gmres_bf1 == NULL){
-      HIP_CHECK(hipHostMalloc(&gmres_bf1, nb*sizeof(real)));
-      HIP_CHECK(hipMalloc(&gmres_bfd1, nb*sizeof(real)));
-      gmres_bf_len = nb;
-    }
+    hip_buffer_reserve(&gmres_redbuf, nb*sizeof(real));
+    real *gmres_bf1 = (real *) gmres_redbuf.host;
+    real *gmres_bfd1 = (real *) gmres_redbuf.dev;
      
     hipLaunchKernelGGL(HIP_KERNEL_NAME(gmres_part2_kernel<real>),
 		       nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,

--- a/src/krylov/bcknd/device/hip/pipecg_aux.hip
+++ b/src/krylov/bcknd/device/hip/pipecg_aux.hip
@@ -35,16 +35,15 @@
 #include <hip/hip_runtime.h>
 #include <device/device_config.h>
 #include <device/hip/check.h>
+#include <device/hip/buffer.h>
 #include "pipecg_kernel.h"
 
 /**
- * @todo Make sure that this gets deleted at some point...
+ * Reduction buffer, owned by the device layer and released on device
+ * teardown (hip_buffer_free_all in hip_finalize); the device side
+ * holds the three partial-reduction arrays back to back
  */
-real *buf = NULL;
-real *buf_d1 = NULL;
-real *buf_d2 = NULL;
-real *buf_d3 = NULL;
-int buf_len = 0;
+hip_buffer_t pipecg_buf = HIP_BUFFER_INIT;
 
 extern "C" {
   
@@ -72,21 +71,11 @@ extern "C" {
     const int nb = ((*n) + 1024 - 1)/ 1024;
     const hipStream_t stream = (hipStream_t) glb_cmd_queue;
 
-    if (buf != NULL && buf_len < nb) {
-      HIP_CHECK(hipHostFree(buf));
-      HIP_CHECK(hipFree(buf_d1));
-      HIP_CHECK(hipFree(buf_d2));
-      HIP_CHECK(hipFree(buf_d3));
-      buf = NULL;
-    }
-
-    if (buf == NULL){
-      HIP_CHECK(hipHostMalloc(&buf, nb*sizeof(real)));
-      HIP_CHECK(hipMalloc(&buf_d1, nb*sizeof(real)));
-      HIP_CHECK(hipMalloc(&buf_d2, nb*sizeof(real)));
-      HIP_CHECK(hipMalloc(&buf_d3, nb*sizeof(real)));
-      buf_len = nb;
-    }
+    hip_buffer_reserve(&pipecg_buf, 3*nb*sizeof(real));
+    real *buf = (real *) pipecg_buf.host;
+    real *buf_d1 = (real *) pipecg_buf.dev;
+    real *buf_d2 = buf_d1 + nb;
+    real *buf_d3 = buf_d1 + 2*nb;
      
     hipLaunchKernelGGL(HIP_KERNEL_NAME(pipecg_vecops_kernel<real>),
                        nblcks, nthrds, 0, stream,

--- a/src/math/bcknd/device/cuda/math.cu
+++ b/src/math/bcknd/device/cuda/math.cu
@@ -35,6 +35,7 @@
 #include "math_kernel.h"
 #include <device/device_config.h>
 #include <device/cuda/check.h>
+#include <device/cuda/buffer.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -701,59 +702,24 @@ extern "C" {
 
 
   /*
-   * Reduction buffer
+   * Reduction buffers, owned by the device layer and released
+   * on device teardown (cuda_buffer_free_all in cuda_finalize)
    */
-  int red_s = 0;
-  real * bufred = NULL;
-  void * bufred_d = NULL;
-  int red_xp_s = 0;
-  real_xp * bufred_xp = NULL;
-  void * bufred_xp_d = NULL;
+  cuda_buffer_t redbuf = CUDA_BUFFER_INIT_SYMM;
+  cuda_buffer_t redbuf_xp = CUDA_BUFFER_INIT_SYMM;
 
   /**
    *Checks and allocates a buffer of size nb*sizeof(real) for reductions
   */
   void cuda_redbuf_check_alloc(int nb) {
-    if ( nb >= red_s) {
-      red_s = nb+1;
-      if (bufred != NULL) {
-        CUDA_CHECK(cudaFreeHost(bufred));
-#ifdef HAVE_NVSHMEM
-        nvshmem_free(bufred_d);
-#else
-        CUDA_CHECK(cudaFree(bufred_d));
-#endif
-      }
-      CUDA_CHECK(cudaMallocHost(&bufred,red_s*sizeof(real)));
-#ifdef HAVE_NVSHMEM
-      bufred_d = (real *) nvshmem_malloc(red_s*sizeof(real));
-#else
-      CUDA_CHECK(cudaMalloc(&bufred_d, red_s*sizeof(real)));
-#endif
-    }
+    cuda_buffer_reserve(&redbuf, (nb + 1) * sizeof(real));
   }
 
   /**
    *Checks and allocates a buffer of size nb*sizeof(real_xp) for reductions
   */
   void cuda_redbuf_check_alloc_xp(int nb) {
-    if ( nb >= red_xp_s) {
-      red_xp_s = nb+1;
-      if (bufred_xp != NULL) {
-        CUDA_CHECK(cudaFreeHost(bufred_xp));
-#ifdef HAVE_NVSHMEM
-        nvshmem_free(bufred_xp_d);
-#else
-        CUDA_CHECK(cudaFree(bufred_xp_d));
-#endif
-      }
-      CUDA_CHECK(cudaMallocHost(&bufred_xp, red_xp_s*sizeof(real_xp)));
-#ifdef HAVE_NVSHMEM
-      bufred_xp_d = (real_xp *) nvshmem_malloc(red_xp_s*sizeof(real_xp));
-#else
-      CUDA_CHECK(cudaMalloc(&bufred_xp_d, red_xp_s*sizeof(real_xp)));
-#endif
-    }
+    cuda_buffer_reserve(&redbuf_xp, (nb + 1) * sizeof(real_xp));
   }
 
   /**
@@ -918,16 +884,16 @@ extern "C" {
     cuda_redbuf_check_alloc(nb);
 
     vlsc3_kernel<real><<<nblcks, nthrds, 0, stream>>>
-      ((real *) u, (real *) v, (real *) w, (real *) bufred_d, *n);
+      ((real *) u, (real *) v, (real *) w, (real *) redbuf.dev, *n);
     CUDA_CHECK(cudaGetLastError());
-    reduce_kernel<real><<<1, 1024, 0, stream>>> ((real *) bufred_d, nb);
+    reduce_kernel<real><<<1, 1024, 0, stream>>> ((real *) redbuf.dev, nb);
     CUDA_CHECK(cudaGetLastError());
 
-    CUDA_CHECK(cudaMemcpyAsync(bufred, bufred_d, sizeof(real),
+    CUDA_CHECK(cudaMemcpyAsync(((real *) redbuf.host), redbuf.dev, sizeof(real),
                                cudaMemcpyDeviceToHost, stream));
     cudaStreamSynchronize(stream);
 
-    return bufred[0];
+    return ((real *) redbuf.host)[0];
   }
 
 
@@ -947,17 +913,17 @@ extern "C" {
 
     if ( *n > 0) {
       glsc3_kernel<real, real_xp><<<nblcks, nthrds, 0, stream>>>
-        ((real *) a, (real *) b, (real *) c, (real_xp *) bufred_xp_d, *n);
+        ((real *) a, (real *) b, (real *) c, (real_xp *) redbuf_xp.dev, *n);
       CUDA_CHECK(cudaGetLastError());
-      reduce_kernel<real_xp><<<1, 1024, 0, stream>>> ((real_xp *) bufred_xp_d, nb);
+      reduce_kernel<real_xp><<<1, 1024, 0, stream>>> ((real_xp *) redbuf_xp.dev, nb);
       CUDA_CHECK(cudaGetLastError());
     }
     else {
-      CUDA_CHECK(cudaMemsetAsync(bufred_xp_d, 0, red_xp_s * sizeof(real_xp), stream));
+      CUDA_CHECK(cudaMemsetAsync(redbuf_xp.dev, 0, redbuf_xp.size, stream));
     }
-    cuda_global_reduce_add_xp(bufred_xp, bufred_xp_d, 1, stream);
+    cuda_global_reduce_add_xp(((real_xp *) redbuf_xp.host), redbuf_xp.dev, 1, stream);
 
-    return bufred_xp[0];
+    return ((real_xp *) redbuf_xp.host)[0];
   }
 
   /**
@@ -980,16 +946,16 @@ extern "C" {
     if ( *n > 0) {
       glsc3_many_kernel<real, real_xp><<<nblcks, nthrds, 0, stream>>>
         ((const real *) w, (const real **) v,
-         (const real *)mult, (real_xp *)bufred_xp_d, *j, *n);
+         (const real *)mult, (real_xp *)redbuf_xp.dev, *j, *n);
       CUDA_CHECK(cudaGetLastError());
       glsc3_reduce_kernel<real_xp>
-        <<<(*j), 1024, 0, stream>>>((real_xp *) bufred_xp_d, nb, *j);
+        <<<(*j), 1024, 0, stream>>>((real_xp *) redbuf_xp.dev, nb, *j);
       CUDA_CHECK(cudaGetLastError());
     }
     else {
-      CUDA_CHECK(cudaMemsetAsync(bufred_xp_d, 0, red_xp_s * sizeof(real_xp), stream));
+      CUDA_CHECK(cudaMemsetAsync(redbuf_xp.dev, 0, redbuf_xp.size, stream));
     }
-    cuda_global_reduce_add_xp(h, bufred_xp_d, (*j), stream);
+    cuda_global_reduce_add_xp(h, redbuf_xp.dev, (*j), stream);
   }
 
   /**
@@ -1008,17 +974,17 @@ extern "C" {
       glsc2_kernel<real, real_xp>
         <<<nblcks, nthrds, 0, stream>>>((real *) a,
                                         (real *) b,
-                                        (real_xp *) bufred_xp_d, *n);
+                                        (real_xp *) redbuf_xp.dev, *n);
       CUDA_CHECK(cudaGetLastError());
-      reduce_kernel<real_xp><<<1, 1024, 0, stream>>> ((real_xp *) bufred_xp_d, nb);
+      reduce_kernel<real_xp><<<1, 1024, 0, stream>>> ((real_xp *) redbuf_xp.dev, nb);
       CUDA_CHECK(cudaGetLastError());
     }
     else {
-      CUDA_CHECK(cudaMemsetAsync(bufred_xp_d, 0, red_xp_s * sizeof(real_xp), stream));
+      CUDA_CHECK(cudaMemsetAsync(redbuf_xp.dev, 0, redbuf_xp.size, stream));
     }
-    cuda_global_reduce_add_xp(bufred_xp, bufred_xp_d, 1, stream);
+    cuda_global_reduce_add_xp(((real_xp *) redbuf_xp.host), redbuf_xp.dev, 1, stream);
 
-    return bufred_xp[0];
+    return ((real_xp *) redbuf_xp.host)[0];
   }
 
   /**
@@ -1037,17 +1003,17 @@ extern "C" {
       glsubnorm2_kernel<real, real_xp>
         <<<nblcks, nthrds, 0, stream>>>((real *) a,
                                         (real *) b,
-                                        (real_xp *) bufred_xp_d, *n);
+                                        (real_xp *) redbuf_xp.dev, *n);
       CUDA_CHECK(cudaGetLastError());
-      reduce_kernel<real_xp><<<1, 1024, 0, stream>>> ((real_xp *) bufred_xp_d, nb);
+      reduce_kernel<real_xp><<<1, 1024, 0, stream>>> ((real_xp *) redbuf_xp.dev, nb);
       CUDA_CHECK(cudaGetLastError());
     }
     else {
-      CUDA_CHECK(cudaMemsetAsync(bufred_xp_d, 0, red_xp_s * sizeof(real_xp), stream));
+      CUDA_CHECK(cudaMemsetAsync(redbuf_xp.dev, 0, redbuf_xp.size, stream));
     }
-    cuda_global_reduce_add_xp(bufred_xp, bufred_xp_d, 1, stream);
+    cuda_global_reduce_add_xp(((real_xp *) redbuf_xp.host), redbuf_xp.dev, 1, stream);
 
-    return bufred_xp[0];
+    return ((real_xp *) redbuf_xp.host)[0];
   }
 
    /**
@@ -1063,18 +1029,18 @@ extern "C" {
     if ( *n > 0) {
       glsum_kernel<real, real_xp>
         <<<nblcks, nthrds, 0, stream>>>((real *) a,
-                                        (real_xp *) bufred_xp_d, *n);
+                                        (real_xp *) redbuf_xp.dev, *n);
       CUDA_CHECK(cudaGetLastError());
-      reduce_kernel<real_xp><<<1, 1024, 0, stream>>> ((real_xp *) bufred_xp_d, nb);
+      reduce_kernel<real_xp><<<1, 1024, 0, stream>>> ((real_xp *) redbuf_xp.dev, nb);
       CUDA_CHECK(cudaGetLastError());
     }
     else {
-      CUDA_CHECK(cudaMemsetAsync(bufred_xp_d, 0, red_xp_s * sizeof(real_xp), stream));
+      CUDA_CHECK(cudaMemsetAsync(redbuf_xp.dev, 0, redbuf_xp.size, stream));
     }
 
-    cuda_global_reduce_add_xp(bufred_xp, bufred_xp_d, 1, stream);
+    cuda_global_reduce_add_xp(((real_xp *) redbuf_xp.host), redbuf_xp.dev, 1, stream);
 
-    return bufred_xp[0];
+    return ((real_xp *) redbuf_xp.host)[0];
   }
 
   /**
@@ -1090,19 +1056,20 @@ extern "C" {
     if ( *n > 0) {
       glmax_kernel<real>
         <<<nblcks, nthrds, 0, stream>>>((real *) a, *ninf,
-                                        (real *) bufred_d, *n);
+                                        (real *) redbuf.dev, *n);
       CUDA_CHECK(cudaGetLastError());
-      reduce_max_kernel<real><<<1, 1024, 0, stream>>> ((real *) bufred_d,
+      reduce_max_kernel<real><<<1, 1024, 0, stream>>> ((real *) redbuf.dev,
                                                         *ninf, nb);
       CUDA_CHECK(cudaGetLastError());
     }
     else {
-      cuda_rzero(bufred_d, &red_s, stream);
+      int nel = (int) (redbuf.size / sizeof(real));
+      cuda_rzero(redbuf.dev, &nel, stream);
     }
 
-    cuda_global_reduce_max(bufred, bufred_d, 1, stream);
+    cuda_global_reduce_max(((real *) redbuf.host), redbuf.dev, 1, stream);
 
-    return bufred[0];
+    return ((real *) redbuf.host)[0];
   }
 
   /**
@@ -1118,19 +1085,20 @@ extern "C" {
     if ( *n > 0) {
       glmin_kernel<real>
         <<<nblcks, nthrds, 0, stream>>>((real *) a, *pinf,
-                                        (real *) bufred_d, *n);
+                                        (real *) redbuf.dev, *n);
       CUDA_CHECK(cudaGetLastError());
-      reduce_min_kernel<real><<<1, 1024, 0, stream>>> ((real *) bufred_d,
+      reduce_min_kernel<real><<<1, 1024, 0, stream>>> ((real *) redbuf.dev,
                                                         *pinf, nb);
       CUDA_CHECK(cudaGetLastError());
     }
     else {
-      cuda_rzero(bufred_d, &red_s, stream);
+      int nel = (int) (redbuf.size / sizeof(real));
+      cuda_rzero(redbuf.dev, &nel, stream);
     }
 
-    cuda_global_reduce_min(bufred, bufred_d, 1, stream);
+    cuda_global_reduce_min(((real *) redbuf.host), redbuf.dev, 1, stream);
 
-    return bufred[0];
+    return ((real *) redbuf.host)[0];
   }
 
   /**

--- a/src/math/bcknd/device/cuda/opr_cfl.cu
+++ b/src/math/bcknd/device/cuda/opr_cfl.cu
@@ -36,6 +36,7 @@
 #include "cfl_kernel.h"
 #include <device/device_config.h>
 #include <device/cuda/check.h>
+#include <device/cuda/buffer.h>
 
 
 #ifdef HAVE_NVSHMEM
@@ -54,17 +55,19 @@ extern "C" {
 #endif
 
   /**
-   * @todo Make sure that this gets deleted at some point...
+   * Device-only work buffer for the CFL reduction, owned by the
+   * device layer and released on device teardown
+   * (cuda_buffer_free_all in cuda_finalize)
    */
-  void *cfl_d = NULL;
+  cuda_buffer_t cfl_buf = CUDA_BUFFER_INIT_DEV;
 
 #ifdef HAVE_NVSHMEM
   /**
    * Symmetric one-element buffer for the NVSHMEM reduction; the work
-   * buffer cfl_d cannot live on the symmetric heap since its size
+   * buffer cfl_buf cannot live on the symmetric heap since its size
    * (nel) differs between PEs
    */
-  void *cfl_red_d = NULL;
+  cuda_buffer_t cfl_red_buf = CUDA_BUFFER_INIT_SYMM;
 #endif
 
   /**
@@ -81,12 +84,12 @@ extern "C" {
     const dim3 nblcks((*nel), 1, 1);
     const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
-    if (cfl_d == NULL) {
-      CUDA_CHECK(cudaMalloc(&cfl_d, (*nel) * sizeof(real)));
+    cuda_buffer_reserve(&cfl_buf, (*nel) * sizeof(real));
+    real *cfl_d = (real *) cfl_buf.dev;
 #ifdef HAVE_NVSHMEM
-      cfl_red_d = (real *) nvshmem_malloc(sizeof(real));
+    cuda_buffer_reserve(&cfl_red_buf, sizeof(real));
+    real *cfl_red_d = (real *) cfl_red_buf.dev;
 #endif
-    }
 
 #define CASE(LX)                                                                \
     case LX:                                                                    \

--- a/src/math/bcknd/device/hip/math.hip
+++ b/src/math/bcknd/device/hip/math.hip
@@ -939,10 +939,10 @@ extern "C" {
     if( *n > 0) {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc2_kernel<real, real_xp>),
                          nblcks, nthrds, 0, stream,
-                         (real *) a, (real *) b, redbuf_xp.dev, *n);
+                         (real *) a, (real *) b, (real_xp *) redbuf_xp.dev, *n);
       HIP_CHECK(hipGetLastError());
       hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real_xp>),
-                         1, 1024, 0, stream, (real_xp * ) redbuf_xp.dev, nb);
+                         1, 1024, 0, stream, (real_xp *) redbuf_xp.dev, nb);
       HIP_CHECK(hipGetLastError());
     }
     else {

--- a/src/math/bcknd/device/hip/math.hip
+++ b/src/math/bcknd/device/hip/math.hip
@@ -35,6 +35,7 @@
 #include <hip/hip_runtime.h>
 #include <device/device_config.h>
 #include <device/hip/check.h>
+#include <device/hip/buffer.h>
 #include "math_kernel.h"
 
 extern "C" {
@@ -726,38 +727,18 @@ extern "C" {
 
 
   /*
-   * Reduction buffer
+   * Reduction buffers, owned by the device layer and released
+   * on device teardown (hip_buffer_free_all in hip_finalize)
    */
-  int red_s = 0;
-  real * bufred = NULL;
-  real * bufred_d = NULL;
-  int red_xp_s = 0;
-  real_xp * bufred_xp = NULL;
-  real_xp * bufred_xp_d = NULL;
+  hip_buffer_t redbuf = HIP_BUFFER_INIT;
+  hip_buffer_t redbuf_xp = HIP_BUFFER_INIT;
 
   void hip_redbuf_check_alloc(int nb) {
-    if ( nb >= red_s) {
-      red_s = nb+1;
-      if (bufred != NULL) {
-        HIP_CHECK(hipHostFree(bufred));
-        HIP_CHECK(hipFree(bufred_d));
-      }
-      HIP_CHECK(hipHostMalloc(&bufred,red_s*sizeof(real),hipHostMallocDefault));
-      HIP_CHECK(hipMalloc(&bufred_d, red_s*sizeof(real)));
-    }
+    hip_buffer_reserve(&redbuf, (nb + 1) * sizeof(real));
   }
 
   void hip_redbuf_check_alloc_xp(int nb) {
-    if ( nb >= red_xp_s) {
-      red_xp_s = nb+1;
-      if (bufred_xp != NULL) {
-        HIP_CHECK(hipHostFree(bufred_xp));
-        HIP_CHECK(hipFree(bufred_xp_d));
-      }
-      HIP_CHECK(hipHostMalloc(&bufred_xp, red_xp_s*sizeof(real_xp),
-                              hipHostMallocDefault));
-      HIP_CHECK(hipMalloc(&bufred_xp_d, red_xp_s*sizeof(real_xp)));
-    }
+    hip_buffer_reserve(&redbuf_xp, (nb + 1) * sizeof(real_xp));
   }
 
   /**
@@ -861,17 +842,17 @@ extern "C" {
     hipLaunchKernelGGL(HIP_KERNEL_NAME(vlsc3_kernel<real>),
                        nblcks, nthrds, 0, stream,
                        (real *) u, (real *) v,
-                       (real *) w, bufred_d, *n);
+                       (real *) w, redbuf.dev, *n);
     HIP_CHECK(hipGetLastError());
     hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real>),
-                       1, 1024, 0, stream, bufred_d, nb);
+                       1, 1024, 0, stream, redbuf.dev, nb);
     HIP_CHECK(hipGetLastError());
 
-    HIP_CHECK(hipMemcpyAsync(bufred, bufred_d, sizeof(real),
+    HIP_CHECK(hipMemcpyAsync(((real *) redbuf.host), redbuf.dev, sizeof(real),
                              hipMemcpyDeviceToHost, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
 
-    return bufred[0];
+    return ((real *) redbuf.host)[0];
   }
 
   /**
@@ -890,18 +871,18 @@ extern "C" {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_kernel<real, real_xp>),
                          nblcks, nthrds, 0, stream,
                          (real *) a, (real *) b,
-                         (real *) c, bufred_xp_d, *n);
+                         (real *) c, redbuf_xp.dev, *n);
       HIP_CHECK(hipGetLastError());
       hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real_xp>),
-                         1, 1024, 0, stream, bufred_xp_d, nb);
+                         1, 1024, 0, stream, redbuf_xp.dev, nb);
       HIP_CHECK(hipGetLastError());
     }
     else {
-      HIP_CHECK(hipMemsetAsync(bufred_xp_d, 0, red_xp_s * sizeof(real_xp), stream));
+      HIP_CHECK(hipMemsetAsync(redbuf_xp.dev, 0, redbuf_xp.size, stream));
     }
-    hip_global_reduce_add_xp(bufred_xp, bufred_xp_d, 1, stream);
+    hip_global_reduce_add_xp(((real_xp *) redbuf_xp.host), redbuf_xp.dev, 1, stream);
 
-    return bufred_xp[0];
+    return ((real_xp *) redbuf_xp.host)[0];
   }
 
   /**
@@ -927,18 +908,18 @@ extern "C" {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_many_kernel<real, real_xp>),
                          nblcks, nthrds, 0, stream,
                          (const real *) w, (const real **) v,
-                         (const real *)mult, bufred_xp_d, *j, *n);
+                         (const real *)mult, redbuf_xp.dev, *j, *n);
       HIP_CHECK(hipGetLastError());
 
       hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_reduce_kernel<real_xp>),
                          nblcks_red, nthrds_red, 0, stream,
-                         bufred_xp_d, nb, *j);
+                         redbuf_xp.dev, nb, *j);
       HIP_CHECK(hipGetLastError());
     }
     else {
-      HIP_CHECK(hipMemsetAsync(bufred_xp_d, 0, red_xp_s * sizeof(real_xp), stream));
+      HIP_CHECK(hipMemsetAsync(redbuf_xp.dev, 0, redbuf_xp.size, stream));
     }
-    hip_global_reduce_add_xp(h, bufred_xp_d, (*j), stream);
+    hip_global_reduce_add_xp(h, redbuf_xp.dev, (*j), stream);
   }
 
   /**
@@ -957,18 +938,18 @@ extern "C" {
     if( *n > 0) {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc2_kernel<real, real_xp>),
                          nblcks, nthrds, 0, stream,
-                         (real *) a, (real *) b, bufred_xp_d, *n);
+                         (real *) a, (real *) b, redbuf_xp.dev, *n);
       HIP_CHECK(hipGetLastError());
       hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real_xp>),
-                         1, 1024, 0, stream, bufred_xp_d, nb);
+                         1, 1024, 0, stream, redbuf_xp.dev, nb);
       HIP_CHECK(hipGetLastError());
     }
     else {
-      HIP_CHECK(hipMemsetAsync(bufred_xp_d, 0, red_xp_s * sizeof(real_xp), stream));
+      HIP_CHECK(hipMemsetAsync(redbuf_xp.dev, 0, redbuf_xp.size, stream));
     }
-    hip_global_reduce_add_xp(bufred_xp, bufred_xp_d, 1, stream);
+    hip_global_reduce_add_xp(((real_xp *) redbuf_xp.host), redbuf_xp.dev, 1, stream);
 
-    return bufred_xp[0];
+    return ((real_xp *) redbuf_xp.host)[0];
   }
 
   /**
@@ -986,18 +967,18 @@ extern "C" {
       if (*n > 0) {
         hipLaunchKernelGGL(HIP_KERNEL_NAME(glsubnorm2_kernel<real, real_xp>),
                            nblcks, nthrds, 0, stream,
-                           (real*)a, (real*)b, bufred_xp_d, *n);
+                           (real*)a, (real*)b, redbuf_xp.dev, *n);
         HIP_CHECK(hipGetLastError());
         hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real_xp>),
-                           1, 1024, 0, stream, bufred_xp_d, nb);
+                           1, 1024, 0, stream, redbuf_xp.dev, nb);
         HIP_CHECK(hipGetLastError());
       }
       else {
-        HIP_CHECK(hipMemsetAsync(bufred_xp_d, 0, red_xp_s * sizeof(real_xp), stream));
+        HIP_CHECK(hipMemsetAsync(redbuf_xp.dev, 0, redbuf_xp.size, stream));
       }
-      hip_global_reduce_add_xp(bufred_xp, bufred_xp_d, 1, stream);
+      hip_global_reduce_add_xp(((real_xp *) redbuf_xp.host), redbuf_xp.dev, 1, stream);
 
-      return bufred_xp[0];
+      return ((real_xp *) redbuf_xp.host)[0];
   }
 
   /**
@@ -1013,19 +994,19 @@ extern "C" {
     if( *n > 0) {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(glsum_kernel<real, real_xp>),
                          nblcks, nthrds, 0, stream,
-                         (real *) a, bufred_xp_d, *n);
+                         (real *) a, redbuf_xp.dev, *n);
       HIP_CHECK(hipGetLastError());
       hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real_xp>),
-                         1, 1024, 0, stream, bufred_xp_d, nb);
+                         1, 1024, 0, stream, redbuf_xp.dev, nb);
       HIP_CHECK(hipGetLastError());
     }
     else {
-      HIP_CHECK(hipMemsetAsync(bufred_xp_d, 0, red_xp_s * sizeof(real_xp), stream));
+      HIP_CHECK(hipMemsetAsync(redbuf_xp.dev, 0, redbuf_xp.size, stream));
     }
 
-    hip_global_reduce_add_xp(bufred_xp, bufred_xp_d, 1, stream);
+    hip_global_reduce_add_xp(((real_xp *) redbuf_xp.host), redbuf_xp.dev, 1, stream);
 
-    return bufred_xp[0];
+    return ((real_xp *) redbuf_xp.host)[0];
   }
 
 
@@ -1042,19 +1023,20 @@ extern "C" {
     if( *n > 0) {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(glmax_kernel<real>),
                          nblcks, nthrds, 0, stream,
-                         (real *) a, *ninf, bufred_d, *n);
+                         (real *) a, *ninf, redbuf.dev, *n);
       HIP_CHECK(hipGetLastError());
       hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_max_kernel<real>),
-                         1, 1024, 0, stream, bufred_d, *ninf, nb);
+                         1, 1024, 0, stream, redbuf.dev, *ninf, nb);
       HIP_CHECK(hipGetLastError());
     }
     else {
-      hip_rzero(bufred_d, &red_s, stream);
+      int nel = (int) (redbuf.size / sizeof(real));
+      hip_rzero(redbuf.dev, &nel, stream);
     }
 
-    hip_global_reduce_max(bufred, bufred_d, 1, stream);
+    hip_global_reduce_max(((real *) redbuf.host), redbuf.dev, 1, stream);
 
-    return bufred[0];
+    return ((real *) redbuf.host)[0];
   }
 
   /**
@@ -1070,19 +1052,20 @@ extern "C" {
     if( *n > 0) {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(glmin_kernel<real>),
                          nblcks, nthrds, 0, stream,
-                         (real *) a, *pinf, bufred_d, *n);
+                         (real *) a, *pinf, redbuf.dev, *n);
       HIP_CHECK(hipGetLastError());
       hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_min_kernel<real>),
-                         1, 1024, 0, stream, bufred_d, *pinf, nb);
+                         1, 1024, 0, stream, redbuf.dev, *pinf, nb);
       HIP_CHECK(hipGetLastError());
     }
     else {
-      hip_rzero(bufred_d, &red_s, stream);
+      int nel = (int) (redbuf.size / sizeof(real));
+      hip_rzero(redbuf.dev, &nel, stream);
     }
 
-    hip_global_reduce_min(bufred, bufred_d, 1, stream);
+    hip_global_reduce_min(((real *) redbuf.host), redbuf.dev, 1, stream);
 
-    return bufred[0];
+    return ((real *) redbuf.host)[0];
   }
 
   /**

--- a/src/math/bcknd/device/hip/math.hip
+++ b/src/math/bcknd/device/hip/math.hip
@@ -842,14 +842,14 @@ extern "C" {
     hipLaunchKernelGGL(HIP_KERNEL_NAME(vlsc3_kernel<real>),
                        nblcks, nthrds, 0, stream,
                        (real *) u, (real *) v,
-                       (real *) w, redbuf.dev, *n);
+                       (real *) w, (real *) redbuf.dev, *n);
     HIP_CHECK(hipGetLastError());
     hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real>),
-                       1, 1024, 0, stream, redbuf.dev, nb);
+                       1, 1024, 0, stream, (real *) redbuf.dev, nb);
     HIP_CHECK(hipGetLastError());
 
-    HIP_CHECK(hipMemcpyAsync(((real *) redbuf.host), redbuf.dev, sizeof(real),
-                             hipMemcpyDeviceToHost, stream));
+    HIP_CHECK(hipMemcpyAsync(((real *) redbuf.host), (real *) redbuf.dev,
+                             sizeof(real), hipMemcpyDeviceToHost, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
 
     return ((real *) redbuf.host)[0];
@@ -871,16 +871,17 @@ extern "C" {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_kernel<real, real_xp>),
                          nblcks, nthrds, 0, stream,
                          (real *) a, (real *) b,
-                         (real *) c, redbuf_xp.dev, *n);
+                         (real *) c, (real_xp *) redbuf_xp.dev, *n);
       HIP_CHECK(hipGetLastError());
       hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real_xp>),
-                         1, 1024, 0, stream, redbuf_xp.dev, nb);
+                         1, 1024, 0, stream, (real_xp * ) redbuf_xp.dev, nb);
       HIP_CHECK(hipGetLastError());
     }
     else {
       HIP_CHECK(hipMemsetAsync(redbuf_xp.dev, 0, redbuf_xp.size, stream));
     }
-    hip_global_reduce_add_xp(((real_xp *) redbuf_xp.host), redbuf_xp.dev, 1, stream);
+    hip_global_reduce_add_xp(((real_xp *) redbuf_xp.host),
+                             (real_xp *) redbuf_xp.dev, 1, stream);
 
     return ((real_xp *) redbuf_xp.host)[0];
   }
@@ -908,12 +909,12 @@ extern "C" {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_many_kernel<real, real_xp>),
                          nblcks, nthrds, 0, stream,
                          (const real *) w, (const real **) v,
-                         (const real *)mult, redbuf_xp.dev, *j, *n);
+                         (const real *)mult, (real_xp *) redbuf_xp.dev, *j, *n);
       HIP_CHECK(hipGetLastError());
 
       hipLaunchKernelGGL(HIP_KERNEL_NAME(glsc3_reduce_kernel<real_xp>),
                          nblcks_red, nthrds_red, 0, stream,
-                         redbuf_xp.dev, nb, *j);
+                         (real_xp *) redbuf_xp.dev, nb, *j);
       HIP_CHECK(hipGetLastError());
     }
     else {
@@ -941,13 +942,14 @@ extern "C" {
                          (real *) a, (real *) b, redbuf_xp.dev, *n);
       HIP_CHECK(hipGetLastError());
       hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real_xp>),
-                         1, 1024, 0, stream, redbuf_xp.dev, nb);
+                         1, 1024, 0, stream, (real_xp * ) redbuf_xp.dev, nb);
       HIP_CHECK(hipGetLastError());
     }
     else {
       HIP_CHECK(hipMemsetAsync(redbuf_xp.dev, 0, redbuf_xp.size, stream));
     }
-    hip_global_reduce_add_xp(((real_xp *) redbuf_xp.host), redbuf_xp.dev, 1, stream);
+    hip_global_reduce_add_xp(((real_xp *) redbuf_xp.host),
+                             (real_xp *) redbuf_xp.dev, 1, stream);
 
     return ((real_xp *) redbuf_xp.host)[0];
   }
@@ -967,16 +969,18 @@ extern "C" {
       if (*n > 0) {
         hipLaunchKernelGGL(HIP_KERNEL_NAME(glsubnorm2_kernel<real, real_xp>),
                            nblcks, nthrds, 0, stream,
-                           (real*)a, (real*)b, redbuf_xp.dev, *n);
+                           (real *) a, (real *) b,
+                           (real_xp *) redbuf_xp.dev, *n);
         HIP_CHECK(hipGetLastError());
         hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real_xp>),
-                           1, 1024, 0, stream, redbuf_xp.dev, nb);
+                           1, 1024, 0, stream, (real_xp *) redbuf_xp.dev, nb);
         HIP_CHECK(hipGetLastError());
       }
       else {
         HIP_CHECK(hipMemsetAsync(redbuf_xp.dev, 0, redbuf_xp.size, stream));
       }
-      hip_global_reduce_add_xp(((real_xp *) redbuf_xp.host), redbuf_xp.dev, 1, stream);
+      hip_global_reduce_add_xp(((real_xp *) redbuf_xp.host),
+                               (real_xp *) redbuf_xp.dev, 1, stream);
 
       return ((real_xp *) redbuf_xp.host)[0];
   }
@@ -994,17 +998,18 @@ extern "C" {
     if( *n > 0) {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(glsum_kernel<real, real_xp>),
                          nblcks, nthrds, 0, stream,
-                         (real *) a, redbuf_xp.dev, *n);
+                         (real *) a, (real_xp * ) redbuf_xp.dev, *n);
       HIP_CHECK(hipGetLastError());
       hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_kernel<real_xp>),
-                         1, 1024, 0, stream, redbuf_xp.dev, nb);
+                         1, 1024, 0, stream, (real_xp *) redbuf_xp.dev, nb);
       HIP_CHECK(hipGetLastError());
     }
     else {
       HIP_CHECK(hipMemsetAsync(redbuf_xp.dev, 0, redbuf_xp.size, stream));
     }
 
-    hip_global_reduce_add_xp(((real_xp *) redbuf_xp.host), redbuf_xp.dev, 1, stream);
+    hip_global_reduce_add_xp(((real_xp *) redbuf_xp.host),
+                             redbuf_xp.dev, 1, stream);
 
     return ((real_xp *) redbuf_xp.host)[0];
   }
@@ -1023,10 +1028,10 @@ extern "C" {
     if( *n > 0) {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(glmax_kernel<real>),
                          nblcks, nthrds, 0, stream,
-                         (real *) a, *ninf, redbuf.dev, *n);
+                         (real *) a, *ninf, (real *) redbuf.dev, *n);
       HIP_CHECK(hipGetLastError());
       hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_max_kernel<real>),
-                         1, 1024, 0, stream, redbuf.dev, *ninf, nb);
+                         1, 1024, 0, stream, (real *) redbuf.dev, *ninf, nb);
       HIP_CHECK(hipGetLastError());
     }
     else {
@@ -1034,7 +1039,8 @@ extern "C" {
       hip_rzero(redbuf.dev, &nel, stream);
     }
 
-    hip_global_reduce_max(((real *) redbuf.host), redbuf.dev, 1, stream);
+    hip_global_reduce_max(((real *) redbuf.host),
+                          (real *) redbuf.dev, 1, stream);
 
     return ((real *) redbuf.host)[0];
   }
@@ -1052,10 +1058,10 @@ extern "C" {
     if( *n > 0) {
       hipLaunchKernelGGL(HIP_KERNEL_NAME(glmin_kernel<real>),
                          nblcks, nthrds, 0, stream,
-                         (real *) a, *pinf, redbuf.dev, *n);
+                         (real *) a, *pinf, (real *) redbuf.dev, *n);
       HIP_CHECK(hipGetLastError());
       hipLaunchKernelGGL(HIP_KERNEL_NAME(reduce_min_kernel<real>),
-                         1, 1024, 0, stream, redbuf.dev, *pinf, nb);
+                         1, 1024, 0, stream, (real *) redbuf.dev, *pinf, nb);
       HIP_CHECK(hipGetLastError());
     }
     else {
@@ -1063,7 +1069,8 @@ extern "C" {
       hip_rzero(redbuf.dev, &nel, stream);
     }
 
-    hip_global_reduce_min(((real *) redbuf.host), redbuf.dev, 1, stream);
+    hip_global_reduce_min(((real *) redbuf.host),
+                          (real *) redbuf.dev, 1, stream);
 
     return ((real *) redbuf.host)[0];
   }

--- a/src/math/bcknd/device/hip/math_kernel.h
+++ b/src/math/bcknd/device/hip/math_kernel.h
@@ -1,7 +1,7 @@
 #ifndef __MATH_MATH_KERNEL_H__
 #define __MATH_MATH_KERNEL_H__
 /*
- Copyright (c) 2021-2023, The Neko Authors
+ Copyright (c) 2021-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/src/math/bcknd/device/hip/opr_cfl.hip
+++ b/src/math/bcknd/device/hip/opr_cfl.hip
@@ -36,6 +36,7 @@
 #include <hip/hip_runtime.h>
 #include <device/device_config.h>
 #include <device/hip/check.h>
+#include <device/hip/buffer.h>
 #include "cfl_kernel.h"
 
 extern "C" {
@@ -49,10 +50,12 @@ extern "C" {
 #endif
 
   /**
-   * @todo Make sure that this gets deleted at some point...
+   * Device-only work buffer for the CFL reduction, owned by the
+   * device layer and released on device teardown
+   * (hip_buffer_free_all in hip_finalize)
    */
-  real *cfl_d = NULL;
-  
+  hip_buffer_t cfl_buf = HIP_BUFFER_INIT_DEV;
+
   /** 
    * Fortran wrapper for device hip CFL
    */
@@ -66,9 +69,8 @@ extern "C" {
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks((*nel), 1, 1);
   
-    if (cfl_d == NULL) {
-      HIP_CHECK(hipMalloc(&cfl_d, (*nel) * sizeof(real)));
-    }
+    hip_buffer_reserve(&cfl_buf, (*nel) * sizeof(real));
+    real *cfl_d = (real *) cfl_buf.dev;
 
 #define CASE(LX)                                                                \
     case LX:                                                                    \

--- a/src/math/bcknd/device/opencl/math.c
+++ b/src/math/bcknd/device/opencl/math.c
@@ -44,6 +44,7 @@
 #include <device/device_config.h>
 #include <device/opencl/jit.h>
 #include <device/opencl/prgm_lib.h>
+#include <device/opencl/buffer.h>
 #include <device/opencl/check.h>
 
 #include "math_kernel.cl.h"
@@ -1298,13 +1299,11 @@ void opencl_vcross(void *u1, void *u2, void *u3,
 
 }
 
-/** @todo cleanup this mess */
-int red_s = 0;
-real *bufred = NULL;
-cl_mem bufred_d = NULL;
-int red_xp_s = 0;
-real_xp *bufred_xp = NULL;
-cl_mem bufred_xp_d = NULL;
+/*
+ * Reduction buffer, owned by the device layer and released
+ * on device teardown (opencl_buffer_free_all in opencl_finalize)
+ */
+opencl_buffer_t redbuf_xp = OPENCL_BUFFER_INIT;
 
 /**
  * Fortran wrapper glsc3
@@ -1327,18 +1326,7 @@ real_xp opencl_glsc3(void *a, void *b, void *c, int *n,
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  if (nb > red_xp_s) {
-    red_xp_s = nb;
-    if (bufred_xp != NULL) {
-      free(bufred_xp);
-      CL_CHECK(clReleaseMemObject(bufred_xp_d));
-    }
-    bufred_xp = (real_xp *) malloc(nb * sizeof(real_xp));
-
-    bufred_xp_d = clCreateBuffer(glb_ctx, CL_MEM_READ_WRITE,
-                                 nb * sizeof(real_xp), NULL, &err);
-    CL_CHECK(err);
-  }
+  opencl_buffer_reserve(&redbuf_xp, nb * sizeof(real_xp));
 
   cl_kernel kernel = clCreateKernel(math_program, "glsc3_kernel", &err);
   CL_CHECK(err);
@@ -1346,20 +1334,20 @@ real_xp opencl_glsc3(void *a, void *b, void *c, int *n,
   CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &a));
   CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &b));
   CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &c));
-  CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &bufred_xp_d));
+  CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &redbuf_xp.dev));
   CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int), n));
 
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, &kern_wait));
 
-  CL_CHECK(clEnqueueReadBuffer(cmd_queue, bufred_xp_d, CL_TRUE, 0,
-                               nb * sizeof(real_xp), bufred_xp, 1,
+  CL_CHECK(clEnqueueReadBuffer(cmd_queue, redbuf_xp.dev, CL_TRUE, 0,
+                               nb * sizeof(real_xp), ((real_xp *) redbuf_xp.host), 1,
                                &kern_wait, NULL));
 
   real_xp res = 0.0;
   for (i = 0; i < nb; i++) {
-    res += bufred_xp[i];
+    res += ((real_xp *) redbuf_xp.host)[i];
   }
 
   CL_CHECK(clReleaseEvent(kern_wait));
@@ -1398,18 +1386,7 @@ void opencl_glsc3_many(real_xp *h, void * w, void *v, void *mult, int *j,
   const size_t local_item_size[2] = {nt, pow2};
   const size_t global_item_size[2] = {nb * nt, pow2};
 
-  if ((*j) * nb > red_xp_s) {
-    red_xp_s = (*j) * nb;
-    if (bufred_xp != NULL) {
-      free(bufred_xp);
-      CL_CHECK(clReleaseMemObject(bufred_xp_d));
-    }
-    bufred_xp = (real_xp *) malloc((*j) * nb * sizeof(real_xp));
-
-    bufred_xp_d = clCreateBuffer(glb_ctx, CL_MEM_READ_WRITE,
-                                 (*j) * nb * sizeof(real_xp), NULL, &err);
-    CL_CHECK(err);
-  }
+  opencl_buffer_reserve(&redbuf_xp, (*j) * nb * sizeof(real_xp));
 
   cl_kernel kernel = clCreateKernel(math_program, "glsc3_many_kernel", &err);
   CL_CHECK(err);
@@ -1417,7 +1394,7 @@ void opencl_glsc3_many(real_xp *h, void * w, void *v, void *mult, int *j,
   CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &w));
   CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &v));
   CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &mult));
-  CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &bufred_xp_d));
+  CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &redbuf_xp.dev));
   CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int), j));
   CL_CHECK(clSetKernelArg(kernel, 5, sizeof(int), n));
 
@@ -1425,9 +1402,9 @@ void opencl_glsc3_many(real_xp *h, void * w, void *v, void *mult, int *j,
                                   global_item_size, local_item_size,
                                   0, NULL, &kern_wait));
 
-  CL_CHECK(clEnqueueReadBuffer(cmd_queue, bufred_xp_d, CL_TRUE, 0,
+  CL_CHECK(clEnqueueReadBuffer(cmd_queue, redbuf_xp.dev, CL_TRUE, 0,
                                (*j) * nb * sizeof(real_xp),
-                               bufred_xp, 1, &kern_wait, NULL));
+                               ((real_xp *) redbuf_xp.host), 1, &kern_wait, NULL));
 
   for (k = 0; k < (*j); k++) {
     h[k] = 0.0;
@@ -1435,7 +1412,7 @@ void opencl_glsc3_many(real_xp *h, void * w, void *v, void *mult, int *j,
 
   for (i = 0; i < nb; i++) {
     for (k = 0; k < (*j); k++) {
-        h[k] += bufred_xp[i*(*j)+k];
+        h[k] += ((real_xp *) redbuf_xp.host)[i*(*j)+k];
     }
   }
 
@@ -1463,38 +1440,27 @@ real_xp opencl_glsc2(void *a, void *b, int *n, cl_command_queue cmd_queue) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  if (nb > red_xp_s) {
-    red_xp_s = nb;
-    if (bufred_xp != NULL) {
-      free(bufred_xp);
-      CL_CHECK(clReleaseMemObject(bufred_xp_d));
-    }
-    bufred_xp = (real_xp *) malloc(nb * sizeof(real_xp));
-
-    bufred_xp_d = clCreateBuffer(glb_ctx, CL_MEM_READ_WRITE,
-                                 nb * sizeof(real_xp), NULL, &err);
-    CL_CHECK(err);
-  }
+  opencl_buffer_reserve(&redbuf_xp, nb * sizeof(real_xp));
 
   cl_kernel kernel = clCreateKernel(math_program, "glsc2_kernel", &err);
   CL_CHECK(err);
 
   CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &a));
   CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &b));
-  CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &bufred_xp_d));
+  CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &redbuf_xp.dev));
   CL_CHECK(clSetKernelArg(kernel, 3, sizeof(int), n));
 
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, &kern_wait));
 
-  CL_CHECK(clEnqueueReadBuffer(cmd_queue, bufred_xp_d, CL_TRUE, 0,
-                               nb * sizeof(real_xp), bufred_xp, 1,
+  CL_CHECK(clEnqueueReadBuffer(cmd_queue, redbuf_xp.dev, CL_TRUE, 0,
+                               nb * sizeof(real_xp), ((real_xp *) redbuf_xp.host), 1,
                                &kern_wait, NULL));
 
   real_xp res = 0.0;
   for (i = 0; i < nb; i++) {
-    res += bufred_xp[i];
+    res += ((real_xp *) redbuf_xp.host)[i];
   }
 
   CL_CHECK(clReleaseEvent(kern_wait));
@@ -1523,38 +1489,27 @@ real_xp opencl_glsubnorm2(void *a, void *b, int *n, cl_command_queue cmd_queue) 
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  if (nb > red_xp_s) {
-    red_xp_s = nb;
-    if (bufred_xp != NULL) {
-      free(bufred_xp);
-      CL_CHECK(clReleaseMemObject(bufred_xp_d));
-    }
-    bufred_xp = (real_xp *) malloc(nb * sizeof(real_xp));
-
-    bufred_xp_d = clCreateBuffer(glb_ctx, CL_MEM_READ_WRITE,
-                                 nb * sizeof(real_xp), NULL, &err);
-    CL_CHECK(err);
-  }
+  opencl_buffer_reserve(&redbuf_xp, nb * sizeof(real_xp));
 
   cl_kernel kernel = clCreateKernel(math_program, "glsubnorm2_kernel", &err);
   CL_CHECK(err);
 
   CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &a));
   CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &b));
-  CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &bufred_xp_d));
+  CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &redbuf_xp.dev));
   CL_CHECK(clSetKernelArg(kernel, 3, sizeof(int), n));
 
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, &kern_wait));
 
-  CL_CHECK(clEnqueueReadBuffer(cmd_queue, bufred_xp_d, CL_TRUE, 0,
-                               nb * sizeof(real_xp), bufred_xp, 1,
+  CL_CHECK(clEnqueueReadBuffer(cmd_queue, redbuf_xp.dev, CL_TRUE, 0,
+                               nb * sizeof(real_xp), ((real_xp *) redbuf_xp.host), 1,
                                &kern_wait, NULL));
 
   real_xp res = 0.0;
   for (i = 0; i < nb; i++) {
-    res += bufred_xp[i];
+    res += ((real_xp *) redbuf_xp.host)[i];
   }
 
   CL_CHECK(clReleaseEvent(kern_wait));
@@ -1583,36 +1538,25 @@ real_xp opencl_glsum(void *a, int *n, cl_command_queue cmd_queue) {
   const size_t global_item_size = 256 * nb;
   const size_t local_item_size = 256;
 
-  if (nb > red_xp_s) {
-    red_xp_s = nb;
-    if (bufred_xp != NULL) {
-      free(bufred_xp);
-      CL_CHECK(clReleaseMemObject(bufred_xp_d));
-    }
-    bufred_xp = (real_xp *) malloc(nb * sizeof(real_xp));
-
-    bufred_xp_d = clCreateBuffer(glb_ctx, CL_MEM_READ_WRITE,
-                                 nb * sizeof(real_xp), NULL, &err);
-    CL_CHECK(err);
-  }
+  opencl_buffer_reserve(&redbuf_xp, nb * sizeof(real_xp));
 
   cl_kernel kernel = clCreateKernel(math_program, "glsum_kernel", &err);
   CL_CHECK(err);
 
   CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &a));
-  CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &bufred_xp_d));
+  CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &redbuf_xp.dev));
   CL_CHECK(clSetKernelArg(kernel, 2, sizeof(int), n));
 
   CL_CHECK(clEnqueueNDRangeKernel(cmd_queue, kernel, 1, NULL,
                                   &global_item_size, &local_item_size,
                                   0, NULL, &kern_wait));
 
-  CL_CHECK(clEnqueueReadBuffer(cmd_queue, bufred_xp_d, CL_TRUE, 0,
-                               nb * sizeof(real_xp), bufred_xp, 1, &kern_wait, NULL));
+  CL_CHECK(clEnqueueReadBuffer(cmd_queue, redbuf_xp.dev, CL_TRUE, 0,
+                               nb * sizeof(real_xp), ((real_xp *) redbuf_xp.host), 1, &kern_wait, NULL));
 
   real_xp res = 0.0;
   for (i = 0; i < nb; i++) {
-    res += bufred_xp[i];
+    res += ((real_xp *) redbuf_xp.host)[i];
   }
 
   CL_CHECK(clReleaseEvent(kern_wait));

--- a/src/sem/bcknd/device/opencl/coef.c
+++ b/src/sem/bcknd/device/opencl/coef.c
@@ -277,12 +277,10 @@ void opencl_coef_generate_area_and_normal(void *area,
 #define AREA_CASE(LX)                                                           \
   case LX:                                                                      \
     {                                                                           \
-      printf("%s\n",  STR(coef_generate_area_and_normal_kernel_lx##LX));        \
       cl_kernel kernel =                                                        \
         clCreateKernel(coef_program,                                            \
                        STR(coef_generate_area_and_normal_kernel_lx##LX), &err); \
       CL_CHECK(err);                                                            \
-      printf("Done\n"); \
                                                                                 \
       CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *) &area));      \
       CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &nx));        \

--- a/tests/unit/jobctrl/Makefile.in
+++ b/tests/unit/jobctrl/Makefile.in
@@ -13,7 +13,7 @@ check: jobctrl_suite
 
 
 jobctrl_suite_TESTS := test_jobctrl_parallel.pf
-jobctrl_suite_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko 
+jobctrl_suite_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,jobctrl_suite))
 jobctrl_suite.inc: Makefile
 


### PR DESCRIPTION
This PR adds a device reduction buffer type, removing several stale reductions buffers that were never freed during teardown.

Fixes #2210 

