### PR TITLE
Fix failing GPU tests

### DIFF
--- a/m4/ax_pfunit.m4
+++ b/m4/ax_pfunit.m4
@@ -30,6 +30,7 @@ AC_DEFUN([AX_PFUNIT], [
  else
       AC_MSG_RESULT([yes])
       have_pfunit=yes
+      AC_DEFINE(HAVE_PFUNIT, 1, [Define if built with pFUnit unit tests.])
  fi
 
  AC_SUBST(PFUNIT_DIR)

--- a/src/device/cuda_intf.F90
+++ b/src/device/cuda_intf.F90
@@ -1,4 +1,4 @@
-! Copyright (c) 2021-2025, The Neko Authors
+! Copyright (c) 2021-2026, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -308,9 +308,17 @@ contains
        call neko_error('Error destroying aux stream')
     end if
 
-    ! Best-effort context teardown to release runtime-owned allocations.
     ierr = cudaDeviceSynchronize()
+
+    ! Best-effort context teardown to release runtime-owned allocations.
+    ! Skipped in pFUnit-enabled builds: unit tests cycle device
+    ! init/finalize with MPI still up, and device-aware communication
+    ! backends (CUDA-aware MPI, NCCL, NVSHMEM) cache the primary
+    ! context from first use; destroying it here would leave them with
+    ! a dangling context
+#ifndef HAVE_PFUNIT
     ierr = cudaDeviceReset()
+#endif
   end subroutine cuda_finalize
 
   subroutine cuda_device_name(name)

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -1,4 +1,4 @@
-! Copyright (c) 2021-2025, The Neko Authors
+! Copyright (c) 2021-2026, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -280,9 +280,17 @@ contains
        call neko_error('Error destroying aux stream')
     end if
 
-    ! Best-effort context teardown to release runtime-owned allocations.
     ierr = hipDeviceSynchronize()
+
+    ! Best-effort context teardown to release runtime-owned allocations.
+    ! Skipped in pFUnit-enabled builds: unit tests cycle device
+    ! init/finalize with MPI still up, and device-aware communication
+    ! backends (GPU-aware MPI, RCCL) cache device state from first
+    ! use; resetting the device here would leave them with dangling
+    ! handles
+#ifndef HAVE_PFUNIT
     ierr = hipDeviceReset()
+#endif
   end subroutine hip_finalize
 
   subroutine hip_device_name(name)


### PR DESCRIPTION
The unit tests cycle `device_init`/`device_finalize` around every test while MPI stays initialized. Device aware MPI caches the primary context the first time it sees a device pointer, the first device-side reduction, so the `cudaDeviceReset`/`hipDeviceReset` in the subsequent teardown leaves the communication layer with a dangling context.

Since `neko_finalize` calls `comm_free` before `device_finalize`, the reset is safe in production and is kept there. It is now only skipped in pFUnit-enabled builds, via a new `HAVE_PFUNIT` define in `ax_pfunit.m4`, where the device layer is re-initialized with communication still up.