### PR TITLE
Improve JSON schema and fix broken example case files

### DIFF
--- a/.agents/skills/neko-simulation-setup/SKILL.md
+++ b/.agents/skills/neko-simulation-setup/SKILL.md
@@ -29,6 +29,9 @@ needed to run a case.
 
 - Use `doc/pages/user-guide/case-file.md` as the definitive reference for case
   file contents, and acknowledge that you got access to this file.
+- The `doc/schema` folder contains JSON schema files that define the structure 
+  of case files. Use these to validate generated case files. You can use the 
+  `contrib/validate_case_schema.py` script to that end.
 - Name generated case files after the case folder, using `.json` unless the user
   specifically asks for `.case`.
 - Pretty-format generated JSON.

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ m4/ltversion.m4
 m4/lt~obsolete.m4
 ltmain.sh
 *.cl.h
+*.1
 
 # Ignore installation files
 lib/*

--- a/contrib/validate_case_schema.py
+++ b/contrib/validate_case_schema.py
@@ -35,6 +35,18 @@ DEFAULT_SCHEMA = (
 )
 
 
+def validate_neko_real(validator, expected, instance, schema):
+    """Require a JSON real, rather than an integer-valued JSON number."""
+    if (
+        expected
+        and isinstance(instance, (int, float))
+        and not isinstance(instance, (bool, float))
+    ):
+        yield jsonschema.ValidationError(
+            f"{instance!r} is not encoded as a JSON real"
+        )
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
@@ -91,7 +103,22 @@ def load_schema(path: Path) -> jsonschema.protocols.Validator:
     # instance that resolves `$ref`s through the preloaded registry above.
     validator_cls = jsonschema.validators.validator_for(schema)
     validator_cls.check_schema(schema)
-    return validator_cls(schema, registry=registry)
+
+    # JSON Schema treats integral-valued reals such as 10.0 as integers. Neko's
+    # JSON reader distinguishes the stored JSON types, however, and rejects
+    # 10.0 where an integer is requested. Match Neko's stricter behavior.
+    strict_type_checker = validator_cls.TYPE_CHECKER.redefine(
+        "integer",
+        lambda checker, instance: (
+            isinstance(instance, int) and not isinstance(instance, bool)
+        ),
+    )
+    strict_validator_cls = jsonschema.validators.extend(
+        validator_cls,
+        validators={"x-neko-real": validate_neko_real},
+        type_checker=strict_type_checker,
+    )
+    return strict_validator_cls(schema, registry=registry)
 
 
 def main() -> int:

--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -27,6 +27,11 @@ files against that schema.
 Since some shipped example files use `//` comments and trailing commas, the
 helper parses the input using a JSON5-compatible frontend before applying the
 schema.
+Neko distinguishes JSON integers such as `10` from JSON reals such as `10.0`,
+even though the JSON Schema specification considers both to be numbers and
+considers `10.0` to satisfy the `integer` type. The schemas mark real-only
+values with the Neko-specific `x-neko-real` annotation, and the validation
+helper enforces both that annotation and strict JSON integer encoding.
 
 ## High-level structure
 The current high-level structure of the case file is shown below.
@@ -67,9 +72,11 @@ The frequency is controlled by two parameters, ending with `_control` and
 The latter name is perhaps not ideal, but it is somewhat difficult to come up
 with a good one, suggestions are welcome.
 
-The `_value` parameter is a *real* number, that defines the output frequency,
-but the interpretation of that number depends on the choice of `_control`. The
-three following options are possible.
+The `_value` parameter defines the output frequency, but both its JSON type and
+interpretation depend on the choice of `_control`. Neko requires an integer
+literal for `tsteps` and `nsamples`, and a real literal for `simulationtime`.
+For example, use `10` for ten time steps but `10.0` for ten simulation-time
+units. The following options are possible.
 1. `simulationtime`, then `_value` is the time interval between the outputs.
 2. `tsteps`, then `_value` is the number of time steps between the outputs.
 3. `nsamples`, then `_value` is the total number of outputs that will be
@@ -88,7 +95,6 @@ but also defines several parameters that pertain to the simulation as a whole.
 | `mesh_file`           | The name of the mesh file.                                                                            | Strings ending with `.nmsh`                     | -             |
 | `output_boundary`     | Whether to write a `bdry0.f0000` file with boundary labels. Can be used to check boundary conditions. | `true` or `false`                               | `false`       |
 | `output_directory`    | Folder for redirecting solver output. Note that the folder has to exist!                              | Path to an existing directory                   | `.`           |
-| `output_format`       | The file format of field data.                                                                        | `nek5000`, `adios2`, or `vtkhdf`                | `nek5000`     |
 | `output_precision`    | Whether to output snapshots in single or double precision                                             | `single` or `double`                            | `single`      |
 | `output_layout`       | Data layout for `adios2` files. (Choose `2` or `3` for ADIOS2 supported compressors BigWhoop or ZFP.) | Positive integer `1`, `2`, `3`                  | `1`           |
 | `load_balancing`      | Whether to apply load balancing.                                                                      | `true` or `false`                               | `false`       |
@@ -828,7 +834,7 @@ file documentation.
       - `tanh`, hyperbolic tangent approximation of Savaş (2012). In this case `delta` is the 99\% thickness.
 4. `point_zone`, the values are set to a constant base value, supplied under the
    `base_value` keyword, and then assigned a zone value inside a point zone. The
-   point zone is specified by the `name` keyword, and should be defined in the
+   point zone is specified by the `zone_name` keyword, and should be defined in the
    `case.point_zones` object. See more about [point zones](@ref point-zones).
 5. `field`, where the initial condition is retrieved from a field file.
    The following keywords can be used:
@@ -1819,6 +1825,7 @@ concisely directly in the table.
 | `nut_field`                                        | The name of the turbulent viscosity field.                                                        | String                                                      | -             |
 | `output_control`                                   | Defines the interpretation of `output_value` to define the frequency of writing checkpoint files. | `nsamples`, `simulationtime`, `tsteps`, `never`             | -             |
 | `output_value`                                     | The frequency of sampling in terms of `output_control`.                                           | Positive real or integer                                    | -             |
+| `output_format`                                    | The file format of field data.                                                                     | `nek5000`, `adios2`, or `vtkhdf`                            | `nek5000`     |
 | `output_mesh_in_all_files`                         | Indicates if the mesh should be written in every output fld file.                                 | `true` or `false`                                           | `false`       |
 | `output_filename`                                  | The output filename.                                                                              | String                                                      | `field`       |
 | `output_subdivide`                                 | Whether to subdivide spectral elements into linear sub-cells for VTKHDF output.                   | `true` or `false`                                           | `false`       |
@@ -1955,7 +1962,7 @@ file documentation.
    keyword.
 3. `point_zone`, the values are set to a constant base value, supplied under the
    `base_value` keyword, and then assigned a zone value inside a point zone. The
-   point zone is specified by the `name` keyword, and should be defined in the
+   point zone is specified by the `zone_name` keyword, and should be defined in the
    `case.point_zones` object. See more about [point zones](@ref point-zones).
 4. `field`, where the initial condition is retrieved from a field file. Works
    in the same way as for the fluid. See the

--- a/doc/schemas/case-file.schema.json
+++ b/doc/schemas/case-file.schema.json
@@ -49,6 +49,9 @@
         "fluid"
       ],
       "properties": {
+        "load_balance": false,
+        "joblimit": false,
+        "output_format": false,
         "no_defaults": {
           "type": "boolean"
         },
@@ -61,14 +64,6 @@
         "output_directory": {
           "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
         },
-        "output_format": {
-          "type": "string",
-          "enum": [
-            "nek5000",
-            "adios2",
-            "vtkhdf"
-          ]
-        },
         "output_precision": {
           "type": "string",
           "enum": [
@@ -77,13 +72,18 @@
           ]
         },
         "output_layout": {
-          "type": "integer",
-          "minimum": 1
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 3
+            },
+            {
+              "$ref": "urn:neko:schema:common#/$defs/constRef"
+            }
+          ]
         },
         "load_balancing": {
-          "type": "boolean"
-        },
-        "load_balance": {
           "type": "boolean"
         },
         "output_partitions": {
@@ -96,7 +96,7 @@
           "$ref": "urn:neko:schema:common#/$defs/frequencyControl"
         },
         "checkpoint_value": {
-          "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+          "$ref": "urn:neko:schema:common#/$defs/numericOrRef"
         },
         "checkpoint_filename": {
           "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
@@ -119,10 +119,25 @@
         },
         "job_timelimit": {
           "type": "string",
-          "pattern": "^\\d{2}:\\d{2}:\\d{2}$"
+          "pattern": "^(?:[0-9]+(?:\\.[0-9]+)?|[0-9]+:[0-5]?[0-9](?:\\.[0-9]+)?|[0-9]+:[0-5]?[0-9]:[0-5]?[0-9](?:\\.[0-9]+)?|[0-9]+-(?:[01]?[0-9]|2[0-3]):[0-5]?[0-9]:[0-5]?[0-9](?:\\.[0-9]+)?)$"
         },
         "output_at_end": {
           "type": "boolean"
+        },
+        "nsamples": {
+          "$ref": "urn:neko:schema:common#/$defs/positiveIntegerOrRef"
+        },
+        "runtime_statistics": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "output_profile": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
         },
         "constants": {
           "type": "array",
@@ -161,6 +176,67 @@
           }
         }
       },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "output_checkpoints": {"const": true}
+            },
+            "required": ["output_checkpoints"]
+          },
+          "then": {
+            "required": ["checkpoint_control"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "output_checkpoints": {"const": true},
+              "checkpoint_control": {
+                "enum": ["simulationtime", "tsteps", "nsamples"]
+              }
+            },
+            "required": ["output_checkpoints", "checkpoint_control"]
+          },
+          "then": {
+            "required": ["checkpoint_value"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "output_checkpoints": {"const": true},
+              "checkpoint_control": {
+                "enum": ["tsteps", "nsamples"]
+              }
+            },
+            "required": ["output_checkpoints", "checkpoint_control"]
+          },
+          "then": {
+            "properties": {
+              "checkpoint_value": {
+                "$ref": "urn:neko:schema:common#/$defs/positiveIntegerOrRef"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "output_checkpoints": {"const": true},
+              "checkpoint_control": {"const": "simulationtime"}
+            },
+            "required": ["output_checkpoints", "checkpoint_control"]
+          },
+          "then": {
+            "properties": {
+              "checkpoint_value": {
+                "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+              }
+            }
+          }
+        }
+      ],
       "additionalProperties": true
     }
   }

--- a/doc/schemas/common.schema.json
+++ b/doc/schemas/common.schema.json
@@ -12,7 +12,8 @@
     "numberOrRef": {
       "oneOf": [
         {
-          "type": "number"
+          "type": "number",
+          "x-neko-real": true
         },
         {
           "$ref": "#/$defs/constRef"
@@ -23,6 +24,7 @@
       "oneOf": [
         {
           "type": "number",
+          "x-neko-real": true,
           "exclusiveMinimum": 0
         },
         {
@@ -34,6 +36,7 @@
       "oneOf": [
         {
           "type": "number",
+          "x-neko-real": true,
           "minimum": 0
         },
         {
@@ -45,6 +48,16 @@
       "oneOf": [
         {
           "type": "integer"
+        },
+        {
+          "$ref": "#/$defs/constRef"
+        }
+      ]
+    },
+    "numericOrRef": {
+      "oneOf": [
+        {
+          "type": "number"
         },
         {
           "$ref": "#/$defs/constRef"
@@ -77,6 +90,7 @@
       "oneOf": [
         {
           "type": "number",
+          "x-neko-real": true,
           "exclusiveMinimum": 0,
           "exclusiveMaximum": 1
         },
@@ -89,6 +103,7 @@
       "oneOf": [
         {
           "type": "number",
+          "x-neko-real": true,
           "exclusiveMinimum": 1
         },
         {
@@ -99,14 +114,16 @@
     "numberArray": {
       "type": "array",
       "items": {
-        "type": "number"
+        "type": "number",
+        "x-neko-real": true
       },
       "minItems": 1
     },
     "integerArray": {
       "type": "array",
       "items": {
-        "type": "integer"
+        "type": "integer",
+        "minimum": 1
       },
       "minItems": 1
     },
@@ -133,10 +150,30 @@
     "vector3": {
       "type": "array",
       "items": {
-        "type": "number"
+        "type": "number",
+        "x-neko-real": true
       },
       "minItems": 3,
       "maxItems": 3
+    },
+    "vector2": {
+      "type": "array",
+      "items": {
+        "type": "number",
+        "x-neko-real": true
+      },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "vector2OrRef": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/vector2"
+        },
+        {
+          "$ref": "#/$defs/constRef"
+        }
+      ]
     },
     "vector3OrRef": {
       "oneOf": [
@@ -316,7 +353,9 @@
     "linearSolver": {
       "type": "object",
       "required": [
-        "type"
+        "type",
+        "preconditioner",
+        "absolute_tolerance"
       ],
       "properties": {
         "type": {
@@ -331,6 +370,9 @@
         "projection_reorthogonalize_basis": {
           "type": "boolean"
         },
+        "projection_hold_steps": {
+          "$ref": "#/$defs/nonNegativeIntegerOrRef"
+        },
         "absolute_tolerance": {
           "$ref": "#/$defs/numberOrRef"
         },
@@ -338,7 +380,7 @@
           "$ref": "#/$defs/numberOrRef"
         },
         "max_iterations": {
-          "$ref": "#/$defs/integerOrRef"
+          "$ref": "#/$defs/positiveIntegerOrRef"
         },
         "monitor": {
           "type": "boolean"

--- a/doc/schemas/fluid-pnpn-boundary-conditions.schema.json
+++ b/doc/schemas/fluid-pnpn-boundary-conditions.schema.json
@@ -22,6 +22,9 @@
         },
         "h_index": {
           "$ref": "urn:neko:schema:common#/$defs/integerOrRef"
+        },
+        "model": {
+          "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
         }
       },
       "additionalProperties": true
@@ -57,10 +60,8 @@
             "type": {
               "enum": [
                 "outflow",
-                "outflow+dong",
                 "outflow+user",
                 "normal_outflow",
-                "normal_outflow+dong",
                 "normal_outflow+user"
               ]
             },
@@ -84,6 +85,37 @@
           ],
           "properties": {
             "type": {
+              "enum": [
+                "outflow+dong",
+                "normal_outflow+dong"
+              ]
+            },
+            "zone_indices": {
+              "$ref": "urn:neko:schema:common#/$defs/integerArrayOrRef"
+            },
+            "name": {
+              "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+            },
+            "value": {
+              "$ref": "urn:neko:schema:common#/$defs/vector3OrRef"
+            },
+            "delta": {
+              "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+            },
+            "velocity_scale": {
+              "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "zone_indices"
+          ],
+          "properties": {
+            "type": {
               "const": "overset_interface"
             },
             "zone_indices": {
@@ -93,6 +125,26 @@
               "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
             },
             "couple_pressure": {
+              "type": "boolean"
+            },
+            "interpolation": {
+              "type": "object",
+              "properties": {
+                "tolerance": {
+                  "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+                },
+                "padding": {
+                  "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+                }
+              },
+              "additionalProperties": false
+            },
+            "order": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 3
+            },
+            "log": {
               "type": "boolean"
             }
           },
@@ -142,6 +194,38 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/wallModelBase"
+            },
+            {
+              "type": "object",
+              "required": [
+                "kappa",
+                "B"
+              ],
+              "properties": {
+                "model": {
+                  "const": "cai_sagaut_model_ii"
+                },
+                "kappa": {
+                  "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+                },
+                "B": {
+                  "$ref": "urn:neko:schema:common#/$defs/nonNegativeNumberOrRef"
+                },
+                "p": {
+                  "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+                },
+                "s": {
+                  "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+                }
+              },
+              "additionalProperties": true
+            }
+          ]
         },
         {
           "allOf": [
@@ -331,7 +415,8 @@
           "type": "object",
           "required": [
             "type",
-            "zone_indices"
+            "zone_indices",
+            "value"
           ],
           "properties": {
             "type": {

--- a/doc/schemas/fluid.schema.json
+++ b/doc/schemas/fluid.schema.json
@@ -6,17 +6,29 @@
       "type": "object",
       "required": [
         "direction",
-        "value"
+        "value",
+        "use_averaged_flow"
       ],
       "properties": {
         "direction": {
-          "type": "integer",
-          "minimum": 1
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 3
+            },
+            {
+              "$ref": "urn:neko:schema:common#/$defs/constRef"
+            }
+          ]
         },
         "value": {
           "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
         },
         "use_averaged_flow": {
+          "type": "boolean"
+        },
+        "log": {
           "type": "boolean"
         }
       },
@@ -88,13 +100,16 @@
           "type": "object",
           "required": [
             "type",
-            "name"
+            "zone_name",
+            "base_value",
+            "zone_value"
           ],
           "properties": {
             "type": {
               "const": "point_zone"
             },
-            "name": {
+            "name": false,
+            "zone_name": {
               "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
             },
             "base_value": {
@@ -142,6 +157,42 @@
         }
       ]
     },
+    "compressibleBoundaryCondition": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["type", "zone_indices", "value"],
+          "properties": {
+            "type": {"const": "velocity_value"},
+            "zone_indices": {"$ref": "urn:neko:schema:common#/$defs/integerArrayOrRef"},
+            "name": {"$ref": "urn:neko:schema:common#/$defs/nonEmptyString"},
+            "value": {"$ref": "urn:neko:schema:common#/$defs/vector3OrRef"}
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["type", "zone_indices", "value"],
+          "properties": {
+            "type": {"enum": ["density_value", "pressure_value"]},
+            "zone_indices": {"$ref": "urn:neko:schema:common#/$defs/integerArrayOrRef"},
+            "name": {"$ref": "urn:neko:schema:common#/$defs/nonEmptyString"},
+            "value": {"$ref": "urn:neko:schema:common#/$defs/numberOrRef"}
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["type", "zone_indices"],
+          "properties": {
+            "type": {"enum": ["no_slip", "symmetry", "outflow", "normal_outflow"]},
+            "zone_indices": {"$ref": "urn:neko:schema:common#/$defs/integerArrayOrRef"},
+            "name": {"$ref": "urn:neko:schema:common#/$defs/nonEmptyString"}
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "ale": {
       "type": "object",
       "required": [
@@ -152,7 +203,47 @@
           "type": "boolean"
         },
         "solver": {
-          "$ref": "urn:neko:schema:common#/$defs/linearSolver"
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["cg", "gmres"]
+            },
+            "preconditioner": {
+              "$ref": "urn:neko:schema:common#/$defs/preconditioner"
+            },
+            "absolute_tolerance": {
+              "type": "number",
+              "x-neko-real": true,
+              "exclusiveMinimum": 0
+            },
+            "max_iterations": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "monitor": {
+              "type": "boolean"
+            },
+            "output_base_shape": {
+              "type": "boolean"
+            },
+            "output_stiffness": {
+              "type": "boolean"
+            },
+            "import_base_shape": {
+              "type": "boolean"
+            },
+            "mesh_stiffness": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "const": "built-in"
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false
         },
         "mesh_preview": {
           "type": "object",
@@ -161,16 +252,23 @@
               "type": "boolean"
             },
             "start_time": {
-              "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+              "type": "number",
+              "x-neko-real": true,
+              "minimum": 0
             },
             "end_time": {
-              "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+              "type": "number",
+              "x-neko-real": true,
+              "exclusiveMinimum": 0
             },
             "output_freq": {
-              "$ref": "urn:neko:schema:common#/$defs/integerOrRef"
+              "type": "integer",
+              "minimum": 1
             },
             "dt": {
-              "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+              "type": "number",
+              "x-neko-real": true,
+              "exclusiveMinimum": 0
             }
           },
           "additionalProperties": true
@@ -180,7 +278,6 @@
           "items": {
             "type": "object",
             "required": [
-              "name",
               "zone_indices"
             ],
             "properties": {
@@ -188,81 +285,201 @@
                 "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
               },
               "zone_indices": {
-                "$ref": "urn:neko:schema:common#/$defs/integerArrayOrRef"
+                "$ref": "urn:neko:schema:common#/$defs/integerArray"
               },
               "oscillation": {
                 "type": "object",
+                "required": [
+                  "amplitude",
+                  "frequency"
+                ],
                 "properties": {
                   "amplitude": {
-                    "$ref": "urn:neko:schema:common#/$defs/vector3OrRef"
+                    "$ref": "urn:neko:schema:common#/$defs/vector3"
                   },
                   "frequency": {
-                    "$ref": "urn:neko:schema:common#/$defs/vector3OrRef"
+                    "$ref": "urn:neko:schema:common#/$defs/vector3"
                   }
                 },
-                "additionalProperties": true
+                "additionalProperties": false
               },
               "rotation": {
-                "type": "object",
-                "properties": {
-                  "amplitude": {
-                    "$ref": "urn:neko:schema:common#/$defs/vector3OrRef"
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "required": ["type", "amplitude_deg", "frequency"],
+                    "properties": {
+                      "type": {"const": "harmonic"},
+                      "amplitude_deg": {"$ref": "urn:neko:schema:common#/$defs/vector3"},
+                      "frequency": {"$ref": "urn:neko:schema:common#/$defs/vector3"}
+                    },
+                    "additionalProperties": false
                   },
-                  "frequency": {
-                    "$ref": "urn:neko:schema:common#/$defs/vector3OrRef"
+                  {
+                    "type": "object",
+                    "required": ["type", "ramp_t0", "ramp_omega0"],
+                    "properties": {
+                      "type": {"const": "ramp"},
+                      "ramp_t0": {"$ref": "urn:neko:schema:common#/$defs/vector3"},
+                      "ramp_omega0": {"$ref": "urn:neko:schema:common#/$defs/vector3"}
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "required": ["type", "step_control_times", "target_angle_deg"],
+                    "properties": {
+                      "type": {"const": "smooth_step"},
+                      "axis": {"type": "integer", "minimum": 1, "maximum": 3},
+                      "step_control_times": {
+                        "type": "array",
+                        "items": {
+                          "type": "number",
+                          "x-neko-real": true
+                        },
+                        "minItems": 4,
+                        "maxItems": 4
+                      },
+                      "target_angle_deg": {
+                        "type": "number",
+                        "x-neko-real": true
+                      }
+                    },
+                    "additionalProperties": false
                   }
-                },
-                "additionalProperties": true
+                ]
               },
               "pivot": {
                 "type": "object",
+                "required": [
+                  "value"
+                ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": ["relative", "relative_sin"]
+                  },
                   "value": {
-                    "$ref": "urn:neko:schema:common#/$defs/vector3OrRef"
+                    "$ref": "urn:neko:schema:common#/$defs/vector3"
                   }
                 },
-                "additionalProperties": true
+                "additionalProperties": false
               },
               "stiff_geom": {
                 "type": "object",
+                "required": ["type", "gain", "decay_profile"],
                 "properties": {
                   "type": {
-                    "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+                    "type": "string",
+                    "enum": ["cylinder", "sphere", "cheap_dist"]
                   },
                   "stiff_dist": {
-                    "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+                    "type": "number",
+                    "x-neko-real": true,
+                    "exclusiveMinimum": 0
                   },
                   "decay_profile": {
-                    "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+                    "type": "string",
+                    "enum": ["gaussian", "tanh"]
                   },
                   "gain": {
-                    "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+                    "type": "number",
+                    "x-neko-real": true,
+                    "exclusiveMinimum": 0
+                  },
+                  "cutoff_coef": {
+                    "type": "number",
+                    "x-neko-real": true,
+                    "exclusiveMinimum": 0
+                  },
+                  "center": {
+                    "$ref": "urn:neko:schema:common#/$defs/vector3"
+                  },
+                  "radius": {
+                    "type": "number",
+                    "x-neko-real": true,
+                    "exclusiveMinimum": 0
                   }
                 },
-                "additionalProperties": true
+                "allOf": [
+                  {
+                    "if": {
+                      "properties": {
+                        "type": {"enum": ["cylinder", "sphere"]}
+                      },
+                      "required": ["type"]
+                    },
+                    "then": {"required": ["center", "radius"]}
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "type": {"const": "cheap_dist"}
+                      },
+                      "required": ["type"]
+                    },
+                    "then": {"required": ["stiff_dist"]}
+                  }
+                ],
+                "additionalProperties": false
+              },
+              "base_shape_import_file": {
+                "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
               }
             },
-            "additionalProperties": true
+            "allOf": [
+              {
+                "if": {"required": ["rotation"]},
+                "then": {"required": ["pivot"]}
+              }
+            ],
+            "additionalProperties": false
           }
         }
       },
-      "additionalProperties": true
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "mesh_preview": {
+                "type": "object",
+                "properties": {
+                  "enabled": {"const": true}
+                },
+                "required": ["enabled"]
+              }
+            },
+            "required": ["mesh_preview"]
+          },
+          "then": {
+            "properties": {
+              "mesh_preview": {
+                "required": ["start_time", "end_time", "output_freq", "dt"]
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false
     },
     "fluid": {
       "type": "object",
       "required": [
         "scheme",
         "initial_condition",
-        "output_control",
-        "output_value"
+        "output_control"
       ],
       "properties": {
+        "variable_material_properties": false,
         "scheme": {
           "type": "string",
           "enum": [
             "pnpn",
             "compressible"
           ]
+        },
+        "name": {
+          "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
         },
         "Re": {
           "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
@@ -271,7 +488,10 @@
           "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
         },
         "mu": {
-          "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+          "$ref": "urn:neko:schema:common#/$defs/nonNegativeNumberOrRef"
+        },
+        "kappa": {
+          "$ref": "urn:neko:schema:common#/$defs/nonNegativeNumberOrRef"
         },
         "gamma": {
           "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
@@ -279,11 +499,23 @@
         "freeze": {
           "type": "boolean"
         },
-        "variable_material_properties": {
-          "type": "boolean"
-        },
         "full_stress_formulation": {
           "type": "boolean"
+        },
+        "cyclic": {
+          "type": "boolean"
+        },
+        "strict_convergence": {
+          "type": "boolean"
+        },
+        "allow_stabilization": {
+          "type": "boolean"
+        },
+        "advection": {
+          "type": "boolean"
+        },
+        "schwarz_iterations": {
+          "$ref": "urn:neko:schema:common#/$defs/nonNegativeIntegerOrRef"
         },
         "nut_field": {
           "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
@@ -314,16 +546,80 @@
           }
         },
         "output_control": {
-          "$ref": "urn:neko:schema:common#/$defs/frequencyControl"
+          "type": "string",
+          "enum": ["simulationtime", "tsteps", "nsamples", "never", "org"]
         },
         "output_value": {
-          "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+          "$ref": "urn:neko:schema:common#/$defs/numericOrRef"
+        },
+        "output_filename": {
+          "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+        },
+        "output_format": {
+          "type": "string",
+          "enum": ["fld", "nek5000", "adios2", "vtkhdf"]
+        },
+        "output_mesh_in_all_files": {
+          "type": "boolean"
+        },
+        "output_subdivide": {
+          "type": "boolean"
+        },
+        "wall_zone_indices": {
+          "$ref": "urn:neko:schema:common#/$defs/integerArrayOrRef"
         },
         "ale": {
           "$ref": "#/$defs/ale"
         }
       },
       "allOf": [
+        {
+          "if": {
+            "properties": {
+              "output_control": {
+                "enum": ["simulationtime", "tsteps", "nsamples"]
+              }
+            },
+            "required": ["output_control"]
+          },
+          "then": {
+            "required": ["output_value"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "output_control": {
+                "enum": ["tsteps", "nsamples"]
+              }
+            },
+            "required": ["output_control"]
+          },
+          "then": {
+            "properties": {
+              "output_value": {
+                "$ref": "urn:neko:schema:common#/$defs/positiveIntegerOrRef"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "output_control": {
+                "const": "simulationtime"
+              }
+            },
+            "required": ["output_control"]
+          },
+          "then": {
+            "properties": {
+              "output_value": {
+                "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+              }
+            }
+          }
+        },
         {
           "if": {
             "properties": {
@@ -360,25 +656,10 @@
               "boundary_conditions": {
                 "type": "array",
                 "items": {
-                  "type": "object",
-                  "additionalProperties": true
+                  "$ref": "#/$defs/compressibleBoundaryCondition"
                 }
               }
             }
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "scheme": {
-                "const": "compressible"
-              }
-            }
-          },
-          "then": {
-            "required": [
-              "gamma"
-            ]
           }
         }
       ],

--- a/doc/schemas/numerics.schema.json
+++ b/doc/schemas/numerics.schema.json
@@ -10,20 +10,33 @@
       ],
       "properties": {
         "time_order": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 4
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 4
+            },
+            {
+              "$ref": "urn:neko:schema:common#/$defs/constRef"
+            }
+          ]
         },
         "polynomial_order": {
-          "type": "integer",
-          "minimum": 3
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 3
+            },
+            {
+              "$ref": "urn:neko:schema:common#/$defs/constRef"
+            }
+          ]
         },
         "dealias": {
           "type": "boolean"
         },
         "dealiased_polynomial_order": {
-          "type": "integer",
-          "minimum": 1
+          "$ref": "urn:neko:schema:common#/$defs/positiveIntegerOrRef"
         },
         "oifs": {
           "type": "boolean"

--- a/doc/schemas/point-zones.schema.json
+++ b/doc/schemas/point-zones.schema.json
@@ -21,13 +21,13 @@
               "const": "box"
             },
             "x_bounds": {
-              "$ref": "urn:neko:schema:common#/$defs/numberArray"
+              "$ref": "urn:neko:schema:common#/$defs/vector2OrRef"
             },
             "y_bounds": {
-              "$ref": "urn:neko:schema:common#/$defs/numberArray"
+              "$ref": "urn:neko:schema:common#/$defs/vector2OrRef"
             },
             "z_bounds": {
-              "$ref": "urn:neko:schema:common#/$defs/numberArray"
+              "$ref": "urn:neko:schema:common#/$defs/vector2OrRef"
             },
             "invert": {
               "type": "boolean"
@@ -54,7 +54,7 @@
               "const": "sphere"
             },
             "center": {
-              "$ref": "urn:neko:schema:common#/$defs/vector3"
+              "$ref": "urn:neko:schema:common#/$defs/vector3OrRef"
             },
             "radius": {
               "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
@@ -85,13 +85,62 @@
               "const": "cylinder"
             },
             "start": {
-              "$ref": "urn:neko:schema:common#/$defs/vector3"
+              "$ref": "urn:neko:schema:common#/$defs/vector3OrRef"
             },
             "end": {
-              "$ref": "urn:neko:schema:common#/$defs/vector3"
+              "$ref": "urn:neko:schema:common#/$defs/vector3OrRef"
             },
             "radius": {
               "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+            },
+            "invert": {
+              "type": "boolean"
+            },
+            "full_elements": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "name",
+            "geometry",
+            "subsets",
+            "operator"
+          ],
+          "properties": {
+            "name": {
+              "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+            },
+            "geometry": {
+              "const": "combine"
+            },
+            "subsets": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/pointZone"
+                  },
+                  {
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                      "name": {
+                        "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
+            "operator": {
+              "type": "string",
+              "enum": ["OR", "AND", "XOR"]
             },
             "invert": {
               "type": "boolean"

--- a/doc/schemas/scalar.schema.json
+++ b/doc/schemas/scalar.schema.json
@@ -4,15 +4,42 @@
   "$defs": {
     "alphat": {
       "type": "object",
+      "required": [
+        "nut_dependency"
+      ],
       "properties": {
         "nut_dependency": {
           "type": "boolean"
         },
         "alphat_field": {
           "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+        },
+        "nut_field": {
+          "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+        },
+        "Pr_t": {
+          "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
         }
       },
-      "additionalProperties": true
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "nut_dependency": {"const": true}
+            }
+          },
+          "then": {"required": ["Pr_t", "nut_field"]}
+        },
+        {
+          "if": {
+            "properties": {
+              "nut_dependency": {"const": false}
+            }
+          },
+          "then": {"required": ["alphat_field"]}
+        }
+      ],
+      "additionalProperties": false
     },
     "scalarInitialCondition": {
       "oneOf": [
@@ -48,13 +75,16 @@
           "type": "object",
           "required": [
             "type",
-            "name"
+            "zone_name",
+            "base_value",
+            "zone_value"
           ],
           "properties": {
             "type": {
               "const": "point_zone"
             },
-            "name": {
+            "name": false,
+            "zone_name": {
               "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
             },
             "base_value": {
@@ -84,6 +114,9 @@
             },
             "mesh_file_name": {
               "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+            },
+            "target_index": {
+              "$ref": "urn:neko:schema:common#/$defs/nonNegativeIntegerOrRef"
             },
             "interpolation": {
               "type": "object",
@@ -153,7 +186,8 @@
           "type": "object",
           "required": [
             "type",
-            "zone_indices"
+            "zone_indices",
+            "flux"
           ],
           "properties": {
             "type": {
@@ -166,7 +200,10 @@
               "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
             },
             "flux": {
-              "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+              "anyOf": [
+                {"$ref": "urn:neko:schema:common#/$defs/numberOrRef"},
+                {"$ref": "urn:neko:schema:common#/$defs/vector3"}
+              ]
             }
           },
           "additionalProperties": false
@@ -208,6 +245,26 @@
             },
             "name": {
               "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+            },
+            "interpolation": {
+              "type": "object",
+              "properties": {
+                "tolerance": {
+                  "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+                },
+                "padding": {
+                  "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+                }
+              },
+              "additionalProperties": false
+            },
+            "order": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 3
+            },
+            "log": {
+              "type": "boolean"
             }
           },
           "additionalProperties": false
@@ -216,16 +273,21 @@
     },
     "scalarField": {
       "type": "object",
-      "required": [
-        "initial_condition",
-        "solver"
-      ],
       "properties": {
         "name": {
           "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
         },
+        "scheme": {
+          "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+        },
         "enabled": {
           "type": "boolean"
+        },
+        "freeze": {
+          "type": "boolean"
+        },
+        "Pe": {
+          "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
         },
         "cp": {
           "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
@@ -235,6 +297,9 @@
         },
         "Pr": {
           "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+        },
+        "advection": {
+          "type": "boolean"
         },
         "initial_condition": {
           "$ref": "#/$defs/scalarInitialCondition"
@@ -258,6 +323,19 @@
           }
         }
       },
+      "allOf": [
+        {
+          "if": {
+            "required": ["enabled"],
+            "properties": {
+              "enabled": {"const": false}
+            }
+          },
+          "else": {
+            "required": ["initial_condition", "solver"]
+          }
+        }
+      ],
       "additionalProperties": true
     }
   }

--- a/doc/schemas/simcomps/boundary_flux.schema.json
+++ b/doc/schemas/simcomps/boundary_flux.schema.json
@@ -18,7 +18,7 @@
               "const": "boundary_flux"
             },
             "zone_indices": {
-              "$ref": "urn:neko:schema:simulation-components#/$defs/integerArrayOrRef"
+              "$ref": "urn:neko:schema:simulation-components#/$defs/integerArray"
             },
             "field_names": {
               "$ref": "urn:neko:schema:simulation-components#/$defs/simcompFields3"

--- a/doc/schemas/simcomps/boundary_operation.schema.json
+++ b/doc/schemas/simcomps/boundary_operation.schema.json
@@ -19,7 +19,7 @@
               "const": "boundary_operation"
             },
             "zone_indices": {
-              "$ref": "urn:neko:schema:simulation-components#/$defs/integerArrayOrRef"
+              "$ref": "urn:neko:schema:simulation-components#/$defs/integerArray"
             },
             "field_name": {
               "$ref": "urn:neko:schema:simulation-components#/$defs/nonEmptyString"

--- a/doc/schemas/simcomps/field_subsampler.schema.json
+++ b/doc/schemas/simcomps/field_subsampler.schema.json
@@ -26,9 +26,14 @@
               "$ref": "urn:neko:schema:simulation-components#/$defs/nonEmptyString"
             },
             "polynomial_order": {
-              "$ref": "urn:neko:schema:simulation-components#/$defs/integerOrRef"
+              "type": "integer",
+              "minimum": 1
             }
           },
+          "anyOf": [
+            {"required": ["point_zone"]},
+            {"required": ["polynomial_order"]}
+          ],
           "additionalProperties": true
         }
       ]

--- a/doc/schemas/simcomps/lagrangian_particles.schema.json
+++ b/doc/schemas/simcomps/lagrangian_particles.schema.json
@@ -24,6 +24,7 @@
             "inertia"
           ],
           "properties": {
+            "wall_zone_indices": false,
             "type": {
               "const": "lagrangian_particles"
             },
@@ -53,13 +54,12 @@
               ]
             },
             "nonlinear_coefficient": {
-              "$ref": "urn:neko:schema:simulation-components#/$defs/numberOrRef"
+              "type": "number",
+              "x-neko-real": true
             },
             "nonlinear_exponent": {
-              "$ref": "urn:neko:schema:simulation-components#/$defs/numberOrRef"
-            },
-            "wall_zone_indices": {
-              "$ref": "urn:neko:schema:simulation-components#/$defs/integerArrayOrRef"
+              "type": "number",
+              "x-neko-real": true
             },
             "interpolation": {
               "type": "object",
@@ -77,7 +77,8 @@
               "type": "boolean"
             },
             "start_time": {
-              "$ref": "urn:neko:schema:simulation-components#/$defs/numberOrRef"
+              "type": "number",
+              "x-neko-real": true
             },
             "output_filename": {
               "$ref": "urn:neko:schema:simulation-components#/$defs/nonEmptyString"
@@ -94,16 +95,21 @@
               "$ref": "#/$defs/positiveIntegerOrAll"
             }
           },
-          "oneOf": [
+          "allOf": [
             {
-              "required": [
-                "coordinates"
+              "anyOf": [
+                {"required": ["coordinates"]},
+                {"required": ["points_file"]}
               ]
             },
             {
-              "required": [
-                "points_file"
-              ]
+              "if": {
+                "properties": {"inertia": {"const": true}},
+                "required": ["inertia", "coordinates"]
+              },
+              "then": {
+                "required": ["velocities", "diameters", "densities"]
+              }
             }
           ],
           "additionalProperties": true

--- a/doc/schemas/simcomps/lambda2.schema.json
+++ b/doc/schemas/simcomps/lambda2.schema.json
@@ -8,6 +8,9 @@
           "$ref": "urn:neko:schema:simulation-components#/$defs/simcompBase"
         },
         {
+          "$ref": "urn:neko:schema:simulation-components#/$defs/simcompFieldWriterOptions"
+        },
+        {
           "type": "object",
           "properties": {
             "type": {

--- a/doc/schemas/simcomps/les_model.schema.json
+++ b/doc/schemas/simcomps/les_model.schema.json
@@ -24,7 +24,8 @@
                       "const": "smagorinsky"
                     },
                     "c_s": {
-                      "$ref": "urn:neko:schema:simulation-components#/$defs/numberOrRef"
+                      "type": "number",
+                      "x-neko-real": true
                     }
                   },
                   "additionalProperties": true
@@ -60,10 +61,10 @@
                       "$ref": "urn:neko:schema:simulation-components#/$defs/nonEmptyString"
                     },
                     "Ri_c": {
-                      "$ref": "urn:neko:schema:simulation-components#/$defs/numberOrRef"
+                      "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
                     },
                     "reference_temperature": {
-                      "$ref": "urn:neko:schema:simulation-components#/$defs/numberOrRef"
+                      "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
                     },
                     "g": {
                       "$ref": "urn:neko:schema:simulation-components#/$defs/vector3OrRef"
@@ -100,7 +101,8 @@
                       "const": "sigma"
                     },
                     "c": {
-                      "$ref": "urn:neko:schema:simulation-components#/$defs/numberOrRef"
+                      "type": "number",
+                      "x-neko-real": true
                     }
                   },
                   "additionalProperties": true
@@ -112,7 +114,8 @@
                       "const": "wale"
                     },
                     "c_w": {
-                      "$ref": "urn:neko:schema:simulation-components#/$defs/numberOrRef"
+                      "type": "number",
+                      "x-neko-real": true
                     }
                   },
                   "additionalProperties": true
@@ -150,6 +153,9 @@
                     },
                     "TKE_source_field": {
                       "$ref": "urn:neko:schema:simulation-components#/$defs/nonEmptyString"
+                    },
+                    "extrapolation": {
+                      "const": false
                     }
                   },
                   "additionalProperties": true

--- a/doc/schemas/simcomps/probes.schema.json
+++ b/doc/schemas/simcomps/probes.schema.json
@@ -52,7 +52,7 @@
               "$ref": "urn:neko:schema:simulation-components#/$defs/numberOrRef"
             }
           },
-          "oneOf": [
+          "anyOf": [
             {
               "required": [
                 "points_file"

--- a/doc/schemas/simcomps/spatial_average.schema.json
+++ b/doc/schemas/simcomps/spatial_average.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "urn:neko:schema:simcomps:user_stats",
+  "$id": "urn:neko:schema:simcomps:spatial_average",
   "$defs": {
     "simulationComponent": {
       "allOf": [
@@ -10,17 +10,15 @@
         {
           "type": "object",
           "required": [
-            "fields"
+            "fields",
+            "avg_direction"
           ],
           "properties": {
             "type": {
-              "const": "user_stats"
+              "const": "spatial_average"
             },
             "fields": {
               "$ref": "urn:neko:schema:simulation-components#/$defs/simcompFields"
-            },
-            "start_time": {
-              "$ref": "urn:neko:schema:simulation-components#/$defs/numberOrRef"
             },
             "avg_direction": {
               "$ref": "urn:neko:schema:simulation-components#/$defs/simcompAvgDirection"

--- a/doc/schemas/simcomps/spectral_error.schema.json
+++ b/doc/schemas/simcomps/spectral_error.schema.json
@@ -8,6 +8,9 @@
           "$ref": "urn:neko:schema:simulation-components#/$defs/simcompBase"
         },
         {
+          "$ref": "urn:neko:schema:simulation-components#/$defs/simcompFieldWriterOptions"
+        },
+        {
           "type": "object",
           "properties": {
             "type": {

--- a/doc/schemas/simulation-components.schema.json
+++ b/doc/schemas/simulation-components.schema.json
@@ -12,6 +12,17 @@
     "numberOrRef": {
       "oneOf": [
         {
+          "type": "number",
+          "x-neko-real": true
+        },
+        {
+          "$ref": "#/$defs/constRef"
+        }
+      ]
+    },
+    "numericOrRef": {
+      "oneOf": [
+        {
           "type": "number"
         },
         {
@@ -32,14 +43,16 @@
     "numberArray": {
       "type": "array",
       "items": {
-        "type": "number"
+        "type": "number",
+        "x-neko-real": true
       },
       "minItems": 1
     },
     "integerArray": {
       "type": "array",
       "items": {
-        "type": "integer"
+        "type": "integer",
+        "minimum": 1
       },
       "minItems": 1
     },
@@ -56,7 +69,8 @@
     "vector3": {
       "type": "array",
       "items": {
-        "type": "number"
+        "type": "number",
+        "x-neko-real": true
       },
       "minItems": 3,
       "maxItems": 3
@@ -123,33 +137,178 @@
           "$ref": "#/$defs/nonEmptyString"
         },
         "order": {
-          "$ref": "#/$defs/integerOrRef"
+          "type": "integer"
         },
         "preprocess_control": {
           "$ref": "#/$defs/simcompComputeControl"
         },
         "preprocess_value": {
-          "$ref": "#/$defs/numberOrRef"
+          "$ref": "#/$defs/numericOrRef"
         },
         "compute_control": {
           "$ref": "#/$defs/simcompComputeControl"
         },
         "compute_value": {
-          "$ref": "#/$defs/numberOrRef"
+          "$ref": "#/$defs/numericOrRef"
         },
         "output_control": {
           "$ref": "#/$defs/simcompOutputControl"
         },
         "output_value": {
-          "$ref": "#/$defs/numberOrRef"
+          "$ref": "#/$defs/numericOrRef"
         },
         "comment": {
           "$ref": "#/$defs/nonEmptyString"
         },
         "is_user": {
-          "type": "boolean"
+          "const": false
         }
       },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "preprocess_control": {
+                "enum": ["tsteps", "nsamples"]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "preprocess_value": {
+                "$ref": "urn:neko:schema:common#/$defs/positiveIntegerOrRef"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "compute_control": {
+                "enum": ["tsteps", "nsamples"]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "compute_value": {
+                "$ref": "urn:neko:schema:common#/$defs/positiveIntegerOrRef"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "preprocess_control": {
+                "const": "simulationtime"
+              }
+            },
+            "required": ["preprocess_control"]
+          },
+          "then": {
+            "properties": {
+              "preprocess_value": {
+                "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "compute_control": {
+                "const": "simulationtime"
+              }
+            },
+            "required": ["compute_control"]
+          },
+          "then": {
+            "properties": {
+              "compute_value": {
+                "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "output_control": {
+                "enum": ["tsteps", "nsamples"]
+              }
+            },
+            "required": ["output_control"]
+          },
+          "then": {
+            "properties": {
+              "output_value": {
+                "$ref": "urn:neko:schema:common#/$defs/positiveIntegerOrRef"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "output_control": {
+                "const": "simulationtime"
+              }
+            },
+            "required": ["output_control"]
+          },
+          "then": {
+            "properties": {
+              "output_value": {
+                "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "allOf": [
+              {"not": {"required": ["output_control"]}},
+              {
+                "properties": {
+                  "compute_control": {
+                    "enum": ["tsteps", "nsamples"]
+                  }
+                }
+              }
+            ]
+          },
+          "then": {
+            "properties": {
+              "output_value": {
+                "$ref": "urn:neko:schema:common#/$defs/positiveIntegerOrRef"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "allOf": [
+              {"not": {"required": ["output_control"]}},
+              {
+                "properties": {
+                  "compute_control": {
+                    "const": "simulationtime"
+                  }
+                },
+                "required": ["compute_control"]
+              }
+            ]
+          },
+          "then": {
+            "properties": {
+              "output_value": {
+                "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+              }
+            }
+          }
+        }
+      ],
       "additionalProperties": true
     },
     "simcompFields": {
@@ -184,6 +343,7 @@
           "type": "string",
           "enum": [
             "nek5000",
+            "fld",
             "vtkhdf",
             "adios2"
           ]
@@ -198,54 +358,59 @@
       "additionalProperties": true
     },
     "simcompProbesPoint": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "file",
-            "points",
-            "line",
-            "plane",
-            "circle",
-            "point_zone"
-          ]
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["type", "file_name"],
+          "properties": {
+            "type": {"const": "file"},
+            "file_name": {"$ref": "#/$defs/nonEmptyString"}
+          },
+          "additionalProperties": false
         },
-        "file_name": {
-          "$ref": "#/$defs/nonEmptyString"
+        {
+          "type": "object",
+          "required": ["type", "coordinates"],
+          "properties": {
+            "type": {"const": "points"},
+            "coordinates": {"$ref": "#/$defs/numberArray"}
+          },
+          "additionalProperties": false
         },
-        "coordinates": {
-          "$ref": "#/$defs/numberArray"
+        {
+          "type": "object",
+          "required": ["type", "start", "end", "amount"],
+          "properties": {
+            "type": {"const": "line"},
+            "start": {"$ref": "#/$defs/vector3OrRef"},
+            "end": {"$ref": "#/$defs/vector3OrRef"},
+            "amount": {"$ref": "#/$defs/integerOrRef"}
+          },
+          "additionalProperties": false
         },
-        "start": {
-          "$ref": "#/$defs/vector3"
+        {
+          "type": "object",
+          "required": ["type", "center", "normal", "radius", "amount", "axis"],
+          "properties": {
+            "type": {"const": "circle"},
+            "center": {"$ref": "#/$defs/vector3OrRef"},
+            "normal": {"$ref": "#/$defs/vector3OrRef"},
+            "radius": {"$ref": "#/$defs/numberOrRef"},
+            "amount": {"$ref": "#/$defs/integerOrRef"},
+            "axis": {"$ref": "#/$defs/nonEmptyString"}
+          },
+          "additionalProperties": false
         },
-        "end": {
-          "$ref": "#/$defs/vector3"
-        },
-        "amount": {
-          "$ref": "#/$defs/integerOrRef"
-        },
-        "center": {
-          "$ref": "#/$defs/vector3"
-        },
-        "radius": {
-          "$ref": "#/$defs/numberOrRef"
-        },
-        "normal": {
-          "$ref": "#/$defs/vector3"
-        },
-        "axis": {
-          "$ref": "#/$defs/nonEmptyString"
-        },
-        "name": {
-          "$ref": "#/$defs/nonEmptyString"
+        {
+          "type": "object",
+          "required": ["type", "name"],
+          "properties": {
+            "type": {"const": "point_zone"},
+            "name": {"$ref": "#/$defs/nonEmptyString"}
+          },
+          "additionalProperties": false
         }
-      },
-      "additionalProperties": true
+      ]
     },
     "simcompAlphat": {
       "type": "object",
@@ -341,55 +506,23 @@
       "additionalProperties": true
     },
     "lesModelTestFilter": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "elementwise"
-            },
-            "elementwise_filter_type": {
-              "type": "string",
-              "enum": [
-                "Boyd",
-                "nonBoyd"
-              ]
-            },
-            "transfer_function": {
-              "$ref": "#/$defs/numberArray"
-            }
-          },
-          "additionalProperties": true
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "elementwise"
         },
-        {
-          "type": "object",
-          "required": [
-            "filter"
-          ],
-          "properties": {
-            "filter": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "const": "elementwise"
-                },
-                "elementwise_filter_type": {
-                  "type": "string",
-                  "enum": [
-                    "Boyd",
-                    "nonBoyd"
-                  ]
-                },
-                "transfer_function": {
-                  "$ref": "#/$defs/numberArray"
-                }
-              },
-              "additionalProperties": true
-            }
-          },
-          "additionalProperties": true
+        "elementwise_filter_type": {
+          "type": "string",
+          "enum": [
+            "Boyd",
+            "nonBoyd"
+          ]
+        },
+        "transfer_function": {
+          "$ref": "#/$defs/numberArray"
         }
-      ]
+      },
+      "additionalProperties": false
     },
     "simulationComponent": {
       "oneOf": [
@@ -446,6 +579,9 @@
         },
         {
           "$ref": "urn:neko:schema:simcomps:force_torque#/$defs/simulationComponent"
+        },
+        {
+          "$ref": "urn:neko:schema:simcomps:spatial_average#/$defs/simulationComponent"
         },
         {
           "$ref": "urn:neko:schema:simcomps:les_model#/$defs/simulationComponent"

--- a/doc/schemas/source-terms.schema.json
+++ b/doc/schemas/source-terms.schema.json
@@ -10,7 +10,8 @@
         {
           "type": "array",
           "items": {
-            "type": "number"
+            "type": "number",
+            "x-neko-real": true
           },
           "minItems": 1,
           "maxItems": 1
@@ -43,40 +44,108 @@
       ],
       "properties": {
         "type": {
-          "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+          "type": "string",
+          "enum": ["boundary_mesh", "point_zone", "field", "file"]
         },
         "name": {
           "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
         },
         "distance_transform": {
           "type": "object",
+          "required": ["type", "value"],
           "properties": {
             "type": {
-              "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+              "type": "string",
+              "enum": ["smooth_step", "step"]
             },
             "value": {
               "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
             }
           },
-          "additionalProperties": true
-        },
-        "filter": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
-            }
-          },
-          "additionalProperties": true
+          "additionalProperties": false
         },
         "cache": {
           "type": "boolean"
         },
         "cache_file": {
           "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+        },
+        "mesh_transform": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["none", "bounding_box"]
+            },
+            "box_min": {
+              "$ref": "urn:neko:schema:common#/$defs/vector3OrRef"
+            },
+            "box_max": {
+              "$ref": "urn:neko:schema:common#/$defs/vector3OrRef"
+            },
+            "keep_aspect_ratio": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "file_name": {
+          "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+        },
+        "field_name": {
+          "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+        },
+        "file_index": {
+          "$ref": "urn:neko:schema:common#/$defs/nonNegativeIntegerOrRef"
         }
       },
-      "additionalProperties": true
+      "allOf": [
+        {
+          "if": {
+            "properties": {"type": {"enum": ["boundary_mesh", "point_zone", "field"]}},
+            "required": ["type"]
+          },
+          "then": {"required": ["name"]}
+        },
+        {
+          "if": {
+            "properties": {"type": {"const": "boundary_mesh"}},
+            "required": ["type"]
+          },
+          "then": {"required": ["distance_transform"]}
+        },
+        {
+          "if": {
+            "properties": {"type": {"const": "file"}},
+            "required": ["type"]
+          },
+          "then": {"required": ["file_name"]}
+        },
+        {
+          "if": {
+            "properties": {"cache": {"const": true}},
+            "required": ["cache"]
+          },
+          "then": {"required": ["cache_file"]}
+        },
+        {
+          "if": {
+            "properties": {
+              "mesh_transform": {
+                "properties": {"type": {"const": "bounding_box"}},
+                "required": ["type"]
+              }
+            },
+            "required": ["mesh_transform"]
+          },
+          "then": {
+            "properties": {
+              "mesh_transform": {"required": ["box_min", "box_max"]}
+            }
+          }
+        }
+      ],
+      "additionalProperties": false
     },
     "scalarConstantSourceTerm": {
       "type": "object",
@@ -98,7 +167,7 @@
           "$ref": "urn:neko:schema:common#/$defs/nonNegativeNumberOrRef"
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "fluidConstantSourceTerm": {
       "type": "object",
@@ -120,7 +189,7 @@
           "$ref": "urn:neko:schema:common#/$defs/nonNegativeNumberOrRef"
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "userSourceTerm": {
       "type": "object",
@@ -261,7 +330,9 @@
     "boussinesqSourceTerm": {
       "type": "object",
       "required": [
-        "type"
+        "type",
+        "g",
+        "reference_value"
       ],
       "properties": {
         "type": {
@@ -286,7 +357,7 @@
           "$ref": "urn:neko:schema:common#/$defs/nonNegativeNumberOrRef"
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "coriolisSourceTerm": {
       "type": "object",
@@ -319,12 +390,19 @@
           "$ref": "urn:neko:schema:common#/$defs/nonNegativeNumberOrRef"
         }
       },
-      "additionalProperties": true
+      "anyOf": [
+        {"required": ["rotation_vector"]},
+        {"required": ["omega", "phi"]},
+        {"required": ["f"]}
+      ],
+      "additionalProperties": false
     },
     "brinkmanSourceTerm": {
       "type": "object",
       "required": [
         "type",
+        "limits",
+        "penalty",
         "objects"
       ],
       "properties": {
@@ -332,22 +410,29 @@
           "const": "brinkman"
         },
         "limits": {
-          "$ref": "urn:neko:schema:common#/$defs/numberArrayOrRef"
+          "$ref": "urn:neko:schema:common#/$defs/vector2OrRef"
         },
         "penalty": {
           "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
         },
-        "brinkman": {
+        "output": {
           "type": "object",
           "properties": {
-            "limits": {
-              "$ref": "urn:neko:schema:common#/$defs/numberArrayOrRef"
+            "enable": {
+              "type": "boolean"
             },
-            "penalty": {
-              "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+            "precision": {
+              "type": "string",
+              "enum": ["sp", "single", "dp", "double"]
+            },
+            "path": {
+              "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+            },
+            "format": {
+              "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
             }
           },
-          "additionalProperties": true
+          "additionalProperties": false
         },
         "objects": {
           "type": "array",
@@ -356,6 +441,31 @@
           },
           "minItems": 1
         },
+        "filter": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["none", "PDE"]
+            },
+            "radius": {
+              "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+            },
+            "tolerance": {
+              "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+            },
+            "max_iter": {
+              "$ref": "urn:neko:schema:common#/$defs/positiveIntegerOrRef"
+            },
+            "solver": {
+              "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+            },
+            "preconditioner": {
+              "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+            }
+          },
+          "additionalProperties": false
+        },
         "start_time": {
           "$ref": "urn:neko:schema:common#/$defs/nonNegativeNumberOrRef"
         },
@@ -363,7 +473,7 @@
           "$ref": "urn:neko:schema:common#/$defs/nonNegativeNumberOrRef"
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "spongeSourceTerm": {
       "type": "object",
@@ -405,11 +515,36 @@
             "interpolate": {
               "type": "boolean"
             },
-            "tolerance": {
-              "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+            "interpolation": {
+              "type": "object",
+              "properties": {
+                "tolerance": {
+                  "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+                },
+                "padding": {
+                  "$ref": "urn:neko:schema:common#/$defs/numberOrRef"
+                }
+              },
+              "additionalProperties": false
             }
           },
-          "additionalProperties": true
+          "allOf": [
+            {
+              "if": {
+                "properties": {"method": {"const": "constant"}},
+                "required": ["method"]
+              },
+              "then": {"required": ["value"]}
+            },
+            {
+              "if": {
+                "properties": {"method": {"const": "field"}},
+                "required": ["method"]
+              },
+              "then": {"required": ["file_name"]}
+            }
+          ],
+          "additionalProperties": false
         },
         "fringe_registry_name": {
           "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
@@ -430,7 +565,7 @@
           "$ref": "urn:neko:schema:common#/$defs/nonNegativeNumberOrRef"
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "centrifugalSourceTerm": {
       "type": "object",

--- a/doc/schemas/time.schema.json
+++ b/doc/schemas/time.schema.json
@@ -48,6 +48,19 @@
           "$ref": "urn:neko:schema:common#/$defs/unitIntervalExclusiveOrRef"
         }
       },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "variable_timestep": {"const": true}
+            },
+            "required": ["variable_timestep"]
+          },
+          "else": {
+            "required": ["timestep"]
+          }
+        }
+      ],
       "additionalProperties": false
     }
   }

--- a/examples/TS_channel/TS_channel.case
+++ b/examples/TS_channel/TS_channel.case
@@ -7,7 +7,7 @@
         "output_checkpoints": false,
         "output_precision": "double",
         "checkpoint_control": "simulationtime",
-        "checkpoint_value": 100,
+        "checkpoint_value": 100.0,
         "time": {
             "end_time": 200.0,
             "timestep": 0.02,

--- a/examples/advecting_cone/advecting_cone.case
+++ b/examples/advecting_cone/advecting_cone.case
@@ -41,7 +41,7 @@
         "max_iterations": 800
       },
       "output_control": "nsamples",
-      "output_value": 100.0
+      "output_value": 100
     },
     "scalar": {
       "enabled": true,
@@ -64,7 +64,7 @@
       {
         "type": "probes",
         "compute_control": "nsamples",
-        "compute_value": 1.0,
+        "compute_value": 1,
         "points_file": "probes.csv",
         "output_file": "output.csv",
         "fields": [

--- a/examples/api/Neko.jl/cylinder.case
+++ b/examples/api/Neko.jl/cylinder.case
@@ -6,7 +6,7 @@
     "output_boundary": true,
     "output_checkpoints": true,
     "checkpoint_control": "simulationtime",
-    "checkpoint_value": 50,
+    "checkpoint_value": 50.0,
     "time": {
         "end_time": 200.0,
         "variable_timestep": true,
@@ -20,7 +20,7 @@
     },
     "fluid": {
         "scheme": "pnpn",
-        "Re": 200,
+        "Re": 200.0,
         "initial_condition": {
             "type": "user"
         },
@@ -82,13 +82,13 @@
       "compute_value": 10,
       "zone_id": 7,
       "zone_name": "Cylinder",
-      "center": [0,0,0]
+      "center": [0.0, 0.0, 0.0]
     },
     {
       "type": "fluid_stats",
       "output_control": "simulationtime",
-      "output_value": 10,
-      "start_time": 50,
+      "output_value": 10.0,
+      "start_time": 50.0,
       "compute_control": "tsteps",
       "compute_value": 10,
       "avg_direction": "z",

--- a/examples/api/c/cylinder.case
+++ b/examples/api/c/cylinder.case
@@ -6,7 +6,7 @@
     "output_boundary": true,
     "output_checkpoints": true,
     "checkpoint_control": "simulationtime",
-    "checkpoint_value": 50,
+    "checkpoint_value": 50.0,
     "time": {
         "end_time": 200.0,
         "variable_timestep": true,
@@ -20,7 +20,7 @@
     },
     "fluid": {
         "scheme": "pnpn",
-        "Re": 200,
+        "Re": 200.0,
         "initial_condition": {
             "type": "uniform",
             "value": [1.0, 0.0, 0.0]
@@ -46,7 +46,7 @@
         "boundary_conditions": [
         {
             "type": "velocity_value",
-            "value": [1, 0, 0],
+            "value": [1.0, 0.0, 0.0],
             "zone_indices": [1]
         },
         {
@@ -84,13 +84,13 @@
       "compute_value": 10,
       "zone_id": 7,
       "zone_name": "Cylinder",
-      "center": [0,0,0]
+      "center": [0.0, 0.0, 0.0]
     },
     {
       "type": "fluid_stats",
       "output_control": "simulationtime",
-      "output_value": 10,
-      "start_time": 50,
+      "output_value": 10.0,
+      "start_time": 50.0,
       "compute_control": "tsteps",
       "compute_value": 10,
       "avg_direction": "z",

--- a/examples/cyl_boundary_layer/cyl_bl_basic.case
+++ b/examples/cyl_boundary_layer/cyl_bl_basic.case
@@ -65,7 +65,7 @@
                 }
             ],
             "output_control": "nsamples",
-            "output_value": 400.0
+            "output_value": 400
         }
     }
 }

--- a/examples/cyl_boundary_layer/cyl_bl_rot.case
+++ b/examples/cyl_boundary_layer/cyl_bl_rot.case
@@ -71,7 +71,7 @@
                 }
             ],
             "output_control": "nsamples",
-            "output_value": 400.0
+            "output_value": 400
         }
     }
 }

--- a/examples/cyl_boundary_layer/cyl_bl_user.case
+++ b/examples/cyl_boundary_layer/cyl_bl_user.case
@@ -64,7 +64,7 @@
                 }
             ],
             "output_control": "nsamples",
-            "output_value": 400.0
+            "output_value": 400
         }
     }
 }

--- a/examples/rayleigh_benard_cylinder/rayleigh.case
+++ b/examples/rayleigh_benard_cylinder/rayleigh.case
@@ -20,7 +20,6 @@
         "fluid": {
             "scheme": "pnpn",
             "Ra": 1e8,
-            "variable_material_properties": false,
             "source_terms": [
                 {
                     "type": "boussinesq",
@@ -57,7 +56,7 @@
                 "max_iterations": 800
             },
             "output_control": "nsamples",
-            "output_value": 10.0,
+            "output_value": 10,
             "boundary_conditions": [
                 {
                     "type": "no_slip",

--- a/examples/recycling/recycling.case
+++ b/examples/recycling/recycling.case
@@ -78,7 +78,7 @@
             {
                 "type": "force_torque",
                 "compute_control": "tsteps",
-                "compute_value": 10.0,
+                "compute_value": 10,
                 "zone_id": 4,
                 "zone_name": "Top wall",
                 "center": [ 0.0, 0.0, 0.0 ]

--- a/examples/tgv/tgv.case
+++ b/examples/tgv/tgv.case
@@ -6,7 +6,7 @@
         "output_boundary": true,
         "output_checkpoints": false,
         "output_at_end": true,
-        "load_balance": false,
+        "load_balancing": false,
         "job_timelimit": "00:00:00",
         "time": {
             "end_time": 3.0,

--- a/src/simulation_components/user_stats.f90
+++ b/src/simulation_components/user_stats.f90
@@ -41,7 +41,8 @@ module user_stats
   use field, only : field_t
   use case, only : case_t
   use mean_field_output, only : mean_field_output_t
-  use json_utils, only : json_get, json_get_or_default
+  use json_utils, only : json_get, json_get_or_default, &
+      json_get_or_lookup_or_default
   use mean_field, only : mean_field_t
   use coefs, only : coef_t
   use time_state, only : time_state_t
@@ -110,7 +111,7 @@ contains
     !> Get the number of stat fields and their names
     call json%info('fields', n_children = this%n_avg_fields)
     call json_get(json, 'fields', this%field_names)
-    call json_get_or_default(json, 'start_time', this%start_time, 0.0_rp)
+    call json_get_or_lookup_default(json, 'start_time', this%start_time, 0.0_rp)
     call json_get_or_default(json, 'avg_direction', avg_dir, 'none')
 
     if (json%valid_path('output_filename')) then

--- a/src/simulation_components/user_stats.f90
+++ b/src/simulation_components/user_stats.f90
@@ -111,7 +111,7 @@ contains
     !> Get the number of stat fields and their names
     call json%info('fields', n_children = this%n_avg_fields)
     call json_get(json, 'fields', this%field_names)
-    call json_get_or_lookup_default(json, 'start_time', this%start_time, 0.0_rp)
+    call json_get_or_lookup_or_default(json, 'start_time', this%start_time, 0.0_rp)
     call json_get_or_default(json, 'avg_direction', avg_dir, 'none')
 
     if (json%valid_path('output_filename')) then

--- a/tests/bench/tgv32/tgv.case
+++ b/tests/bench/tgv32/tgv.case
@@ -17,31 +17,36 @@
         },
         "fluid": {
             "scheme": "pnpn",
-            "Re": 1600,
+            "Re": 1600.0,
             "initial_condition": {
                 "type": "user"
             },
             "velocity_solver": {
                 "type": "cg",
-                "preconditioner": "jacobi",
+                "preconditioner": {
+                    "type": "jacobi"
+                },
                 "projection_space_size": 0,
                 "absolute_tolerance": 1e-9,
                 "max_iterations": 800
             },
             "pressure_solver": {
                 "type": "gmres",
-                "preconditioner": "hsmg",
+                "preconditioner": {
+                    "type": "hsmg"
+                },
                 "projection_space_size": 20,
                 "absolute_tolerance": 1e-9,
                 "max_iterations": 800
             },
             "output_control": "simulationtime",
-            "output_value": 10
+            "output_value": 10.0
         },
         "simulation_components":
         [
             {
-                "type": "vorticity",
+                "type": "curl",
+                "fields": ["u", "v", "w"],
                 "computed_field": "omega",
                 "compute_control": "tsteps",
                 "compute_value": 50

--- a/tests/integration/tests/test_case_schema/test_case_schema.py
+++ b/tests/integration/tests/test_case_schema/test_case_schema.py
@@ -1,14 +1,22 @@
+import json
 from pathlib import Path
+import re
 import subprocess
 import sys
 
+import json5
 import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 VALIDATOR = REPO_ROOT / "contrib" / "validate_case_schema.py"
 EXAMPLES_DIR = REPO_ROOT / "examples"
-CASE_FILES = sorted(EXAMPLES_DIR.rglob("*.case")) + sorted(EXAMPLES_DIR.rglob("*.json"))
+TESTS_DIR = REPO_ROOT / "tests"
+CASE_FILES = (
+    sorted(EXAMPLES_DIR.rglob("*.case"))
+    + sorted(EXAMPLES_DIR.rglob("*.json"))
+    + sorted(TESTS_DIR.rglob("*.case"))
+)
 
 
 @pytest.mark.parametrize(
@@ -28,3 +36,241 @@ def test_example_case_schema(case_file):
         f"stdout:\n{result.stdout}\n"
         f"stderr:\n{result.stderr}"
     )
+
+
+@pytest.mark.parametrize(
+    "property_path",
+    [
+        ("case", "load_balance"),
+        ("case", "joblimit"),
+        ("case", "output_format"),
+        ("case", "fluid", "variable_material_properties"),
+    ],
+)
+def test_rejects_known_ignored_properties(tmp_path, property_path):
+    with (EXAMPLES_DIR / "tgv" / "tgv.case").open(encoding="utf-8") as handle:
+        data = json5.load(handle)
+
+    target = data
+    for key in property_path[:-1]:
+        target = target[key]
+    target[property_path[-1]] = False
+
+    case_file = tmp_path / "invalid.case"
+    case_file.write_text(json.dumps(data), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR), str(case_file)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+
+
+def test_allows_user_extension_properties(tmp_path):
+    with (EXAMPLES_DIR / "tgv" / "tgv.case").open(encoding="utf-8") as handle:
+        data = json5.load(handle)
+    data["case"]["fluid"]["user_parameter"] = 42
+
+    case_file = tmp_path / "custom.case"
+    case_file.write_text(json.dumps(data), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR), str(case_file)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_rejects_real_encoding_for_integer_controller_value(tmp_path):
+    with (EXAMPLES_DIR / "rayleigh_benard_cylinder" / "rayleigh.case").open(
+        encoding="utf-8"
+    ) as handle:
+        data = json5.load(handle)
+    data["case"]["fluid"]["output_value"] = 10.0
+
+    case_file = tmp_path / "invalid.case"
+    case_file.write_text(json.dumps(data), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR), str(case_file)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+
+
+def test_rejects_integer_encoding_for_real_parameter(tmp_path):
+    with (EXAMPLES_DIR / "api" / "c" / "cylinder.case").open(
+        encoding="utf-8"
+    ) as handle:
+        data = json5.load(handle)
+    data["case"]["fluid"]["Re"] = 200
+
+    case_file = tmp_path / "invalid.case"
+    case_file.write_text(json.dumps(data), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR), str(case_file)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+
+
+def test_rejects_integer_encoding_in_real_array(tmp_path):
+    with (EXAMPLES_DIR / "api" / "c" / "cylinder.case").open(
+        encoding="utf-8"
+    ) as handle:
+        data = json5.load(handle)
+    boundary = data["case"]["fluid"]["boundary_conditions"][0]
+    boundary["value"] = [1, 0, 0]
+
+    case_file = tmp_path / "invalid.case"
+    case_file.write_text(json.dumps(data), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR), str(case_file)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+
+
+@pytest.mark.parametrize(
+    "boundary_type",
+    ["outflow", "normal_outflow", "outflow+user", "normal_outflow+user"],
+)
+@pytest.mark.parametrize("property_name", ["delta", "velocity_scale"])
+def test_rejects_dong_parameters_for_non_dong_outflow(
+    tmp_path, boundary_type, property_name
+):
+    with (EXAMPLES_DIR / "cylinder" / "cylinder.case").open(
+        encoding="utf-8"
+    ) as handle:
+        data = json5.load(handle)
+
+    boundary = data["case"]["fluid"]["boundary_conditions"][1]
+    boundary["type"] = boundary_type
+    boundary[property_name] = 0.1
+
+    case_file = tmp_path / "invalid.case"
+    case_file.write_text(json.dumps(data), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR), str(case_file)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+
+
+@pytest.mark.parametrize("boundary_type", ["outflow+dong", "normal_outflow+dong"])
+def test_allows_dong_outflow_parameters(tmp_path, boundary_type):
+    with (EXAMPLES_DIR / "cylinder" / "cylinder.case").open(
+        encoding="utf-8"
+    ) as handle:
+        data = json5.load(handle)
+
+    boundary = data["case"]["fluid"]["boundary_conditions"][1]
+    boundary["type"] = boundary_type
+    boundary["delta"] = 0.01
+    boundary["velocity_scale"] = 1.0
+
+    case_file = tmp_path / "valid.case"
+    case_file.write_text(json.dumps(data), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR), str(case_file)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def collect_const_values(value, property_name):
+    values = set()
+    if isinstance(value, dict):
+        property_schema = value.get(property_name)
+        if isinstance(property_schema, dict) and "const" in property_schema:
+            values.add(property_schema["const"])
+        for child in value.values():
+            values.update(collect_const_values(child, property_name))
+    elif isinstance(value, list):
+        for child in value:
+            values.update(collect_const_values(child, property_name))
+    return values
+
+
+def factory_case_values(path):
+    source = path.read_text(encoding="utf-8")
+    return set(re.findall(r"case \([\"']([^\"']+)[\"']\)", source))
+
+
+def referenced_definition_consts(schema, union_name, property_name):
+    definition = schema["$defs"][union_name]
+    property_schema = definition.get("properties", {}).get(property_name, {})
+    if "const" in property_schema:
+        return {property_schema["const"]}
+
+    values = set()
+    for variant in definition["oneOf"]:
+        definition_name = variant["$ref"].removeprefix("#/$defs/")
+        values.update(
+            referenced_definition_consts(schema, definition_name, property_name)
+        )
+    return values
+
+
+def test_all_builtin_simcomps_have_schemas():
+    runtime_types = factory_case_values(
+        REPO_ROOT / "src/simulation_components/simulation_component_fctry.f90"
+    )
+    with (REPO_ROOT / "doc/schemas/simulation-components.schema.json").open(
+        encoding="utf-8"
+    ) as handle:
+        schema = json.load(handle)
+    refs = json.dumps(schema["$defs"]["simulationComponent"])
+    schema_types = set(re.findall(r"urn:neko:schema:simcomps:([^#]+)#", refs))
+
+    assert schema_types == runtime_types
+
+
+@pytest.mark.parametrize(
+    ("factory", "schema", "property_name", "extra_runtime_types"),
+    [
+        (
+            "src/wall_models/wall_model_fctry.f90",
+            "doc/schemas/fluid-pnpn-boundary-conditions.schema.json",
+            "model",
+            set(),
+        ),
+        (
+            "src/source_terms/source_term_fctry.f90",
+            "doc/schemas/source-terms.schema.json",
+            "type",
+            {"user"},
+        ),
+        (
+            "src/mesh/point_zone_fctry.f90",
+            "doc/schemas/point-zones.schema.json",
+            "geometry",
+            {"combine"},
+        ),
+    ],
+)
+def test_all_builtin_factory_types_have_schemas(
+    factory, schema, property_name, extra_runtime_types
+):
+    runtime_types = factory_case_values(REPO_ROOT / factory) | extra_runtime_types
+    with (REPO_ROOT / schema).open(encoding="utf-8") as handle:
+        schema_data = json.load(handle)
+    if schema == "doc/schemas/source-terms.schema.json":
+        schema_types = referenced_definition_consts(
+            schema_data, "fluidSourceTerm", property_name
+        )
+    else:
+        schema_types = collect_const_values(schema_data, property_name)
+
+    assert schema_types == runtime_types

--- a/tests/integration/tests/test_cylinder/cylinder_part1.case
+++ b/tests/integration/tests/test_cylinder/cylinder_part1.case
@@ -7,7 +7,7 @@
         "output_checkpoints": true,
         "checkpoint_control": "simulationtime",
         "checkpoint_value": 0.05,
-        "joblimit": "00:02:00",
+        "job_timelimit": "00:02:00",
         "time": {
             "end_time": 0.1,
             "timestep": 0.01


### PR DESCRIPTION
This is a significant update to the json schemas that update them with all the missing stuff, and improves multiple mistakes in existing schemas. The works was done by Codex 5.6 Sol, but I manually checked pretty much everything, except for all the ALE stuff, but it looked reasonable at least.

Some inconsistencies were found, and the documentation files are updated to reflect that.

Several .case files had incorrect typing, which led them to fail. Some used outdated keywords. The examples are fixed. The json schema is now also better at detecting those.

The integration test is expanded with extra tests. Some are a bit defensive, targeting specific outdated keywords, but I guess it is OK.