### PR TITLE
Cleanup gs tune, and fix issue with single image CAF

### DIFF
--- a/doc/man/neko.1.in
+++ b/doc/man/neko.1.in
@@ -183,11 +183,37 @@ is native one\-sided communication over the Tofu interconnect and
 is host MPI using an
 .B MPI_Ineighbor_alltoallv
 neighbourhood collective. When unset, a device\-aware variant is used
-on accelerator builds; otherwise the host backends available in the build
+on accelerator builds; otherwise the host backends selected by
+.B NEKO_GS_TUNE
 are benchmarked at startup and the fastest one is used.
 .TP
 .B NEKO_GS_STRTGY
 Selects the gather\-scatter strategy.
+.TP
+.B NEKO_GS_TUNE
+Selects which communication backends are benchmarked at startup when
+.B NEKO_GS_COMM
+is unset. Takes a list of backend names, spelled as for
+.BR NEKO_GS_COMM ,
+separated by commas or spaces and matched case insensitively. Names
+prefixed with
+.B +
+or
+.B \-
+are added to and removed from the default set, plain names replace it
+altogether, and the two forms cannot be mixed. When unset, the default set
+is every host backend the build supports except
+.BR CAF ,
+which has to be asked for with
+.B NEKO_GS_TUNE=+CAF
+since a compiler may accept coarrays at configure time and still give each
+process a single image, which the coarray backend cannot communicate over.
+A list leaving a single candidate pins that backend without benchmarking.
+Selecting a backend outright with
+.B NEKO_GS_COMM
+ignores this variable;
+.B NEKO_GS_COMM=CAF
+fails with an error if the run does not provide one image per rank.
 .TP
 .B NEKO_GS_CAF_SIGNALING
 Selects the per\-pair synchronisation used by the coarray gather\-scatter
@@ -204,7 +230,11 @@ thereafter, so
 only takes effect when the communication backend is autotuned as well, that
 is when
 .B NEKO_GS_COMM
-is unset; it falls back to
+is unset and
+.B CAF
+is among the backends selected by
+.BR NEKO_GS_TUNE ;
+it falls back to
 .B sync
 otherwise.
 .TP

--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -26,6 +26,7 @@ of the code. But can be useful for users and developers alike.
 | `NEKO_LOG_LEVEL`         | Log verbosity level (integer > 0, default: 1)                         | Unset         |
 | `NEKO_GS_STRTGY`         | Gather-scatter device MPI sync. strategy (0 < integer < 5 )           | Unset         |
 | `NEKO_GS_COMM`           | Gather-scatter communication backend                                  | Unset         |
+| `NEKO_GS_TUNE`           | Comm. backends the gather-scatter autotuning benchmarks (list)        | Unset (all but `CAF`) |
 | `NEKO_GS_CAF_SIGNALING`  | Coarray Fortran gather-scatter signaling mode                         | Unset         |
 | `NEKO_COMM_ID`           | Communicator id for this process (non-negative integer)               | 0             |
 | `NEKO_HIP_ZEROCOPY`      | Zero-copy host/device mapping on unified memory (HIP), 1 enables      | 0             |
@@ -103,10 +104,26 @@ A number of gather-scatter backends are supported.
 
 When `NEKO_GS_COMM` is unset and the build has no device-aware MPI,
 the host backends are benchmarked at initialisation and the fastest
-one is kept (see @ref performance-gs-autotuning). `MPI` and
-`NEIGHBOUR` are always benchmarked; `SHMEM`, `CAF` and `UTOFU` join
-them if the build has the corresponding support. Set `NEKO_GS_COMM`
-explicitly to skip the benchmark and pin a backend.
+one is kept (see @ref performance-gs-autotuning). Which ones take part
+is set by `NEKO_GS_TUNE`, a list of backend names spelled as for
+`NEKO_GS_COMM` (comma or space separated, case insensitive). Unset, it
+means every host backend the build supports except `CAF`, which a
+compiler can accept at configure time while still giving the job a
+single image the coarray backend cannot use.
+
+- `NEKO_GS_TUNE=+CAF` adds the coarray backend to that default set,
+  `NEKO_GS_TUNE=-SHMEM` removes a backend from it, and the two can be
+  combined (`NEKO_GS_TUNE=+CAF,-SHMEM`).
+- Plain names replace the set outright: `NEKO_GS_TUNE=MPI,NEIGHBOUR`
+  benchmarks those two and nothing else. A single name pins that
+  backend without benchmarking anything.
+- The two forms cannot be mixed, and a name that is not a host
+  gather-scatter backend is an error.
+
+Backends that are selected but cannot run in this build or run are
+dropped; those named explicitly are reported in the log as
+`unavailable`. Set `NEKO_GS_COMM` to skip the benchmark and pin a
+backend outright; that path ignores `NEKO_GS_TUNE`.
 
 ### MPI thread level details
 

--- a/doc/pages/user-guide/installation.md
+++ b/doc/pages/user-guide/installation.md
@@ -198,7 +198,7 @@ supported backends are listed below.
 | NCCL / RCCL      | Collective comms library on GPUs (NVIDIA / AMD) | CUDA, HIP        | `--with-nccl` / `--with-rccl` | `NCCL`         |
 | NVSHMEM          | NVIDIA OpenSHMEM, one-sided on device buffers   | CUDA             | `--with-nvshmem`              | `SHMEM`        |
 | OpenSHMEM        | Host OpenSHMEM, one-sided                        | CPU              | `--with-openshmem`           | `SHMEM`        |
-| Co-Array Fortran | Fortran coarrays                                | CPU              | coarray-capable compiler      | `CAF`          |
+| Co-Array Fortran | Fortran coarrays (one image per rank required)   | CPU              | coarray-capable compiler      | `CAF`          |
 | uTofu            | Native Tofu interconnect, one-sided RDMA        | CPU              | `--with-utofu`                | `UTOFU`        |
 
 @note Every device backend (CUDA, HIP, OpenCL, Metal) can use host `MPI`, which
@@ -209,6 +209,13 @@ host `MPI`.
 
 @note `NEKO_GS_COMM=SHMEM` selects NVSHMEM on a device (GPU) build and host
 OpenSHMEM otherwise.
+
+@note `CAF` needs the coarray images to map one-to-one onto the MPI ranks.
+Compilers that accept coarrays but build a single-image program (for example
+gfortran without an `-fcoarray=lib` runtime) pass the configure check yet
+cannot run the backend, so it is left out of the startup benchmark unless
+asked for with `NEKO_GS_TUNE=+CAF`, and `NEKO_GS_COMM=CAF` aborts with an
+error on such a build.
 
 @note `UTOFU` targets the native Tofu interconnect (Tofu-D, e.g. Fugaku) and
 requires the `libtofucom` library; it is a host (CPU) backend. The number of

--- a/doc/pages/user-guide/performance.md
+++ b/doc/pages/user-guide/performance.md
@@ -269,18 +269,53 @@ fastest one. This mirrors the autotuning of the device MPI
 synchronisation strategy (`NEKO_GS_STRTGY`) already done on
 accelerator builds.
 
-The candidates are `MPI` and `NEIGHBOUR`, which need nothing but
-MPI-3 and are therefore always benchmarked, plus `SHMEM`
-(OpenSHMEM), `CAF` and `UTOFU` when the corresponding support was
+By default the candidates are every host backend the build supports
+except `CAF`: `MPI` and `NEIGHBOUR`, which need nothing but MPI-3, plus
+`SHMEM` (OpenSHMEM) and `UTOFU` when the corresponding support was
 built in -- a backend whose support is missing aborts in its `init`,
 so it is left out of the list rather than tried. `SHMEM` and `CAF` are
 additionally skipped when `NEKO_COMM` does not span every process
 (`NEKO_COMM_ID`), since they address their peers by global PE / image
 number; `UTOFU` exchanges its addresses over `NEKO_COMM` itself and is
-kept in that case. `CAF` is benchmarked in the single signaling mode
-bound by `NEKO_GS_CAF_SIGNALING` (`sync` unless set), unless that
-variable is set to `auto`, which tunes the modes as well -- see
-@ref performance-caf-backend.
+kept in that case.
+
+##### Choosing the candidates
+
+`NEKO_GS_TUNE` overrides that set. It takes a list of backend names,
+spelled as for `NEKO_GS_COMM`, separated by commas or spaces and
+matched case insensitively:
+
+| `NEKO_GS_TUNE` | Candidates |
+|---|---|
+| unset | every supported host backend but `CAF` |
+| `+CAF` | the default set, plus the coarray backend |
+| `-SHMEM` | the default set, without OpenSHMEM |
+| `+CAF,-SHMEM` | both deltas applied to the default set |
+| `MPI,NEIGHBOUR` | exactly those two, whatever the build supports |
+| `UTOFU` | uTofu alone -- nothing to compare, so it is simply used |
+
+Names prefixed with `+`/`-` modify the default set, plain names
+replace it, and mixing the two forms is an error, as is naming
+something that is not a host gather-scatter backend. Backends selected
+but unusable in this build or run are dropped from the comparison; a
+backend that was named explicitly says so in the log:
+
+```
+ CAF          : unavailable
+```
+
+`CAF` is out of the default set because coarray support at configure
+time says nothing about the job running more than one image: a
+compiler may accept the syntax and still build every process as a
+single-image program (gfortran's `-fcoarray=single`, or a coarray
+runtime that was never linked in), where the backend has no peers to
+put to. The case Neko can detect, `num_images() /= pe_size`, makes
+`CAF` unusable no matter how it was asked for, and requesting the
+backend outright with `NEKO_GS_COMM=CAF` then fails with an error
+rather than exchanging nothing. When `CAF` is benchmarked, it runs in
+the single signaling mode bound by `NEKO_GS_CAF_SIGNALING` (`sync`
+unless set), unless that variable is set to `auto`, which tunes the
+modes as well -- see @ref performance-caf-backend.
 
 The gs schedule is computed once, by `gs_schedule`, and handed over
 from one candidate backend to the next (`gs_comm_t%take_schedule`), so
@@ -310,7 +345,9 @@ backend that was kept:
 
 Tuning is skipped, keeping the host MPI backend, if any rank holds
 zero dofs: such a rank skips the halo exchange entirely, which would
-hang the other ranks in a collective-based backend. Since each `gs_t`
+hang the other ranks in a collective-based backend. It is likewise
+skipped when `NEKO_GS_TUNE` leaves fewer than two candidates, the
+single candidate then simply being switched to. Since each `gs_t`
 instance is tuned separately, a multigrid hierarchy tunes each level
 on its own message sizes. Set `NEKO_GS_COMM` explicitly to pin a
 backend and skip the benchmark, for example when comparing runs where
@@ -421,7 +458,7 @@ synchronisation strategy controlled by `NEKO_GS_CAF_SIGNALING`:
 | `sync` (default) | F2008 | `sync images` over the union of neighbour pairs, with a double-buffered receive coarray so only one rendezvous is needed per gs op | Most portable; works on every coarray-capable compiler |
 | `atomic` | F2008 | Per-pair atomic counters via `atomic_define`/`atomic_ref` and a busy-wait spin | Avoids the image-set barrier; trade-off depends on the relative cost of pairwise atomics versus `sync images` on the target runtime |
 | `event` | F2018 | F2018 events (`event post`/`event wait`) | Lowest theoretical overhead; requires a runtime that implements F2018 event semantics |
-| `auto` | -- | Benchmarks the modes above that the build supports and binds the fastest | Only takes effect when the comm. backend is autotuned as well; see below |
+| `auto` | -- | Benchmarks the modes above that the build supports and binds the fastest | Only takes effect when the comm. backend is autotuned as well, with `CAF` among the candidates (`NEKO_GS_TUNE=+CAF`); see below |
 
 The signaling mode is bound on the first gs initialisation and cannot
 be changed thereafter. If the chosen mode requires a feature
@@ -430,9 +467,11 @@ events), Neko aborts with a clear error.
 
 With `NEKO_GS_CAF_SIGNALING=auto` the mode is chosen by measurement
 instead, as part of the host backend autotuning described in
-@ref performance-gs-autotuning. When that tuning reaches the `CAF`
-candidate, it times each available mode on a freshly built backend --
-the mode determines what per-instance state `gs_caf_init` sets up, so
+@ref performance-gs-autotuning -- which needs `CAF` among the tuning
+candidates (`NEKO_GS_TUNE=+CAF`), as it is not one by default. When
+that tuning reaches the `CAF` candidate, it times each available mode
+on a freshly built backend -- the mode determines what per-instance
+state `gs_caf_init` sets up, so
 switching modes means rebuilding -- and the fastest one becomes the
 `CAF` entry in the backend comparison:
 
@@ -455,8 +494,10 @@ same module-level mode -- so it is benchmarked only on the *first*
 later would swap the protocol under instances that are already live,
 and in `atomic` mode desynchronise the round counters they share.
 `auto` therefore has no effect when the comm. backend itself is not
-autotuned (`NEKO_GS_COMM=CAF`, or a `comm_bcknd` argument); the mode
-falls back to `sync` in that case.
+autotuned (`NEKO_GS_COMM=CAF`, or a `comm_bcknd` argument), nor when
+the autotuning runs without `CAF` among its candidates
+(`NEKO_GS_TUNE` without `CAF`); the mode falls back to `sync` in those
+cases.
 
 @warning A signaling mode that the runtime does not really implement
 fails by hanging, not by aborting, and the benchmark has no timeout.

--- a/src/.depends
+++ b/src/.depends
@@ -68,6 +68,7 @@ gs/bcknd/device/gs_device_mpi.lo : gs/bcknd/device/gs_device_mpi.F90 common/util
 gs/bcknd/device/gs_device_nccl.lo : gs/bcknd/device/gs_device_nccl.F90 common/utils.lo device/device.lo adt/htable.lo comm/comm.lo adt/stack.lo gs/gs_comm.lo config/num_types.lo 
 gs/bcknd/device/gs_device_shmem.lo : gs/bcknd/device/gs_device_shmem.F90 common/utils.lo comm/comm.lo device/device.lo adt/htable.lo adt/stack.lo gs/gs_comm.lo config/num_types.lo 
 gs/gather_scatter.lo : gs/gather_scatter.f90 device/device.lo common/profiler.lo common/log.lo common/utils.lo math/math.lo comm/crystal_router.lo adt/stack.lo adt/htable.lo config/num_types.lo field/field.lo sem/dofmap.lo comm/comm.lo mesh/mesh.lo gs/bcknd/device/gs_device_shmem.lo gs/bcknd/device/gs_device_nccl.lo gs/bcknd/device/gs_device_mpi.lo gs/gs_utofu.lo gs/gs_caf.lo gs/gs_shmem.lo gs/gs_neighbour.lo gs/gs_mpi.lo gs/gs_comm.lo gs/gs_ops.lo gs/bcknd/cpu/gs_cpu.lo gs/bcknd/sx/gs_sx.lo gs/bcknd/device/gs_device.lo gs/gs_bcknd.lo config/neko_config.lo 
+gs/gs_tune.lo : gs/gs_tune.f90 gs/gs_utofu.lo gs/gs_caf.lo gs/gs_shmem.lo gs/gather_scatter.lo 
 mesh/entity.lo : mesh/entity.f90 
 mesh/point.lo : mesh/point.f90 mesh/entity.lo math/math.lo config/num_types.lo 
 mesh/element.lo : mesh/element.f90 mesh/point.lo adt/tuple.lo mesh/entity.lo config/num_types.lo 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -71,6 +71,7 @@ neko_fortran_SOURCES = \
 	gs/bcknd/device/gs_device_nccl.F90\
 	gs/bcknd/device/gs_device_shmem.F90\
 	gs/gather_scatter.f90\
+	gs/gs_tune.f90\
 	mesh/entity.f90\
 	mesh/point.f90\
 	mesh/element.f90\

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -44,10 +44,12 @@ module gather_scatter
        GS_COMM_UTOFU, GS_VEC_NC
   use gs_mpi, only : gs_mpi_t
   use gs_neighbour, only : gs_neighbour_t
-  use gs_shmem, only : gs_shmem_t, GS_SHMEM_AVAIL
-  use gs_caf, only : gs_caf_t, GS_CAF_AVAIL, gs_caf_signal_auto, &
-       gs_caf_signal_modes, gs_caf_mode_name, gs_caf_mode_get, gs_caf_set_mode
-  use gs_utofu, only : gs_utofu_t, GS_UTOFU_AVAIL
+  ! Only the backend types are needed here; what tells whether a backend can
+  ! run at all is used by the autotuning, and imported by the gs_tune
+  ! submodule instead
+  use gs_shmem, only : gs_shmem_t
+  use gs_caf, only : gs_caf_t
+  use gs_utofu, only : gs_utofu_t
   use gs_device_mpi, only : gs_device_mpi_t
   use gs_device_nccl, only : gs_device_nccl_t
   use gs_device_shmem, only : gs_device_shmem_t
@@ -135,12 +137,29 @@ module gather_scatter
   integer, parameter :: GS_TUNE_NTRIALS = 100
   integer, parameter :: GS_TUNE_NWARMUP = 2
 
-  !> Whether the coarray signaling mode has already been selected by the
-  !! autotuner (NEKO_GS_CAF_SIGNALING=auto). The mode is a program-wide
-  !! binding shared by every gs_caf_t instance, so it is benchmarked once,
-  !! on the first gs_t that tunes the CAF backend, and kept: re-binding it
-  !! later would change the protocol under instances already running.
-  logical, save :: caf_signal_tuned = .false.
+  !> The runtime autotuning of the comm. backend, implemented in the gs_tune
+  !! submodule: everything the selection needs (the candidate list, the
+  !! NEKO_GS_TUNE parsing, switching a live gs over to another backend) is
+  !! private to it, and only what gs_init drives is declared here.
+  interface
+     !> Time @a ntrials gather-scatter operations on @a u, returning the
+     !! average wall time (s) per operation on this rank
+     module function gs_time_ops(gs, u, n, op, ntrials) result(t)
+       type(gs_t), intent(inout) :: gs
+       integer, intent(in) :: n
+       real(kind=rp), dimension(n), intent(inout) :: u
+       integer, intent(in) :: op, ntrials
+       real(kind=dp) :: t
+     end function gs_time_ops
+
+     !> Benchmark the candidate comm. backends and leave @a gs holding the
+     !! fastest one
+     module subroutine gs_tune_comm(gs, n, comm_bcknd)
+       type(gs_t), intent(inout) :: gs
+       integer, intent(in) :: n
+       integer, intent(in) :: comm_bcknd
+     end subroutine gs_tune_comm
+  end interface
 
 contains
 
@@ -395,7 +414,7 @@ contains
 
     ! Select the fastest host comm. backend at runtime
     if (tune_comm) then
-       call gs_tune_comm(gs, dofmap%size(), gs_comm_host_cand())
+       call gs_tune_comm(gs, dofmap%size(), comm_bcknd_)
     end if
 
     call neko_log%end_section()
@@ -407,7 +426,7 @@ contains
   !! entry: intent(out) releases it without running its free, which would
   !! leak whatever resources it holds (symmetric memory, coarrays, uTofu
   !! VCQs). Both callers free the previous backend themselves, see gs_free
-  !! and gs_comm_switch.
+  !! and gs_comm_switch (in the gs_tune submodule).
   !! @param comm_bcknd comm. backend to allocate, one of the GS_COMM_*
   !! constants
   subroutine gs_comm_alloc(comm, comm_bcknd)
@@ -436,46 +455,6 @@ contains
     end select
 
   end subroutine gs_comm_alloc
-
-  !> Host comm. backends to consider in the runtime autotuning, in the order
-  !! they are benchmarked. MPI and the neighbourhood collective need nothing
-  !! but MPI-3; the remaining ones are only included if the corresponding
-  !! support was built in, as their init aborts otherwise.
-  !! @note The first entry is the backend the gs schedule is built with in
-  !! gs_init, and must stay that way (see gs_tune_comm).
-  !! @return the candidate backends, as GS_COMM_* constants
-  function gs_comm_host_cand() result(cand)
-    integer, allocatable :: cand(:)
-    integer :: c(5), n
-
-    n = 2
-    c(1) = GS_COMM_MPI
-    c(2) = GS_COMM_NEIGHBOUR
-
-    ! The one-sided backends that address their peers by global PE or image
-    ! number (OpenSHMEM PEs, coarray images) are only correct when NEKO_COMM
-    ! spans every process, so skip them when the run has been split into
-    ! several communicators (NEKO_COMM_ID). uTofu exchanges its addresses
-    ! over NEKO_COMM itself and is unaffected.
-    if (GS_SHMEM_AVAIL .and. (pe_size .eq. global_pe_size)) then
-       n = n + 1
-       c(n) = GS_COMM_OPENSHMEM
-    end if
-
-    if (GS_CAF_AVAIL .and. (pe_size .eq. global_pe_size)) then
-       n = n + 1
-       c(n) = GS_COMM_CAF
-    end if
-
-    if (GS_UTOFU_AVAIL) then
-       n = n + 1
-       c(n) = GS_COMM_UTOFU
-    end if
-
-    allocate(cand(n))
-    cand = c(1:n)
-
-  end function gs_comm_host_cand
 
   !> Name of the gather-scatter comm. backend @a comm_bcknd, right-adjusted
   !! for the log
@@ -507,225 +486,6 @@ contains
     end select
 
   end function gs_comm_name
-
-  !> Switch the comm. backend of @a gs to @a comm_bcknd, retaining the
-  !! schedule computed in gs_schedule (the dof lists are moved over to the
-  !! new backend, not recomputed). The old backend is freed before the new
-  !! one is set up, so backends holding scarce resources (uTofu VCQs,
-  !! symmetric memory, coarrays) never overlap.
-  !! @param gs gather-scatter kernel whose comm. backend is replaced
-  !! @param comm_bcknd comm. backend to switch to, one of the GS_COMM_*
-  !! constants
-  !! @note Collective, every rank must switch to the same backend.
-  subroutine gs_comm_switch(gs, comm_bcknd)
-    type(gs_t), intent(inout) :: gs
-    integer, intent(in) :: comm_bcknd
-    class(gs_comm_t), allocatable :: comm_new
-
-    call gs_comm_alloc(comm_new, comm_bcknd)
-    call comm_new%take_schedule(gs%comm)
-    call gs%comm%free()
-    deallocate(gs%comm)
-    call move_alloc(comm_new, gs%comm)
-    call gs%comm%init_schedule()
-
-  end subroutine gs_comm_switch
-
-  !> Time @a ntrials gather-scatter operations on @a u, returning the
-  !! average wall time (s) per operation. The backend is warmed up and all
-  !! ranks are synchronised before the timing window is opened.
-  !! @param gs gather-scatter kernel to time
-  !! @param u working vector to operate on
-  !! @param n length of @a u
-  !! @param op gather-scatter operation, one of the GS_OP_* constants
-  !! @param ntrials number of timed operations to average over
-  !! @return the average wall time (s) per operation on this rank
-  function gs_time_ops(gs, u, n, op, ntrials) result(t)
-    type(gs_t), intent(inout) :: gs
-    integer, intent(in) :: n
-    real(kind=rp), dimension(n), intent(inout) :: u
-    integer, intent(in) :: op, ntrials
-    real(kind=dp) :: t
-    integer :: i
-
-    do i = 1, GS_TUNE_NWARMUP
-       call gs_op_vector(gs, u, n, op)
-    end do
-
-    if (NEKO_BCKND_DEVICE .eq. 1) call device_sync
-    call MPI_Barrier(NEKO_COMM)
-
-    t = MPI_Wtime()
-    do i = 1, ntrials
-       call gs_op_vector(gs, u, n, op)
-    end do
-    if (NEKO_BCKND_DEVICE .eq. 1) call device_sync
-    t = (MPI_Wtime() - t) / real(ntrials, dp)
-
-  end function gs_time_ops
-
-  !> Select the fastest of the comm. backends in @a cand at runtime.
-  !!
-  !! Each candidate is benchmarked in turn on a dummy vector of length @a n,
-  !! reusing the schedule computed by gs_schedule (handed over from one
-  !! candidate to the next, see gs_comm_t%take_schedule), and @a gs is left
-  !! with the fastest backend allocated. On entry @a gs%comm must be the
-  !! first candidate, i.e. the backend the schedule was built with.
-  !!
-  !! @param gs gather-scatter kernel to tune, left holding the fastest
-  !! backend
-  !! @param n length of the dummy vector to benchmark on (the dofmap size)
-  !! @param cand comm. backends to consider, as GS_COMM_* constants, in the
-  !! order they are benchmarked (see gs_comm_host_cand)
-  !!
-  !! @note Setting up and running a comm. backend is collective over
-  !! NEKO_COMM (the neighbourhood backend builds a graph communicator, the
-  !! one-sided backends allocate symmetric memory), so every rank has to
-  !! arrive at the same decision: the per-rank timings are averaged over all
-  !! ranks before the winner is picked.
-  subroutine gs_tune_comm(gs, n, cand)
-    type(gs_t), intent(inout) :: gs
-    integer, intent(in) :: n
-    integer, intent(in) :: cand(:)
-    character(len=LOG_SIZE) :: log_buf
-    character(len=13) :: label
-    real(kind=dp), allocatable :: cand_time(:)
-    real(kind=rp), allocatable :: tmp(:)
-    type(c_ptr) :: tmp_d
-    integer :: i, best, nmin
-
-    ! A rank without any dofs skips the halo exchange in gs_op_vector, which
-    ! would leave every other rank hanging in a collective based backend.
-    ! Keep the default backend in that case.
-    nmin = n
-    call MPI_Allreduce(MPI_IN_PLACE, nmin, 1, MPI_INTEGER, MPI_MIN, NEKO_COMM)
-    if (nmin .eq. 0) then
-       call neko_log%message('Comm tuning  :      skipped')
-       call neko_log%message('Tuned comm   : ' // gs_comm_name(cand(1)))
-       return
-    end if
-
-    allocate(cand_time(size(cand)))
-
-    tmp_d = C_NULL_PTR
-    allocate(tmp(n))
-    tmp = 1.0_rp
-    if (NEKO_BCKND_DEVICE .eq. 1) then
-       call device_map(tmp, tmp_d, n)
-       call device_memcpy(tmp, tmp_d, n, HOST_TO_DEVICE, sync = .false.)
-    end if
-
-    ! GS_OP_MIN leaves the working vector untouched, so the benchmark can
-    ! run for any number of trials without the values growing out of range
-    do i = 1, size(cand)
-       if (cand(i) .eq. GS_COMM_CAF .and. gs_caf_signal_auto() .and. &
-            .not. caf_signal_tuned) then
-          ! Benchmark the signaling modes as well; this leaves the CAF
-          ! backend allocated in the winning mode
-          cand_time(i) = gs_tune_caf_signal(gs, tmp, n)
-          caf_signal_tuned = .true.
-       else
-          if (i .gt. 1) call gs_comm_switch(gs, cand(i))
-          cand_time(i) = gs_time_ops(gs, tmp, n, GS_OP_MIN, GS_TUNE_NTRIALS)
-       end if
-    end do
-
-    if (NEKO_BCKND_DEVICE .eq. 1) call device_unmap(tmp, tmp_d)
-    deallocate(tmp)
-
-    call MPI_Allreduce(MPI_IN_PLACE, cand_time, size(cand), &
-         MPI_DOUBLE_PRECISION, MPI_SUM, NEKO_COMM)
-    cand_time = cand_time / pe_size
-
-    best = minloc(cand_time, 1)
-
-    do i = 1, size(cand)
-       label = adjustl(gs_comm_name(cand(i)))
-       ! What the coarray backend costs depends on the signaling mode in
-       ! force, so report the timing under the mode it was measured in
-       if (cand(i) .eq. GS_COMM_CAF .and. gs_caf_mode_get() .ne. 0) then
-          label = 'CAF (' // &
-               trim(adjustl(gs_caf_mode_name(gs_caf_mode_get()))) // ')'
-       end if
-       ! ES10.3 + ' s' fills the same 12 columns as the right-adjusted
-       ! backend names, so the unit lines up with their last letter
-       write(log_buf, '(A,A,ES10.3,A)') label, ': ', cand_time(i), ' s'
-       call neko_log%message(log_buf)
-    end do
-
-    ! The last candidate is the one currently allocated
-    if (best .ne. size(cand)) call gs_comm_switch(gs, cand(best))
-
-    call neko_log%message('Tuned comm   : ' // gs_comm_name(cand(best)))
-
-    deallocate(cand_time)
-
-  end subroutine gs_tune_comm
-
-  !> Benchmark the coarray signaling modes and bind the fastest one, leaving
-  !! @a gs holding a CAF backend that runs in that mode. Returns the winning
-  !! mode's average time per gather-scatter operation, so the caller can use
-  !! it as the CAF entry of the comm. backend benchmark.
-  !!
-  !! The mode is a program-wide binding shared by every gs_caf_t instance
-  !! and the per-instance state depends on it, so every mode is measured on
-  !! a freshly built backend. As in gs_tune_comm the timings are averaged
-  !! over all ranks before the winner is picked, so every rank binds the
-  !! same mode; the returned time is that rank-invariant average, which the
-  !! caller's own averaging leaves unchanged.
-  !!
-  !! @param gs gather-scatter kernel to tune, left holding a CAF backend
-  !! running in the winning mode
-  !! @param u working vector to operate on
-  !! @param n length of @a u
-  !! @return the winning mode's average wall time (s) per operation
-  function gs_tune_caf_signal(gs, u, n) result(t)
-    type(gs_t), intent(inout) :: gs
-    integer, intent(in) :: n
-    real(kind=rp), dimension(n), intent(inout) :: u
-    real(kind=dp) :: t
-    character(len=LOG_SIZE) :: log_buf
-    character(len=13) :: label
-    integer, allocatable :: mode(:)
-    real(kind=dp), allocatable :: mode_time(:)
-    integer :: i, best
-
-    allocate(mode, source = gs_caf_signal_modes())
-    allocate(mode_time(size(mode)))
-
-    do i = 1, size(mode)
-       ! Bind the mode before building the backend: gs_caf_init sets up its
-       ! per-instance signaling state according to the mode in force
-       call gs_caf_set_mode(mode(i))
-       call gs_comm_switch(gs, GS_COMM_CAF)
-       mode_time(i) = gs_time_ops(gs, u, n, GS_OP_MIN, GS_TUNE_NTRIALS)
-    end do
-
-    call MPI_Allreduce(MPI_IN_PLACE, mode_time, size(mode), &
-         MPI_DOUBLE_PRECISION, MPI_SUM, NEKO_COMM)
-    mode_time = mode_time / pe_size
-
-    best = minloc(mode_time, 1)
-
-    do i = 1, size(mode)
-       label = 'CAF ' // adjustl(gs_caf_mode_name(mode(i)))
-       write(log_buf, '(A,A,ES10.3,A)') label, ': ', mode_time(i), ' s'
-       call neko_log%message(log_buf)
-    end do
-
-    ! The last mode is the one currently allocated
-    if (best .ne. size(mode)) then
-       call gs_caf_set_mode(mode(best))
-       call gs_comm_switch(gs, GS_COMM_CAF)
-    end if
-
-    call neko_log%message('Tuned CAF sig: ' // gs_caf_mode_name(mode(best)))
-
-    t = mode_time(best)
-
-    deallocate(mode, mode_time)
-
-  end function gs_tune_caf_signal
 
   !> Deallocate a gather-scatter kernel
   subroutine gs_free(gs)

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -131,6 +131,10 @@ module gather_scatter
   public :: GS_COMM_MPI, GS_COMM_MPIGPU, GS_COMM_NCCL, GS_COMM_NVSHMEM, &
        GS_COMM_OPENSHMEM, GS_COMM_CAF, GS_COMM_NEIGHBOUR, GS_COMM_UTOFU
 
+  ! These routines (used by the gs_tune submodule) have to be public
+  ! since gfortran gives a private module procedure internal linkage
+  public :: gs_comm_t, gs_comm_alloc, gs_comm_name
+
   !> Number of timed (and untimed, warm-up) gather-scatter operations per
   !! candidate in the runtime autotuning of comm. backends and device
   !! synchronisation strategies

--- a/src/gs/gs_caf.F90
+++ b/src/gs/gs_caf.F90
@@ -201,10 +201,30 @@ module gs_caf
      procedure, pass(this) :: nbwait_vec => gs_nbwait_vec_caf
   end type gs_caf_t
 
-  public :: gs_caf_signal_auto, gs_caf_signal_modes, gs_caf_mode_name, &
-       gs_caf_mode_get, gs_caf_set_mode
+  public :: gs_caf_usable, gs_caf_signal_auto, gs_caf_signal_modes, &
+       gs_caf_mode_name, gs_caf_mode_get, gs_caf_set_mode
 
 contains
+
+  !> Whether the coarray backend can actually run in this job. GS_CAF_AVAIL
+  !! only says that the compiler accepted coarrays when Neko was configured;
+  !! a compiler may well do so and still provide a single image per process
+  !! (gfortran's -fcoarray=single, a coarray runtime that was not linked in),
+  !! in which case every image sees num_images() == 1 and no halo can be
+  !! exchanged. The images must map one-to-one onto the ranks of NEKO_COMM,
+  !! as the backend addresses its peers by image number (rank + 1) -- which
+  !! also rules out a run split into several communicators (NEKO_COMM_ID).
+  !! @return whether a gs_caf_t can be used by this run
+  function gs_caf_usable() result(usable)
+    logical :: usable
+
+#ifdef HAVE_COARRAY
+    usable = (num_images() .eq. pe_size)
+#else
+    usable = .false.
+#endif
+
+  end function gs_caf_usable
 
   !> Whether the signaling mode should be selected by benchmarking, i.e.
   !! NEKO_GS_CAF_SIGNALING=auto. The mode is a program-wide binding shared
@@ -343,6 +363,14 @@ contains
     integer :: i, nsend, nrecv, send_total, recv_total, max_total, n_neigh
     integer :: me, env_len
     character(len=64) :: env_val
+
+    ! A build with coarray support is not necessarily a build that can run
+    ! them across the job (see gs_caf_usable). Catch it here rather than
+    ! silently exchanging nothing, or deadlocking in the first put.
+    if (.not. gs_caf_usable()) then
+       call neko_error("Coarray gather-scatter needs one image per rank; " // &
+            "this build or run has num_images() /= pe_size")
+    end if
 
     ! Bind the signaling mode on the first init. With
     ! NEKO_GS_CAF_SIGNALING=auto the mode is instead selected by

--- a/src/gs/gs_tune.f90
+++ b/src/gs/gs_tune.f90
@@ -1,0 +1,507 @@
+! Copyright (c) 2026, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Runtime autotuning of the gather-scatter communication
+submodule (gather_scatter) gs_tune
+  use gs_shmem, only : GS_SHMEM_AVAIL
+  use gs_caf, only : GS_CAF_AVAIL, gs_caf_usable, gs_caf_signal_auto, &
+       gs_caf_signal_modes, gs_caf_mode_name, gs_caf_mode_get, &
+       gs_caf_set_mode
+  use gs_utofu, only : GS_UTOFU_AVAIL
+  implicit none
+
+  !> The host comm. backends the runtime autotuning can benchmark, in the
+  !! order they are benchmarked and reported. The device backends are not
+  !! among them: the autotuning only runs on host builds (see gs_init).
+  integer, parameter :: GS_TUNE_BCKND(5) = [GS_COMM_MPI, GS_COMM_NEIGHBOUR, &
+       GS_COMM_OPENSHMEM, GS_COMM_CAF, GS_COMM_UTOFU]
+
+  !> Which of GS_TUNE_BCKND are benchmarked when NEKO_GS_TUNE is unset: all
+  !! of them the build supports but CAF, which has to be asked for (see
+  !! gs_tune_select).
+  logical, parameter :: GS_TUNE_DEFAULT(5) = [.true., .true., .true., &
+       .false., .true.]
+
+  !> Whether the coarray signaling mode has already been selected by the
+  !! autotuner (NEKO_GS_CAF_SIGNALING=auto). The mode is a program-wide
+  !! binding shared by every gs_caf_t instance, so it is benchmarked once,
+  !! on the first gs_t that tunes the CAF backend, and kept: re-binding it
+  !! later would change the protocol under instances already running.
+  logical, save :: caf_signal_tuned = .false.
+
+contains
+
+  !> Host comm. backends to benchmark in the runtime autotuning: the ones
+  !! selected by NEKO_GS_TUNE (see gs_tune_select) that this run can
+  !! actually use (see gs_comm_tunable), in GS_TUNE_BCKND order. A selected
+  !! backend the run cannot use is dropped, and reported in the log if it
+  !! was named explicitly rather than merely part of the default set.
+  !! @return the candidate backends, as GS_COMM_* constants. May be empty,
+  !! or hold a single entry, in which case gs_tune_comm benchmarks nothing
+  !! @note The list says nothing about which backend the gs kernel holds
+  !! when the tuning starts; gs_tune_comm is told that separately.
+  function gs_comm_host_cand() result(cand)
+    integer, allocatable :: cand(:)
+    character(len=LOG_SIZE) :: log_buf
+    character(len=13) :: label
+    logical :: sel(size(GS_TUNE_BCKND)), named(size(GS_TUNE_BCKND))
+    integer :: c(size(GS_TUNE_BCKND)), i, n
+
+    call gs_tune_select(sel, named)
+
+    n = 0
+    do i = 1, size(GS_TUNE_BCKND)
+       if (.not. sel(i)) cycle
+       if (gs_comm_tunable(GS_TUNE_BCKND(i))) then
+          n = n + 1
+          c(n) = GS_TUNE_BCKND(i)
+       else if (named(i)) then
+          ! Asked for by name, but this build or run cannot drive it: say so
+          ! rather than leaving the candidate quietly missing from the
+          ! comparison below
+          label = adjustl(gs_comm_name(GS_TUNE_BCKND(i)))
+          write(log_buf, '(A,A,A12)') label, ': ', 'unavailable'
+          call neko_log%message(log_buf)
+       end if
+    end do
+
+    allocate(cand(n))
+    cand = c(1:n)
+
+  end function gs_comm_host_cand
+
+  !> Whether the comm. backend @a comm_bcknd can be driven by this build and
+  !! this run, and may therefore be benchmarked. MPI and the neighbourhood
+  !! collective need nothing but MPI-3; the rest abort in their init unless
+  !! the corresponding support was built in.
+  !! @param comm_bcknd comm. backend to check, one of the GS_TUNE_BCKND
+  !! entries
+  !! @return whether the backend is usable as a candidate
+  function gs_comm_tunable(comm_bcknd) result(tunable)
+    integer, intent(in) :: comm_bcknd
+    logical :: tunable
+
+    select case (comm_bcknd)
+    case (GS_COMM_MPI, GS_COMM_NEIGHBOUR)
+       tunable = .true.
+    case (GS_COMM_OPENSHMEM)
+       ! The one-sided backends that address their peers by global PE or
+       ! image number (OpenSHMEM PEs, coarray images) are only correct when
+       ! NEKO_COMM spans every process, so skip them when the run has been
+       ! split into several communicators (NEKO_COMM_ID). uTofu exchanges
+       ! its addresses over NEKO_COMM itself and is unaffected.
+       tunable = GS_SHMEM_AVAIL .and. (pe_size .eq. global_pe_size)
+    case (GS_COMM_CAF)
+       ! Coarray support at configure time says nothing about the job
+       ! actually running more than one image, see gs_caf_usable
+       tunable = GS_CAF_AVAIL .and. gs_caf_usable() .and. &
+            (pe_size .eq. global_pe_size)
+    case (GS_COMM_UTOFU)
+       tunable = GS_UTOFU_AVAIL
+    case default
+       tunable = .false.
+    end select
+
+  end function gs_comm_tunable
+
+  !> Which of GS_TUNE_BCKND the autotuning should consider, as requested by
+  !! the NEKO_GS_TUNE environment variable. Its value is a list of backend
+  !! names (comma or space separated, case insensitive) spelled as for
+  !! NEKO_GS_COMM, in either of two forms:
+  !!
+  !! - plain names, which replace the default set outright
+  !!   (`NEKO_GS_TUNE=MPI,NEIGHBOUR`), or
+  !! - names prefixed with `+` or `-`, which add to and remove from it
+  !!   (`NEKO_GS_TUNE=+CAF`).
+  !!
+  !! The two forms cannot be mixed. When the variable is unset the default
+  !! set GS_TUNE_DEFAULT is used, which is everything but CAF -- a compiler
+  !! may accept coarrays and still give the job a single image, and a
+  !! backend that cannot communicate is at best wasted setup, so CAF has to
+  !! be asked for. Selecting a backend outright (NEKO_GS_COMM) bypasses all
+  !! of this.
+  !!
+  !! @param sel whether each entry of GS_TUNE_BCKND was selected
+  !! @param named whether each entry was named explicitly, i.e. is a request
+  !! rather than a default, which is what makes it worth reporting when the
+  !! run cannot use it
+  subroutine gs_tune_select(sel, named)
+    logical, intent(out) :: sel(:), named(:)
+    character(len=255) :: env_val
+    character(len=32) :: tok, name
+    character(len=1) :: op
+    integer :: env_len, i, j, k
+    logical :: delta, first
+
+    sel = GS_TUNE_DEFAULT
+    named = .false.
+
+    call get_environment_variable("NEKO_GS_TUNE", env_val, env_len)
+    if (env_len .eq. 0) return
+    ! env_len is the length of the value, which may well exceed the buffer
+    env_len = min(env_len, len(env_val))
+
+    delta = .false.
+    first = .true.
+    i = 1
+    do while (i .le. env_len)
+       if (scan(env_val(i:i), ', ') .ne. 0) then
+          i = i + 1
+          cycle
+       end if
+
+       j = i
+       do while (j .le. env_len)
+          if (scan(env_val(j:j), ', ') .ne. 0) exit
+          j = j + 1
+       end do
+       tok = gs_tune_upcase(env_val(i:j-1))
+       i = j
+
+       op = ' '
+       name = tok
+       if (tok(1:1) .eq. '+' .or. tok(1:1) .eq. '-') then
+          op = tok(1:1)
+          name = tok(2:)
+       end if
+
+       if (first) then
+          ! The first name decides how the list is read; a plain one starts
+          ! the set from nothing rather than from the default
+          delta = (op .ne. ' ')
+          if (.not. delta) sel = .false.
+          first = .false.
+       else if ((op .ne. ' ') .neqv. delta) then
+          call neko_error('NEKO_GS_TUNE: plain backend names and +/- ' // &
+               'prefixed ones cannot be mixed')
+       end if
+
+       k = gs_tune_index(name)
+       if (k .eq. 0) then
+          call neko_error('NEKO_GS_TUNE: not a tunable Gather-scatter ' // &
+               'comm. backend: ' // trim(name))
+       end if
+       sel(k) = (op .ne. '-')
+       named(k) = .true.
+    end do
+
+  end subroutine gs_tune_select
+
+  !> Index into GS_TUNE_BCKND of the comm. backend named @a name, using the
+  !! spellings NEKO_GS_COMM accepts, or 0 if it names no backend that takes
+  !! part in the autotuning (the device backends among them: the autotuning
+  !! only runs on host builds).
+  !! @param name upper case backend name to look up
+  !! @return the index into GS_TUNE_BCKND, or 0
+  function gs_tune_index(name) result(idx)
+    character(len=*), intent(in) :: name
+    integer :: idx, bcknd, i
+
+    select case (trim(name))
+    case ('MPI')
+       bcknd = GS_COMM_MPI
+    case ('NEIGHBOUR', 'NEIGHBOR')
+       bcknd = GS_COMM_NEIGHBOUR
+    case ('SHMEM', 'OPENSHMEM')
+       bcknd = GS_COMM_OPENSHMEM
+    case ('CAF')
+       bcknd = GS_COMM_CAF
+    case ('UTOFU')
+       bcknd = GS_COMM_UTOFU
+    case default
+       bcknd = 0
+    end select
+
+    idx = 0
+    do i = 1, size(GS_TUNE_BCKND)
+       if (GS_TUNE_BCKND(i) .eq. bcknd) idx = i
+    end do
+
+  end function gs_tune_index
+
+  !> Upper case copy of @a str, so that the backend names in NEKO_GS_TUNE
+  !! may be given in any case
+  !! @param str string to convert
+  !! @return the converted string
+  function gs_tune_upcase(str) result(upper)
+    character(len=*), intent(in) :: str
+    character(len=len(str)) :: upper
+    integer :: i, c
+
+    do i = 1, len(str)
+       c = iachar(str(i:i))
+       if (c .ge. iachar('a') .and. c .le. iachar('z')) then
+          upper(i:i) = achar(c - (iachar('a') - iachar('A')))
+       else
+          upper(i:i) = str(i:i)
+       end if
+    end do
+
+  end function gs_tune_upcase
+
+  !> Switch the comm. backend of @a gs to @a comm_bcknd, retaining the
+  !! schedule computed in gs_schedule (the dof lists are moved over to the
+  !! new backend, not recomputed). The old backend is freed before the new
+  !! one is set up, so backends holding scarce resources (uTofu VCQs,
+  !! symmetric memory, coarrays) never overlap.
+  !! @param gs gather-scatter kernel whose comm. backend is replaced
+  !! @param comm_bcknd comm. backend to switch to, one of the GS_COMM_*
+  !! constants
+  !! @note Collective, every rank must switch to the same backend.
+  subroutine gs_comm_switch(gs, comm_bcknd)
+    type(gs_t), intent(inout) :: gs
+    integer, intent(in) :: comm_bcknd
+    class(gs_comm_t), allocatable :: comm_new
+
+    call gs_comm_alloc(comm_new, comm_bcknd)
+    call comm_new%take_schedule(gs%comm)
+    call gs%comm%free()
+    deallocate(gs%comm)
+    call move_alloc(comm_new, gs%comm)
+    call gs%comm%init_schedule()
+
+  end subroutine gs_comm_switch
+
+  !> Time @a ntrials gather-scatter operations on @a u, returning the
+  !! average wall time (s) per operation. The backend is warmed up and all
+  !! ranks are synchronised before the timing window is opened.
+  !! @param gs gather-scatter kernel to time
+  !! @param u working vector to operate on
+  !! @param n length of @a u
+  !! @param op gather-scatter operation, one of the GS_OP_* constants
+  !! @param ntrials number of timed operations to average over
+  !! @return the average wall time (s) per operation on this rank
+  module function gs_time_ops(gs, u, n, op, ntrials) result(t)
+    type(gs_t), intent(inout) :: gs
+    integer, intent(in) :: n
+    real(kind=rp), dimension(n), intent(inout) :: u
+    integer, intent(in) :: op, ntrials
+    real(kind=dp) :: t
+    integer :: i
+
+    do i = 1, GS_TUNE_NWARMUP
+       call gs_op_vector(gs, u, n, op)
+    end do
+
+    if (NEKO_BCKND_DEVICE .eq. 1) call device_sync
+    call MPI_Barrier(NEKO_COMM)
+
+    t = MPI_Wtime()
+    do i = 1, ntrials
+       call gs_op_vector(gs, u, n, op)
+    end do
+    if (NEKO_BCKND_DEVICE .eq. 1) call device_sync
+    t = (MPI_Wtime() - t) / real(ntrials, dp)
+
+  end function gs_time_ops
+
+  !> Select the fastest of the candidate comm. backends at runtime.
+  !!
+  !! Each candidate returned by gs_comm_host_cand is benchmarked in turn on
+  !! a dummy vector of length @a n, reusing the schedule computed by
+  !! gs_schedule (handed over from one candidate to the next, see
+  !! gs_comm_t%take_schedule), and @a gs is left with the fastest backend
+  !! allocated. Fewer than two candidates leaves nothing to compare: @a gs
+  !! is switched to the single candidate, if it is not already running it,
+  !! and no benchmark is run.
+  !!
+  !! @param gs gather-scatter kernel to tune, left holding the fastest
+  !! backend
+  !! @param n length of the dummy vector to benchmark on (the dofmap size)
+  !! @param comm_bcknd the comm. backend @a gs holds on entry, i.e. the one
+  !! the schedule was built with, which need not be a candidate itself
+  !!
+  !! @note Setting up and running a comm. backend is collective over
+  !! NEKO_COMM (the neighbourhood backend builds a graph communicator, the
+  !! one-sided backends allocate symmetric memory), so every rank has to
+  !! arrive at the same decision: the per-rank timings are averaged over all
+  !! ranks before the winner is picked.
+  module subroutine gs_tune_comm(gs, n, comm_bcknd)
+    type(gs_t), intent(inout) :: gs
+    integer, intent(in) :: n
+    integer, intent(in) :: comm_bcknd
+    character(len=LOG_SIZE) :: log_buf
+    character(len=13) :: label
+    integer, allocatable :: cand(:)
+    real(kind=dp), allocatable :: cand_time(:)
+    real(kind=rp), allocatable :: tmp(:)
+    type(c_ptr) :: tmp_d
+    integer :: i, best, nmin, cur
+
+    allocate(cand, source = gs_comm_host_cand())
+
+    ! Track what gs is running as the sweep proceeds. The candidate list
+    ! need neither start with the backend the schedule was built with nor
+    ! contain it at all, and switching is what costs, so every candidate is
+    ! switched to exactly once
+    cur = comm_bcknd
+
+    ! A rank without any dofs skips the halo exchange in gs_op_vector, which
+    ! would leave every other rank hanging in a collective based backend.
+    ! Keep the current backend in that case. NEKO_GS_TUNE may also have left
+    ! us with nothing to compare, in which case a lone candidate is simply
+    ! switched to, as if it had been requested with NEKO_GS_COMM.
+    nmin = n
+    call MPI_Allreduce(MPI_IN_PLACE, nmin, 1, MPI_INTEGER, MPI_MIN, NEKO_COMM)
+    if (nmin .eq. 0 .or. size(cand) .lt. 2) then
+       call neko_log%message('Comm tuning  :      skipped')
+       if (nmin .gt. 0 .and. size(cand) .eq. 1) then
+          if (cand(1) .ne. cur) call gs_comm_switch(gs, cand(1))
+          cur = cand(1)
+       end if
+       call neko_log%message('Tuned comm   : ' // gs_comm_name(cur))
+       return
+    end if
+
+    allocate(cand_time(size(cand)))
+
+    tmp_d = C_NULL_PTR
+    allocate(tmp(n))
+    tmp = 1.0_rp
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_map(tmp, tmp_d, n)
+       call device_memcpy(tmp, tmp_d, n, HOST_TO_DEVICE, sync = .false.)
+    end if
+
+    ! GS_OP_MIN leaves the working vector untouched, so the benchmark can
+    ! run for any number of trials without the values growing out of range
+    do i = 1, size(cand)
+       if (cand(i) .eq. GS_COMM_CAF .and. gs_caf_signal_auto() .and. &
+            .not. caf_signal_tuned) then
+          ! Benchmark the signaling modes as well; this leaves the CAF
+          ! backend allocated in the winning mode
+          cand_time(i) = gs_tune_caf_signal(gs, tmp, n)
+          caf_signal_tuned = .true.
+       else
+          if (cand(i) .ne. cur) call gs_comm_switch(gs, cand(i))
+          cand_time(i) = gs_time_ops(gs, tmp, n, GS_OP_MIN, GS_TUNE_NTRIALS)
+       end if
+       cur = cand(i)
+    end do
+
+    if (NEKO_BCKND_DEVICE .eq. 1) call device_unmap(tmp, tmp_d)
+    deallocate(tmp)
+
+    call MPI_Allreduce(MPI_IN_PLACE, cand_time, size(cand), &
+         MPI_DOUBLE_PRECISION, MPI_SUM, NEKO_COMM)
+    cand_time = cand_time / pe_size
+
+    best = minloc(cand_time, 1)
+
+    do i = 1, size(cand)
+       label = adjustl(gs_comm_name(cand(i)))
+       ! What the coarray backend costs depends on the signaling mode in
+       ! force, so report the timing under the mode it was measured in
+       if (cand(i) .eq. GS_COMM_CAF .and. gs_caf_mode_get() .ne. 0) then
+          label = 'CAF (' // &
+               trim(adjustl(gs_caf_mode_name(gs_caf_mode_get()))) // ')'
+       end if
+       ! ES10.3 + ' s' fills the same 12 columns as the right-adjusted
+       ! backend names, so the unit lines up with their last letter
+       write(log_buf, '(A,A,ES10.3,A)') label, ': ', cand_time(i), ' s'
+       call neko_log%message(log_buf)
+    end do
+
+    if (cand(best) .ne. cur) call gs_comm_switch(gs, cand(best))
+
+    call neko_log%message('Tuned comm   : ' // gs_comm_name(cand(best)))
+
+    deallocate(cand_time)
+
+  end subroutine gs_tune_comm
+
+  !> Benchmark the coarray signaling modes and bind the fastest one, leaving
+  !! @a gs holding a CAF backend that runs in that mode. Returns the winning
+  !! mode's average time per gather-scatter operation, so the caller can use
+  !! it as the CAF entry of the comm. backend benchmark.
+  !!
+  !! The mode is a program-wide binding shared by every gs_caf_t instance
+  !! and the per-instance state depends on it, so every mode is measured on
+  !! a freshly built backend. As in gs_tune_comm the timings are averaged
+  !! over all ranks before the winner is picked, so every rank binds the
+  !! same mode; the returned time is that rank-invariant average, which the
+  !! caller's own averaging leaves unchanged.
+  !!
+  !! @param gs gather-scatter kernel to tune, left holding a CAF backend
+  !! running in the winning mode
+  !! @param u working vector to operate on
+  !! @param n length of @a u
+  !! @return the winning mode's average wall time (s) per operation
+  function gs_tune_caf_signal(gs, u, n) result(t)
+    type(gs_t), intent(inout) :: gs
+    integer, intent(in) :: n
+    real(kind=rp), dimension(n), intent(inout) :: u
+    real(kind=dp) :: t
+    character(len=LOG_SIZE) :: log_buf
+    character(len=13) :: label
+    integer, allocatable :: mode(:)
+    real(kind=dp), allocatable :: mode_time(:)
+    integer :: i, best
+
+    allocate(mode, source = gs_caf_signal_modes())
+    allocate(mode_time(size(mode)))
+
+    do i = 1, size(mode)
+       ! Bind the mode before building the backend: gs_caf_init sets up its
+       ! per-instance signaling state according to the mode in force
+       call gs_caf_set_mode(mode(i))
+       call gs_comm_switch(gs, GS_COMM_CAF)
+       mode_time(i) = gs_time_ops(gs, u, n, GS_OP_MIN, GS_TUNE_NTRIALS)
+    end do
+
+    call MPI_Allreduce(MPI_IN_PLACE, mode_time, size(mode), &
+         MPI_DOUBLE_PRECISION, MPI_SUM, NEKO_COMM)
+    mode_time = mode_time / pe_size
+
+    best = minloc(mode_time, 1)
+
+    do i = 1, size(mode)
+       label = 'CAF ' // adjustl(gs_caf_mode_name(mode(i)))
+       write(log_buf, '(A,A,ES10.3,A)') label, ': ', mode_time(i), ' s'
+       call neko_log%message(log_buf)
+    end do
+
+    ! The last mode is the one currently allocated
+    if (best .ne. size(mode)) then
+       call gs_caf_set_mode(mode(best))
+       call gs_comm_switch(gs, GS_COMM_CAF)
+    end if
+
+    call neko_log%message('Tuned CAF sig: ' // gs_caf_mode_name(mode(best)))
+
+    t = mode_time(best)
+
+    deallocate(mode, mode_time)
+
+  end function gs_tune_caf_signal
+
+end submodule gs_tune


### PR DESCRIPTION
This PR clean up (refactor) the gs backend autotune to a submodule. Furthermore, since CAF enabled compilers might only support single images, or are not compatible with MPI, the gs CAF backend is excluded from the default set of tuned (and available) host backends.
