### PR TITLE
Add precon and ksp user type injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Develop
 
+- *BREAKING* Renamed the allocation-only `precon_factory` API to
+  `precon_allocator`. Added runtime registration of user-defined
+  preconditioner and Krylov solver types.
 - Added opt-in zero-copy unified memory mapping for the HIP backend on AMD
   MI300A APUs: with `NEKO_HIP_ZEROCOPY=1` (and `HSA_XNACK=1`), mapped arrays
   alias their host allocation instead of being replicated on the device,

--- a/doc/pages/user-guide/extension.md
+++ b/doc/pages/user-guide/extension.md
@@ -31,9 +31,11 @@ supports this. Here is a list of things you can implement.
 - Simulation components (`simulation_component_t` descendants).
 - Source terms (`source_term_t` descendants).
 - Point zones (`point_zone_t` descendants).
+- Preconditioners (`pc_t` descendants).
+- Krylov solvers (`ksp_t` descendants).
 
 This list will hopefully be extended later. Notable omissions are scalar and
-fluid schemes, so currently you cannot add new solvers like this. 
+fluid schemes.
 
 To implement a new type, the easiest thing is to start by copying over the
 `.f90` of an already existing type, renaming things inside and then adding the
@@ -130,4 +132,3 @@ advantages:
 
 That said, writing a custom type does take more effort than simply filling in 
 the user routine.
-

--- a/src/ale/ale_manager.f90
+++ b/src/ale/ale_manager.f90
@@ -687,7 +687,7 @@ contains
 
                    ! Smooth Step
                 elseif (trim(this%config%bodies(i)%rotation_type) &
-                   .eq. 'smooth_step') then
+                     .eq. 'smooth_step') then
                    if (has_user_rigid_kin .or. has_user_mesh_vel) then
                       call neko_log%message('   Rotation     : ' // &
                            'Smooth Step Control + User')
@@ -1667,11 +1667,11 @@ contains
 
        if (c_associated(coef%dof%x_d)) then
           call device_memcpy(coef%dof%x, coef%dof%x_d, &
-              size(coef%dof%x), HOST_TO_DEVICE, sync = .false.)
+               size(coef%dof%x), HOST_TO_DEVICE, sync = .false.)
           call device_memcpy(coef%dof%y, coef%dof%y_d, &
-              size(coef%dof%y), HOST_TO_DEVICE, sync = .false.)
+               size(coef%dof%y), HOST_TO_DEVICE, sync = .false.)
           call device_memcpy(coef%dof%z, coef%dof%z_d, &
-              size(coef%dof%z), HOST_TO_DEVICE, sync = .false.)
+               size(coef%dof%z), HOST_TO_DEVICE, sync = .false.)
        end if
 
        if (c_associated(coef%Blag_d)) then
@@ -1720,11 +1720,11 @@ contains
        if (NEKO_BCKND_DEVICE .eq. 1) then
           if (c_associated(coef%Blag_d)) then
              call device_memcpy(coef%Blag, coef%Blag_d, n, &
-                   HOST_TO_DEVICE, sync = .false.)
+                  HOST_TO_DEVICE, sync = .false.)
           end if
           if (c_associated(coef%Blaglag_d)) then
              call device_memcpy(coef%Blaglag, coef%Blaglag_d, n, &
-                   HOST_TO_DEVICE, sync = .false.)
+                  HOST_TO_DEVICE, sync = .false.)
           end if
           call device_sync()
        end if
@@ -1955,11 +1955,11 @@ contains
     if (NEKO_BCKND_DEVICE .eq. 1) then
        associate(mesh => coef%dof)
          call device_memcpy(mesh%x, mesh%x_d, mesh%size(), &
-            DEVICE_TO_HOST, sync = .false.)
+              DEVICE_TO_HOST, sync = .false.)
          call device_memcpy(mesh%y, mesh%y_d, mesh%size(), &
-            DEVICE_TO_HOST, sync = .false.)
+              DEVICE_TO_HOST, sync = .false.)
          call device_memcpy(mesh%z, mesh%z_d, mesh%size(), &
-            DEVICE_TO_HOST, sync = .false.)
+              DEVICE_TO_HOST, sync = .false.)
        end associate
     end if
 

--- a/src/ale/ale_manager.f90
+++ b/src/ale/ale_manager.f90
@@ -40,7 +40,7 @@ module ale_manager
   use space, only : space_t
   use ax_product, only : ax_t, ax_helm_factory
   use krylov, only : ksp_t, ksp_monitor_t, krylov_solver_factory
-  use precon, only : pc_t, precon_factory, precon_destroy
+  use precon, only : pc_t, precon_allocator, precon_destroy
   use bc_list, only : bc_list_t
   use checkpoint, only : chkp_t
   use zero_dirichlet, only : zero_dirichlet_t
@@ -1522,7 +1522,7 @@ contains
     type(bc_list_t), target, intent(inout) :: bclst
     character(len=*), intent(in) :: pctype
     type(json_file), intent(inout) :: params
-    call precon_factory(pc, pctype)
+    call precon_allocator(pc, pctype)
     select type (pcp => pc)
     type is (jacobi_t)
        call pcp%init(coef, dof, gs)

--- a/src/filter/PDE_filter.f90
+++ b/src/filter/PDE_filter.f90
@@ -41,7 +41,7 @@ module PDE_filter
   use coefs, only : coef_t
   use ax_product, only : ax_t, ax_helm_factory
   use krylov, only : ksp_t, ksp_monitor_t, krylov_solver_factory
-  use precon, only : pc_t, precon_factory, precon_destroy
+  use precon, only : pc_t, precon_allocator, precon_destroy
   use bc_list, only : bc_list_t
   use neumann, only : neumann_t
   use profiler, only : profiler_start_region, profiler_end_region
@@ -304,7 +304,7 @@ contains
     type(bc_list_t), target, intent(inout) :: bclst
     character(len=*) :: pctype
 
-    call precon_factory(pc, pctype)
+    call precon_allocator(pc, pctype)
 
     select type (pcp => pc)
     type is (jacobi_t)

--- a/src/fluid/fluid_scheme_incompressible.f90
+++ b/src/fluid/fluid_scheme_incompressible.f90
@@ -49,7 +49,7 @@ module fluid_scheme_incompressible
   use device_jacobi, only : device_jacobi_t
   use hsmg, only : hsmg_t
   use phmg, only : phmg_t
-  use precon, only : pc_t, precon_factory, precon_destroy
+  use precon, only : pc_t, precon_allocator, precon_destroy
   use fluid_stats, only : fluid_stats_t
   use bc, only : bc_t
   use bc_list, only : bc_list_t
@@ -562,7 +562,7 @@ contains
     character(len=*) :: pctype
     type(json_file), intent(inout) :: pcparams
 
-    call precon_factory(pc, pctype)
+    call precon_allocator(pc, pctype)
 
     select type (pcp => pc)
     type is (jacobi_t)

--- a/src/krylov/krylov.f90
+++ b/src/krylov/krylov.f90
@@ -231,7 +231,52 @@ module krylov
 
   end interface
 
-  public :: krylov_solver_factory
+  interface
+     !> Krylov solver allocator.
+     !! @param object The object to be allocated.
+     !! @param type_name The name of the solver type.
+     module subroutine krylov_solver_allocator(object, type_name)
+       class(ksp_t), allocatable, intent(inout) :: object
+       character(len=*), intent(in) :: type_name
+     end subroutine krylov_solver_allocator
+  end interface
+
+  !
+  ! Machinery for injecting user-defined types
+  !
+
+  !> Interface for a Krylov solver allocator.
+  !! Implemented in user modules, should allocate `obj` to the custom user
+  !! type.
+  abstract interface
+     subroutine krylov_allocate(obj)
+       import ksp_t
+       class(ksp_t), allocatable, intent(inout) :: obj
+     end subroutine krylov_allocate
+  end interface
+
+  interface
+     !> Called in user modules to add an allocator for custom types.
+     module subroutine register_krylov(type_name, allocator)
+       character(len=*), intent(in) :: type_name
+       procedure(krylov_allocate), pointer, intent(in) :: allocator
+     end subroutine register_krylov
+  end interface
+
+  !> A name-allocator pair for user-defined Krylov solver types.
+  type krylov_allocator_entry
+     character(len=20) :: type_name
+     procedure(krylov_allocate), pointer, nopass :: allocator
+  end type krylov_allocator_entry
+
+  !> Registry of allocators for user-defined Krylov solver types.
+  type(krylov_allocator_entry), allocatable :: krylov_registry(:)
+
+  !> The size of the `krylov_registry`.
+  integer :: krylov_registry_size = 0
+
+  public :: krylov_solver_factory, krylov_solver_allocator, register_krylov, &
+       krylov_allocate
 contains
 
   !> Constructor for the base type.

--- a/src/krylov/krylov_fctry.f90
+++ b/src/krylov/krylov_fctry.f90
@@ -50,7 +50,7 @@ submodule (krylov) krylov_fctry
   use gmres_device, only : gmres_device_t
   use num_Types, only : rp
   use precon, only : pc_t
-  use utils, only : neko_type_error
+  use utils, only : neko_type_error, neko_type_registration_error
   use neko_config, only : NEKO_BCKND_SX, NEKO_BCKND_OPENCL, NEKO_BCKND_METAL
   implicit none
 
@@ -85,6 +85,20 @@ contains
     real(kind=rp), optional :: abstol
     class(pc_t), optional, intent(in), target :: M
     logical, optional, intent(in) :: monitor
+
+    call krylov_solver_allocator(object, type_name)
+
+    call object%init(n, max_iter, M = M, abs_tol = abstol, monitor = monitor)
+
+  end subroutine krylov_solver_factory
+
+  !> Krylov solver allocator.
+  !! @param object The object to be allocated.
+  !! @param type_name The name of the solver type.
+  module subroutine krylov_solver_allocator(object, type_name)
+    class(ksp_t), allocatable, intent(inout) :: object
+    character(len=*), intent(in) :: type_name
+    integer :: i
 
     if (allocated(object)) then
        call object%free()
@@ -163,11 +177,54 @@ contains
        allocate(bicgstab_t::object)
 
     case default
+       do i = 1, krylov_registry_size
+          if (trim(type_name) .eq. trim(krylov_registry(i)%type_name)) then
+             call krylov_registry(i)%allocator(object)
+             return
+          end if
+       end do
+
        call neko_type_error('Krylov solver', type_name, KSP_KNOWN_TYPES)
     end select
 
-    call object%init(n, max_iter, M = M, abs_tol = abstol, monitor = monitor)
+  end subroutine krylov_solver_allocator
 
-  end subroutine krylov_solver_factory
+  !> Register a custom Krylov solver allocator.
+  !! Called in custom user modules inside the `module_name_register_types`
+  !! routine to add a custom type allocator to the registry.
+  !! @param type_name The name of the type to allocate.
+  !! @param allocator The allocator for the custom user type.
+  module subroutine register_krylov(type_name, allocator)
+    character(len=*), intent(in) :: type_name
+    procedure(krylov_allocate), pointer, intent(in) :: allocator
+    type(krylov_allocator_entry), allocatable :: temp(:)
+    integer :: i
+
+    do i = 1, size(KSP_KNOWN_TYPES)
+       if (trim(type_name) .eq. trim(KSP_KNOWN_TYPES(i))) then
+          call neko_type_registration_error("Krylov solver", type_name, &
+               .true.)
+       end if
+    end do
+
+    do i = 1, krylov_registry_size
+       if (trim(type_name) .eq. trim(krylov_registry(i)%type_name)) then
+          call neko_type_registration_error("Krylov solver", type_name, &
+               .false.)
+       end if
+    end do
+
+    if (krylov_registry_size .eq. 0) then
+       allocate(krylov_registry(1))
+    else
+       allocate(temp(krylov_registry_size + 1))
+       temp(1:krylov_registry_size) = krylov_registry
+       call move_alloc(temp, krylov_registry)
+    end if
+
+    krylov_registry_size = krylov_registry_size + 1
+    krylov_registry(krylov_registry_size)%type_name = type_name
+    krylov_registry(krylov_registry_size)%allocator => allocator
+  end subroutine register_krylov
 
 end submodule krylov_fctry

--- a/src/krylov/pc_hsmg.f90
+++ b/src/krylov/pc_hsmg.f90
@@ -63,7 +63,7 @@ module hsmg
   use num_types, only : rp
   use math, only : copy, col2, add2
   use utils, only : neko_error
-  use precon, only : pc_t, precon_factory, precon_destroy
+  use precon, only : pc_t, precon_allocator, precon_destroy
   use ax_product, only : ax_t, ax_helm_factory
   use gather_scatter, only : gs_t, GS_OP_ADD
   use interpolation, only : interpolator_t
@@ -344,7 +344,7 @@ contains
             this%grids(1)%bclst, crs_tamg_itrs, crs_tamg_cheby_degree)
     else
        ! Create a backend specific preconditioner
-       call precon_factory(this%pc_crs, crs_pc)
+       call precon_allocator(this%pc_crs, crs_pc)
 
        select type (pc => this%pc_crs)
        type is (jacobi_t)

--- a/src/krylov/precon.f90
+++ b/src/krylov/precon.f90
@@ -66,11 +66,11 @@ module precon
   end interface
 
   interface
-     !> Create a preconditioner
-     module subroutine precon_factory(pc, type_name)
-       class(pc_t),  allocatable, intent(inout) :: pc
+     !> Allocate a preconditioner
+     module subroutine precon_allocator(pc, type_name)
+       class(pc_t), allocatable, intent(inout) :: pc
        character(len=*), intent(in) :: type_name
-     end subroutine precon_factory
+     end subroutine precon_allocator
 
      !> Destroy a preconditioner
      module subroutine precon_destroy(pc)
@@ -78,6 +78,40 @@ module precon
      end subroutine precon_destroy
   end interface
 
-  public :: precon_factory, precon_destroy
-  
+  !
+  ! Machinery for injecting user-defined types
+  !
+
+  !> Interface for a preconditioner allocator.
+  !! Implemented in user modules, should allocate `obj` to the custom user
+  !! type.
+  abstract interface
+     subroutine precon_allocate(obj)
+       import pc_t
+       class(pc_t), allocatable, intent(inout) :: obj
+     end subroutine precon_allocate
+  end interface
+
+  interface
+     !> Called in user modules to add an allocator for custom types.
+     module subroutine register_precon(type_name, allocator)
+       character(len=*), intent(in) :: type_name
+       procedure(precon_allocate), pointer, intent(in) :: allocator
+     end subroutine register_precon
+  end interface
+
+  !> A name-allocator pair for user-defined preconditioner types.
+  type precon_allocator_entry
+     character(len=20) :: type_name
+     procedure(precon_allocate), pointer, nopass :: allocator
+  end type precon_allocator_entry
+
+  !> Registry of allocators for user-defined preconditioner types.
+  type(precon_allocator_entry), allocatable :: precon_registry(:)
+
+  !> The size of the `precon_registry`.
+  integer :: precon_registry_size = 0
+
+  public :: precon_allocator, precon_destroy, register_precon, precon_allocate
+
 end module precon

--- a/src/krylov/precon_fctry.f90
+++ b/src/krylov/precon_fctry.f90
@@ -38,7 +38,7 @@ submodule (precon) precon_fctry
   use device_jacobi, only : device_jacobi_t
   use hsmg, only : hsmg_t
   use phmg, only : phmg_t
-  use utils, only : neko_type_error
+  use utils, only : neko_type_error, neko_type_registration_error
   use neko_config, only : NEKO_BCKND_DEVICE, NEKO_BCKND_SX
   implicit none
 
@@ -51,10 +51,11 @@ submodule (precon) precon_fctry
 
 contains
 
-  !> Create a preconditioner
-  module subroutine precon_factory(pc, type_name)
+  !> Allocate a preconditioner
+  module subroutine precon_allocator(pc, type_name)
     class(pc_t), allocatable, intent(inout) :: pc
     character(len=*), intent(in) :: type_name
+    integer :: i
 
     if (allocated(pc)) then
        call precon_destroy(pc)
@@ -81,10 +82,17 @@ contains
           allocate(ident_t::pc)
        end if
     case default
+       do i = 1, precon_registry_size
+          if (trim(type_name) .eq. trim(precon_registry(i)%type_name)) then
+             call precon_registry(i)%allocator(pc)
+             return
+          end if
+       end do
+
        call neko_type_error("preconditioner", type_name, PC_KNOWN_TYPES)
     end select
 
-  end subroutine precon_factory
+  end subroutine precon_allocator
 
   !> Destroy a preconditioner
   module subroutine precon_destroy(pc)
@@ -106,5 +114,43 @@ contains
     end if
 
   end subroutine precon_destroy
+
+  !> Register a custom preconditioner allocator.
+  !! Called in custom user modules inside the `module_name_register_types`
+  !! routine to add a custom type allocator to the registry.
+  !! @param type_name The name of the type to allocate.
+  !! @param allocator The allocator for the custom user type.
+  module subroutine register_precon(type_name, allocator)
+    character(len=*), intent(in) :: type_name
+    procedure(precon_allocate), pointer, intent(in) :: allocator
+    type(precon_allocator_entry), allocatable :: temp(:)
+    integer :: i
+
+    do i = 1, size(PC_KNOWN_TYPES)
+       if (trim(type_name) .eq. trim(PC_KNOWN_TYPES(i))) then
+          call neko_type_registration_error("preconditioner", type_name, &
+               .true.)
+       end if
+    end do
+
+    do i = 1, precon_registry_size
+       if (trim(type_name) .eq. trim(precon_registry(i)%type_name)) then
+          call neko_type_registration_error("preconditioner", type_name, &
+               .false.)
+       end if
+    end do
+
+    if (precon_registry_size .eq. 0) then
+       allocate(precon_registry(1))
+    else
+       allocate(temp(precon_registry_size + 1))
+       temp(1:precon_registry_size) = precon_registry
+       call move_alloc(temp, precon_registry)
+    end if
+
+    precon_registry_size = precon_registry_size + 1
+    precon_registry(precon_registry_size)%type_name = type_name
+    precon_registry(precon_registry_size)%allocator => allocator
+  end subroutine register_precon
 
 end submodule precon_fctry

--- a/src/scalar/scalar_scheme.f90
+++ b/src/scalar/scalar_scheme.f90
@@ -48,7 +48,7 @@ module scalar_scheme
   use hsmg, only : hsmg_t
   use bc_list, only : bc_list_t
   use bc, only : bc_t
-  use precon, only : pc_t, precon_factory, precon_destroy
+  use precon, only : pc_t, precon_allocator, precon_destroy
   use mesh, only : mesh_t
   use time_scheme_controller, only : time_scheme_controller_t
   use logger, only : neko_log, LOG_SIZE, NEKO_LOG_VERBOSE
@@ -585,7 +585,7 @@ contains
     character(len=*) :: pctype
     type(json_file), intent(inout) :: pcparams
 
-    call precon_factory(pc, pctype)
+    call precon_allocator(pc, pctype)
 
     select type (pcp => pc)
     type is (jacobi_t)


### PR DESCRIPTION
Adds the possibility to inject custom preconditioner and krylov solver types.

Renamed the precon factory to a precon allocator, because it does not init. This is the split we have almost everywhere: an allocator just executes allocate, a factory calls the allocator and then calls the deffered `%init`.