### PR TITLE
Fix race in the local interpolation OpenCL kernel

### DIFF
--- a/src/sem/bcknd/device/opencl/local_interpolation_kernel.cl
+++ b/src/sem/bcknd/device/opencl/local_interpolation_kernel.cl
@@ -142,6 +142,8 @@ void find_rst_legendre_kernel_lx##LX(__global real * __restrict__ rst,         \
     zwork2[ijk] = ztmp;                                                        \
   }                                                                            \
                                                                                \
+  barrier(CLK_LOCAL_MEM_FENCE);                                                \
+                                                                               \
   if(idx==0){                                                                  \
     const int ijk = idx;                                                       \
     const int jk = ijk;                                                        \
@@ -201,6 +203,8 @@ void find_rst_legendre_kernel_lx##LX(__global real * __restrict__ rst,         \
     zwork2[ijk] = ztmp;                                                        \
   }                                                                            \
                                                                                \
+  barrier(CLK_LOCAL_MEM_FENCE);                                                \
+                                                                               \
   if (idx == 0) {                                                              \
     const int ijk = idx;                                                       \
     const int jk = ijk;                                                        \
@@ -258,6 +262,8 @@ void find_rst_legendre_kernel_lx##LX(__global real * __restrict__ rst,         \
     ywork2[ijk] = ytmp;                                                        \
     zwork2[ijk] = ztmp;                                                        \
   }                                                                            \
+                                                                               \
+  barrier(CLK_LOCAL_MEM_FENCE);                                                \
                                                                                \
   if (idx == 0) {                                                              \
     const int ijk = idx;                                                       \


### PR DESCRIPTION
This fixes a race in the local interpolation kernel, if work items are larger than the SIMD group width in OpenCL. The CUDA/HIP kernel, share a similar issue for an lx > warp size, since that is > 16, we leave it for unfixed for now.
