### PR TITLE
Fix OIFS selection for scalars

### DIFF
--- a/src/scalar/scalar_pnpn.f90
+++ b/src/scalar/scalar_pnpn.f90
@@ -245,7 +245,7 @@ contains
          this%projection_activ_step)
 
     ! Determine the time-interpolation scheme
-    call json_get_or_default(params, 'case.numerics.oifs', this%oifs, .false.)
+    call json_get_or_default(numerics_params, 'oifs', this%oifs, .false.)
     ! Point to case checkpoint
     this%chkp => chkp
     ! Initialize advection factory


### PR DESCRIPTION
scalar_pnpn_t read the OIFS from the wrong dictionary, therefore always setting it to false as the default value.

The correct dictionary is `numerics_params`, whereas `params` contains the scalar-local json object, extracted by `case_t`.
