### PR TITLE
Fix the release doc. workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,7 +27,7 @@ jobs:
         ./regen.sh
         ./configure FC=${FC} --enable-python
         make html
-    
+
     # Deploy the HTML documentation to GitHub Pages
     - name: GH Pages Deployment
       uses: peaceiris/actions-gh-pages@v4
@@ -35,8 +35,8 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./doc/html/
         allow_empty_commit: false
-        force_orphan: true
+        keep_files: false
+        force_orphan: false
         publish_branch: gh-pages
         destination_dir: docs/release
-        keep_files: true
         enable_jekyll: true


### PR DESCRIPTION
This fixed an issue with the documentation workflow for releases, which nuked the entire homepage when publishing the data.

