### PR TITLE
Die when a dep is not found during configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,8 +82,12 @@ if test "x${enable_openmp}" != xno; then
       AX_OPENMP([have_openmp=yes], [have_openmp=no])
       if test "x${have_openmp}" != xno; then
          CFLAGS="$CFLAGS $OPENMP_CFLAGS"
+      else
+         AC_MSG_ERROR([OpenMP requested but not supported by the C compiler])
       fi
       AC_LANG_POP([C])
+   else
+      AC_MSG_ERROR([OpenMP requested but not supported by the Fortran compiler])
    fi
 fi
 
@@ -335,6 +339,9 @@ if (test "x${have_cuda}" = xyes ||
       AC_SUBST(device_mpi, .false.)
    fi
 else
+   if test "x${enable_device_mpi}" = xyes; then
+      AC_MSG_ERROR([Device-aware MPI requires a CUDA, HIP, or OpenCL backend])
+   fi
    AC_SUBST(device_mpi, .false.)
 fi
 
@@ -368,6 +375,11 @@ if (test "x${is_cray}" = xyes || test "x${is_hpe_cray}" = xyes); then
    AX_CRAY_SHMEM
 fi
 
+if test -n "${with_openshmem}" &&
+   test "x${with_openshmem}" != xno &&
+   test "x${have_cray_shmem}" != xyes; then
+   AC_MSG_ERROR([OpenSHMEM requested but it is only available through a Cray environment])
+fi
 
 
 # JSON-Fortran

--- a/doc/pages/user-guide/installation.md
+++ b/doc/pages/user-guide/installation.md
@@ -150,6 +150,14 @@ Optional packages are controlled by passing either `--with-PACKAGE[=ARG]` or `--
 | `--with-utofu=DIR`              | Compile with support for the native Tofu interconnect (uTofu) |
 | `--with-hdf5`                   | Compile with support for HDF5                 |
 | `--with-pfunit=DIR`             | Directory for pFUnit (see \subpage testing)   |
+| `--with-openshmem`              | Compile with Cray OpenSHMEM support           |
+| `--with-darshan-libdir=LIBDIR`  | Link with the Darshan profiler                |
+
+An explicitly requested package is required: if its headers, libraries, or
+configuration tools cannot be found, `configure` exits with an error. The same
+applies to dependency-backed features such as `--enable-openmp`. Omit the
+option (or use the corresponding `--without-PACKAGE`) when the dependency is
+optional for a particular build.
 
 @note Accelerators backends are not enabled as a feature in Neko, but rather via optional packages.
 

--- a/m4/ax_adios.m4
+++ b/m4/ax_adios.m4
@@ -14,21 +14,23 @@ AC_DEFUN([AX_ADIOS2],[
 	      PATH="$ac_adios2_path/bin:$PATH"
 	   fi
 
-	   AC_CHECK_PROG(ADIOS2CONF,adios2-config,yes)
+	   AC_PATH_PROG(ADIOS2CONF,adios2-config,no)
 
-	   if test x"${ADIOS2CONF}" == x"yes"; then
-	      ADIOS2_CXXFLAGS=`adios2-config --cxx-flags`
+	   if test x"${ADIOS2CONF}" = xno; then
+	      have_adios2=no
+	      AC_MSG_ERROR([ADIOS2 requested but adios2-config was not found])
+	   elif ADIOS2_CXXFLAGS=`${ADIOS2CONF} --cxx-flags` &&
+	        ADIOS2_LDFLAGS=`${ADIOS2CONF} --cxx-libs`; then
 	      CXXFLAGS="$ADIOS2_CXXFLAGS $CXXFLAGS"
-
-	      ADIOS2_LDFLAGS=`adios2-config --cxx-libs`
 	      LDFLAGS="$ADIOS2_LDFLAGS $LDFLAGS"
       	      with_adios2=yes
 	      have_adios2=yes
 	      AC_SUBST(have_adios2)
               AC_DEFINE(HAVE_ADIOS2,1,[Define if you have ADIOS2.])
-	    else
-	      with_adios2=no
-	    fi
+	   else
+	      have_adios2=no
+	      AC_MSG_ERROR([ADIOS2 requested but its C++ configuration is unavailable])
+	   fi
             PATH="$PATH_SAVED"
 	    
 	fi

--- a/m4/ax_adios2_fortran.m4
+++ b/m4/ax_adios2_fortran.m4
@@ -14,23 +14,24 @@ AC_DEFUN([AX_ADIOS2_FORTRAN],[
 	      PATH="$ac_adios2_fortran_path/bin:$PATH"
 	   fi
 
-	   AC_CHECK_PROG(ADIOS2_FORTRAN_CONF,adios2-config,yes)
+	   AC_PATH_PROG(ADIOS2_FORTRAN_CONF,adios2-config,no)
 
-	   if test x"${ADIOS2_FORTRAN_CONF}" == x"yes"; then
-	      ADIOS2_FORTRAN_FCFLAGS=`adios2-config --fortran-flags`
+	   if test x"${ADIOS2_FORTRAN_CONF}" = xno; then
+	      have_adios2_fortran=no
+	      AC_MSG_ERROR([ADIOS2 Fortran support requested but adios2-config was not found])
+	   elif ADIOS2_FORTRAN_FCFLAGS=`${ADIOS2_FORTRAN_CONF} --fortran-flags` &&
+	        ADIOS2_FORTRAN_LIBS=`${ADIOS2_FORTRAN_CONF} --fortran-libs`; then
 	      FCFLAGS="$ADIOS2_FORTRAN_FCFLAGS $FCFLAGS"
-
-	      ADIOS2_FORTRAN_LIBS=`adios2-config --fortran-libs`
 	      LIBS="$ADIOS2_FORTRAN_LIBS $LIBS"
               with_adios2_fortran=yes
 	      have_adios2_fortran=yes
 	      AC_SUBST(have_adios2_fortran)
               AC_DEFINE(HAVE_ADIOS2_FORTRAN,1,[Define if you want to use ADIOS2 with Fortran bindings.])
-	    else
-	      with_adios2_fortran=no
-	    fi
+	   else
+	      have_adios2_fortran=no
+	      AC_MSG_ERROR([ADIOS2 Fortran support requested but its Fortran configuration is unavailable])
+	   fi
             PATH="$PATH_SAVED"
 
 	fi
 ])
-

--- a/m4/ax_blas.m4
+++ b/m4/ax_blas.m4
@@ -98,6 +98,14 @@ if test "x$BLAS_LIBS" != x; then
 fi
 fi
 
+# An explicitly selected BLAS library is a requirement, not a hint.
+case $with_blas in
+	yes | no | "") ;;
+	*) if test $ax_blas_ok != yes; then
+		AC_MSG_ERROR([Requested BLAS library '$with_blas' was not found])
+	   fi ;;
+esac
+
 # BLAS linked to by default?  (happens on some supercomputers)
 if test $ax_blas_ok = no; then
 	save_LIBS="$LIBS"; LIBS="$LIBS"

--- a/m4/ax_cray.m4
+++ b/m4/ax_cray.m4
@@ -243,6 +243,11 @@ AC_DEFUN([AX_CRAY_HDF5_PARALLEL],[
 	else
 	   AC_MSG_RESULT([no])
 	   have_cray_hdf5="no"
+	   have_hdf5="no"
+	   AC_MSG_ERROR([Cray parallel HDF5 requested but not found])
+	fi
+	if test "x${have_cray_hdf5}" = xyes; then
+	   have_hdf5="yes"
 	fi
 	AC_SUBST(have_cray_hdf5)
         fi
@@ -270,6 +275,7 @@ AC_DEFUN([AX_CRAY_SHMEM],[
            else
               AC_MSG_RESULT([no])
               have_cray_shmem="no"
+              AC_MSG_ERROR([OpenSHMEM requested but no Cray OpenSHMEM library was found])
            fi
        fi
        AC_SUBST(have_cray_shmem)

--- a/m4/ax_darshan.m4
+++ b/m4/ax_darshan.m4
@@ -3,18 +3,36 @@ AC_DEFUN([AX_DARSHAN],[
 	AS_HELP_STRING([--with-darshan-libdir=DIR],
 	[Specify the library directory of Darshan to link with the profiler.]),
 	[	   
-	if test -d "$withval"; then
+	if test "x${withval}" = xno; then
+		with_darshan=no
+	elif test -d "$withval"; then
 		ac_darshan_libdir="$withval";
-		DARSHAN_LDFLAGS="-L$ac_darshan_libdir -Wl,-rpath=$ac_darshan_libdir -ldarshan"
+		DARSHAN_LDFLAGS="-L$ac_darshan_libdir -Wl,-rpath=$ac_darshan_libdir"
+		with_darshan=yes
+	else
+		AC_MSG_ERROR([Darshan library directory '$withval' was not found])
 	fi
 	],[with_darshan=no])
 
+    ax_darshan_ok=no
     if test "x${with_darshan}" != xno; then
         if test -d "$ac_darshan_libdir"; then
             DARSHAN_LIBS="-ldarshan"
-            AC_SUBST(DARSHAN_LIBS)
+            darshan_save_LIBS="$LIBS"
+            darshan_save_LDFLAGS="$LDFLAGS"
+            LIBS="$DARSHAN_LIBS $LIBS"
             LDFLAGS="$DARSHAN_LDFLAGS $LDFLAGS"
-            export LDFLAGS
+            AC_MSG_CHECKING([for Darshan in $ac_darshan_libdir])
+            AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+                           [ax_darshan_ok=yes], [ax_darshan_ok=no])
+            AC_MSG_RESULT([$ax_darshan_ok])
+            LIBS="$darshan_save_LIBS"
+            LDFLAGS="$darshan_save_LDFLAGS"
+            if test "x${ax_darshan_ok}" != xyes; then
+                AC_MSG_ERROR([Darshan requested but libdarshan was not found])
+            fi
+            LDFLAGS="$DARSHAN_LDFLAGS $LDFLAGS"
         fi
     fi
+    AC_SUBST(DARSHAN_LIBS)
 ])

--- a/m4/ax_hdf5.m4
+++ b/m4/ax_hdf5.m4
@@ -21,6 +21,8 @@ AC_DEFUN([AX_HDF5],[
               NEKO_PKG_FCFLAGS="$HDF5_Fortran_CFLAGS $NEKO_PKG_FCFLAGS"
               AC_DEFINE(HAVE_HDF5,[1],
                      [Define if you have the HDF5 library.])
+           else
+              AC_MSG_ERROR([HDF5 Fortran >= 1.14.0 requested but not found])
            fi
 	fi
 ])

--- a/m4/ax_lapack.m4
+++ b/m4/ax_lapack.m4
@@ -104,6 +104,14 @@ if test "x$LAPACK_LIBS" != x; then
         fi
 fi
 
+# An explicitly selected LAPACK library is a requirement, not a hint.
+case $with_lapack in
+        yes | no | "") ;;
+        *) if test $ax_lapack_ok != yes; then
+                AC_MSG_ERROR([Requested LAPACK library '$with_lapack' was not found])
+           fi ;;
+esac
+
 # LAPACK linked to by default?  (is sometimes included in BLAS lib)
 if test $ax_lapack_ok = no; then
         save_LIBS="$LIBS"; LIBS="$LIBS $BLAS_LIBS $FLIBS"

--- a/m4/ax_libxsmm.m4
+++ b/m4/ax_libxsmm.m4
@@ -23,6 +23,8 @@ AC_DEFUN([AX_LIBXSMM],[
 	      LIBS="$LIBS $libxsmmf_LIBS"
 	      AC_DEFINE(HAVE_LIBXSMM,[1],
 			[Define if you have the LIBXSMM library.])
+           else
+              AC_MSG_ERROR([libxsmmf >= 0.16.1 requested but not found])
 	   fi
 	fi
         AC_SUBST(xsmm_bcknd)

--- a/m4/ax_metis.m4
+++ b/m4/ax_metis.m4
@@ -23,13 +23,18 @@ AC_DEFUN([AX_METIS],[
 	AS_HELP_STRING([--with-metis-libdir=LIBDIR],
 	[Directory for metis library]),
 	[
-	if test -d "$withval"; then
+	if test "x${withval}" = xno; then
+	   ac_metis_libdir=""
+	elif test -d "$withval"; then
 	   ac_metis_libdir="$withval"
+	else
+	   AC_MSG_ERROR([METIS library directory '$withval' was not found])
 	fi
 	],)
 
 	if test -d "$ac_metis_libdir"; then	   
 	    METIS_LDFLAGS="-L$ac_metis_libdir"  	   
+	    with_metis=yes
         fi
 
 	if test -d "$ac_metis_path"; then
@@ -61,9 +66,11 @@ AC_DEFUN([AX_METIS],[
 	      	 LDFLAGS="$LDFLAGS_SAVED"
 	      fi
 	   fi
+	   if test x"${have_metis}" != xyes ||
+	      test x"${have_metis_h}" != xyes; then
+	      AC_MSG_ERROR([METIS requested but metis.h or libmetis was not found])
+	   fi
 	fi
 
 ])
-
-
 

--- a/m4/ax_parmetis.m4
+++ b/m4/ax_parmetis.m4
@@ -26,13 +26,18 @@ AC_DEFUN([AX_PARMETIS],[
 	AS_HELP_STRING([--with-parmetis-libdir=LIBDIR],
 	[Directory for parmetis library]),
 	[
-	if test -d "$withval"; then
+	if test "x${withval}" = xno; then
+	   ac_parmetis_libdir=""
+	elif test -d "$withval"; then
 	   ac_parmetis_libdir="$withval"
+	else
+	   AC_MSG_ERROR([ParMETIS library directory '$withval' was not found])
 	fi
 	],)
 
 	if test -d "$ac_parmetis_libdir"; then	   
 	    PARMETIS_LDFLAGS="-L$ac_parmetis_libdir"  	   
+	    with_parmetis=yes
         fi
 
 	if test -d "$ac_parmetis_path"; then
@@ -89,9 +94,11 @@ AC_DEFUN([AX_PARMETIS],[
 	      	 LDFLAGS="$LDFLAGS_SAVED"
 	      fi
 	   fi
+	   if test x"${have_parmetis}" != xyes ||
+	      test x"${have_parmetis_h}" != xyes; then
+	      AC_MSG_ERROR([ParMETIS requested but parmetis.h or libparmetis was not found])
+	   fi
 	fi
 
 ])
-
-
 

--- a/m4/ax_pfunit.m4
+++ b/m4/ax_pfunit.m4
@@ -12,21 +12,28 @@ AC_DEFUN([AX_PFUNIT], [
 		      AS_HELP_STRING([--with-pfunit=DIR],
 		      [Directory for pFUnit]),
 		      [
-			if test -d "$withval"; then
+			if test "x${withval}" = xno; then
+			   PFUNIT_DIR=""
+			elif test "x${withval}" = xyes; then
+			   PFUNIT_DIR="/usr"
+			elif test -d "$withval"; then
 			   PFUNIT_DIR="$withval";
 			else
-			   PFUNIT_DIR="/usr";
+			   AC_MSG_ERROR([pFUnit directory '$withval' was not found])
 			fi
-		      ],)
+		      ], [with_pfunit=no])
 		      
  AC_REQUIRE([AC_PROG_FC])
  AC_LANG_PUSH([Fortran])
 
 
  AC_MSG_CHECKING([for pFUnit])
- if ! test -f $PFUNIT_DIR/include/PFUNIT.mk; then
+ if ! test -f "$PFUNIT_DIR/include/PFUNIT.mk"; then
       AC_MSG_RESULT([no])
       have_pfunit=no
+      if test "x${with_pfunit}" != xno; then
+         AC_MSG_ERROR([pFUnit requested but PFUNIT.mk was not found in $PFUNIT_DIR/include])
+      fi
  else
       AC_MSG_RESULT([yes])
       have_pfunit=yes


### PR DESCRIPTION
Currently, when specifying additional capabilities in configure, it may silently not find them (like hdf5 for example). This is quite annoying, basically one has to inspect the config log to make sure things really worked.

This PR changes that, so configure will actually fail when a requested dep is not found.

Now, the issue is that this is **100% vibe-coded** because I am really not versed in autotools that much ^^. However, due to the pretty small diff and the huge quality of life bonus this would provide, I dare put it up for review by competent people. 