### PR TITLE
Add support for unified memory in the Metal backend

### DIFF
--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -23,6 +23,7 @@ of the code. But can be useful for users and developers alike.
 | `NEKO_GS_COMM`           | Gather-scatter communication backend                                  | Unset         |
 | `NEKO_GS_CAF_SIGNALING`  | Coarray Fortran gather-scatter signaling mode                         | Unset         |
 | `NEKO_COMM_ID`           | Communicator id for this process (non-negative integer)               | 0             |
+| `NEKO_METAL_ZEROCOPY`    | Zero-copy host/device mapping on unified memory (Metal), 0 disables   | 1             |
 | `NEKO_MPI_THREAD_LEVEL`  | Requested MPI (and SHMEM) thread support level                        | Unset         |
 | `NEKO_DEPRECATION_ERROR` | Whether to treat deprecated features as errors (boolean)              | Unset         |
 

--- a/doc/pages/user-guide/installation.md
+++ b/doc/pages/user-guide/installation.md
@@ -269,6 +269,8 @@ $ ./configure --with-metal --enable-real=sp
 
 @note Apple GPUs do not support double precision; the Metal backend requires Neko to be configured with single precision (`--enable-real=sp`).
 
+@note On devices with unified memory (Apple Silicon), the Metal backend maps arrays zero-copy: host and device share a single allocation instead of keeping replicated copies, and host-device transfers become no-ops. This roughly halves the memory footprint of mapped data. Zero-copy mapping can be disabled at runtime by setting the environment variable `NEKO_METAL_ZEROCOPY=0`, which restores fully replicated buffers. On GPUs without unified memory (e.g. AMD GPUs in Intel-based Macs), buffers are always replicated.
+
 @note More examples, and instructions for specific machines can be found on Neko's [user discussions](https://github.com/ExtremeFLOW/neko/discussions) pages.
 
 #### Compiling Neko with a collective communications library

--- a/src/device/device.F90
+++ b/src/device/device.F90
@@ -127,7 +127,7 @@ module device
        device_finalize, device_stream_wait_event, device_count, &
        device_memset, device_stream_create_with_priority
 
-  private :: device_memcpy_common
+  private :: device_memcpy_common, device_map_common
 
 contains
 
@@ -858,11 +858,37 @@ contains
 
   end subroutine device_deassociate_r4
 
+  !> Allocate device memory backing a mapped host array
+  !! @note On unified memory architectures (Metal) the device pointer
+  !! aliases the host array whenever possible, such that host and
+  !! device share a single allocation instead of replicating data
+  subroutine device_map_common(ptr_h, x_d, s)
+    type(c_ptr), intent(in) :: ptr_h
+    type(c_ptr), intent(inout) :: x_d
+    integer(c_size_t), intent(in) :: s
+
+#ifdef HAVE_METAL
+    if (s .eq. 0) then
+       call device_sync()
+       x_d = C_NULL_PTR
+       return
+    end if
+
+    if (metalMap(x_d, ptr_h, s) .ne. metalSuccess) then
+       call neko_error('Memory map on device failed')
+    end if
+#else
+    call device_alloc(x_d, s)
+#endif
+
+  end subroutine device_map_common
+
   !> Map a Fortran rank 1 array to a device (allocate and associate)
   subroutine device_map_r1(x, x_d, n)
     integer, intent(in) :: n
     class(*), intent(inout), target :: x(:)
     type(c_ptr), intent(inout) :: x_d
+    type(c_ptr) :: ptr_h
     integer(c_size_t) :: s
 
     if (c_associated(x_d)) then
@@ -872,17 +898,21 @@ contains
     select type (x)
     type is (integer)
        s = n * int(4, c_size_t)
+       ptr_h = c_loc(x)
     type is (integer(i8))
        s = n * int(8, c_size_t)
+       ptr_h = c_loc(x)
     type is (real)
        s = n * int(4, c_size_t)
+       ptr_h = c_loc(x)
     type is (double precision)
        s = n * int(8, c_size_t)
+       ptr_h = c_loc(x)
     class default
        call neko_error('Unknown Fortran type')
     end select
 
-    call device_alloc(x_d, s)
+    call device_map_common(ptr_h, x_d, s)
     call device_associate(x, x_d, n)
 
   end subroutine device_map_r1
@@ -892,6 +922,7 @@ contains
     integer, intent(in) :: n
     class(*), intent(inout), target :: x(:,:)
     type(c_ptr), intent(inout) :: x_d
+    type(c_ptr) :: ptr_h
     integer(c_size_t) :: s
 
     if (c_associated(x_d)) then
@@ -901,17 +932,21 @@ contains
     select type (x)
     type is (integer)
        s = n * int(4, c_size_t)
+       ptr_h = c_loc(x)
     type is (integer(i8))
        s = n * int(8, c_size_t)
+       ptr_h = c_loc(x)
     type is (real)
        s = n * int(4, c_size_t)
+       ptr_h = c_loc(x)
     type is (double precision)
        s = n * int(8, c_size_t)
+       ptr_h = c_loc(x)
     class default
        call neko_error('Unknown Fortran type')
     end select
 
-    call device_alloc(x_d, s)
+    call device_map_common(ptr_h, x_d, s)
     call device_associate(x, x_d, n)
 
   end subroutine device_map_r2
@@ -921,6 +956,7 @@ contains
     integer, intent(in) :: n
     class(*), intent(inout), target :: x(:,:,:)
     type(c_ptr), intent(inout) :: x_d
+    type(c_ptr) :: ptr_h
     integer(c_size_t) :: s
 
     if (c_associated(x_d)) then
@@ -930,17 +966,21 @@ contains
     select type (x)
     type is (integer)
        s = n * int(4, c_size_t)
+       ptr_h = c_loc(x)
     type is (integer(i8))
        s = n * int(8, c_size_t)
+       ptr_h = c_loc(x)
     type is (real)
        s = n * int(4, c_size_t)
+       ptr_h = c_loc(x)
     type is (double precision)
        s = n * int(8, c_size_t)
+       ptr_h = c_loc(x)
     class default
        call neko_error('Unknown Fortran type')
     end select
 
-    call device_alloc(x_d, s)
+    call device_map_common(ptr_h, x_d, s)
     call device_associate(x, x_d, n)
 
   end subroutine device_map_r3
@@ -950,6 +990,7 @@ contains
     integer, intent(in) :: n
     class(*), intent(inout), target :: x(:,:,:,:)
     type(c_ptr), intent(inout) :: x_d
+    type(c_ptr) :: ptr_h
     integer(c_size_t) :: s
 
     if (c_associated(x_d)) then
@@ -959,17 +1000,21 @@ contains
     select type (x)
     type is (integer)
        s = n * int(4, c_size_t)
+       ptr_h = c_loc(x)
     type is (integer(i8))
        s = n * int(8, c_size_t)
+       ptr_h = c_loc(x)
     type is (real)
        s = n * int(4, c_size_t)
+       ptr_h = c_loc(x)
     type is (double precision)
        s = n * int(8, c_size_t)
+       ptr_h = c_loc(x)
     class default
        call neko_error('Unknown Fortran type')
     end select
 
-    call device_alloc(x_d, s)
+    call device_map_common(ptr_h, x_d, s)
     call device_associate(x, x_d, n)
 
   end subroutine device_map_r4

--- a/src/device/metal/metal.m
+++ b/src/device/metal/metal.m
@@ -39,6 +39,11 @@
  * MTLResourceStorageModeShared so that a single MTLBuffer is
  * accessible from both sides.  The opaque c_ptr that Fortran stores
  * is the ARC-retained MTLBuffer pointer.
+ *
+ * Mapped host arrays (metal_map) exploit the unified memory fully:
+ * when the host allocation permits, the buffer is created with
+ * newBufferWithBytesNoCopy so that host and device share a single
+ * allocation and host-device copies degenerate to no-ops.
  */
 
 #ifdef __APPLE__
@@ -47,6 +52,9 @@
 #import <Foundation/Foundation.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
+#include <malloc/malloc.h>
+#include <mach/vm_page_size.h>
 
 /*
  *  Module-local Metal device and default command queue
@@ -173,6 +181,57 @@ int metal_alloc(void **ptr, size_t s)
 }
 
 /**
+ * Whether mapped buffers may alias host allocations (zero-copy).
+ *
+ * Requires a device with unified memory (Apple Silicon); discrete
+ * GPUs (AMD in Intel Macs) support Metal but not unified memory and
+ * always use replicated buffers.  Can be disabled with
+ * NEKO_METAL_ZEROCOPY=0.
+ */
+static int metal_zerocopy(void)
+{
+    static int zerocopy = -1;
+    if (zerocopy < 0) {
+        const char *env = getenv("NEKO_METAL_ZEROCOPY");
+        zerocopy = (env == NULL || atoi(env) != 0) &&
+            [_mtl_device hasUnifiedMemory];
+    }
+    return zerocopy;
+}
+
+/**
+ * Map \p s bytes of host memory at \p ptr_h to a Metal buffer.
+ *
+ * On unified memory (see metal_zerocopy), when the host allocation is
+ * page-aligned and its malloc block covers whole VM pages we wrap it
+ * in a no-copy shared buffer; host and device then operate on the
+ * same allocation and copies between them become no-ops.  Otherwise
+ * (small, stack or unaligned allocations, or a discrete GPU) we fall
+ * back to a separate buffer as in metal_alloc.
+ */
+int metal_map(void **ptr, void *ptr_h, size_t s)
+{
+    if (metal_zerocopy() && ptr_h != NULL) {
+        const size_t page = vm_page_size;
+        const size_t len = (s + page - 1) & ~(page - 1);
+        if (((uintptr_t) ptr_h & (page - 1)) == 0 &&
+            malloc_size(ptr_h) >= len) {
+            id<MTLBuffer> buf =
+                [_mtl_device newBufferWithBytesNoCopy:ptr_h
+                                length:len
+                                options:MTLResourceStorageModeShared
+                                deallocator:nil];
+            if (buf) {
+                *ptr = (__bridge_retained void *)buf;
+                return 0;
+            }
+        }
+    }
+
+    return metal_alloc(ptr, s);
+}
+
+/**
  * Free a previously allocated Metal buffer.
  * Returns 0 on success.
  */
@@ -196,14 +255,22 @@ int metal_free(void *ptr)
 /**
  * Copy \p s bytes from host memory \p src to Metal buffer \p dst_d.
  *
- * Because we use shared-mode buffers the copy is a plain memcpy.
- * A blit encoder could be used for managed-mode on discrete GPUs,
- * but Apple Silicon only has shared memory.
+ * Because we use shared-mode buffers the copy is a host-side copy.
+ * On unified memory the buffer may be a no-copy mapping of \p src
+ * (see metal_map): an exact alias makes the copy a no-op, and any
+ * other overlap requires memmove.  Otherwise buffers are separate
+ * allocations and a plain memcpy suffices.
  */
 int metal_memcpy_htod(void *dst_d, const void *src, size_t s)
 {
     id<MTLBuffer> buf = (__bridge id<MTLBuffer>)dst_d;
-    memcpy([buf contents], src, s);
+    void *contents = [buf contents];
+    if (metal_zerocopy()) {
+        if (contents != src)
+            memmove(contents, src, s);
+    } else {
+        memcpy(contents, src, s);
+    }
     return 0;
 }
 
@@ -213,7 +280,13 @@ int metal_memcpy_htod(void *dst_d, const void *src, size_t s)
 int metal_memcpy_dtoh(void *dst, void *src_d, size_t s)
 {
     id<MTLBuffer> buf = (__bridge id<MTLBuffer>)src_d;
-    memcpy(dst, [buf contents], s);
+    void *contents = [buf contents];
+    if (metal_zerocopy()) {
+        if (contents != dst)
+            memmove(dst, contents, s);
+    } else {
+        memcpy(dst, contents, s);
+    }
     return 0;
 }
 
@@ -224,7 +297,12 @@ int metal_memcpy_dtod(void *dst_d, void *src_d, size_t s)
 {
     id<MTLBuffer> dst_buf = (__bridge id<MTLBuffer>)dst_d;
     id<MTLBuffer> src_buf = (__bridge id<MTLBuffer>)src_d;
-    memcpy([dst_buf contents], [src_buf contents], s);
+    if (metal_zerocopy()) {
+        if ([dst_buf contents] != [src_buf contents])
+            memmove([dst_buf contents], [src_buf contents], s);
+    } else {
+        memcpy([dst_buf contents], [src_buf contents], s);
+    }
     return 0;
 }
 

--- a/src/device/metal_intf.F90
+++ b/src/device/metal_intf.F90
@@ -52,6 +52,17 @@ module metal_intf
        integer(c_size_t), value :: s
      end function metalAlloc
 
+     !> Map host memory to a Metal buffer of @a s bytes
+     !! (zero-copy on unified memory when the host allocation allows it)
+     integer(c_int) function metalMap(ptr_d, ptr_h, s) &
+          bind(c, name = 'metal_map')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr) :: ptr_d
+       type(c_ptr), value :: ptr_h
+       integer(c_size_t), value :: s
+     end function metalMap
+
      !> Free a Metal buffer
      integer(c_int) function metalFree(ptr_d) &
           bind(c, name = 'metal_free')


### PR DESCRIPTION
This PR add support for unified memory in the Metal backend. On supported platforms (Apple Silicon) the host pointer will be wrapped to a device pointer, with zero copies, while on unsupported platforms (Intel Macs), it follows the normal behaviour of replicating the arrays on the device. This reduces the host memory footprint (ref. #2633).