### PR TITLE
Fix target lifetime issues in ALE checkpoint field registration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,6 +47,19 @@ The list of criteria to check are:
   or deallocated. This applies to both local variables and type components.
 - Pay attention to object ownership when `pointer` or `allocatable` components
   are involved. Make sure ownership is correctly handled.
+- If a procedure captures a persistent pointer to one of its dummy arguments
+  (`this%x => y`, where `y` is a dummy argument or reached through one), that
+  dummy must have the `target` attribute, **and so must every dummy along the
+  full call chain back to real storage** — a `target` on the outermost caller's
+  variable does not by itself make an intermediate dummy argument `target` in
+  its own procedure's scope (F2008 §12.5.2.4(5)). Check this especially for:
+  abstract deferred interfaces (every concrete implementation is forced to
+  match whatever attribute the interface declares, so a missing `target` there
+  breaks every implementer), and secondary/alternate constructors that
+  independently redeclare the same dummy argument instead of forwarding the
+  original. This bug class is not caught by Neko's own CI (GNU build runs with
+  `-w`, all warnings suppressed) nor reliably by `gfortran -Wall -Wextra` for
+  the cross-procedure case — review is the only check that catches it today.
 - Make sure types are fully instantiated in the `init` routines. If there are
   several such routines, makes sure they all do it.
 - If a type has a constructor (`init` or similar) from a `json_file` and one

--- a/src/ale/ale_manager.f90
+++ b/src/ale/ale_manager.f90
@@ -2266,7 +2266,7 @@ contains
 
   ! Register ALE fields for checkpointing.
   subroutine register_checkpoint_fields(this, coef, checkpoint)
-    class(ale_manager_t), intent(inout) :: this
+    class(ale_manager_t), intent(inout), target :: this
     type(coef_t), intent(inout) :: coef
     type(chkp_t), intent(inout) :: checkpoint
     integer :: i


### PR DESCRIPTION
Address a target lifetime issue in the `register_checkpoint_fields` subroutine by adding the `target` attribute to the `this` dummy argument. This change prevents undefined behavior in ALE simulations that utilize checkpointing. Document this bug class in the PR-review checklist to enhance awareness and prevent future occurrences.
