### PR TITLE
fixed only_facets in bc%finalize in force_torque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Develop
 
+- Added `only_facets = .true.` to `bc%finalize` in force_torque.
 - Removed the hardcoded `CUDA_ARCH="-arch sm_60"` fallback used for
   `--enable-device-mpi` CUDA builds, which CUDA >= 13 toolkits can no longer
   compile (Pascal support was dropped). `configure` now requires `CUDA_ARCH`

--- a/src/qoi/drag_torque.f90
+++ b/src/qoi/drag_torque.f90
@@ -67,7 +67,7 @@ module drag_torque
   use math, only : rzero, col3, vdot3, col2
   use space, only : space_t
   use num_types, only : rp
-  use utils, only : nonlinear_index
+  use utils, only : nonlinear_index, neko_error
   use iso_c_binding, only : c_ptr
   use neko_config, only : NEKO_BCKND_DEVICE
   use device, only : HOST_TO_DEVICE
@@ -75,7 +75,6 @@ module drag_torque
        device_col3, device_vdot3, device_rzero
   use comm, only : NEKO_COMM, MPI_REAL_PRECISION
   use mpi_f08, only : MPI_ALLREDUCE, MPI_IN_PLACE, MPI_SUM
-  use utils, only : neko_error
   implicit none
   private
   !> Some functions to calculate the lift/drag and torque
@@ -471,17 +470,21 @@ contains
     integer :: n_pts
     type(vector_t), intent(inout) :: n1, n2, n3
     integer :: mask(0:n_pts), facets(0:n_pts), fid, idx(4)
-    real(kind=rp) :: normal(3), area(3)
+    real(kind=rp) :: normal(3), area
     integer :: i
 
     do i = 1, n_pts
        fid = facets(i)
+       if ( (fid .lt. 1) .or. (fid .gt. 6)) then
+          call neko_error('setup_normals: invalid facet id. ' // &
+               'Finalize the bc with only_facets = .true.')
+       end if
        idx = nonlinear_index(mask(i), coef%Xh%lx, coef%Xh%lx, coef%Xh%lx)
        normal = coef%get_normal(idx(1), idx(2), idx(3), idx(4), fid)
        area = coef%get_area(idx(1), idx(2), idx(3), idx(4), fid)
-       n1%x(i) = normal(1)*area(1)
-       n2%x(i) = normal(2)*area(2)
-       n3%x(i) = normal(3)*area(3)
+       n1%x(i) = normal(1)*area
+       n2%x(i) = normal(2)*area
+       n3%x(i) = normal(3)*area
     end do
 
     if (NEKO_BCKND_DEVICE .eq. 1) then

--- a/src/simulation_components/force_torque.f90
+++ b/src/simulation_components/force_torque.f90
@@ -320,7 +320,7 @@ contains
 
     call this%bc%init_base(this%coef)
     call this%bc%mark_zone(this%case%msh%labeled_zones(this%zone_id))
-    call this%bc%finalize()
+    call this%bc%finalize(only_facets = .true.)
     n_pts = this%bc%msk(0)
     if (n_pts .gt. 0) then
        call this%n1%init(n_pts)
@@ -453,12 +453,13 @@ contains
   subroutine force_torque_compute(this, time)
     class(force_torque_t), intent(inout) :: this
     type(time_state_t), intent(in) :: time
-
-    real(kind=rp) :: dgtq(12) = 0.0_rp
+    real(kind=rp) :: dgtq(12)
     integer :: n_pts, temp_indices(6)
     type(field_t), pointer :: s11, s22, s33, s12, s13, s23
     character(len=1000) :: log_buf
     real(kind=rp) :: rot_offset(3)
+
+    dgtq = 0.0_rp
     n_pts = this%bc%msk(0)
 
 


### PR DESCRIPTION
force_torque reads `bc%facet` together with `bc%msk` in `setup_normals`, but the bc (which is `dirichlet_t`, with no guard on `only_facets`) was finalized without `only_facets`. In that case `bc_finalize_base` rebuilds msk and leaves facet stale, so facet(i) no longer belongs to msk(i). This could sometimes lead to wrong and garbage force/torque values.