### PR TITLE
Silence obsolete autoconf macro warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,10 @@ AC_LANG([Fortran])
 AC_PROG_INSTALL
 AC_PROG_SED
 AC_PROG_MAKE_SET
+dnl Expand the C/C++ compiler checks at the top level, before libtool (and
+dnl later AC_REQUIREs) pull them in from within another macro expansion.
+AC_PROG_CC
+AC_PROG_CXX
 AC_LANG_PUSH([C])
 LT_INIT([disable-shared])
 AC_LANG_POP([C])
@@ -33,10 +37,10 @@ AC_ARG_ENABLE(device-mpi,
           AS_HELP_STRING([--enable-device-mpi],[Enable device aware MPI]),
           [enable_device_mpi=${enableval}], [enable_device_mpi=no])
 
-AC_ARG_ENABLE(openmp, AC_HELP_STRING([--enable-openmp], [Enable OpenMP]),
+AC_ARG_ENABLE(openmp, AS_HELP_STRING([--enable-openmp], [Enable OpenMP]),
               [enable_openmp=${enableval}], [enable_openmp=no])
 
-AC_ARG_ENABLE(python, AC_HELP_STRING([--enable-python],
+AC_ARG_ENABLE(python, AS_HELP_STRING([--enable-python],
               [Install Python modules, requires a Python interpreter]),
               [enable_python=${enableval}],[enable_python=no])
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,8 +8,6 @@ AC_LANG([Fortran])
 AC_PROG_INSTALL
 AC_PROG_SED
 AC_PROG_MAKE_SET
-dnl Expand the C/C++ compiler checks at the top level, before libtool (and
-dnl later AC_REQUIREs) pull them in from within another macro expansion.
 AC_PROG_CC
 AC_PROG_CXX
 AC_LANG_PUSH([C])

--- a/m4/ax_mpi.m4
+++ b/m4/ax_mpi.m4
@@ -135,16 +135,16 @@ if test x = x"$MPILIBS"; then
 	AC_CHECK_LIB(mpich, MPI_Init, [MPILIBS="-lmpich"])
 fi
 
-dnl We have to use AC_TRY_COMPILE and not AC_CHECK_HEADER because the
+dnl We have to use AC_COMPILE_IFELSE and not AC_CHECK_HEADER because the
 dnl latter uses $CPP, not $CC (which may be mpicc).
 AC_LANG_CASE([C], [if test x != x"$MPILIBS"; then
 	AC_MSG_CHECKING([for mpi.h])
-	AC_TRY_COMPILE([#include <mpi.h>],[],[AC_MSG_RESULT(yes)], [MPILIBS=""
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <mpi.h>]],[[]])],[AC_MSG_RESULT(yes)], [MPILIBS=""
 		AC_MSG_RESULT(no)])
 fi],
 [C++], [if test x != x"$MPILIBS"; then
 	AC_MSG_CHECKING([for mpi.h])
-	AC_TRY_COMPILE([#include <mpi.h>],[],[AC_MSG_RESULT(yes)], [MPILIBS=""
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <mpi.h>]],[[]])],[AC_MSG_RESULT(yes)], [MPILIBS=""
 		AC_MSG_RESULT(no)])
 fi],
 [Fortran 77], [if test x != x"$MPILIBS"; then


### PR DESCRIPTION
Cleans up the warnings emitted by `autoreconf` with autoconf 2.69:

- `m4/ax_mpi.m4`: replace the obsolete `AC_TRY_COMPILE` with
  `AC_COMPILE_IFELSE`/`AC_LANG_PROGRAM` in the C and C++ `mpi.h` checks
  (the Fortran branches already used it).
- `configure.ac`: expand `AC_PROG_CC`/`AC_PROG_CXX` at the top level before
  `LT_INIT`, so libtool's C++ tag is no longer pulled in from inside
  `AX_MPI`'s `AC_REQUIRE` ("`AC_PROG_CXX` was expanded before it was
  required").
- `configure.ac`: `AC_HELP_STRING` -> `AS_HELP_STRING` for `--enable-openmp`
  and `--enable-python`.

No functional change: the generated `configure` performs the same checks in
the same order, and `--help` output is unchanged. `autoconf -Wall` is now
clean.
