### PR TITLE
Add support for unified memory on MI300A and GH200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Develop
 
+- Added zero-copy `device_map` on unified memory architectures (Apple Silicon
+  Metal, MI300A HIP, Grace Hopper CUDA): mapped arrays alias their host
+  allocation instead of being replicated, halving their footprint; discrete
+  GPUs are unaffected. Disable with `NEKO_{METAL,HIP,CUDA}_ZEROCOPY=0`.
 - Removed the hardcoded `CUDA_ARCH="-arch sm_60"` fallback used for
   `--enable-device-mpi` CUDA builds, which CUDA >= 13 toolkits can no longer
   compile (Pascal support was dropped). `configure` now requires `CUDA_ARCH`

--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -23,6 +23,7 @@ of the code. But can be useful for users and developers alike.
 | `NEKO_GS_COMM`           | Gather-scatter communication backend                                  | Unset         |
 | `NEKO_GS_CAF_SIGNALING`  | Coarray Fortran gather-scatter signaling mode                         | Unset         |
 | `NEKO_COMM_ID`           | Communicator id for this process (non-negative integer)               | 0             |
+| `NEKO_METAL_ZEROCOPY`    | Zero-copy host/device mapping on unified memory (Metal), 0 disables   | 1             |
 | `NEKO_MPI_THREAD_LEVEL`  | Requested MPI (and SHMEM) thread support level                        | Unset         |
 | `NEKO_DEPRECATION_ERROR` | Whether to treat deprecated features as errors (boolean)              | Unset         |
 

--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -23,6 +23,7 @@ of the code. But can be useful for users and developers alike.
 | `NEKO_GS_COMM`           | Gather-scatter communication backend                                  | Unset         |
 | `NEKO_GS_CAF_SIGNALING`  | Coarray Fortran gather-scatter signaling mode                         | Unset         |
 | `NEKO_COMM_ID`           | Communicator id for this process (non-negative integer)               | 0             |
+| `NEKO_CUDA_ZEROCOPY`     | Zero-copy host/device mapping on unified memory (CUDA), 0 disables    | 1             |
 | `NEKO_HIP_ZEROCOPY`      | Zero-copy host/device mapping on unified memory (HIP), 0 disables     | 1             |
 | `NEKO_METAL_ZEROCOPY`    | Zero-copy host/device mapping on unified memory (Metal), 0 disables   | 1             |
 | `NEKO_MPI_THREAD_LEVEL`  | Requested MPI (and SHMEM) thread support level                        | Unset         |

--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -23,6 +23,7 @@ of the code. But can be useful for users and developers alike.
 | `NEKO_GS_COMM`           | Gather-scatter communication backend                                  | Unset         |
 | `NEKO_GS_CAF_SIGNALING`  | Coarray Fortran gather-scatter signaling mode                         | Unset         |
 | `NEKO_COMM_ID`           | Communicator id for this process (non-negative integer)               | 0             |
+| `NEKO_HIP_ZEROCOPY`      | Zero-copy host/device mapping on unified memory (HIP), 0 disables     | 1             |
 | `NEKO_METAL_ZEROCOPY`    | Zero-copy host/device mapping on unified memory (Metal), 0 disables   | 1             |
 | `NEKO_MPI_THREAD_LEVEL`  | Requested MPI (and SHMEM) thread support level                        | Unset         |
 | `NEKO_DEPRECATION_ERROR` | Whether to treat deprecated features as errors (boolean)              | Unset         |

--- a/doc/pages/user-guide/installation.md
+++ b/doc/pages/user-guide/installation.md
@@ -245,7 +245,7 @@ $ ./configure  --with-cuda=/usr/local/cuda CUDA_CFLAGS=-O3  CUDA_ARCH=-arch=sm_8
   cluster's GPUs when cross-compiling.
 * Build using `make && make install`
 
-@note On cache-coherent CPU-GPU platforms (e.g. NVIDIA Grace Hopper), mapped arrays alias their host allocation zero-copy: host and device share a single allocation instead of keeping replicated copies, and host-device transfers become no-ops. Mapped arrays are prefetched to device memory (HBM) and stay resident there, remaining accessible from the host over the coherent interconnect. Zero-copy mapping can be disabled at runtime by setting the environment variable `NEKO_CUDA_ZEROCOPY=0`, which restores fully replicated buffers. Conventional PCIe-attached GPUs always use replicated buffers.
+@note On cache-coherent CPU-GPU platforms (e.g. NVIDIA Grace Hopper), mapped arrays alias their host allocation zero-copy: host and device share a single allocation instead of keeping replicated copies, and host-device transfers become no-ops. Mapped arrays are prefetched to device memory (HBM) and stay resident there, remaining accessible from the host over the coherent interconnect. Zero-copy mapping can be disabled at runtime by setting the environment variable `NEKO_CUDA_ZEROCOPY=0`, which restores fully replicated buffers. Conventional PCIe-attached GPUs always use replicated buffers. Since host and device share one allocation under zero-copy, host code (e.g. user routines) must not write to a mapped array while device work touching it may be in flight; synchronize with `device_sync` first.
 
 #### Compiling Neko for AMD GPUs
 To compile Neko for AMD GPUs
@@ -259,7 +259,7 @@ $ ./configure  --with-hip=/opt/rocm/hip
 $ ./configure  --with-hip=/opt/rocm/hip HIP_HIPCC_FLAGS=-O3  HIPCC=/opt/rocm/hip/bin/hipcc
 ```
 
-@note On APUs with unified physical memory (e.g. AMD Instinct MI300A) and XNACK enabled (`HSA_XNACK=1`), mapped arrays alias their host allocation zero-copy: host and device share a single allocation instead of keeping replicated copies, and host-device transfers become no-ops. This roughly halves the memory footprint of mapped data. Zero-copy mapping can be disabled at runtime by setting the environment variable `NEKO_HIP_ZEROCOPY=0`, which restores fully replicated buffers. Discrete GPUs (e.g. MI250X) always use replicated buffers, regardless of the XNACK setting.
+@note On APUs with unified physical memory (e.g. AMD Instinct MI300A) and XNACK enabled (`HSA_XNACK=1`), mapped arrays alias their host allocation zero-copy: host and device share a single allocation instead of keeping replicated copies, and host-device transfers become no-ops. This roughly halves the memory footprint of mapped data. Zero-copy mapping can be disabled at runtime by setting the environment variable `NEKO_HIP_ZEROCOPY=0`, which restores fully replicated buffers. Discrete GPUs (e.g. MI250X) always use replicated buffers, regardless of the XNACK setting. Since host and device share one allocation under zero-copy, host code (e.g. user routines) must not write to a mapped array while device work touching it may be in flight; synchronize with `device_sync` first.
 
 #### Compiling Neko for Apple Silicon GPUs
 To compile Neko for Apple Silicon GPUs (macOS only)

--- a/doc/pages/user-guide/installation.md
+++ b/doc/pages/user-guide/installation.md
@@ -257,6 +257,8 @@ $ ./configure  --with-hip=/opt/rocm/hip
 $ ./configure  --with-hip=/opt/rocm/hip HIP_HIPCC_FLAGS=-O3  HIPCC=/opt/rocm/hip/bin/hipcc
 ```
 
+@note On APUs with unified physical memory (e.g. AMD Instinct MI300A) and XNACK enabled (`HSA_XNACK=1`), mapped arrays alias their host allocation zero-copy: host and device share a single allocation instead of keeping replicated copies, and host-device transfers become no-ops. This roughly halves the memory footprint of mapped data. Zero-copy mapping can be disabled at runtime by setting the environment variable `NEKO_HIP_ZEROCOPY=0`, which restores fully replicated buffers. Discrete GPUs (e.g. MI250X) always use replicated buffers, regardless of the XNACK setting.
+
 #### Compiling Neko for Apple Silicon GPUs
 To compile Neko for Apple Silicon GPUs (macOS only)
 * Make sure you have Xcode with the Metal shader compiler installed (since Xcode 26 the Metal toolchain is a separate download, install via `xcodebuild -downloadComponent MetalToolchain`)

--- a/doc/pages/user-guide/installation.md
+++ b/doc/pages/user-guide/installation.md
@@ -269,6 +269,8 @@ $ ./configure --with-metal --enable-real=sp
 
 @note Apple GPUs do not support double precision; the Metal backend requires Neko to be configured with single precision (`--enable-real=sp`).
 
+@note On devices with unified memory (Apple Silicon), the Metal backend maps arrays zero-copy: host and device share a single allocation instead of keeping replicated copies, and host-device transfers become no-ops. This roughly halves the memory footprint of mapped data. Zero-copy mapping can be disabled at runtime by setting the environment variable `NEKO_METAL_ZEROCOPY=0`, which restores fully replicated buffers. On GPUs without unified memory (e.g. AMD GPUs in Intel-based Macs), buffers are always replicated.
+
 @note More examples, and instructions for specific machines can be found on Neko's [user discussions](https://github.com/ExtremeFLOW/neko/discussions) pages.
 
 #### Compiling Neko with a collective communications library

--- a/doc/pages/user-guide/installation.md
+++ b/doc/pages/user-guide/installation.md
@@ -245,6 +245,8 @@ $ ./configure  --with-cuda=/usr/local/cuda CUDA_CFLAGS=-O3  CUDA_ARCH=-arch=sm_8
   cluster's GPUs when cross-compiling.
 * Build using `make && make install`
 
+@note On cache-coherent CPU-GPU platforms (e.g. NVIDIA Grace Hopper), mapped arrays alias their host allocation zero-copy: host and device share a single allocation instead of keeping replicated copies, and host-device transfers become no-ops. Mapped arrays are prefetched to device memory (HBM) and stay resident there, remaining accessible from the host over the coherent interconnect. Zero-copy mapping can be disabled at runtime by setting the environment variable `NEKO_CUDA_ZEROCOPY=0`, which restores fully replicated buffers. Conventional PCIe-attached GPUs always use replicated buffers.
+
 #### Compiling Neko for AMD GPUs
 To compile Neko for AMD GPUs
 * Make sure you have the ROCm Toolkit installed

--- a/src/.depends_device
+++ b/src/.depends_device
@@ -55,6 +55,7 @@ krylov/bcknd/device/hip/cheby_aux.lo : krylov/bcknd/device/hip/cheby_aux.hip
 comm/bcknd/device/cuda/nvshmem.lo : comm/bcknd/device/cuda/nvshmem.cu comm/comm.h
 device/cuda/check.lo : device/cuda/check.cu device/cuda/check.h
 device/cuda/buffer.lo : device/cuda/buffer.cu device/cuda/buffer.h
+device/cuda/unified.lo : device/cuda/unified.cu device/cuda/unified.h
 device/cuda/nvtx_wrapper.lo : device/cuda/nvtx_wrapper.cu
 math/bcknd/device/cuda/math.lo : math/bcknd/device/cuda/math.cu math/bcknd/device/cuda/math_kernel.h device/cuda/buffer.lo
 math/bcknd/device/cuda/mathops.lo : math/bcknd/device/cuda/mathops.cu math/bcknd/device/cuda/mathops_kernel.h

--- a/src/.depends_device
+++ b/src/.depends_device
@@ -1,7 +1,7 @@
 device/hip/check.lo : device/hip/check.hip device/hip/check.h
 device/hip/buffer.lo : device/hip/buffer.hip device/hip/buffer.h
 device/hip/unified.lo : device/hip/unified.hip device/hip/unified.h
-math/bcknd/device/hip/math.lo : math/bcknd/device/hip/math.hip math/bcknd/device/hip/math_kernel.h device/hip/buffer.lo
+math/bcknd/device/hip/math.lo : math/bcknd/device/hip/math.hip math/bcknd/device/hip/math_kernel.h device/hip/unified.h device/hip/buffer.lo
 math/bcknd/device/hip/mathops.lo : math/bcknd/device/hip/mathops.hip math/bcknd/device/hip/mathops_kernel.h
 math/bcknd/device/hip/opr_dudxyz.lo : math/bcknd/device/hip/opr_dudxyz.hip math/bcknd/device/hip/dudxyz_kernel.h
 math/bcknd/device/hip/opr_cdtp.lo : math/bcknd/device/hip/opr_cdtp.hip math/bcknd/device/hip/cdtp_kernel.h
@@ -32,7 +32,7 @@ bc/bcknd/device/hip/inhom_dirichlet.lo : bc/bcknd/device/hip/inhom_dirichlet.hip
 bc/bcknd/device/hip/dong_outflow.lo : bc/bcknd/device/hip/dong_outflow.hip bc/bcknd/device/hip/dong_outflow_kernel.h
 bc/bcknd/device/hip/neumann.lo : bc/bcknd/device/hip/neumann.hip bc/bcknd/device/hip/neumann_kernel.h
 common/bcknd/device/hip/rhs_maker.lo : common/bcknd/device/hip/rhs_maker.hip common/bcknd/device/hip/sumab_kernel.h common/bcknd/device/hip/makeext_kernel.h common/bcknd/device/hip/makebdf_kernel.h common/bcknd/device/hip/makeoifs_kernel.h
-common/bcknd/device/hip/projection.lo : common/bcknd/device/hip/projection.hip common/bcknd/device/hip/projection_kernel.h device/hip/buffer.lo
+common/bcknd/device/hip/projection.lo : common/bcknd/device/hip/projection.hip common/bcknd/device/hip/projection_kernel.h device/hip/unified.h device/hip/buffer.lo
 common/bcknd/device/hip/gradient_jump_penalty.lo : common/bcknd/device/hip/gradient_jump_penalty.hip common/bcknd/device/hip/gradient_jump_penalty_kernel.h
 fluid/bcknd/device/hip/pnpn_res.lo : fluid/bcknd/device/hip/pnpn_res.hip fluid/bcknd/device/hip/vel_res_update_kernel.h fluid/bcknd/device/hip/prs_res_kernel.h
 fluid/bcknd/device/hip/compressible_res.lo : fluid/bcknd/device/hip/compressible_res.hip fluid/bcknd/device/hip/compressible_res_kernel.h
@@ -57,7 +57,7 @@ device/cuda/check.lo : device/cuda/check.cu device/cuda/check.h
 device/cuda/buffer.lo : device/cuda/buffer.cu device/cuda/buffer.h
 device/cuda/unified.lo : device/cuda/unified.cu device/cuda/unified.h
 device/cuda/nvtx_wrapper.lo : device/cuda/nvtx_wrapper.cu
-math/bcknd/device/cuda/math.lo : math/bcknd/device/cuda/math.cu math/bcknd/device/cuda/math_kernel.h device/cuda/buffer.lo
+math/bcknd/device/cuda/math.lo : math/bcknd/device/cuda/math.cu math/bcknd/device/cuda/math_kernel.h device/cuda/unified.h device/cuda/buffer.lo
 math/bcknd/device/cuda/mathops.lo : math/bcknd/device/cuda/mathops.cu math/bcknd/device/cuda/mathops_kernel.h
 math/bcknd/device/cuda/opr_dudxyz.lo : math/bcknd/device/cuda/opr_dudxyz.cu math/bcknd/device/cuda/dudxyz_kernel.h
 math/bcknd/device/cuda/opr_cdtp.lo : math/bcknd/device/cuda/opr_cdtp.cu math/bcknd/device/cuda/cdtp_kernel.h
@@ -89,7 +89,7 @@ bc/bcknd/device/cuda/neumann.lo : bc/bcknd/device/cuda/neumann.cu bc/bcknd/devic
 bc/bcknd/device/cuda/inhom_dirichlet.lo : bc/bcknd/device/cuda/inhom_dirichlet.cu bc/bcknd/device/cuda/inhom_dirichlet_kernel.h
 bc/bcknd/device/cuda/dong_outflow.lo : bc/bcknd/device/cuda/dong_outflow.cu bc/bcknd/device/cuda/dong_outflow_kernel.h
 common/bcknd/device/cuda/rhs_maker.lo : common/bcknd/device/cuda/rhs_maker.cu common/bcknd/device/cuda/sumab_kernel.h common/bcknd/device/cuda/makeext_kernel.h common/bcknd/device/cuda/makebdf_kernel.h common/bcknd/device/cuda/makeoifs_kernel.h
-common/bcknd/device/cuda/projection.lo : common/bcknd/device/cuda/projection.cu common/bcknd/device/cuda/projection_kernel.h device/cuda/buffer.lo
+common/bcknd/device/cuda/projection.lo : common/bcknd/device/cuda/projection.cu common/bcknd/device/cuda/projection_kernel.h device/cuda/unified.h device/cuda/buffer.lo
 fluid/bcknd/device/cuda/pnpn_res.lo : fluid/bcknd/device/cuda/pnpn_res.cu fluid/bcknd/device/cuda/vel_res_update_kernel.h fluid/bcknd/device/cuda/prs_res_kernel.h
 fluid/bcknd/device/cuda/compressible_res.lo : fluid/bcknd/device/cuda/compressible_res.cu fluid/bcknd/device/cuda/compressible_res_kernel.h
 fluid/bcknd/device/cuda/compressible_ops_compute_max_wave_speed.lo : fluid/bcknd/device/cuda/compressible_ops_compute_max_wave_speed.cu fluid/bcknd/device/cuda/compressible_ops_kernel.h

--- a/src/.depends_device
+++ b/src/.depends_device
@@ -1,5 +1,6 @@
 device/hip/check.lo : device/hip/check.hip device/hip/check.h
 device/hip/buffer.lo : device/hip/buffer.hip device/hip/buffer.h
+device/hip/unified.lo : device/hip/unified.hip device/hip/unified.h
 math/bcknd/device/hip/math.lo : math/bcknd/device/hip/math.hip math/bcknd/device/hip/math_kernel.h device/hip/buffer.lo
 math/bcknd/device/hip/mathops.lo : math/bcknd/device/hip/mathops.hip math/bcknd/device/hip/mathops_kernel.h
 math/bcknd/device/hip/opr_dudxyz.lo : math/bcknd/device/hip/opr_dudxyz.hip math/bcknd/device/hip/dudxyz_kernel.h

--- a/src/.depends_device
+++ b/src/.depends_device
@@ -19,8 +19,8 @@ math/bcknd/device/hip/tensor.lo : math/bcknd/device/hip/tensor.hip math/bcknd/de
 math/bcknd/device/hip/fdm.lo : math/bcknd/device/hip/fdm.hip math/bcknd/device/hip/fdm_kernel.h
 krylov/bcknd/device/hip/pc_jacobi.lo : krylov/bcknd/device/hip/pc_jacobi.hip
 krylov/bcknd/device/hip/pipecg_aux.lo : krylov/bcknd/device/hip/pipecg_aux.hip krylov/bcknd/device/hip/pipecg_kernel.h device/hip/buffer.lo
-krylov/bcknd/device/hip/fusedcg_aux.lo : krylov/bcknd/device/hip/fusedcg_aux.hip krylov/bcknd/device/hip/fusedcg_kernel.h device/hip/buffer.lo
-krylov/bcknd/device/hip/fusedcg_cpld_aux.lo : krylov/bcknd/device/hip/fusedcg_cpld_aux.hip krylov/bcknd/device/hip/fusedcg_cpld_kernel.h device/hip/buffer.lo
+krylov/bcknd/device/hip/fusedcg_aux.lo : krylov/bcknd/device/hip/fusedcg_aux.hip krylov/bcknd/device/hip/fusedcg_kernel.h device/hip/unified.h device/hip/buffer.lo
+krylov/bcknd/device/hip/fusedcg_cpld_aux.lo : krylov/bcknd/device/hip/fusedcg_cpld_aux.hip krylov/bcknd/device/hip/fusedcg_cpld_kernel.h device/hip/unified.h device/hip/buffer.lo
 krylov/bcknd/device/hip/gmres_aux.lo : krylov/bcknd/device/hip/gmres_aux.hip krylov/bcknd/device/hip/gmres_kernel.h device/hip/buffer.lo
 gs/bcknd/device/hip/gs.lo : gs/bcknd/device/hip/gs.hip gs/bcknd/device/hip/gs_kernels.h
 bc/bcknd/device/hip/dirichlet.lo : bc/bcknd/device/hip/dirichlet.hip bc/bcknd/device/hip/dirichlet_kernel.h
@@ -75,8 +75,8 @@ math/bcknd/device/cuda/tensor.lo : math/bcknd/device/cuda/tensor.cu math/bcknd/d
 math/bcknd/device/cuda/fdm.lo : math/bcknd/device/cuda/fdm.cu math/bcknd/device/cuda/fdm_kernel.h
 krylov/bcknd/device/cuda/pc_jacobi.lo : krylov/bcknd/device/cuda/pc_jacobi.cu
 krylov/bcknd/device/cuda/pipecg_aux.lo : krylov/bcknd/device/cuda/pipecg_aux.cu krylov/bcknd/device/cuda/pipecg_kernel.h device/cuda/buffer.lo
-krylov/bcknd/device/cuda/fusedcg_aux.lo : krylov/bcknd/device/cuda/fusedcg_aux.cu krylov/bcknd/device/cuda/fusedcg_kernel.h device/cuda/buffer.lo
-krylov/bcknd/device/cuda/fusedcg_cpld_aux.lo : krylov/bcknd/device/cuda/fusedcg_cpld_aux.cu krylov/bcknd/device/cuda/fusedcg_cpld_kernel.h device/cuda/buffer.lo
+krylov/bcknd/device/cuda/fusedcg_aux.lo : krylov/bcknd/device/cuda/fusedcg_aux.cu krylov/bcknd/device/cuda/fusedcg_kernel.h device/cuda/unified.h device/cuda/buffer.lo
+krylov/bcknd/device/cuda/fusedcg_cpld_aux.lo : krylov/bcknd/device/cuda/fusedcg_cpld_aux.cu krylov/bcknd/device/cuda/fusedcg_cpld_kernel.h device/cuda/unified.h device/cuda/buffer.lo
 krylov/bcknd/device/cuda/gmres_aux.lo : krylov/bcknd/device/cuda/gmres_aux.cu krylov/bcknd/device/cuda/gmres_kernel.h device/cuda/buffer.lo
 gs/bcknd/device/cuda/gs.lo : gs/bcknd/device/cuda/gs.cu gs/bcknd/device/cuda/gs_kernels.h
 gs/bcknd/device/cuda/gs_nvshmem.lo : gs/bcknd/device/cuda/gs_nvshmem.cu gs/bcknd/device/cuda/gs_kernels.h gs/bcknd/device/cuda/gs_nvshmem_kernels.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -499,6 +499,7 @@ libneko_la_SOURCES += \
     ale/bcknd/device/hip/ale_kinematics.hip\
 	device/hip/check.hip\
 	device/hip/buffer.hip\
+	device/hip/unified.hip\
 	math/bcknd/device/hip/math.hip\
 	math/bcknd/device/hip/schwarz.hip\
 	math/bcknd/device/hip/tensor.hip\
@@ -1185,6 +1186,7 @@ EXTRA_DIST = \
 	device/cuda/check.h\
 	device/cuda/buffer.h\
 	device/hip/buffer.h\
+	device/hip/unified.h\
 	device/opencl/buffer.h\
 	comm/comm_nccl.h\
 	comm/comm.h\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -567,6 +567,7 @@ libneko_la_SOURCES += \
     ale/bcknd/device/cuda/ale_kinematics.cu\
 	device/cuda/check.cu\
 	device/cuda/buffer.cu\
+	device/cuda/unified.cu\
 	device/cuda/nvtx_wrapper.cu\
 	math/bcknd/device/cuda/math.cu\
 	math/bcknd/device/cuda/schwarz.cu\
@@ -1185,6 +1186,7 @@ EXTRA_DIST = \
 	device/hip/check.h\
 	device/cuda/check.h\
 	device/cuda/buffer.h\
+	device/cuda/unified.h\
 	device/hip/buffer.h\
 	device/hip/unified.h\
 	device/opencl/buffer.h\

--- a/src/common/bcknd/device/cuda/projection.cu
+++ b/src/common/bcknd/device/cuda/projection.cu
@@ -83,7 +83,7 @@ extern "C" {
       /* xbar may alias pageable host memory, which cudaMemset rejects;
          zero with a kernel instead (works on any pointer) */
       const dim3 zero_nthrds(1024, 1, 1);
-      const dim3 zero_nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
+      const dim3 zero_nblcks((*n) > 0 ? ((*n) + 1024 - 1) / 1024 : 1, 1, 1);
 
       cfill_kernel<real><<<zero_nblcks, zero_nthrds, 0, stream>>>
         ((real *) xbar, (real) 0.0, *n);

--- a/src/common/bcknd/device/cuda/projection.cu
+++ b/src/common/bcknd/device/cuda/projection.cu
@@ -35,6 +35,7 @@
 #include <device/device_config.h>
 #include <device/cuda/check.h>
 #include <device/cuda/buffer.h>
+#include <device/cuda/unified.h>
 
 #include "projection_kernel.h"
 #include <math/bcknd/device/cuda/math_kernel.h>
@@ -78,7 +79,19 @@ extern "C" {
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaMemcpyAsync(alpha, proj_bufred_d, (*j) * sizeof(real),
                                cudaMemcpyDeviceToDevice, stream));
-    CUDA_CHECK(cudaMemsetAsync(xbar, 0, (*n) * sizeof(real), stream));
+    if (cuda_zerocopy()) {
+      /* xbar may alias pageable host memory, which cudaMemset rejects;
+         zero with a kernel instead (works on any pointer) */
+      const dim3 zero_nthrds(1024, 1, 1);
+      const dim3 zero_nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
+
+      cfill_kernel<real><<<zero_nblcks, zero_nthrds, 0, stream>>>
+        ((real *) xbar, (real) 0.0, *n);
+      CUDA_CHECK(cudaGetLastError());
+    }
+    else {
+      CUDA_CHECK(cudaMemsetAsync(xbar, 0, (*n) * sizeof(real), stream));
+    }
 
     cudaStreamSynchronize(stream);
     device_mpi_allreduce_inplace(alpha, (*j), sizeof(real), DEVICE_MPI_SUM);

--- a/src/common/bcknd/device/hip/projection.hip
+++ b/src/common/bcknd/device/hip/projection.hip
@@ -85,7 +85,7 @@ extern "C" {
       /* xbar may alias pageable host memory, which hipMemset rejects;
          zero with a kernel instead (works on any pointer) */
       const dim3 zero_nthrds(1024, 1, 1);
-      const dim3 zero_nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
+      const dim3 zero_nblcks((*n) > 0 ? ((*n) + 1024 - 1) / 1024 : 1, 1, 1);
 
       hipLaunchKernelGGL(HIP_KERNEL_NAME(cfill_kernel<real>),
                          zero_nblcks, zero_nthrds, 0,

--- a/src/common/bcknd/device/hip/projection.hip
+++ b/src/common/bcknd/device/hip/projection.hip
@@ -36,6 +36,7 @@
 #include <device/device_config.h>
 #include <device/hip/check.h>
 #include <device/hip/buffer.h>
+#include <device/hip/unified.h>
 
 #include "projection_kernel.h"
 #include <math/bcknd/device/hip/math_kernel.h>
@@ -80,7 +81,21 @@ extern "C" {
     HIP_CHECK(hipMemcpyAsync(alpha, proj_bufred_d, (*j) * sizeof(real),
                              hipMemcpyDeviceToDevice,
                              (hipStream_t) glb_cmd_queue));
-    HIP_CHECK(hipMemsetAsync(xbar, 0, (*n) * sizeof(real)));
+    if (hip_zerocopy()) {
+      /* xbar may alias pageable host memory, which hipMemset rejects;
+         zero with a kernel instead (works on any pointer) */
+      const dim3 zero_nthrds(1024, 1, 1);
+      const dim3 zero_nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
+
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(cfill_kernel<real>),
+                         zero_nblcks, zero_nthrds, 0,
+                         (hipStream_t) glb_cmd_queue,
+                         (real *) xbar, (real) 0.0, *n);
+      HIP_CHECK(hipGetLastError());
+    }
+    else {
+      HIP_CHECK(hipMemsetAsync(xbar, 0, (*n) * sizeof(real)));
+    }
 
     HIP_CHECK(hipStreamSynchronize((hipStream_t) glb_cmd_queue));
     device_mpi_allreduce_inplace(alpha, (*j), sizeof(real), DEVICE_MPI_SUM);

--- a/src/device/cuda/unified.cu
+++ b/src/device/cuda/unified.cu
@@ -1,0 +1,177 @@
+/*
+ Copyright (c) 2026, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/**
+ * Zero-copy mapping of host arrays for unified memory architectures.
+ *
+ * On coherent CPU-GPU platforms (e.g. Grace Hopper), system
+ * allocations are directly and coherently accessible from device
+ * kernels via NVLink-C2C and ATS.  Mapped host arrays then alias
+ * their host allocation instead of being replicated in a separate
+ * cudaMalloc buffer, and host-device copies degenerate to no-ops.
+ *
+ * Unlike a single-memory APU, Grace Hopper has two physical
+ * memories (LPDDR on the CPU, HBM on the GPU) and host first-touch
+ * places mapped arrays in LPDDR.  Aliased ranges are therefore
+ * prefetched to device memory and advised to stay there, giving
+ * device-resident data that remains host-visible over the coherent
+ * interconnect.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <cuda_runtime.h>
+#include <device/cuda/unified.h>
+
+extern "C" {
+
+/**
+ * Whether mapped arrays may alias host allocations (zero-copy).
+ *
+ * Zero-copy is only possible on a cache-coherent platform where the
+ * device accesses pageable system memory through the host's page
+ * tables (ATS), e.g. Grace Hopper:
+ *
+ *  - Pageable memory access reflects whether system allocations are
+ *    accessible from the device at all.
+ *  - Pageable memory access using host page tables identifies a
+ *    hardware-coherent platform.  Without it (e.g. x86 + HMM),
+ *    pageable access means page fault-and-migrate, which would
+ *    thrash host arrays back and forth -- such systems always use
+ *    replicated buffers.
+ *
+ * On capable devices, zero-copy can be disabled with
+ * NEKO_CUDA_ZEROCOPY=0.
+ */
+int cuda_zerocopy(void)
+{
+  static int zerocopy = -1;
+  if (zerocopy < 0) {
+    int dev = 0, pageable = 0, hostpt = 0;
+    const char *env = getenv("NEKO_CUDA_ZEROCOPY");
+
+    if (cudaGetDevice(&dev) == cudaSuccess &&
+        cudaDeviceGetAttribute(&pageable,
+                               cudaDevAttrPageableMemoryAccess,
+                               dev) == cudaSuccess &&
+        cudaDeviceGetAttribute(&hostpt,
+                          cudaDevAttrPageableMemoryAccessUsesHostPageTables,
+                               dev) == cudaSuccess)
+      zerocopy = (pageable && hostpt);
+    else
+      zerocopy = 0;
+    (void) cudaGetLastError();
+
+    if (zerocopy && env != NULL && atoi(env) == 0)
+      zerocopy = 0;
+  }
+  return zerocopy;
+}
+
+/**
+ * Map \p s bytes of host memory at \p ptr_h to the device.
+ *
+ * On coherent platforms (see cuda_zerocopy) the device pointer
+ * aliases the host allocation; otherwise a separate replicated
+ * buffer is allocated with cudaMalloc.  Aliased ranges are advised
+ * to prefer device memory and prefetched there, counteracting the
+ * host-side first touch which would otherwise leave them in the
+ * (slower) CPU memory.
+ */
+cudaError_t cuda_map(void **ptr_d, void *ptr_h, size_t s)
+{
+  if (cuda_zerocopy() && ptr_h != NULL) {
+    int dev = 0;
+    *ptr_d = ptr_h;
+    /* Placement only; ignore failures */
+    if (cudaGetDevice(&dev) == cudaSuccess) {
+      (void) cudaMemAdvise(ptr_h, s, cudaMemAdviseSetPreferredLocation, dev);
+      (void) cudaMemPrefetchAsync(ptr_h, s, dev, 0);
+    }
+    (void) cudaGetLastError();
+    return cudaSuccess;
+  }
+
+  return cudaMalloc(ptr_d, s);
+}
+
+/**
+ * Whether \p ptr_d is a device allocation (cudaMalloc); zero-copy
+ * mappings are unregistered host pointers.
+ */
+static int cuda_is_device_alloc(void *ptr_d)
+{
+  struct cudaPointerAttributes attr;
+  if (cudaPointerGetAttributes(&attr, ptr_d) != cudaSuccess) {
+    (void) cudaGetLastError();
+    return 0;
+  }
+  return (attr.type == cudaMemoryTypeDevice);
+}
+
+/**
+ * Free a device pointer obtained from cuda_map (or cudaMalloc).
+ *
+ * Pointers aliasing host memory are left untouched; their
+ * allocation is owned by the host side.
+ */
+cudaError_t cuda_map_free(void *ptr_d)
+{
+  if (cuda_zerocopy() && !cuda_is_device_alloc(ptr_d))
+    return cudaSuccess;
+
+  return cudaFree(ptr_d);
+}
+
+/**
+ * Memset on a device pointer obtained from cuda_map (or cudaMalloc).
+ *
+ * cudaMemset only accepts device allocations, so pointers aliasing
+ * host memory are set on the host instead, ordered after any
+ * in-flight device work on \p stream.
+ */
+cudaError_t cuda_map_memset(void *ptr_d, int value, size_t s, void *stream)
+{
+  if (cuda_zerocopy() && !cuda_is_device_alloc(ptr_d)) {
+    cudaError_t err = cudaStreamSynchronize((cudaStream_t) stream);
+    if (err != cudaSuccess)
+      return err;
+    memset(ptr_d, value, s);
+    return cudaSuccess;
+  }
+
+  return cudaMemsetAsync(ptr_d, value, s, (cudaStream_t) stream);
+}
+
+} /* extern "C" */

--- a/src/device/cuda/unified.cu
+++ b/src/device/cuda/unified.cu
@@ -116,8 +116,17 @@ cudaError_t cuda_map(void **ptr_d, void *ptr_h, size_t s)
     *ptr_d = ptr_h;
     /* Placement only; ignore failures */
     if (cudaGetDevice(&dev) == cudaSuccess) {
+#if CUDART_VERSION >= 13000
+      /* CUDA 13 dropped the int-device overloads */
+      struct cudaMemLocation loc;
+      loc.type = cudaMemLocationTypeDevice;
+      loc.id = dev;
+      (void) cudaMemAdvise(ptr_h, s, cudaMemAdviseSetPreferredLocation, loc);
+      (void) cudaMemPrefetchAsync(ptr_h, s, loc, 0, 0);
+#else
       (void) cudaMemAdvise(ptr_h, s, cudaMemAdviseSetPreferredLocation, dev);
       (void) cudaMemPrefetchAsync(ptr_h, s, dev, 0);
+#endif
     }
     (void) cudaGetLastError();
     return cudaSuccess;

--- a/src/device/cuda/unified.cu
+++ b/src/device/cuda/unified.cu
@@ -49,10 +49,83 @@
  * interconnect.
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #include <cuda_runtime.h>
 #include <device/cuda/unified.h>
+
+/**
+ * Prefetch a range to device memory (see cuda_map, cuda_map_prefetch).
+ * Placement only, but warn on the first failure: if migration is
+ * unavailable, zero-copy arrays stay CPU-resident and kernels run
+ * at interconnect bandwidth.
+ */
+static void cuda_unified_prefetch(void *ptr, size_t s, cudaStream_t stream)
+{
+  static int warned = 0;
+  int dev = 0;
+  cudaError_t err;
+
+  if (cudaGetDevice(&dev) != cudaSuccess) {
+    (void) cudaGetLastError();
+    return;
+  }
+
+#if CUDART_VERSION >= 13000
+  struct cudaMemLocation loc;
+  loc.type = cudaMemLocationTypeDevice;
+  loc.id = dev;
+  err = cudaMemPrefetchAsync(ptr, s, loc, 0, stream);
+#else
+  err = cudaMemPrefetchAsync(ptr, s, dev, stream);
+#endif
+  if (err != cudaSuccess && !warned) {
+    fprintf(stderr,
+            "Neko: warning: prefetch of zero-copy mapping failed (%s); "
+            "mapped arrays may stay CPU-resident (slow kernels)\n",
+            cudaGetErrorString(err));
+    warned = 1;
+  }
+  (void) cudaGetLastError();
+}
+
+/**
+ * Grid-stride byte memset kernel for zero-copy mappings.
+ */
+__global__ void cuda_unified_memset_kernel(unsigned char *a,
+                                           unsigned char v, size_t n)
+{
+  const size_t idx = blockIdx.x * (size_t) blockDim.x + threadIdx.x;
+  const size_t str = (size_t) blockDim.x * gridDim.x;
+  for (size_t i = idx; i < n; i += str)
+    a[i] = v;
+}
+
+/**
+ * Grid-stride copy kernels for zero-copy mappings (word and byte
+ * variants).
+ */
+__global__ void cuda_unified_copy8_kernel(unsigned long long * __restrict__ a,
+                                          const unsigned long long
+                                          * __restrict__ b, size_t n)
+{
+  const size_t idx = blockIdx.x * (size_t) blockDim.x + threadIdx.x;
+  const size_t str = (size_t) blockDim.x * gridDim.x;
+  for (size_t i = idx; i < n; i += str)
+    a[i] = b[i];
+}
+
+__global__ void cuda_unified_copy1_kernel(unsigned char * __restrict__ a,
+                                          const unsigned char * __restrict__ b,
+                                          size_t n)
+{
+  const size_t idx = blockIdx.x * (size_t) blockDim.x + threadIdx.x;
+  const size_t str = (size_t) blockDim.x * gridDim.x;
+  for (size_t i = idx; i < n; i += str)
+    a[i] = b[i];
+}
 
 extern "C" {
 
@@ -77,6 +150,8 @@ extern "C" {
 int cuda_zerocopy(void)
 {
   static int zerocopy = -1;
+  /* Cached on first use; device selection must already have
+     happened (device_init runs before any map/memset/copy) */
   if (zerocopy < 0) {
     int dev = 0, pageable = 0, hostpt = 0;
     const char *env = getenv("NEKO_CUDA_ZEROCOPY");
@@ -114,7 +189,8 @@ cudaError_t cuda_map(void **ptr_d, void *ptr_h, size_t s)
   if (cuda_zerocopy() && ptr_h != NULL) {
     int dev = 0;
     *ptr_d = ptr_h;
-    /* Placement only; ignore failures */
+    /* Placement only; prefer device memory and migrate any pages the
+       host has already touched (failures ignored, see helper) */
     if (cudaGetDevice(&dev) == cudaSuccess) {
 #if CUDART_VERSION >= 13000
       /* CUDA 13 dropped the int-device overloads */
@@ -122,13 +198,12 @@ cudaError_t cuda_map(void **ptr_d, void *ptr_h, size_t s)
       loc.type = cudaMemLocationTypeDevice;
       loc.id = dev;
       (void) cudaMemAdvise(ptr_h, s, cudaMemAdviseSetPreferredLocation, loc);
-      (void) cudaMemPrefetchAsync(ptr_h, s, loc, 0, 0);
 #else
       (void) cudaMemAdvise(ptr_h, s, cudaMemAdviseSetPreferredLocation, dev);
-      (void) cudaMemPrefetchAsync(ptr_h, s, dev, 0);
 #endif
     }
     (void) cudaGetLastError();
+    cuda_unified_prefetch(ptr_h, s, 0);
     return cudaSuccess;
   }
 
@@ -152,35 +227,94 @@ static int cuda_is_device_alloc(void *ptr_d)
 /**
  * Free a device pointer obtained from cuda_map (or cudaMalloc).
  *
- * Pointers aliasing host memory are left untouched; their
- * allocation is owned by the host side.
+ * Pointers aliasing host memory are left untouched; their allocation
+ * is owned by the host side.  cudaFree implicitly synchronizes the
+ * device, and the host typically deallocates right after an unmap,
+ * so preserve that barrier for aliased mappings such that the
+ * allocation cannot be released under in-flight device work.
  */
 cudaError_t cuda_map_free(void *ptr_d)
 {
   if (cuda_zerocopy() && !cuda_is_device_alloc(ptr_d))
-    return cudaSuccess;
+    return cudaDeviceSynchronize();
 
   return cudaFree(ptr_d);
+}
+
+/**
+ * Memcpy between device pointers obtained from cuda_map (or
+ * cudaMalloc) and/or host pointers.
+ *
+ * Under zero-copy either side may alias pageable host memory, which
+ * cudaMemcpy treats as a staged pageable copy (slow, serializing);
+ * copy with a kernel instead, which runs at full memory bandwidth
+ * and stays stream-ordered (on a coherent platform any pointer is
+ * dereferenceable from the device).
+ */
+cudaError_t cuda_map_memcpy(void *dst, void *src, size_t s,
+                            int kind, void *stream)
+{
+  if (cuda_zerocopy()) {
+    if (s == 0)
+      return cudaSuccess;
+    if ((((uintptr_t) dst | (uintptr_t) src | s) & 7) == 0) {
+      const size_t n = s / 8;
+      const size_t nb = (n + 1024 - 1) / 1024;
+      const unsigned int nblcks = (unsigned int) (nb > 65535 ? 65535 : nb);
+      cuda_unified_copy8_kernel<<<nblcks, 1024, 0, (cudaStream_t) stream>>>
+        ((unsigned long long *) dst, (const unsigned long long *) src, n);
+    }
+    else {
+      const size_t nb = (s + 1024 - 1) / 1024;
+      const unsigned int nblcks = (unsigned int) (nb > 65535 ? 65535 : nb);
+      cuda_unified_copy1_kernel<<<nblcks, 1024, 0, (cudaStream_t) stream>>>
+        ((unsigned char *) dst, (const unsigned char *) src, s);
+    }
+    return cudaGetLastError();
+  }
+
+  return cudaMemcpyAsync(dst, src, s, (enum cudaMemcpyKind) kind,
+                         (cudaStream_t) stream);
 }
 
 /**
  * Memset on a device pointer obtained from cuda_map (or cudaMalloc).
  *
  * cudaMemset only accepts device allocations, so pointers aliasing
- * host memory are set on the host instead, ordered after any
- * in-flight device work on \p stream.
+ * host memory are set with a kernel instead.  This keeps the
+ * operation stream-ordered, and on platforms with separate physical
+ * memories (e.g. Grace Hopper) a device-side first touch places the
+ * pages in device memory, where mapped arrays should reside.
  */
 cudaError_t cuda_map_memset(void *ptr_d, int value, size_t s, void *stream)
 {
   if (cuda_zerocopy() && !cuda_is_device_alloc(ptr_d)) {
-    cudaError_t err = cudaStreamSynchronize((cudaStream_t) stream);
-    if (err != cudaSuccess)
-      return err;
-    memset(ptr_d, value, s);
-    return cudaSuccess;
+    const size_t nb = (s + 1024 - 1) / 1024;
+    const unsigned int nblcks = (unsigned int) (nb > 65535 ? 65535 :
+                                                (nb == 0 ? 1 : nb));
+    cuda_unified_memset_kernel<<<nblcks, 1024, 0, (cudaStream_t) stream>>>
+      ((unsigned char *) ptr_d, (unsigned char) value, s);
+    return cudaGetLastError();
   }
 
   return cudaMemsetAsync(ptr_d, value, s, (cudaStream_t) stream);
+}
+
+/**
+ * Prefetch a zero-copy mapping to device memory.
+ *
+ * Stands in for the host-to-device copy of an aliased mapping: on
+ * platforms with separate physical memories (e.g. Grace Hopper),
+ * host-side writes populate pages in CPU memory, and this migrates
+ * them to device memory at the point where the copy semantics say
+ * the data moves.  Placement only; failures are ignored.
+ */
+cudaError_t cuda_map_prefetch(void *ptr_d, size_t s, void *stream)
+{
+  if (cuda_zerocopy())
+    cuda_unified_prefetch(ptr_d, s, (cudaStream_t) stream);
+
+  return cudaSuccess;
 }
 
 } /* extern "C" */

--- a/src/device/cuda/unified.h
+++ b/src/device/cuda/unified.h
@@ -44,6 +44,9 @@ int cuda_zerocopy(void);
 cudaError_t cuda_map(void **ptr_d, void *ptr_h, size_t s);
 cudaError_t cuda_map_free(void *ptr_d);
 cudaError_t cuda_map_memset(void *ptr_d, int value, size_t s, void *stream);
+cudaError_t cuda_map_prefetch(void *ptr_d, size_t s, void *stream);
+cudaError_t cuda_map_memcpy(void *dst, void *src, size_t s, int kind,
+                            void *stream);
 
 #ifdef __cplusplus
 }

--- a/src/device/cuda/unified.h
+++ b/src/device/cuda/unified.h
@@ -1,5 +1,5 @@
-#ifndef __HIP_UNIFIED_H
-#define __HIP_UNIFIED_H
+#ifndef __CUDA_UNIFIED_H
+#define __CUDA_UNIFIED_H
 /*
  Copyright (c) 2026, The Neko Authors
  All rights reserved.
@@ -34,16 +34,16 @@
  POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int hip_zerocopy(void);
-hipError_t hip_map(void **ptr_d, void *ptr_h, size_t s);
-hipError_t hip_map_free(void *ptr_d);
-hipError_t hip_map_memset(void *ptr_d, int value, size_t s, void *stream);
+int cuda_zerocopy(void);
+cudaError_t cuda_map(void **ptr_d, void *ptr_h, size_t s);
+cudaError_t cuda_map_free(void *ptr_d);
+cudaError_t cuda_map_memset(void *ptr_d, int value, size_t s, void *stream);
 
 #ifdef __cplusplus
 }

--- a/src/device/cuda_intf.F90
+++ b/src/device/cuda_intf.F90
@@ -72,6 +72,39 @@ module cuda_intf
        type(c_ptr), value :: ptr_d
      end function cudaFree
 
+     !> Map host memory to the device (zero-copy on coherent
+     !! unified memory platforms, e.g. Grace Hopper,
+     !! see device/cuda/unified.cu)
+     integer(c_int) function cudaMap(ptr_d, ptr_h, s) &
+          bind(c, name = 'cuda_map')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr) :: ptr_d
+       type(c_ptr), value :: ptr_h
+       integer(c_size_t), value :: s
+     end function cudaMap
+
+     !> Free a device pointer obtained from cudaMap
+     !! (no-op for pointers aliasing host memory)
+     integer(c_int) function cudaMapFree(ptr_d) &
+          bind(c, name = 'cuda_map_free')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr), value :: ptr_d
+     end function cudaMapFree
+
+     !> Memset on a device pointer obtained from cudaMap
+     !! (host-side memset for pointers aliasing host memory)
+     integer(c_int) function cudaMapMemset(ptr_d, v, s, stream) &
+          bind(c, name = 'cuda_map_memset')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr), value :: ptr_d
+       integer(c_int), value :: v
+       integer(c_size_t), value :: s
+       type(c_ptr), value :: stream
+     end function cudaMapMemset
+
      integer(c_int) function cudaMemcpy(ptr_dst, ptr_src, s, dir) &
           bind(c, name = 'cudaMemcpy')
        use, intrinsic :: iso_c_binding

--- a/src/device/cuda_intf.F90
+++ b/src/device/cuda_intf.F90
@@ -93,8 +93,20 @@ module cuda_intf
        type(c_ptr), value :: ptr_d
      end function cudaMapFree
 
+     !> Copy between device/host pointers via the mapping layer
+     !! (kernel-based copy under zero-copy, where either side may
+     !! alias pageable host memory)
+     integer(c_int) function cudaMapMemcpy(ptr_dst, ptr_src, s, dir, stream) &
+          bind(c, name = 'cuda_map_memcpy')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr), value :: ptr_dst, ptr_src, stream
+       integer(c_size_t), value :: s
+       integer(c_int), value :: dir
+     end function cudaMapMemcpy
+
      !> Memset on a device pointer obtained from cudaMap
-     !! (host-side memset for pointers aliasing host memory)
+     !! (kernel-based memset for pointers aliasing host memory)
      integer(c_int) function cudaMapMemset(ptr_d, v, s, stream) &
           bind(c, name = 'cuda_map_memset')
        use, intrinsic :: iso_c_binding
@@ -104,6 +116,17 @@ module cuda_intf
        integer(c_size_t), value :: s
        type(c_ptr), value :: stream
      end function cudaMapMemset
+
+     !> Prefetch a zero-copy mapping to device memory (stands in for
+     !! the host-to-device copy of an aliased mapping)
+     integer(c_int) function cudaMapPrefetch(ptr_d, s, stream) &
+          bind(c, name = 'cuda_map_prefetch')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr), value :: ptr_d
+       integer(c_size_t), value :: s
+       type(c_ptr), value :: stream
+     end function cudaMapPrefetch
 
      integer(c_int) function cudaMemcpy(ptr_dst, ptr_src, s, dir) &
           bind(c, name = 'cudaMemcpy')

--- a/src/device/device.F90
+++ b/src/device/device.F90
@@ -75,6 +75,11 @@ module device
   end interface device_memcpy
 
   !> Map a Fortran array to a device (allocate and associate)
+  !! @note On unified memory backends the device pointer may alias the
+  !! host array (zero-copy) and host-device copies of the pair become
+  !! no-ops. The host side must then not be written while device work
+  !! touching the array may be in flight; call device_sync before
+  !! host-side writes to a mapped array.
   interface device_map
      module procedure device_map_r1, device_map_r2, &
           device_map_r3, device_map_r4
@@ -513,24 +518,26 @@ contains
 #ifdef HAVE_HIP
     ! Copies where the device pointer aliases the host pointer
     ! (zero-copy mappings on unified memory) are skipped; a
-    ! requested sync still synchronizes the stream below
+    ! requested sync still synchronizes the stream below. Other
+    ! copies go via the mapping layer, which handles zero-copy
+    ! pointers aliasing pageable host memory
     if (dir .eq. HOST_TO_DEVICE) then
        if (.not. c_associated(x_d, ptr_h)) then
-          if (hipMemcpyAsync(x_d, ptr_h, s, &
+          if (hipMapMemcpy(x_d, ptr_h, s, &
                hipMemcpyHostToDevice, stream) .ne. hipSuccess) then
              call neko_error('Device memcpy async (host-to-device) failed')
           end if
        end if
     else if (dir .eq. DEVICE_TO_HOST) then
        if (.not. c_associated(ptr_h, x_d)) then
-          if (hipMemcpyAsync(ptr_h, x_d, s, &
+          if (hipMapMemcpy(ptr_h, x_d, s, &
                hipMemcpyDeviceToHost, stream) .ne. hipSuccess) then
              call neko_error('Device memcpy async (device-to-host) failed')
           end if
        end if
     else if (dir .eq. DEVICE_TO_DEVICE) then
        if (.not. c_associated(ptr_h, x_d)) then
-          if (hipMemcpyAsync(ptr_h, x_d, s, hipMemcpyDeviceToDevice, stream) &
+          if (hipMapMemcpy(ptr_h, x_d, s, hipMemcpyDeviceToDevice, stream) &
                .ne. hipSuccess) then
              call neko_error('Device memcpy async (device-to-device) failed')
           end if
@@ -544,24 +551,32 @@ contains
 #elif HAVE_CUDA
     ! Copies where the device pointer aliases the host pointer
     ! (zero-copy mappings on unified memory) are skipped; a
-    ! requested sync still synchronizes the stream below
+    ! requested sync still synchronizes the stream below. Other
+    ! copies go via the mapping layer, which handles zero-copy
+    ! pointers aliasing pageable host memory
     if (dir .eq. HOST_TO_DEVICE) then
        if (.not. c_associated(x_d, ptr_h)) then
-          if (cudaMemcpyAsync(x_d, ptr_h, s, cudaMemcpyHostToDevice, stream) &
+          if (cudaMapMemcpy(x_d, ptr_h, s, cudaMemcpyHostToDevice, stream) &
                .ne. cudaSuccess) then
              call neko_error('Device memcpy async (host-to-device) failed')
+          end if
+       else
+          ! Migrate host-resident pages to device memory in place of
+          ! the copy (placement only, no-op on a single physical memory)
+          if (cudaMapPrefetch(x_d, s, stream) .ne. cudaSuccess) then
+             call neko_error('Device prefetch (host-to-device) failed')
           end if
        end if
     else if (dir .eq. DEVICE_TO_HOST) then
        if (.not. c_associated(ptr_h, x_d)) then
-          if (cudaMemcpyAsync(ptr_h, x_d, s, cudaMemcpyDeviceToHost, stream) &
+          if (cudaMapMemcpy(ptr_h, x_d, s, cudaMemcpyDeviceToHost, stream) &
                .ne. cudaSuccess) then
              call neko_error('Device memcpy async (device-to-host) failed')
           end if
        end if
     else if (dir .eq. DEVICE_TO_DEVICE) then
        if (.not. c_associated(ptr_h, x_d)) then
-          if (cudaMemcpyAsync(ptr_h, x_d, s, cudaMemcpyDeviceToDevice, &
+          if (cudaMapMemcpy(ptr_h, x_d, s, cudaMemcpyDeviceToDevice, &
                stream) .ne. cudaSuccess) then
              call neko_error('Device memcpy async (device-to-device) failed')
           end if

--- a/src/device/device.F90
+++ b/src/device/device.F90
@@ -239,7 +239,9 @@ contains
   subroutine device_free(x_d)
     type(c_ptr), intent(inout) :: x_d
 #ifdef HAVE_HIP
-    if (hipfree(x_d) .ne. hipSuccess) then
+    ! Free via the mapping layer, which leaves zero-copy pointers
+    ! aliasing host memory untouched (unified memory architectures)
+    if (hipMapFree(x_d) .ne. hipSuccess) then
        call neko_error('Memory deallocation on device failed')
     end if
 #elif HAVE_CUDA
@@ -505,20 +507,29 @@ contains
     end if
 
 #ifdef HAVE_HIP
+    ! Copies where the device pointer aliases the host pointer
+    ! (zero-copy mappings on unified memory) are skipped; a
+    ! requested sync still synchronizes the stream below
     if (dir .eq. HOST_TO_DEVICE) then
-       if (hipMemcpyAsync(x_d, ptr_h, s, &
-            hipMemcpyHostToDevice, stream) .ne. hipSuccess) then
-          call neko_error('Device memcpy async (host-to-device) failed')
+       if (.not. c_associated(x_d, ptr_h)) then
+          if (hipMemcpyAsync(x_d, ptr_h, s, &
+               hipMemcpyHostToDevice, stream) .ne. hipSuccess) then
+             call neko_error('Device memcpy async (host-to-device) failed')
+          end if
        end if
     else if (dir .eq. DEVICE_TO_HOST) then
-       if (hipMemcpyAsync(ptr_h, x_d, s, &
-            hipMemcpyDeviceToHost, stream) .ne. hipSuccess) then
-          call neko_error('Device memcpy async (device-to-host) failed')
+       if (.not. c_associated(ptr_h, x_d)) then
+          if (hipMemcpyAsync(ptr_h, x_d, s, &
+               hipMemcpyDeviceToHost, stream) .ne. hipSuccess) then
+             call neko_error('Device memcpy async (device-to-host) failed')
+          end if
        end if
     else if (dir .eq. DEVICE_TO_DEVICE) then
-       if (hipMemcpyAsync(ptr_h, x_d, s, hipMemcpyDeviceToDevice, stream) &
-            .ne. hipSuccess) then
-          call neko_error('Device memcpy async (device-to-device) failed')
+       if (.not. c_associated(ptr_h, x_d)) then
+          if (hipMemcpyAsync(ptr_h, x_d, s, hipMemcpyDeviceToDevice, stream) &
+               .ne. hipSuccess) then
+             call neko_error('Device memcpy async (device-to-device) failed')
+          end if
        end if
     else
        call neko_error('Device memcpy failed (invalid direction')
@@ -875,6 +886,16 @@ contains
     end if
 
     if (metalMap(x_d, ptr_h, s) .ne. metalSuccess) then
+       call neko_error('Memory map on device failed')
+    end if
+#elif HAVE_HIP
+    if (s .eq. 0) then
+       call device_sync()
+       x_d = C_NULL_PTR
+       return
+    end if
+
+    if (hipMap(x_d, ptr_h, s) .ne. hipSuccess) then
        call neko_error('Memory map on device failed')
     end if
 #else

--- a/src/device/device.F90
+++ b/src/device/device.F90
@@ -127,7 +127,7 @@ module device
        device_finalize, device_stream_wait_event, device_count, &
        device_memset, device_stream_create_with_priority
 
-  private :: device_memcpy_common
+  private :: device_memcpy_common, device_map_common
 
 contains
 
@@ -858,11 +858,37 @@ contains
 
   end subroutine device_deassociate_r4
 
+  !> Allocate device memory backing a mapped host array
+  !! @note On unified memory architectures (Metal) the device pointer
+  !! aliases the host array whenever possible, such that host and
+  !! device share a single allocation instead of replicating data
+  subroutine device_map_common(ptr_h, x_d, s)
+    type(c_ptr), intent(in) :: ptr_h
+    type(c_ptr), intent(inout) :: x_d
+    integer(c_size_t), intent(in) :: s
+
+#ifdef HAVE_METAL
+    if (s .eq. 0) then
+       call device_sync()
+       x_d = C_NULL_PTR
+       return
+    end if
+
+    if (metalMap(x_d, ptr_h, s) .ne. metalSuccess) then
+       call neko_error('Memory map on device failed')
+    end if
+#else
+    call device_alloc(x_d, s)
+#endif
+
+  end subroutine device_map_common
+
   !> Map a Fortran rank 1 array to a device (allocate and associate)
   subroutine device_map_r1(x, x_d, n)
     integer, intent(in) :: n
     class(*), intent(inout), target :: x(:)
     type(c_ptr), intent(inout) :: x_d
+    type(c_ptr) :: ptr_h
     integer(c_size_t) :: s
 
     if (c_associated(x_d)) then
@@ -872,17 +898,21 @@ contains
     select type (x)
     type is (integer)
        s = n * int(4, c_size_t)
+       ptr_h = c_loc(x)
     type is (integer(i8))
        s = n * int(8, c_size_t)
+       ptr_h = c_loc(x)
     type is (real)
        s = n * int(4, c_size_t)
+       ptr_h = c_loc(x)
     type is (double precision)
        s = n * int(8, c_size_t)
+       ptr_h = c_loc(x)
     class default
        call neko_error('Unknown Fortran type')
     end select
 
-    call device_alloc(x_d, s)
+    call device_map_common(ptr_h, x_d, s)
     call device_associate(x, x_d, n)
 
   end subroutine device_map_r1
@@ -892,6 +922,7 @@ contains
     integer, intent(in) :: n
     class(*), intent(inout), target :: x(:,:)
     type(c_ptr), intent(inout) :: x_d
+    type(c_ptr) :: ptr_h
     integer(c_size_t) :: s
 
     if (c_associated(x_d)) then
@@ -901,17 +932,21 @@ contains
     select type (x)
     type is (integer)
        s = n * int(4, c_size_t)
+       ptr_h = c_loc(x)
     type is (integer(i8))
        s = n * int(8, c_size_t)
+       ptr_h = c_loc(x)
     type is (real)
        s = n * int(4, c_size_t)
+       ptr_h = c_loc(x)
     type is (double precision)
        s = n * int(8, c_size_t)
+       ptr_h = c_loc(x)
     class default
        call neko_error('Unknown Fortran type')
     end select
 
-    call device_alloc(x_d, s)
+    call device_map_common(ptr_h, x_d, s)
     call device_associate(x, x_d, n)
 
   end subroutine device_map_r2
@@ -921,6 +956,7 @@ contains
     integer, intent(in) :: n
     class(*), intent(inout), target :: x(:,:,:)
     type(c_ptr), intent(inout) :: x_d
+    type(c_ptr) :: ptr_h
     integer(c_size_t) :: s
 
     if (c_associated(x_d)) then
@@ -930,17 +966,21 @@ contains
     select type (x)
     type is (integer)
        s = n * int(4, c_size_t)
+       ptr_h = c_loc(x)
     type is (integer(i8))
        s = n * int(8, c_size_t)
+       ptr_h = c_loc(x)
     type is (real)
        s = n * int(4, c_size_t)
+       ptr_h = c_loc(x)
     type is (double precision)
        s = n * int(8, c_size_t)
+       ptr_h = c_loc(x)
     class default
        call neko_error('Unknown Fortran type')
     end select
 
-    call device_alloc(x_d, s)
+    call device_map_common(ptr_h, x_d, s)
     call device_associate(x, x_d, n)
 
   end subroutine device_map_r3
@@ -950,6 +990,7 @@ contains
     integer, intent(in) :: n
     class(*), intent(inout), target :: x(:,:,:,:)
     type(c_ptr), intent(inout) :: x_d
+    type(c_ptr) :: ptr_h
     integer(c_size_t) :: s
 
     if (c_associated(x_d)) then
@@ -959,17 +1000,21 @@ contains
     select type (x)
     type is (integer)
        s = n * int(4, c_size_t)
+       ptr_h = c_loc(x)
     type is (integer(i8))
        s = n * int(8, c_size_t)
+       ptr_h = c_loc(x)
     type is (real)
        s = n * int(4, c_size_t)
+       ptr_h = c_loc(x)
     type is (double precision)
        s = n * int(8, c_size_t)
+       ptr_h = c_loc(x)
     class default
        call neko_error('Unknown Fortran type')
     end select
 
-    call device_alloc(x_d, s)
+    call device_map_common(ptr_h, x_d, s)
     call device_associate(x, x_d, n)
 
   end subroutine device_map_r4

--- a/src/device/device.F90
+++ b/src/device/device.F90
@@ -243,7 +243,9 @@ contains
        call neko_error('Memory deallocation on device failed')
     end if
 #elif HAVE_CUDA
-    if (cudafree(x_d) .ne. cudaSuccess) then
+    ! Free via the mapping layer, which leaves zero-copy pointers
+    ! aliasing host memory untouched (unified memory architectures)
+    if (cudaMapFree(x_d) .ne. cudaSuccess) then
        call neko_error('Memory deallocation on device failed')
     end if
 #elif HAVE_OPENCL
@@ -281,11 +283,15 @@ contains
     end if
 
 #ifdef HAVE_HIP
-    if (hipMemsetAsync(x_d, v, s, stream) .ne. hipSuccess) then
+    ! Memset via the mapping layer, which handles zero-copy pointers
+    ! aliasing host memory (unified memory architectures)
+    if (hipMapMemset(x_d, v, s, stream) .ne. hipSuccess) then
        call neko_error('Device memset async failed')
     end if
 #elif HAVE_CUDA
-    if (cudaMemsetAsync(x_d, v, s, stream) .ne. cudaSuccess) then
+    ! Memset via the mapping layer, which handles zero-copy pointers
+    ! aliasing host memory (unified memory architectures)
+    if (cudaMapMemset(x_d, v, s, stream) .ne. cudaSuccess) then
        call neko_error('Device memset async failed')
     end if
 #elif HAVE_OPENCL
@@ -536,20 +542,29 @@ contains
        call device_sync_stream(stream)
     end if
 #elif HAVE_CUDA
+    ! Copies where the device pointer aliases the host pointer
+    ! (zero-copy mappings on unified memory) are skipped; a
+    ! requested sync still synchronizes the stream below
     if (dir .eq. HOST_TO_DEVICE) then
-       if (cudaMemcpyAsync(x_d, ptr_h, s, cudaMemcpyHostToDevice, stream) &
-            .ne. cudaSuccess) then
-          call neko_error('Device memcpy async (host-to-device) failed')
+       if (.not. c_associated(x_d, ptr_h)) then
+          if (cudaMemcpyAsync(x_d, ptr_h, s, cudaMemcpyHostToDevice, stream) &
+               .ne. cudaSuccess) then
+             call neko_error('Device memcpy async (host-to-device) failed')
+          end if
        end if
     else if (dir .eq. DEVICE_TO_HOST) then
-       if (cudaMemcpyAsync(ptr_h, x_d, s, cudaMemcpyDeviceToHost, stream) &
-            .ne. cudaSuccess) then
-          call neko_error('Device memcpy async (device-to-host) failed')
+       if (.not. c_associated(ptr_h, x_d)) then
+          if (cudaMemcpyAsync(ptr_h, x_d, s, cudaMemcpyDeviceToHost, stream) &
+               .ne. cudaSuccess) then
+             call neko_error('Device memcpy async (device-to-host) failed')
+          end if
        end if
     else if (dir .eq. DEVICE_TO_DEVICE) then
-       if (cudaMemcpyAsync(ptr_h, x_d, s, cudaMemcpyDeviceToDevice, stream) &
-            .ne. cudaSuccess) then
-          call neko_error('Device memcpy async (device-to-device) failed')
+       if (.not. c_associated(ptr_h, x_d)) then
+          if (cudaMemcpyAsync(ptr_h, x_d, s, cudaMemcpyDeviceToDevice, &
+               stream) .ne. cudaSuccess) then
+             call neko_error('Device memcpy async (device-to-device) failed')
+          end if
        end if
     else
        call neko_error('Device memcpy failed (invalid direction')
@@ -894,6 +909,16 @@ contains
     end if
 
     if (hipMap(x_d, ptr_h, s) .ne. hipSuccess) then
+       call neko_error('Memory map on device failed')
+    end if
+#elif HAVE_CUDA
+    if (s .eq. 0) then
+       call device_sync()
+       x_d = C_NULL_PTR
+       return
+    end if
+
+    if (cudaMap(x_d, ptr_h, s) .ne. cudaSuccess) then
        call neko_error('Memory map on device failed')
     end if
 #else

--- a/src/device/hip/unified.h
+++ b/src/device/hip/unified.h
@@ -44,6 +44,8 @@ int hip_zerocopy(void);
 hipError_t hip_map(void **ptr_d, void *ptr_h, size_t s);
 hipError_t hip_map_free(void *ptr_d);
 hipError_t hip_map_memset(void *ptr_d, int value, size_t s, void *stream);
+hipError_t hip_map_memcpy(void *dst, void *src, size_t s, int kind,
+                          void *stream);
 
 #ifdef __cplusplus
 }

--- a/src/device/hip/unified.h
+++ b/src/device/hip/unified.h
@@ -36,8 +36,16 @@
 
 #include <hip/hip_runtime.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int hip_zerocopy(void);
 hipError_t hip_map(void **ptr_d, void *ptr_h, size_t s);
 hipError_t hip_map_free(void *ptr_d);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/device/hip/unified.h
+++ b/src/device/hip/unified.h
@@ -1,0 +1,43 @@
+#ifndef __HIP_UNIFIED_H
+#define __HIP_UNIFIED_H
+/*
+ Copyright (c) 2026, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <hip/hip_runtime.h>
+
+int hip_zerocopy(void);
+hipError_t hip_map(void **ptr_d, void *ptr_h, size_t s);
+hipError_t hip_map_free(void *ptr_d);
+
+#endif

--- a/src/device/hip/unified.hip
+++ b/src/device/hip/unified.hip
@@ -1,0 +1,146 @@
+/*
+ Copyright (c) 2026, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/**
+ * Zero-copy mapping of host arrays for unified memory architectures.
+ *
+ * On APUs with a single physical memory (e.g. MI300A) and XNACK
+ * enabled (HSA_XNACK=1), system allocations are directly and
+ * coherently accessible from device kernels.  Mapped host arrays
+ * then alias their host allocation instead of being replicated in a
+ * separate hipMalloc buffer, and host-device copies degenerate to
+ * no-ops.
+ */
+
+#include <stdlib.h>
+#include <hip/hip_runtime.h>
+#include <device/hip/unified.h>
+
+/**
+ * Whether mapped arrays may alias host allocations (zero-copy).
+ *
+ * Zero-copy is only possible on an APU with unified physical memory
+ * and XNACK enabled, such that system allocations are directly and
+ * coherently accessible from the device:
+ *
+ *  - The integrated attribute identifies an APU (e.g. MI300A, as
+ *    opposed to the discrete MI300X, which shares the same gfx942
+ *    architecture).  Discrete GPUs (MI250X, MI300X) always use
+ *    replicated buffers; with XNACK they also report pageable
+ *    memory access, but there it means page migration, which
+ *    would thrash host arrays back and forth.
+ *  - Pageable memory access reflects the effective XNACK state of
+ *    the process (HSA_XNACK=1, kernel support and xnack-capable
+ *    code objects); on an APU with XNACK off it reports 0 and we
+ *    fall back to replicated buffers.
+ *
+ * On capable devices, zero-copy can be disabled with
+ * NEKO_HIP_ZEROCOPY=0.
+ */
+int hip_zerocopy(void)
+{
+  static int zerocopy = -1;
+  if (zerocopy < 0) {
+    int dev = 0, integrated = 0, pageable = 0;
+    const char *env = getenv("NEKO_HIP_ZEROCOPY");
+
+    if (hipGetDevice(&dev) == hipSuccess &&
+        hipDeviceGetAttribute(&integrated,
+                              hipDeviceAttributeIntegrated,
+                              dev) == hipSuccess &&
+        hipDeviceGetAttribute(&pageable,
+                              hipDeviceAttributePageableMemoryAccess,
+                              dev) == hipSuccess)
+      zerocopy = (integrated && pageable);
+    else
+      zerocopy = 0;
+    (void) hipGetLastError();
+
+    if (zerocopy && env != NULL && atoi(env) == 0)
+      zerocopy = 0;
+  }
+  return zerocopy;
+}
+
+/**
+ * Map \p s bytes of host memory at \p ptr_h to the device.
+ *
+ * On unified memory (see hip_zerocopy) the device pointer aliases
+ * the host allocation; otherwise a separate replicated buffer is
+ * allocated with hipMalloc.  Aliased ranges are advised to
+ * coarse-grained coherence, since mapped arrays are never accessed
+ * concurrently from host and device and fine-grained system memory
+ * can be slower in kernels.
+ */
+hipError_t hip_map(void **ptr_d, void *ptr_h, size_t s)
+{
+  if (hip_zerocopy() && ptr_h != NULL) {
+    int dev = 0;
+    *ptr_d = ptr_h;
+    /* Advice only; ignore failures */
+    if (hipGetDevice(&dev) == hipSuccess)
+      (void) hipMemAdvise(ptr_h, s, hipMemAdviseSetCoarseGrain, dev);
+    (void) hipGetLastError();
+    return hipSuccess;
+  }
+
+  return hipMalloc(ptr_d, s);
+}
+
+/**
+ * Free a device pointer obtained from hip_map (or hipMalloc).
+ *
+ * Pointers aliasing host memory are left untouched; their
+ * allocation is owned by the host side.
+ */
+hipError_t hip_map_free(void *ptr_d)
+{
+  if (hip_zerocopy()) {
+    hipPointerAttribute_t attr;
+    if (hipPointerGetAttributes(&attr, ptr_d) != hipSuccess) {
+      /* Unregistered host pointer, i.e. a zero-copy mapping */
+      (void) hipGetLastError();
+      return hipSuccess;
+    }
+#if HIP_VERSION_MAJOR >= 6
+    if (attr.type != hipMemoryTypeDevice)
+      return hipSuccess;
+#else
+    if (attr.memoryType != hipMemoryTypeDevice)
+      return hipSuccess;
+#endif
+  }
+
+  return hipFree(ptr_d);
+}

--- a/src/device/hip/unified.hip
+++ b/src/device/hip/unified.hip
@@ -47,6 +47,8 @@
 #include <hip/hip_runtime.h>
 #include <device/hip/unified.h>
 
+extern "C" {
+
 /**
  * Whether mapped arrays may alias host allocations (zero-copy).
  *
@@ -144,3 +146,5 @@ hipError_t hip_map_free(void *ptr_d)
 
   return hipFree(ptr_d);
 }
+
+} /* extern "C" */

--- a/src/device/hip/unified.hip
+++ b/src/device/hip/unified.hip
@@ -44,6 +44,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 #include <hip/hip_runtime.h>
 #include <device/hip/unified.h>
 
@@ -121,6 +122,24 @@ hipError_t hip_map(void **ptr_d, void *ptr_h, size_t s)
 }
 
 /**
+ * Whether \p ptr_d is a device allocation (hipMalloc); zero-copy
+ * mappings are unregistered host pointers.
+ */
+static int hip_is_device_alloc(void *ptr_d)
+{
+  hipPointerAttribute_t attr;
+  if (hipPointerGetAttributes(&attr, ptr_d) != hipSuccess) {
+    (void) hipGetLastError();
+    return 0;
+  }
+#if HIP_VERSION_MAJOR >= 6
+  return (attr.type == hipMemoryTypeDevice);
+#else
+  return (attr.memoryType == hipMemoryTypeDevice);
+#endif
+}
+
+/**
  * Free a device pointer obtained from hip_map (or hipMalloc).
  *
  * Pointers aliasing host memory are left untouched; their
@@ -128,23 +147,30 @@ hipError_t hip_map(void **ptr_d, void *ptr_h, size_t s)
  */
 hipError_t hip_map_free(void *ptr_d)
 {
-  if (hip_zerocopy()) {
-    hipPointerAttribute_t attr;
-    if (hipPointerGetAttributes(&attr, ptr_d) != hipSuccess) {
-      /* Unregistered host pointer, i.e. a zero-copy mapping */
-      (void) hipGetLastError();
-      return hipSuccess;
-    }
-#if HIP_VERSION_MAJOR >= 6
-    if (attr.type != hipMemoryTypeDevice)
-      return hipSuccess;
-#else
-    if (attr.memoryType != hipMemoryTypeDevice)
-      return hipSuccess;
-#endif
-  }
+  if (hip_zerocopy() && !hip_is_device_alloc(ptr_d))
+    return hipSuccess;
 
   return hipFree(ptr_d);
+}
+
+/**
+ * Memset on a device pointer obtained from hip_map (or hipMalloc).
+ *
+ * hipMemset only accepts device allocations, so pointers aliasing
+ * host memory are set on the host instead, ordered after any
+ * in-flight device work on \p stream.
+ */
+hipError_t hip_map_memset(void *ptr_d, int value, size_t s, void *stream)
+{
+  if (hip_zerocopy() && !hip_is_device_alloc(ptr_d)) {
+    hipError_t err = hipStreamSynchronize((hipStream_t) stream);
+    if (err != hipSuccess)
+      return err;
+    memset(ptr_d, value, s);
+    return hipSuccess;
+  }
+
+  return hipMemsetAsync(ptr_d, value, s, (hipStream_t) stream);
 }
 
 } /* extern "C" */

--- a/src/device/hip/unified.hip
+++ b/src/device/hip/unified.hip
@@ -45,8 +45,45 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #include <hip/hip_runtime.h>
 #include <device/hip/unified.h>
+
+/**
+ * Grid-stride byte memset kernel for zero-copy mappings.
+ */
+__global__ void hip_unified_memset_kernel(unsigned char *a,
+                                          unsigned char v, size_t n)
+{
+  const size_t idx = blockIdx.x * (size_t) blockDim.x + threadIdx.x;
+  const size_t str = (size_t) blockDim.x * gridDim.x;
+  for (size_t i = idx; i < n; i += str)
+    a[i] = v;
+}
+
+/**
+ * Grid-stride copy kernels for zero-copy mappings (word and byte
+ * variants).
+ */
+__global__ void hip_unified_copy8_kernel(unsigned long long * __restrict__ a,
+                                         const unsigned long long
+                                         * __restrict__ b, size_t n)
+{
+  const size_t idx = blockIdx.x * (size_t) blockDim.x + threadIdx.x;
+  const size_t str = (size_t) blockDim.x * gridDim.x;
+  for (size_t i = idx; i < n; i += str)
+    a[i] = b[i];
+}
+
+__global__ void hip_unified_copy1_kernel(unsigned char * __restrict__ a,
+                                         const unsigned char * __restrict__ b,
+                                         size_t n)
+{
+  const size_t idx = blockIdx.x * (size_t) blockDim.x + threadIdx.x;
+  const size_t str = (size_t) blockDim.x * gridDim.x;
+  for (size_t i = idx; i < n; i += str)
+    a[i] = b[i];
+}
 
 extern "C" {
 
@@ -74,6 +111,8 @@ extern "C" {
 int hip_zerocopy(void)
 {
   static int zerocopy = -1;
+  /* Cached on first use; device selection must already have
+     happened (device_init runs before any map/memset/copy) */
   if (zerocopy < 0) {
     int dev = 0, integrated = 0, pageable = 0;
     const char *env = getenv("NEKO_HIP_ZEROCOPY");
@@ -142,32 +181,80 @@ static int hip_is_device_alloc(void *ptr_d)
 /**
  * Free a device pointer obtained from hip_map (or hipMalloc).
  *
- * Pointers aliasing host memory are left untouched; their
- * allocation is owned by the host side.
+ * Pointers aliasing host memory are left untouched; their allocation
+ * is owned by the host side.  hipFree implicitly synchronizes the
+ * device, and the host typically deallocates right after an unmap,
+ * so preserve that barrier for aliased mappings such that the
+ * allocation cannot be released under in-flight device work.
  */
 hipError_t hip_map_free(void *ptr_d)
 {
   if (hip_zerocopy() && !hip_is_device_alloc(ptr_d))
-    return hipSuccess;
+    return hipDeviceSynchronize();
 
   return hipFree(ptr_d);
+}
+
+/**
+ * Memcpy between device pointers obtained from hip_map (or
+ * hipMalloc) and/or host pointers.
+ *
+ * Under zero-copy either side may alias pageable host memory, which
+ * hipMemcpy treats as a staged pageable copy (slow, serializing);
+ * copy with a kernel instead, which runs at full memory bandwidth
+ * and stays stream-ordered (on a unified memory APU any pointer is
+ * dereferenceable from the device).
+ */
+hipError_t hip_map_memcpy(void *dst, void *src, size_t s,
+                          int kind, void *stream)
+{
+  if (hip_zerocopy()) {
+    if (s == 0)
+      return hipSuccess;
+    if ((((uintptr_t) dst | (uintptr_t) src | s) & 7) == 0) {
+      const size_t n = s / 8;
+      const size_t nb = (n + 1024 - 1) / 1024;
+      const dim3 nthrds(1024, 1, 1);
+      const dim3 nblcks((unsigned int) (nb > 65535 ? 65535 : nb), 1, 1);
+      hipLaunchKernelGGL(hip_unified_copy8_kernel, nblcks, nthrds, 0,
+                         (hipStream_t) stream,
+                         (unsigned long long *) dst,
+                         (const unsigned long long *) src, n);
+    }
+    else {
+      const size_t nb = (s + 1024 - 1) / 1024;
+      const dim3 nthrds(1024, 1, 1);
+      const dim3 nblcks((unsigned int) (nb > 65535 ? 65535 : nb), 1, 1);
+      hipLaunchKernelGGL(hip_unified_copy1_kernel, nblcks, nthrds, 0,
+                         (hipStream_t) stream,
+                         (unsigned char *) dst,
+                         (const unsigned char *) src, s);
+    }
+    return hipGetLastError();
+  }
+
+  return hipMemcpyAsync(dst, src, s, (hipMemcpyKind) kind,
+                        (hipStream_t) stream);
 }
 
 /**
  * Memset on a device pointer obtained from hip_map (or hipMalloc).
  *
  * hipMemset only accepts device allocations, so pointers aliasing
- * host memory are set on the host instead, ordered after any
- * in-flight device work on \p stream.
+ * host memory are set with a kernel instead, which also keeps the
+ * operation stream-ordered.
  */
 hipError_t hip_map_memset(void *ptr_d, int value, size_t s, void *stream)
 {
   if (hip_zerocopy() && !hip_is_device_alloc(ptr_d)) {
-    hipError_t err = hipStreamSynchronize((hipStream_t) stream);
-    if (err != hipSuccess)
-      return err;
-    memset(ptr_d, value, s);
-    return hipSuccess;
+    const size_t nb = (s + 1024 - 1) / 1024;
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks((unsigned int) (nb > 65535 ? 65535 :
+                                      (nb == 0 ? 1 : nb)), 1, 1);
+    hipLaunchKernelGGL(hip_unified_memset_kernel, nblcks, nthrds, 0,
+                       (hipStream_t) stream,
+                       (unsigned char *) ptr_d, (unsigned char) value, s);
+    return hipGetLastError();
   }
 
   return hipMemsetAsync(ptr_d, value, s, (hipStream_t) stream);

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -110,6 +110,18 @@ module hip_intf
        type(c_ptr), value :: ptr_d
      end function hipMapFree
 
+     !> Memset on a device pointer obtained from hipMap
+     !! (host-side memset for pointers aliasing host memory)
+     integer(c_int) function hipMapMemset(ptr_d, v, s, stream) &
+          bind(c, name = 'hip_map_memset')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr), value :: ptr_d
+       integer(c_int), value :: v
+       integer(c_size_t), value :: s
+       type(c_ptr), value :: stream
+     end function hipMapMemset
+
      integer(c_int) function hipMemcpy(ptr_dst, ptr_src, s, dir) &
           bind(c, name = 'hipMemcpy')
        use, intrinsic :: iso_c_binding

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -110,8 +110,20 @@ module hip_intf
        type(c_ptr), value :: ptr_d
      end function hipMapFree
 
+     !> Copy between device/host pointers via the mapping layer
+     !! (kernel-based copy under zero-copy, where either side may
+     !! alias pageable host memory)
+     integer(c_int) function hipMapMemcpy(ptr_dst, ptr_src, s, dir, stream) &
+          bind(c, name = 'hip_map_memcpy')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr), value :: ptr_dst, ptr_src, stream
+       integer(c_size_t), value :: s
+       integer(c_int), value :: dir
+     end function hipMapMemcpy
+
      !> Memset on a device pointer obtained from hipMap
-     !! (host-side memset for pointers aliasing host memory)
+     !! (kernel-based memset for pointers aliasing host memory)
      integer(c_int) function hipMapMemset(ptr_d, v, s, stream) &
           bind(c, name = 'hip_map_memset')
        use, intrinsic :: iso_c_binding

--- a/src/device/hip_intf.F90
+++ b/src/device/hip_intf.F90
@@ -90,6 +90,26 @@ module hip_intf
        type(c_ptr), value :: ptr_d
      end function hipFree
 
+     !> Map host memory to the device (zero-copy on unified memory
+     !! architectures, e.g. MI300A, see device/hip/unified.hip)
+     integer(c_int) function hipMap(ptr_d, ptr_h, s) &
+          bind(c, name = 'hip_map')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr) :: ptr_d
+       type(c_ptr), value :: ptr_h
+       integer(c_size_t), value :: s
+     end function hipMap
+
+     !> Free a device pointer obtained from hipMap
+     !! (no-op for pointers aliasing host memory)
+     integer(c_int) function hipMapFree(ptr_d) &
+          bind(c, name = 'hip_map_free')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr), value :: ptr_d
+     end function hipMapFree
+
      integer(c_int) function hipMemcpy(ptr_dst, ptr_src, s, dir) &
           bind(c, name = 'hipMemcpy')
        use, intrinsic :: iso_c_binding

--- a/src/device/metal/metal.m
+++ b/src/device/metal/metal.m
@@ -39,6 +39,11 @@
  * MTLResourceStorageModeShared so that a single MTLBuffer is
  * accessible from both sides.  The opaque c_ptr that Fortran stores
  * is the ARC-retained MTLBuffer pointer.
+ *
+ * Mapped host arrays (metal_map) exploit the unified memory fully:
+ * when the host allocation permits, the buffer is created with
+ * newBufferWithBytesNoCopy so that host and device share a single
+ * allocation and host-device copies degenerate to no-ops.
  */
 
 #ifdef __APPLE__
@@ -47,6 +52,9 @@
 #import <Foundation/Foundation.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
+#include <malloc/malloc.h>
+#include <mach/vm_page_size.h>
 
 /*
  *  Module-local Metal device and default command queue
@@ -173,6 +181,57 @@ int metal_alloc(void **ptr, size_t s)
 }
 
 /**
+ * Whether mapped buffers may alias host allocations (zero-copy).
+ *
+ * Requires a device with unified memory (Apple Silicon); discrete
+ * GPUs (AMD in Intel Macs) support Metal but not unified memory and
+ * always use replicated buffers.  Can be disabled with
+ * NEKO_METAL_ZEROCOPY=0.
+ */
+static int metal_zerocopy(void)
+{
+    static int zerocopy = -1;
+    if (zerocopy < 0) {
+        const char *env = getenv("NEKO_METAL_ZEROCOPY");
+        zerocopy = (env == NULL || atoi(env) != 0) &&
+            [_mtl_device hasUnifiedMemory];
+    }
+    return zerocopy;
+}
+
+/**
+ * Map \p s bytes of host memory at \p ptr_h to a Metal buffer.
+ *
+ * On unified memory (see metal_zerocopy), when the host allocation is
+ * page-aligned and its malloc block covers whole VM pages we wrap it
+ * in a no-copy shared buffer; host and device then operate on the
+ * same allocation and copies between them become no-ops.  Otherwise
+ * (small, stack or unaligned allocations, or a discrete GPU) we fall
+ * back to a separate buffer as in metal_alloc.
+ */
+int metal_map(void **ptr, void *ptr_h, size_t s)
+{
+    if (metal_zerocopy() && ptr_h != NULL) {
+        const size_t page = vm_page_size;
+        const size_t len = (s + page - 1) & ~(page - 1);
+        if (((uintptr_t) ptr_h & (page - 1)) == 0 &&
+            malloc_size(ptr_h) >= len) {
+            id<MTLBuffer> buf =
+                [_mtl_device newBufferWithBytesNoCopy:ptr_h
+                                length:len
+                                options:MTLResourceStorageModeShared
+                                deallocator:nil];
+            if (buf) {
+                *ptr = (__bridge_retained void *)buf;
+                return 0;
+            }
+        }
+    }
+
+    return metal_alloc(ptr, s);
+}
+
+/**
  * Free a previously allocated Metal buffer.
  * Returns 0 on success.
  */
@@ -196,14 +255,22 @@ int metal_free(void *ptr)
 /**
  * Copy \p s bytes from host memory \p src to Metal buffer \p dst_d.
  *
- * Because we use shared-mode buffers the copy is a plain memcpy.
- * A blit encoder could be used for managed-mode on discrete GPUs,
- * but Apple Silicon only has shared memory.
+ * Because we use shared-mode buffers the copy is a host-side copy.
+ * On unified memory the buffer may be a no-copy mapping of \p src
+ * (see metal_map): an exact alias makes the copy a no-op, and any
+ * other overlap requires memmove.  Otherwise buffers are separate
+ * allocations and a plain memcpy suffices.
  */
 int metal_memcpy_htod(void *dst_d, const void *src, size_t s)
 {
     id<MTLBuffer> buf = (__bridge id<MTLBuffer>)dst_d;
-    memcpy([buf contents], src, s);
+    void *contents = [buf contents];
+    if (metal_zerocopy()) {
+        if (contents != src)
+            memmove(contents, src, s);
+    } else {
+        memcpy(contents, src, s);
+    }
     return 0;
 }
 
@@ -213,7 +280,13 @@ int metal_memcpy_htod(void *dst_d, const void *src, size_t s)
 int metal_memcpy_dtoh(void *dst, void *src_d, size_t s)
 {
     id<MTLBuffer> buf = (__bridge id<MTLBuffer>)src_d;
-    memcpy(dst, [buf contents], s);
+    void *contents = [buf contents];
+    if (metal_zerocopy()) {
+        if (contents != dst)
+            memmove(dst, contents, s);
+    } else {
+        memcpy(dst, contents, s);
+    }
     return 0;
 }
 
@@ -224,7 +297,12 @@ int metal_memcpy_dtod(void *dst_d, void *src_d, size_t s)
 {
     id<MTLBuffer> dst_buf = (__bridge id<MTLBuffer>)dst_d;
     id<MTLBuffer> src_buf = (__bridge id<MTLBuffer>)src_d;
-    memcpy([dst_buf contents], [src_buf contents], s);
+    if (metal_zerocopy()) {
+        if ([dst_buf contents] != [src_buf contents])
+            memmove([dst_buf contents], [src_buf contents], s);
+    } else {
+        memcpy([dst_buf contents], [src_buf contents], s);
+    }
     return 0;
 }
 

--- a/src/device/metal_intf.F90
+++ b/src/device/metal_intf.F90
@@ -52,6 +52,17 @@ module metal_intf
        integer(c_size_t), value :: s
      end function metalAlloc
 
+     !> Map host memory to a Metal buffer of @a s bytes
+     !! (zero-copy on unified memory when the host allocation allows it)
+     integer(c_int) function metalMap(ptr_d, ptr_h, s) &
+          bind(c, name = 'metal_map')
+       use, intrinsic :: iso_c_binding
+       implicit none
+       type(c_ptr) :: ptr_d
+       type(c_ptr), value :: ptr_h
+       integer(c_size_t), value :: s
+     end function metalMap
+
      !> Free a Metal buffer
      integer(c_int) function metalFree(ptr_d) &
           bind(c, name = 'metal_free')

--- a/src/filter/elementwise_filter.f90
+++ b/src/filter/elementwise_filter.f90
@@ -46,7 +46,8 @@ module elementwise_filter
   use matrix, only : matrix_t
   use mxm_wrapper, only : mxm
   use tensor, only : tnsr3d, trsp
-  use device, only : device_map, device_unmap, device_memcpy, HOST_TO_DEVICE
+  use device, only : device_map, device_unmap, device_memcpy, device_sync, &
+       HOST_TO_DEVICE
   use device_math, only : device_cfill
   use, intrinsic :: iso_c_binding, only : c_ptr, C_NULL_PTR
   implicit none
@@ -157,6 +158,9 @@ contains
        call device_map(this%fht, this%fht_d, this%nx * this%nx)
        call device_cfill(this%fh_d, 0.0_rp, this%nx * this%nx)
        call device_cfill(this%fht_d, 0.0_rp, this%nx * this%nx)
+       ! Order the async fills against the host-side build_1d; on
+       ! unified memory the device pointers may alias fh/fht
+       call device_sync()
     end if
 
     call this%build_1d()

--- a/src/krylov/bcknd/device/cuda/fusedcg_aux.cu
+++ b/src/krylov/bcknd/device/cuda/fusedcg_aux.cu
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2025, The Neko Authors
+ Copyright (c) 2021-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -36,6 +36,7 @@
 #include <device/device_config.h>
 #include <device/cuda/check.h>
 #include <device/cuda/buffer.h>
+#include <device/cuda/unified.h>
 
 #ifdef HAVE_NVSHMEM
 #include <nvshmem.h>
@@ -103,7 +104,9 @@ extern "C" {
     /* Update alpha_d(p_cur) = alpha(p_cur) */
     real *alpha_d_p_cur = ((real *) alpha_d) + ((*p_cur - 1));
     CUDA_CHECK(cudaMemcpyAsync(alpha_d_p_cur, &fusedcg_buf[1], sizeof(real),
-                               cudaMemcpyHostToDevice, stream));
+                               cuda_zerocopy() ?
+                               cudaMemcpyDefault : cudaMemcpyHostToDevice,
+                               stream));
 
 
     fusedcg_part2_kernel<real>

--- a/src/krylov/bcknd/device/cuda/fusedcg_cpld_aux.cu
+++ b/src/krylov/bcknd/device/cuda/fusedcg_cpld_aux.cu
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2024-2025, The Neko Authors
+ Copyright (c) 2024-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -36,6 +36,7 @@
 #include <device/device_config.h>
 #include <device/cuda/check.h>
 #include <device/cuda/buffer.h>
+#include <device/cuda/unified.h>
 
 #ifdef HAVE_NVSHMEM
 #include <nvshmem.h>
@@ -122,7 +123,8 @@ extern "C" {
     /* Update alpha_d(p_cur) = alpha(p_cur) */
     real *alpha_d_p_cur = ((real *) alpha_d) + ((*p_cur - 1));
     CUDA_CHECK(cudaMemcpyAsync(alpha_d_p_cur, &fusedcg_cpld_buf[1],
-                               sizeof(real), cudaMemcpyHostToDevice,
+                               sizeof(real), cuda_zerocopy() ?
+                               cudaMemcpyDefault : cudaMemcpyHostToDevice,
                                stream));
 
 

--- a/src/krylov/bcknd/device/hip/fusedcg_aux.hip
+++ b/src/krylov/bcknd/device/hip/fusedcg_aux.hip
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2025, The Neko Authors
+ Copyright (c) 2021-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -37,6 +37,7 @@
 #include <device/device_config.h>
 #include <device/hip/check.h>
 #include <device/hip/buffer.h>
+#include <device/hip/unified.h>
 
 /**
  * Reduction buffer, owned by the device layer and released on device
@@ -102,7 +103,9 @@ extern "C" {
     /* Update alpha_d(p_cur) = alpha(p_cur) */
     real *alpha_d_p_cur = ((real *) alpha_d) + ((*p_cur - 1));   
     HIP_CHECK(hipMemcpyAsync(alpha_d_p_cur, &fusedcg_buf[1], sizeof(real),
-                               hipMemcpyHostToDevice, stream));
+                               hip_zerocopy() ?
+                               hipMemcpyDefault : hipMemcpyHostToDevice,
+                               stream));
    
     hipLaunchKernelGGL(HIP_KERNEL_NAME(fusedcg_part2_kernel<real>),
                        nblcks, nthrds, 0, stream,

--- a/src/krylov/bcknd/device/hip/fusedcg_cpld_aux.hip
+++ b/src/krylov/bcknd/device/hip/fusedcg_cpld_aux.hip
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2024, The Neko Authors
+ Copyright (c) 2024-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -35,6 +35,7 @@
 #include <device/device_config.h>
 #include <device/hip/check.h>
 #include <device/hip/buffer.h>
+#include <device/hip/unified.h>
 #include "fusedcg_cpld_kernel.h"
 
 /**
@@ -122,7 +123,8 @@ extern "C" {
     /* Update alpha_d(p_cur) = alpha(p_cur) */
     real *alpha_d_p_cur = ((real *) alpha_d) + ((*p_cur - 1));   
     HIP_CHECK(hipMemcpyAsync(alpha_d_p_cur, &fusedcg_cpld_buf[1],
-                               sizeof(real), hipMemcpyHostToDevice,
+                               sizeof(real), hip_zerocopy() ?
+                               hipMemcpyDefault : hipMemcpyHostToDevice,
                                stream));
 
     hipLaunchKernelGGL(HIP_KERNEL_NAME(fusedcg_cpld_part2_kernel<real>),

--- a/src/math/bcknd/device/cuda/math.cu
+++ b/src/math/bcknd/device/cuda/math.cu
@@ -59,11 +59,22 @@ extern "C" {
    * Copy a vector \f$ a = b \f$
    */
   void cuda_copy(void *a, void *b, int *n, cudaStream_t strm) {
-    /* Under zero-copy the pointers may alias pageable host memory;
-       let the runtime infer the direction from the actual pointers */
-    const enum cudaMemcpyKind kind = cuda_zerocopy() ?
-      cudaMemcpyDefault : cudaMemcpyDeviceToDevice;
-    CUDA_CHECK(cudaMemcpyAsync(a, b, (*n) * sizeof(real), kind, strm));
+    if (cuda_zerocopy()) {
+      if (*n == 0) return;
+      /* The pointers may alias pageable host memory, which cudaMemcpy
+         treats as a staged pageable copy (slow, serializing); copy
+         with a kernel instead, which runs at full memory bandwidth
+         on any pointer */
+      const dim3 nthrds(1024, 1, 1);
+      const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
+
+      copy_kernel<real><<<nblcks, nthrds, 0, strm>>>((real *) a,
+                                                     (const real *) b, *n);
+      CUDA_CHECK(cudaGetLastError());
+      return;
+    }
+    CUDA_CHECK(cudaMemcpyAsync(a, b, (*n) * sizeof(real),
+                               cudaMemcpyDeviceToDevice, strm));
   }
 
   /** Fortran wrapper for masked copy
@@ -208,6 +219,7 @@ extern "C" {
    */
   void cuda_rzero(void *a, int *n, cudaStream_t strm) {
     if (cuda_zerocopy()) {
+      if (*n == 0) return;
       /* a may alias pageable host memory, which cudaMemset rejects;
          zero with a kernel instead (works on any pointer) */
       const dim3 nthrds(1024, 1, 1);

--- a/src/math/bcknd/device/cuda/math.cu
+++ b/src/math/bcknd/device/cuda/math.cu
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2025, The Neko Authors
+ Copyright (c) 2021-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -59,8 +59,11 @@ extern "C" {
    * Copy a vector \f$ a = b \f$
    */
   void cuda_copy(void *a, void *b, int *n, cudaStream_t strm) {
-    CUDA_CHECK(cudaMemcpyAsync(a, b, (*n) * sizeof(real),
-                               cudaMemcpyDeviceToDevice, strm));
+    /* Under zero-copy the pointers may alias pageable host memory;
+       let the runtime infer the direction from the actual pointers */
+    const enum cudaMemcpyKind kind = cuda_zerocopy() ?
+      cudaMemcpyDefault : cudaMemcpyDeviceToDevice;
+    CUDA_CHECK(cudaMemcpyAsync(a, b, (*n) * sizeof(real), kind, strm));
   }
 
   /** Fortran wrapper for masked copy

--- a/src/math/bcknd/device/cuda/math.cu
+++ b/src/math/bcknd/device/cuda/math.cu
@@ -36,6 +36,7 @@
 #include <device/device_config.h>
 #include <device/cuda/check.h>
 #include <device/cuda/buffer.h>
+#include <device/cuda/unified.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -203,6 +204,17 @@ extern "C" {
    * Zero a real vector
    */
   void cuda_rzero(void *a, int *n, cudaStream_t strm) {
+    if (cuda_zerocopy()) {
+      /* a may alias pageable host memory, which cudaMemset rejects;
+         zero with a kernel instead (works on any pointer) */
+      const dim3 nthrds(1024, 1, 1);
+      const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
+
+      cfill_kernel<real><<<nblcks, nthrds, 0, strm>>>((real *) a,
+                                                      (real) 0.0, *n);
+      CUDA_CHECK(cudaGetLastError());
+      return;
+    }
     CUDA_CHECK(cudaMemsetAsync(a, 0, (*n) * sizeof(real), strm));
   }
 

--- a/src/math/bcknd/device/cuda/math_kernel.h
+++ b/src/math/bcknd/device/cuda/math_kernel.h
@@ -415,6 +415,22 @@ __global__ void cfill_kernel(T * __restrict__ a,
 }
 
 /**
+ * Device kernel for copy
+ */
+template< typename T >
+__global__ void copy_kernel(T * __restrict__ a,
+                            const T * __restrict__ b,
+                            const int n) {
+
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  for (int i = idx; i < n; i += str) {
+    a[i] = b[i];
+  }
+}
+
+/**
  * Device kernel for add2
  */
 template< typename T >

--- a/src/math/bcknd/device/hip/math.hip
+++ b/src/math/bcknd/device/hip/math.hip
@@ -36,6 +36,7 @@
 #include <device/device_config.h>
 #include <device/hip/check.h>
 #include <device/hip/buffer.h>
+#include <device/hip/unified.h>
 #include "math_kernel.h"
 
 extern "C" {
@@ -213,6 +214,18 @@ extern "C" {
    * Zero a real vector
    */
   void hip_rzero(void *a, int *n, hipStream_t strm) {
+    if (hip_zerocopy()) {
+      /* a may alias pageable host memory, which hipMemset rejects;
+         zero with a kernel instead (works on any pointer) */
+      const dim3 nthrds(1024, 1, 1);
+      const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
+
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(cfill_kernel<real>),
+                         nblcks, nthrds, 0, strm,
+                         (real *) a, (real) 0.0, *n);
+      HIP_CHECK(hipGetLastError());
+      return;
+    }
     HIP_CHECK(hipMemsetAsync(a, 0, (*n) * sizeof(real), strm));
   }
 

--- a/src/math/bcknd/device/hip/math.hip
+++ b/src/math/bcknd/device/hip/math.hip
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2025, The Neko Authors
+ Copyright (c) 2021-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -53,8 +53,11 @@ extern "C" {
    * Copy a vector \f$ a = b \f$
    */
   void hip_copy(void *a, void *b, int *n, hipStream_t strm) {
-    HIP_CHECK(hipMemcpyAsync(a, b, (*n) * sizeof(real),
-                             hipMemcpyDeviceToDevice, strm));
+    /* Under zero-copy the pointers may alias pageable host memory;
+       let the runtime infer the direction from the actual pointers */
+    const hipMemcpyKind kind = hip_zerocopy() ?
+      hipMemcpyDefault : hipMemcpyDeviceToDevice;
+    HIP_CHECK(hipMemcpyAsync(a, b, (*n) * sizeof(real), kind, strm));
   }
 
   /** Fortran wrapper for masked copy

--- a/src/math/bcknd/device/hip/math.hip
+++ b/src/math/bcknd/device/hip/math.hip
@@ -53,11 +53,23 @@ extern "C" {
    * Copy a vector \f$ a = b \f$
    */
   void hip_copy(void *a, void *b, int *n, hipStream_t strm) {
-    /* Under zero-copy the pointers may alias pageable host memory;
-       let the runtime infer the direction from the actual pointers */
-    const hipMemcpyKind kind = hip_zerocopy() ?
-      hipMemcpyDefault : hipMemcpyDeviceToDevice;
-    HIP_CHECK(hipMemcpyAsync(a, b, (*n) * sizeof(real), kind, strm));
+    if (hip_zerocopy()) {
+      if (*n == 0) return;
+      /* The pointers may alias pageable host memory, which hipMemcpy
+         treats as a staged pageable copy (slow, serializing); copy
+         with a kernel instead, which runs at full memory bandwidth
+         on any pointer */
+      const dim3 nthrds(1024, 1, 1);
+      const dim3 nblcks(((*n) + 1024 - 1) / 1024, 1, 1);
+
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(copy_kernel<real>),
+                         nblcks, nthrds, 0, strm,
+                         (real *) a, (const real *) b, *n);
+      HIP_CHECK(hipGetLastError());
+      return;
+    }
+    HIP_CHECK(hipMemcpyAsync(a, b, (*n) * sizeof(real),
+                             hipMemcpyDeviceToDevice, strm));
   }
 
   /** Fortran wrapper for masked copy
@@ -218,6 +230,7 @@ extern "C" {
    */
   void hip_rzero(void *a, int *n, hipStream_t strm) {
     if (hip_zerocopy()) {
+      if (*n == 0) return;
       /* a may alias pageable host memory, which hipMemset rejects;
          zero with a kernel instead (works on any pointer) */
       const dim3 nthrds(1024, 1, 1);

--- a/src/math/bcknd/device/hip/math_kernel.h
+++ b/src/math/bcknd/device/hip/math_kernel.h
@@ -404,6 +404,22 @@ __global__ void cfill_kernel(T * __restrict__ a,
 }
 
 /**
+ * Device kernel for copy
+ */
+template< typename T >
+__global__ void copy_kernel(T * __restrict__ a,
+                            const T * __restrict__ b,
+                            const int n) {
+
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int str = blockDim.x * gridDim.x;
+
+  for (int i = idx; i < n; i += str) {
+    a[i] = b[i];
+  }
+}
+
+/**
  * Device kernel for add2
  */
 template< typename T >

--- a/src/math/matrix.f90
+++ b/src/math/matrix.f90
@@ -96,6 +96,9 @@ contains
     m%x = 0.0_rp
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_cfill(m%x_d, 0.0_rp, m%n)
+       ! Order the async fill against host writes; on unified memory
+       ! the device pointer may alias m%x
+       call device_sync()
     end if
 
     if (present(name)) then

--- a/src/math/matrix.f90
+++ b/src/math/matrix.f90
@@ -35,7 +35,7 @@ module matrix
   use neko_config, only : NEKO_BCKND_DEVICE
   use num_types, only : rp, xp
   use device, only : device_map, device_unmap, device_memcpy, &
-       device_sync
+       device_sync, HOST_TO_DEVICE
   use device_math, only : device_copy, device_cfill
   use utils, only : neko_error, NEKO_VARNAME_LEN
   use, intrinsic :: iso_c_binding
@@ -95,10 +95,10 @@ contains
     call m%alloc(nrows, ncols)
     m%x = 0.0_rp
     if (NEKO_BCKND_DEVICE .eq. 1) then
-       call device_cfill(m%x_d, 0.0_rp, m%n)
-       ! Order the async fill against host writes; on unified memory
-       ! the device pointer may alias m%x
-       call device_sync()
+       ! Copy the host-side zeros instead of a device-side fill: safe
+       ! against aliased host/device pointers on unified memory, where
+       ! this also places the array in device memory
+       call device_memcpy(m%x, m%x_d, m%n, HOST_TO_DEVICE, sync = .false.)
     end if
 
     if (present(name)) then
@@ -122,11 +122,14 @@ contains
     m%nrows = nrows
     m%ncols = ncols
     m%n = nrows*ncols
+    m%x = 0.0_rp
 
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_map(m%x, m%x_d, m%n)
-       call device_cfill(m%x_d, 0.0_rp, m%n)
-       call device_sync()
+       ! Copy the host-side zeros instead of a device-side fill: safe
+       ! against aliased host/device pointers on unified memory, where
+       ! this also places the array in device memory
+       call device_memcpy(m%x, m%x_d, m%n, HOST_TO_DEVICE, sync = .false.)
     end if
 
   end subroutine matrix_allocate

--- a/src/math/vector.f90
+++ b/src/math/vector.f90
@@ -98,8 +98,10 @@ contains
     call v%alloc(n)
     call cfill(v%x, 0.0_rp, n)
     if (NEKO_BCKND_DEVICE .eq. 1) then
-       call device_cfill(v%x_d, 0.0_rp, n)
-       call device_sync()
+       ! Copy the host-side zeros instead of a device-side fill: safe
+       ! against aliased host/device pointers on unified memory, where
+       ! this also places the array in device memory
+       call device_memcpy(v%x, v%x_d, n, HOST_TO_DEVICE, sync = .false.)
     end if
 
     if (present(name)) then

--- a/src/multigrid/tree_amg.f90
+++ b/src/multigrid/tree_amg.f90
@@ -43,7 +43,7 @@ module tree_amg
   use ax_product, only: ax_t
   use bc_list, only: bc_list_t
   use gather_scatter, only : gs_t, GS_OP_ADD
-  use device, only: device_map, device_unmap, &
+  use device, only: device_map, device_unmap, device_sync, &
        device_stream_wait_event, glb_cmd_queue, glb_cmd_event
   use neko_config, only: NEKO_BCKND_DEVICE
   use, intrinsic :: iso_c_binding
@@ -204,6 +204,9 @@ contains
        call device_cfill(tamg_lvl%wrk_in_d, 0.0_rp, ndofs)
        call device_map(tamg_lvl%wrk_out, tamg_lvl%wrk_out_d, ndofs)
        call device_cfill(tamg_lvl%wrk_out_d, 0.0_rp, ndofs)
+       ! Order the async fills against host writes; on unified memory
+       ! the device pointers may alias the work arrays
+       call device_sync()
     end if
   end subroutine tamg_lvl_init
 

--- a/src/time_schemes/time_scheme_controller.f90
+++ b/src/time_schemes/time_scheme_controller.f90
@@ -38,7 +38,8 @@ module time_scheme_controller
   use bdf_time_scheme, only : bdf_time_scheme_t
   use ext_time_scheme, only : ext_time_scheme_t
   use ab_time_scheme, only : ab_time_scheme_t
-  use device, only : device_free, device_map, device_memcpy, HOST_TO_DEVICE
+  use device, only : device_free, device_map, device_memcpy, device_sync, &
+       HOST_TO_DEVICE
   use vector, only : vector_t
   use, intrinsic :: iso_c_binding
   implicit none
@@ -161,6 +162,13 @@ contains
       ndiff = min(ndiff, this%diffusion_time_order)
       nadv = nadv + 1
       nadv = min(nadv, this%advection_time_order)
+
+      ! On unified memory backends the coefficient arrays may alias
+      ! their device pointers; drain in-flight device work reading
+      ! them before rewriting on the host
+      if (NEKO_BCKND_DEVICE .eq. 1) then
+         call device_sync()
+      end if
 
       call this%bdf%compute_coeffs(diff_coeffs%x, dt, ndiff)
 


### PR DESCRIPTION
This PR add support for unified memory in the CUDA and HIP backends. On systems where CPU and GPU share coherent memory, `device_map` now aliases the host array directly instead of allocating a replicated device buffer. Host–device copies of mapped arrays become no-ops, roughly halving the memory footprint of mapped data and eliminating map-related transfer traffic.

- On APUs with XNACK (e.g. MI300A) the device pointer is the host pointer.
- On coherent memory platforms (e.g. GH200) mapped arrays are prefetched to HBM with preferred-location advice, staying host-accessible over NVLink-C2C.

Other discrete or PCIe-attached GPUs keeps the current replicated buffers.

The mapping, can be disabled via `NEKO_HIP_ZEROCOPY=0` / `NEKO_CUDA_ZEROCOPY=0`

Fixes #2633 