### PR TITLE
Remove memcpy after material_properties in the compressible solver

### DIFF
--- a/examples/cns_2d_shock_tube/2d_shock_tube.case
+++ b/examples/cns_2d_shock_tube/2d_shock_tube.case
@@ -20,6 +20,8 @@
         "fluid": {
             "scheme": "compressible",
             "gamma": 1.4,
+            "Re": 1000.0,
+            "Pr": 0.73,
             "initial_condition": {
                 "type": "user"
             },

--- a/examples/cns_2d_shock_tube/2d_shock_tube.f90
+++ b/examples/cns_2d_shock_tube/2d_shock_tube.f90
@@ -51,9 +51,9 @@ contains
   subroutine startup(params)
     type(json_file), intent(inout) :: params
 
-    call params%get('case.fluid.Re', Re)
-    call params%get('case.fluid.gamma', gamma)
-    call params%get('case.fluid.Pr', Pr)
+    call json_get(params, 'case.fluid.Re', Re)
+    call json_get(params, 'case.fluid.gamma', gamma)
+    call json_get(params, 'case.fluid.Pr', Pr)
 
   end subroutine startup
 
@@ -104,7 +104,7 @@ contains
     integer :: i
 
     ! Only set material properties at the first time step
-    if (time%tstep .ne. 0) return 
+    if (time%tstep .ne. 0) return
 
     !! Either this or we can also just add mu and kappa to
     !! the json file under case.fluid

--- a/examples/cns_2d_shock_tube/2d_shock_tube.f90
+++ b/examples/cns_2d_shock_tube/2d_shock_tube.f90
@@ -35,15 +35,27 @@ module user
   use neko
   implicit none
 
+  real(kind=rp) :: Re, gamma, Pr
+
 contains
 
   !> Register user callbacks for the shock-tube example.
   !! @param user User interface object.
   subroutine user_setup(user)
     type(user_t), intent(inout) :: user
+    user%startup => startup
     user%initial_conditions => initial_conditions
     user%material_properties => material_properties
   end subroutine user_setup
+
+  subroutine startup(params)
+    type(json_file), intent(inout) :: params
+
+    call params%get('case.fluid.Re', Re)
+    call params%get('case.fluid.gamma', gamma)
+    call params%get('case.fluid.Pr', Pr)
+
+  end subroutine startup
 
   !> Set the Riemann initial condition with the diaphragm at x = 0.5.
   !! @param scheme_name Name of the fluid scheme.
@@ -54,9 +66,7 @@ contains
 
     type(field_t), pointer :: rho, u, v, w, p
     integer :: i
-    real(kind=rp) :: x, gamma
-
-    gamma = 1.4_rp
+    real(kind=rp) :: x
 
     rho => fields%get_by_name("fluid_rho")
     u => fields%get_by_name("u")
@@ -92,25 +102,23 @@ contains
 
     type(field_t), pointer :: mu, kappa
     integer :: i
-    real(kind=rp) :: Re, Prandtl_number, gamma
+
+    ! Only set material properties at the first time step
+    if (time%tstep .ne. 0) return 
 
     !! Either this or we can also just add mu and kappa to
     !! the json file under case.fluid
     !!     "mu": 0.001,
     !!     "kappa": 0.001917808219178082,
-
-    Re = 1000.0_rp
-    Prandtl_number = 0.73_rp
-    gamma = 1.4_rp
-
     if (scheme_name .eq. "fluid") then
        mu => properties%get_by_name("fluid_mu")
        kappa => properties%get_by_name("fluid_kappa")
 
-       do i = 1, mu%dof%size()
-          mu%x(i, 1, 1, 1) = 1.0_rp / Re
-          kappa%x(i, 1, 1, 1) = mu%x(i, 1, 1, 1) * gamma / Prandtl_number
-       end do
+       call field_cfill(mu, 1.0_rp / Re)
+
+       ! kappa = mu * gamma / Pr
+       call field_cmult2(kappa, mu, gamma / Pr)
+
     end if
   end subroutine material_properties
 

--- a/src/fluid/fluid_scheme_compressible.f90
+++ b/src/fluid/fluid_scheme_compressible.f90
@@ -443,13 +443,6 @@ contains
        call neko_log%message(log_buf)
     end if
 
-    if (NEKO_BCKND_DEVICE .eq. 1) then
-       call device_memcpy(this%mu%x, this%mu%x_d, this%mu%size(), &
-            HOST_TO_DEVICE, sync = .false.)
-       call device_memcpy(this%kappa%x, this%kappa%x_d, this%kappa%size(), &
-            HOST_TO_DEVICE, sync = .false.)
-    end if
-
   end subroutine fluid_scheme_compressible_set_material_properties
 
   !> Update variable material properties
@@ -463,12 +456,6 @@ contains
     call this%user_material_properties(this%name, this%material_properties, &
          time)
 
-    if (NEKO_BCKND_DEVICE .eq. 1) then
-       call device_memcpy(this%mu%x, this%mu%x_d, this%mu%size(), &
-            HOST_TO_DEVICE, sync = .false.)
-       call device_memcpy(this%kappa%x, this%kappa%x_d, this%kappa%size(), &
-            HOST_TO_DEVICE, sync = .false.)
-    end if
   end subroutine fluid_scheme_compressible_update_material_properties
 
   !> Compute entropy field S = 1/(gamma-1) * rho * (log(p) - gamma * log(rho))


### PR DESCRIPTION
Removes memcopies for mu and kappa in the compressible solver. This is done for two reasons:
1. Bugfix: If mu and kappa are constant, they are populated by field_cfill(). With GPUs, field_cfill populates the device arrays but the device_memcpy that follows overwrites the values back to zero, effectively reverting back to Euler instead of NS.
2. Performance: if mu and kappa are computed in the user file (say following Sutherland's law), allows for the user to call device_math routines directly, avoiding the need for memcopies. 

@njansson would be nice if we could cherrypick this into 1.1!