### PR TITLE
Fix linking issues in test Makefiles for non-CPU backends

### DIFF
--- a/tests/unit/bc/Makefile.in
+++ b/tests/unit/bc/Makefile.in
@@ -12,7 +12,7 @@ check: bc_test
 
 
 bc_test_TESTS := test_bc.pf
-bc_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko
+bc_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,bc_test))
 bc_test.inc: Makefile
 

--- a/tests/unit/hex/Makefile.in
+++ b/tests/unit/hex/Makefile.in
@@ -12,7 +12,7 @@ check: hex_test
 
 
 hex_test_TESTS := test_hex.pf
-hex_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs/ -lneko
+hex_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs/ -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,hex_test))
 hex_test.inc: Makefile
 

--- a/tests/unit/htable/Makefile.in
+++ b/tests/unit/htable/Makefile.in
@@ -18,7 +18,7 @@ htable_test_TESTS := test_htable_i4.pf\
 		     test_htable_i4t2.pf\
 		     test_htable_i4t4.pf\
 		     test_htable_cptr.pf
-htable_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs/ -lneko
+htable_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs/ -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,htable_test))
 htable_test.inc: Makefile
 

--- a/tests/unit/krylov/Makefile.in
+++ b/tests/unit/krylov/Makefile.in
@@ -12,7 +12,7 @@ check: krylov_test
 
 
 krylov_test_TESTS := test_krylov.pf
-krylov_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko
+krylov_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,krylov_test))
 krylov_test.inc: Makefile
 

--- a/tests/unit/math/Makefile.in
+++ b/tests/unit/math/Makefile.in
@@ -13,7 +13,7 @@ check: math_suite
 
 
 math_suite_TESTS := test_math_parallel.pf
-math_suite_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko
+math_suite_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,math_suite))
 math_suite.inc: Makefile
 

--- a/tests/unit/octree/Makefile.in
+++ b/tests/unit/octree/Makefile.in
@@ -12,7 +12,7 @@ check: octree_test
 
 
 octree_test_TESTS := test_octree.pf
-octree_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko
+octree_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,octree_test))
 octree_test.inc: Makefile
 

--- a/tests/unit/point/Makefile.in
+++ b/tests/unit/point/Makefile.in
@@ -12,7 +12,7 @@ check: point_test
 
 
 point_test_TESTS := test_point.pf
-point_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs/ -lneko
+point_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs/ -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,point_test))
 point_test.inc: Makefile
 

--- a/tests/unit/quad/Makefile.in
+++ b/tests/unit/quad/Makefile.in
@@ -12,7 +12,7 @@ check: quad_test
 
 
 quad_test_TESTS := test_quad.pf
-quad_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko
+quad_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,quad_test))
 quad_test.inc: Makefile
 

--- a/tests/unit/signal/Makefile.in
+++ b/tests/unit/signal/Makefile.in
@@ -12,7 +12,7 @@ check: signal_test
 
 
 signal_test_TESTS := test_signal.pf
-signal_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko
+signal_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,signal_test))
 signal_test.inc: Makefile
 

--- a/tests/unit/stack/Makefile.in
+++ b/tests/unit/stack/Makefile.in
@@ -24,7 +24,7 @@ stack_test_TESTS := test_stack_i4.pf\
 		    test_stack_nz.pf\
 		    test_stack_nc.pf\
 		    test_stack_pt.pf
-stack_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko
+stack_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,stack_test))
 stack_test.inc: Makefile
 

--- a/tests/unit/tet/Makefile.in
+++ b/tests/unit/tet/Makefile.in
@@ -12,7 +12,7 @@ check: tet_test
 
 
 tet_test_TESTS := test_tet.pf
-tet_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko
+tet_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,tet_test))
 tet_test.inc: Makefile
 

--- a/tests/unit/tri/Makefile.in
+++ b/tests/unit/tri/Makefile.in
@@ -12,7 +12,7 @@ check: tri_test
 
 
 tri_test_TESTS := test_tri.pf
-tri_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko
+tri_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,tri_test))
 tri_test.inc: Makefile
 

--- a/tests/unit/tuple/Makefile.in
+++ b/tests/unit/tuple/Makefile.in
@@ -12,7 +12,7 @@ check: tuple_test
 
 
 tuple_test_TESTS := test_tuple.pf
-tuple_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko
+tuple_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,tuple_test))
 tuple_test.inc: Makefile
 

--- a/tests/unit/uset/Makefile.in
+++ b/tests/unit/uset/Makefile.in
@@ -12,7 +12,7 @@ check: uset_test
 
 
 uset_test_TESTS := test_uset_i4.pf test_uset_i8.pf test_uset_r8.pf
-uset_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs/ -lneko
+uset_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs/ -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,uset_test))
 uset_test.inc: Makefile
 

--- a/tests/unit/utils/Makefile.in
+++ b/tests/unit/utils/Makefile.in
@@ -11,7 +11,7 @@ FC = @FC@
 check: read_duration_test
 
 read_duration_test_TESTS := test_read_duration.pf
-read_duration_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko
+read_duration_test_OTHER_LIBRARIES = -L@top_builddir@/src/.libs -lneko @LDFLAGS@ @LIBS@
 $(eval $(call make_pfunit_test,read_duration_test))
 
 read_duration_test.inc: Makefile


### PR DESCRIPTION
Update the Makefiles for various tests to include `@LDFLAGS@` and `@LIBS@`, addressing a linking gap that caused undefined references under the CUDA backend. This change ensures all relevant libraries are linked correctly across multiple test directories.