### PR TITLE
Fix f08 datatype init in pfunit_comm_utils via %mpi_val (legacy mpi handles are integers)

### DIFF
--- a/src/comm/pfunit_comm_utils.F90.in
+++ b/src/comm/pfunit_comm_utils.F90.in
@@ -37,8 +37,8 @@ contains
     end if
 
 #ifndef HAVE_MPI_PARAM_DTYPE
-    MPI_REAL_PRECISION = @NEKO_MPI_REAL_TYPE@
-    MPI_EXTRA_PRECISION = @NEKO_MPI_XREAL_TYPE@
+    MPI_REAL_PRECISION%mpi_val = @NEKO_MPI_REAL_TYPE@
+    MPI_EXTRA_PRECISION%mpi_val = @NEKO_MPI_XREAL_TYPE@
 #endif
 
     call MPI_Comm_dup(ext_comm, NEKO_GLOBAL_COMM%mpi_val, ierr)


### PR DESCRIPTION
Fix mixed legacy/f08 MPI datatype assignment in `pfunit_comm_utils`: the module uses the legacy `mpi` module, so `MPI_REAL`/`MPI_DOUBLE_PRECISION` are integer handles and can't be assigned directly to the `type(MPI_Datatype)` variables `MPI_REAL_PRECISION`/`MPI_EXTRA_PRECISION`. Assign via the `%mpi_val` component instead. Only visible on MPI libraries without `HAVE_MPI_PARAM_DTYPE` (e.g. Fujitsu MPI), where the `#ifndef` block is actually compiled.
