### PR TITLE
Update C API header with missing callback definitions

### DIFF
--- a/examples/api/c/Makefile
+++ b/examples/api/c/Makefile
@@ -1,6 +1,7 @@
 CFLAGS  = `pkg-config --cflags jansson,neko`
 LIBS    = `pkg-config --libs jansson,neko`
 CC      = mpicc
+FC      = mpif90
 
 DEST    = cylinder
 SRC	= cylinder.c
@@ -14,7 +15,4 @@ clean:
 	-rm -f *.o core *.core $(OBJ) $(DEST)
 
 $(DEST): ${OBJ}
-	$(CC) $(CFLAGS) ${OBJ} -o $@  $(LIBS)
-
-
-
+	${FC} $(CFLAGS) ${OBJ} -o $@  $(LIBS)

--- a/examples/api/c/cylinder.c
+++ b/examples/api/c/cylinder.c
@@ -2,6 +2,67 @@
 #include <jansson.h>
 #include <neko.h>
 
+/*
+ * Helper to compare a callback's scheme name, which is not null-terminated
+ */
+static int scheme_name_is(const char *scheme_name, int scheme_name_len,
+                          const char *name) {
+  return ((scheme_name_len == (int) strlen(name)) &&
+          (strncmp(scheme_name, name, scheme_name_len) == 0));
+}
+
+/* Define initial conditions */
+static void initial(const char *scheme_name, int scheme_name_len) {
+
+  /*
+   * In this case the check is redundant, but if both fluid and scalar
+   * initial conditions should be defined, `scheme_name` can be used
+   * to identify which solver has called the callback
+   */
+  if (scheme_name_is(scheme_name, scheme_name_len, "fluid")) {
+
+    /*
+     * To retrive a pointer to the data in a field from Neko's field
+     * registry use neko_field()
+     */
+    neko_real *u = neko_field("u");
+    int n = neko_field_size("u");
+
+    for (int i = 0; i < n; i++) {
+      u[i] = 1.0;
+    }
+  }
+}
+
+/* Define inflow conditions */
+static void inflow(int *msk, int msk_size, neko_real t, int tstep) {
+  int idx = 1; /* Note: Fortran indices */
+
+  /*
+   * In this case this check is redundant, but if different user provided
+   * boundary conditions share the same callback, one could use the content
+   * of the callback's field list to identify which condition should be
+   * applied, for example a velocity condition passes the fields (u, v, w)
+   */
+  if (neko_cb_field_name_at_index(&idx, "u")) {
+
+    /*
+     * Inside a callback, the fields passed to it are retrived with
+     * neko_cb_field_by_name() rather than from the field registry
+     */
+    neko_real *u = neko_cb_field_by_name("u");
+    neko_real *v = neko_cb_field_by_name("v");
+    neko_real *w = neko_cb_field_by_name("w");
+
+    for (int i = 0; i < msk_size; i++) {
+      int j = msk[i] - 1; /* Neko's mask is based on Fortran indices */
+      u[j] = 1.0;
+      v[j] = 0.0;
+      w[j] = 0.0;
+    }
+  }
+}
+
 int main(int argc, char **argv) {
 
   /* Initialise Neko */
@@ -13,6 +74,16 @@ int main(int argc, char **argv) {
   const char *case_json = json_dumps(json_load_file("cylinder.case", 0,
                                                     &json_error), JSON_COMPACT);
   int *neko_case = NULL;
+
+  /*
+   * To provide user callbacks, the case must be allocated before it is
+   * initialised, such that the callbacks are registered before the case
+   * resolves the "user" entries in the JSON object. Unused callbacks are
+   * left undefined by passing a null pointer.
+   */
+  neko_case_allocate(&neko_case);
+  neko_user_setup(&neko_case, initial, NULL, NULL, inflow, NULL, NULL);
+
   neko_case_init(&case_json, strlen(case_json), &neko_case);
 
   /* To solve the entire case we can call neko_solve() */

--- a/examples/api/c/cylinder.case
+++ b/examples/api/c/cylinder.case
@@ -22,8 +22,7 @@
         "scheme": "pnpn",
         "Re": 200.0,
         "initial_condition": {
-            "type": "uniform",
-            "value": [1.0, 0.0, 0.0]
+            "type": "user"
         },
         "velocity_solver": {
             "type": "cg",
@@ -45,8 +44,7 @@
         },
         "boundary_conditions": [
         {
-            "type": "velocity_value",
-            "value": [1.0, 0.0, 0.0],
+            "type": "user_velocity",
             "zone_indices": [1]
         },
         {

--- a/src/api/neko.h.in
+++ b/src/api/neko.h.in
@@ -1,4 +1,5 @@
 #ifndef __NEKO_H
+#define __NEKO_H
 
 #include <stdint.h>
 
@@ -7,6 +8,39 @@
  * @note Set to the same C/C++ equivalent type as @a rp
  */
 typedef @NEKO_DEV_REAL_TYPE@ neko_real;
+
+/**
+ * Initial condition callback
+ * @note @a scheme_name is not null-terminated, use @a scheme_name_len
+ */
+typedef void (*neko_initial_condition_cb)(const char *scheme_name,
+                                          int scheme_name_len);
+
+/* Pre timestep callback */
+typedef void (*neko_preprocess_cb)(neko_real t, int tstep);
+
+/* End of timestep callback */
+typedef void (*neko_compute_cb)(neko_real t, int tstep);
+
+/* User boundary condition callback */
+typedef void (*neko_dirichlet_condition_cb)(int *msk, int msk_size,
+                                            neko_real t, int tstep);
+
+/**
+ * Material properties callback
+ * @note @a scheme_name is not null-terminated, use @a scheme_name_len
+ */
+typedef void (*neko_material_properties_cb)(const char *scheme_name,
+                                            int scheme_name_len,
+                                            neko_real t, int tstep);
+
+/**
+ * Source term callback
+ * @note @a scheme_name is not null-terminated, use @a scheme_name_len
+ */
+typedef void (*neko_source_term_cb)(const char *scheme_name,
+                                    int scheme_name_len,
+                                    neko_real t, int tstep);
 
 /* Initialise Neko */
 void neko_init();
@@ -59,6 +93,9 @@ void neko_solve(int **case_iptr);
 /* Compute a time-step for a neko case */
 void neko_step(int **case_iptr);
 
+/* Execute a case's output controller */
+void neko_output_ctrl_execute(int **case_iptr, int force_output);
+
 /* Retrive a pointer to a flow field */
 neko_real *neko_field(char *field_name);
 
@@ -77,7 +114,7 @@ void neko_field_dofmap(char *field_name, int64_t **dof, neko_real **x,
 
 /* Retrive the dofmapassociated with a case's fluid solver */
 void neko_case_fluid_dofmap(int **case_iptr, int64_t **dof, neko_real **x,
-                            neko_real **y, neko_real **z);
+                            neko_real **y, neko_real **z, int *size);
 
 /* Retrive the space associated with a field */
 void neko_field_space(char *field_name, int *lx, neko_real **zg,
@@ -103,4 +140,23 @@ void neko_case_fluid_coef(int **case_iptr, neko_real **G11, neko_real **G22,
                           neko_real **dtdy, neko_real **dtdz, neko_real **jac,
                           neko_real **B, neko_real **area, neko_real **nx,
                           neko_real **ny, neko_real **nz);
+
+/* Setup user-provided callbacks, a null pointer leaves a callback undefined */
+void neko_user_setup(int **case_iptr,
+                     neko_initial_condition_cb initial_cb,
+                     neko_preprocess_cb preprocess_cb,
+                     neko_compute_cb compute_cb,
+                     neko_dirichlet_condition_cb dirichlet_cb,
+                     neko_material_properties_cb material_cb,
+                     neko_source_term_cb source_cb);
+
+/* Retrive a pointer to a field of the currently active callback */
+neko_real *neko_cb_field_by_name(char *field_name);
+
+/* Retrive a pointer to a field of the currently active callback */
+neko_real *neko_cb_field_by_index(int *field_idx);
+
+/* Check if the callback's field at a given index has a given name */
+int neko_cb_field_name_at_index(int *field_idx, char *field_name);
+
 #endif


### PR DESCRIPTION
This updates the C API header with the missing callback definitions for initial conditions etc. It also updates the C example to mirror the Python/Julia API example.
