### PR TITLE
More forceful regen.sh

### DIFF
--- a/regen.sh
+++ b/regen.sh
@@ -2,31 +2,31 @@
 
 echo "Updating configuration..."
 echo "Running libtoolize"
-if which libtoolize > /dev/null 2>&1; then
-    libtoolize -i
-elif which glibtoolize > /dev/null 2>&1; then
-    glibtoolize -i
+if command -v libtoolize >/dev/null 2>&1; then
+    libtoolize --install --force
+elif command -v glibtoolize >/dev/null 2>&1; then
+    glibtoolize --install --force
 else
-    echo "No libtoolize found on your system"
+    echo "No libtoolize or glibtoolize found on your system" >&2
     exit 1
 fi
 
-rm -fr autom4te.cache
-rm aclocal.m4 
+rm -rf autom4te.cache
+rm -f aclocal.m4
 
 echo "Running aclocal"
 if which aclocal > /dev/null 2>&1; then
-  aclocal -I m4 --install
+    aclocal -I m4 --install
 else
-  echo "No aclocal found on your system"
-  exit 1
+    echo "No aclocal found on your system" >&2
+    exit 1
 fi
 
 echo "Running autoconf"
 autoconf
+
 echo "Running automake"
-automake -a
+automake --add-missing
 
 echo "Deleting autom4te.cache directory"
-rm -r autom4te.cache
-
+rm -rf autom4te.cache

--- a/regen.sh
+++ b/regen.sh
@@ -2,9 +2,9 @@
 
 echo "Updating configuration..."
 echo "Running libtoolize"
-if command -v libtoolize >/dev/null 2>&1; then
+if which libtoolize > /dev/null 2>&1; then
     libtoolize --install --force
-elif command -v glibtoolize >/dev/null 2>&1; then
+elif which glibtoolize > /dev/null 2>&1; then
     glibtoolize --install --force
 else
     echo "No libtoolize or glibtoolize found on your system" >&2


### PR DESCRIPTION
Adds -f and --force to a few places in regen.sh so it stops complaining about files being newer like

``` 
libtoolize: error: './config.guess' is newer: use '--force' to overwrite libtoolize: error: './config.sub' is newer: use '--force' to overwrite l

libtoolize: error: './install-sh' is newer: use '--force' to overwrite
``` 