### PR TITLE
Fix stale accumulator in SX gs backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Develop
 
+- Fixed stale accumulator in the SX gather-scatter backend (min/max/mul).
 - *BREAKING* Renamed the allocation-only `precon_factory` API to
   `precon_allocator`. Added runtime registration of user-defined
   preconditioner and Krylov solver types.

--- a/src/gs/bcknd/sx/gs_sx.f90
+++ b/src/gs/bcknd/sx/gs_sx.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2020-2021, The Neko Authors
+! Copyright (c) 2020-2026, The Neko Authors
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -189,6 +189,7 @@ contains
     integer :: i
     real(kind=rp) :: tmp
 
+    v = 1d0
     do i = 1, abs(o) - 1
        w(i) = u(gd(i))
     end do
@@ -226,6 +227,7 @@ contains
     integer :: i
     real(kind=rp) :: tmp
 
+    v = huge(0.0_rp)
     do i = 1, abs(o) - 1
        w(i) = u(gd(i))
     end do
@@ -263,6 +265,7 @@ contains
     integer :: i
     real(kind=rp) :: tmp
 
+    v = -huge(0.0_rp)
     do i = 1, abs(o) - 1
        w(i) = u(gd(i))
     end do


### PR DESCRIPTION
This PR fixes stale accumulator in the SX gs backend for min/max/mul kernels. This caused the observed regression in the SX pnpn solver (Fixes #2254)
