### PR TITLE
Print a configuration summary at the end of configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([neko],[1.99.7])
+AC_INIT([neko],[1.99.8])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_MAINTAINER_MODE
 AC_CONFIG_MACRO_DIR([m4])
@@ -158,7 +158,7 @@ fi
 
 if test "x${have_darshan}" != xyes; then
     AX_DARSHAN
-    if test "x${ax_darshan_ok}" != xno; then
+    if test -n "${DARSHAN_LIBS}"; then
         LIBS="$DARSHAN_LIBS $LIBS"
         have_darshan=yes
     else
@@ -368,6 +368,8 @@ fi
 # Checks for OpenSHMEM
 if (test "x${is_cray}" = xyes || test "x${is_hpe_cray}" = xyes); then
    AX_CRAY_SHMEM
+else
+   AX_SHMEM
 fi
 
 
@@ -508,3 +510,184 @@ fi
 AC_CONFIG_FILES([doc/Doxyfile doc/Makefile])
 
 AC_OUTPUT
+
+# ---------------------------------------------------------------------
+# Configuration summary
+#
+# neko_dep <label> <option variable> <found>
+#
+# Prints one entry of the summary of optional dependencies, where
+# <option variable> is the name (not the value) of the variable holding
+# the corresponding --with-*/--enable-* option, or "auto" for
+# dependencies that are always checked for, and <found> the outcome of
+# the check. Anything requested but not found is collected in
+# neko_missing and reported at the end.
+#
+# neko_feature <label> <value>
+#
+# Prints one entry of the summary of (auto detected) compiler features.
+# ---------------------------------------------------------------------
+neko_missing=""
+
+neko_yesno () {
+   neko_val=$1
+   if test "x$neko_val" = x || test "x$neko_val" = xno ||
+      test "x$neko_val" = x0 || test "x$neko_val" = x.false.; then
+      neko_val="no"
+   else
+      neko_val="yes"
+   fi
+}
+
+neko_dep () {
+   if test "x$2" = xauto; then
+      neko_req="auto"
+   else
+      # Anything but an unset variable (option not given) or an explicit
+      # no (--without-foo) counts as requested, including an empty value
+      # as given by e.g. --with-foo= or --with-foo=$UNSET_VARIABLE
+      eval "neko_given=\${$2+set}"
+      eval "neko_reqval=\${$2-}"
+      if test "x$neko_given" != xset || test "x$neko_reqval" = xno; then
+         neko_req="no"
+      else
+         neko_req="yes"
+      fi
+   fi
+
+   neko_yesno "$3"
+   neko_found=$neko_val
+
+   if test "x$neko_req" = xno; then
+      neko_found="-"
+   elif test "x$neko_req" = xyes && test "x$neko_found" = xno; then
+      neko_missing="$neko_missing $1"
+   fi
+
+   printf '    %-30s %-11s %s\n' "$1" "$neko_req" "$neko_found"
+}
+
+neko_feature () {
+   neko_yesno "$2"
+   printf '    %-30s %s\n' "$1" "$neko_val"
+}
+
+# Collect the outcome of checks performed by more than one macro
+neko_hdf5=$have_hdf5
+test "x$have_cray_hdf5" = xyes && neko_hdf5=yes
+
+neko_shmem=$have_openshmem
+test "x$have_cray_shmem" = xyes && neko_shmem=yes
+
+neko_blas=`echo $LAPACK_LIBS $BLAS_LIBS`
+test "x$have_cray_libsci" = xyes && neko_blas="Cray LibSci"
+test -z "$neko_blas" && neko_blas="found in the default libraries"
+
+neko_json=""
+test -n "$PKG_CONFIG" && neko_json=`$PKG_CONFIG --modversion json-fortran 2>/dev/null`
+test -z "$neko_json" && neko_json="yes"
+
+neko_prefix=$prefix
+test "x$neko_prefix" = xNONE && neko_prefix=$ac_default_prefix
+
+# Centre the title inside the horizontal rule, in the style of the
+# section headers printed by Neko itself (see src/common/log.f90)
+neko_width=79
+neko_rule=`printf "%${neko_width}s" "" | tr " " "-"`
+neko_title="Configuration of Neko $PACKAGE_VERSION"
+neko_npre=$(( (neko_width - ${#neko_title} - 2) / 2 ))
+neko_npost=$(( neko_width - neko_npre - ${#neko_title} - 2 ))
+if test $neko_npre -lt 1 || test $neko_npost -lt 1; then
+   neko_head="- $neko_title -"
+else
+   neko_pre=`printf "%${neko_npre}s" "" | tr " " "-"`
+   neko_post=`printf "%${neko_npost}s" "" | tr " " "-"`
+   neko_head="$neko_pre $neko_title $neko_post"
+fi
+
+AS_ECHO([""])
+AS_ECHO(["$neko_head"])
+AS_ECHO([""])
+printf '  %-12s %s\n' "Prefix:" "'$neko_prefix'"
+printf '  %-12s %s\n' "Host:" "$host ($ax_cv_fc_compiler_vendor)"
+printf '  %-12s %s\n' "Fortran:" "$FC${FCFLAGS:+ $FCFLAGS}"
+printf '  %-12s %s\n' "C:" "$CC${CPPFLAGS:+ $CPPFLAGS}${CFLAGS:+ $CFLAGS}"
+printf '  %-12s %s\n' "C++:" "$CXX${CPPFLAGS:+ $CPPFLAGS}${CXXFLAGS:+ $CXXFLAGS}"
+printf '  %-12s %s\n' "Libs:" "${LDFLAGS:+$LDFLAGS }$LIBS"
+AS_ECHO([""])
+AS_ECHO(["  Build configuration:"])
+AS_ECHO([""])
+printf '    %-30s %s\n' "Working precision:" \
+       "$enable_real (rp = $NEKO_REAL_TYPE, xp = $NEKO_XREAL_TYPE)"
+printf '    %-30s %s\n' "Fast memory size (blk_size):" "$blk_size"
+printf '    %-30s %s\n' "Backend:" "$NEKO_BCKND"
+printf '    %-30s %s\n' "Contrib tools:" "$enable_contrib"
+AS_ECHO([""])
+AS_ECHO(["  Compiler and MPI features:"])
+AS_ECHO([""])
+neko_feature "Coarray Fortran:" "$ax_coarray"
+neko_feature "Coarray events:" "$ax_coarray_events"
+neko_feature "MPI Fortran 2008 module:" "$ax_mpif08"
+neko_feature "MPI parameter datatypes:" "$ax_mpi_const_dtype"
+neko_feature "Derived type I/O:" "$ax_dtype_io"
+neko_feature "REAL128:" "$have_real128"
+AS_ECHO([""])
+AS_ECHO(["  Required dependencies:"])
+AS_ECHO([""])
+printf '    %-30s %s\n' "BLAS/LAPACK:" "$neko_blas"
+printf '    %-30s %s\n' "JSON-Fortran:" "$neko_json"
+AS_ECHO([""])
+AS_ECHO(["  Python bindings:"])
+AS_ECHO([""])
+printf '    %-30s %s\n' "Enabled:" "$found_python"
+if test "x${found_python}" = xyes; then
+   printf '    %-30s %s\n' "Interpreter:" "$PYTHON${PYTHON_VERSION:+ ($PYTHON_VERSION)}"
+   # pythondir is expressed in terms of ${PYTHON_PREFIX}, which in turn
+   # is expressed in terms of ${prefix}, hence the repeated expansion
+   neko_pydir=`prefix=$neko_prefix; exec_prefix=$neko_prefix; eval eval echo \"$pythondir\"`
+   printf '    %-30s %s\n' "Install path:" "$neko_pydir"
+fi
+AS_ECHO([""])
+printf '  %-32s %-11s %s\n' "Optional dependencies:" "requested" "found"
+AS_ECHO([""])
+AS_ECHO(["  Parallelism and communication"])
+neko_dep "OpenMP" enable_openmp "$have_openmp"
+neko_dep "Device-aware MPI" enable_device_mpi "$device_mpi"
+neko_dep "NCCL" with_nccl "$have_nccl"
+neko_dep "RCCL" with_rccl "$have_rccl"
+neko_dep "NVSHMEM" with_nvshmem "$have_nvshmem"
+neko_dep "uTofu" with_utofu "$have_utofu"
+neko_dep "OpenSHMEM" with_openshmem "$neko_shmem"
+AS_ECHO([""])
+AS_ECHO(["  Device backends"])
+neko_dep "CUDA" with_cuda "$have_cuda"
+neko_dep "HIP" with_hip "$have_hip"
+neko_dep "OpenCL" with_opencl "$have_opencl"
+neko_dep "Metal" with_metal "$have_metal"
+AS_ECHO([""])
+AS_ECHO(["  Math and partitioning"])
+neko_dep "libxsmm" with_libxsmm "$have_libxsmm"
+neko_dep "ParMETIS" with_parmetis "$found_domain_decomp"
+AS_ECHO([""])
+AS_ECHO(["  I/O and profiling"])
+neko_dep "ADIOS2" with_adios2 "$have_adios2"
+neko_dep "ADIOS2 (Fortran)" with_adios2_fortran "$have_adios2_fortran"
+neko_dep "HDF5" with_hdf5 "$neko_hdf5"
+neko_dep "Darshan" with_darshan_libdir "$have_darshan"
+neko_dep "NVTX" with_nvtx "$have_nvtx"
+neko_dep "ROCTX" with_roctx "$have_roctx"
+AS_ECHO([""])
+AS_ECHO(["  Development tools"])
+neko_dep "pFUnit" auto "$have_pfunit"
+neko_dep "Doxygen" auto "$DOXYGEN"
+neko_dep "graphviz (dot)" auto "$DOXYGEN_DEPS"
+neko_dep "makedepf90" auto "$MAKEDEPF90"
+
+if test -n "$neko_missing"; then
+   AS_ECHO([""])
+   AS_ECHO(["  WARNING: requested but not found:$neko_missing"])
+fi
+
+AS_ECHO([""])
+AS_ECHO(["$neko_rule"])
+AS_ECHO([""])

--- a/configure.ac
+++ b/configure.ac
@@ -659,12 +659,6 @@ neko_dep "NVSHMEM" with_nvshmem "$have_nvshmem"
 neko_dep "uTofu" with_utofu "$have_utofu"
 neko_dep "OpenSHMEM" with_openshmem "$neko_shmem"
 AS_ECHO([""])
-AS_ECHO(["  Device backends"])
-neko_dep "CUDA" with_cuda "$have_cuda"
-neko_dep "HIP" with_hip "$have_hip"
-neko_dep "OpenCL" with_opencl "$have_opencl"
-neko_dep "Metal" with_metal "$have_metal"
-AS_ECHO([""])
 AS_ECHO(["  Math and partitioning"])
 neko_dep "libxsmm" with_libxsmm "$have_libxsmm"
 neko_dep "ParMETIS" with_parmetis "$found_domain_decomp"

--- a/configure.ac
+++ b/configure.ac
@@ -685,3 +685,9 @@ fi
 AS_ECHO([""])
 AS_ECHO(["$neko_rule"])
 AS_ECHO([""])
+
+# Let the caller (e.g. a build script) see that something requested
+# was missing, the warning above says what
+if test -n "$neko_missing"; then
+   AS_EXIT([1])
+fi

--- a/m4/ax_adios.m4
+++ b/m4/ax_adios.m4
@@ -22,12 +22,11 @@ AC_DEFUN([AX_ADIOS2],[
 
 	      ADIOS2_LDFLAGS=`adios2-config --cxx-libs`
 	      LDFLAGS="$ADIOS2_LDFLAGS $LDFLAGS"
-      	      with_adios2=yes
 	      have_adios2=yes
 	      AC_SUBST(have_adios2)
               AC_DEFINE(HAVE_ADIOS2,1,[Define if you have ADIOS2.])
 	    else
-	      with_adios2=no
+	      have_adios2=no
 	    fi
             PATH="$PATH_SAVED"
 	    

--- a/m4/ax_adios2_fortran.m4
+++ b/m4/ax_adios2_fortran.m4
@@ -22,12 +22,11 @@ AC_DEFUN([AX_ADIOS2_FORTRAN],[
 
 	      ADIOS2_FORTRAN_LIBS=`adios2-config --fortran-libs`
 	      LIBS="$ADIOS2_FORTRAN_LIBS $LIBS"
-              with_adios2_fortran=yes
 	      have_adios2_fortran=yes
 	      AC_SUBST(have_adios2_fortran)
               AC_DEFINE(HAVE_ADIOS2_FORTRAN,1,[Define if you want to use ADIOS2 with Fortran bindings.])
 	    else
-	      with_adios2_fortran=no
+	      have_adios2_fortran=no
 	    fi
             PATH="$PATH_SAVED"
 

--- a/m4/ax_libxsmm.m4
+++ b/m4/ax_libxsmm.m4
@@ -17,7 +17,7 @@ AC_DEFUN([AX_LIBXSMM],[
         if test "x${with_libxsmm}" != xno; then
      	   PKG_CHECK_MODULES([libxsmmf], [libxsmmf >= 0.16.1],
 	           	     have_libxsmm=yes xsmm_bcknd="1",
-			     xsmm_bkcnd="0" have_libxsmm=no)
+			     xsmm_bcknd="0" have_libxsmm=no)
 	   if test "x${have_libxsmm}" = xyes; then
 	      NEKO_PKG_FCFLAGS="$NEKO_PKG_FCFLAGS $libxsmmf_CFLAGS"
 	      LIBS="$LIBS $libxsmmf_LIBS"

--- a/m4/ax_shmem.m4
+++ b/m4/ax_shmem.m4
@@ -1,0 +1,68 @@
+#
+# ----------------------------------------------------------------------------
+# "THE BEER-WARE LICENSE" (Revision 42):
+# <njansson@kth.se> wrote this file. As long as you retain this notice you
+# can do whatever you want with this stuff. If we meet some day, and you think
+# this stuff is worth it, you can buy me a beer in return Niclas Jansson
+# ----------------------------------------------------------------------------
+#
+
+AC_DEFUN([AX_SHMEM],[
+	AC_ARG_WITH([openshmem],
+		    AS_HELP_STRING([--with-openshmem=DIR],
+		    [Compile with support for OpenSHMEM]),
+		    [
+		    if test -d "$withval"; then
+		       ac_shmem_path="$withval";
+		       AS_IF([test -d "$ac_shmem_path/lib64"],
+			     [suffix="64"],[suffix=""])
+		       SHMEM_LDFLAGS="-L$ac_shmem_path/lib$suffix"
+		    fi
+		    ], [with_openshmem=no])
+	have_openshmem=no
+	if test "x${with_openshmem}" != xno; then
+	   LDFLAGS_SAVED="$LDFLAGS"
+	   LDFLAGS="$SHMEM_LDFLAGS $LDFLAGS"
+	   export LDFLAGS
+
+	   AC_LANG_PUSH([C])
+
+	   # Sandia OpenSHMEM (SOS) provides libsma, whereas the OSHMEM
+	   # component of Open MPI provides liboshmem. Neko only uses the
+	   # C API (through iso_c_binding), so no Fortran bindings are
+	   # needed from the implementation.
+	   AC_CHECK_LIB([sma], [shmem_init],
+			[have_openshmem=yes; SHMEM_LIBS="-lsma"],
+			[AC_CHECK_LIB([oshmem], [shmem_init],
+				      [have_openshmem=yes
+				       SHMEM_LIBS="-loshmem"],
+				      [have_openshmem=no], [])], [])
+
+	   # The gather-scatter backend relies on the signaling operations
+	   # (put with signal) added in OpenSHMEM 1.5, which are missing in
+	   # implementations that only provide 1.4
+	   if test "x${have_openshmem}" = xyes; then
+	      LIBS_SAVED="$LIBS"
+	      LIBS="$SHMEM_LIBS $LIBS"
+	      have_shmem_signal=yes
+	      AC_CHECK_FUNC([shmem_putmem_signal_nbi], [],
+			    [have_shmem_signal=no])
+	      AC_CHECK_FUNC([shmem_signal_wait_until], [],
+			    [have_shmem_signal=no])
+	      LIBS="$LIBS_SAVED"
+	   fi
+
+	   AC_LANG_POP([C])
+
+	   if test "x${have_openshmem}" != xyes; then
+	      AC_MSG_ERROR([OpenSHMEM requested but neither libsma (SOS) nor liboshmem (Open MPI) was found])
+	   elif test "x${have_shmem_signal}" != xyes; then
+	      AC_MSG_ERROR([OpenSHMEM found, but it lacks the signaling operations (OpenSHMEM 1.5) required by Neko])
+	   else
+	      AC_DEFINE(HAVE_OPENSHMEM, 1, [Define if you have OPENSHMEM.])
+	      LIBS="$SHMEM_LIBS $LIBS"
+	      LDFLAGS="$SHMEM_LDFLAGS $LDFLAGS_SAVED"
+	   fi
+	fi
+	AC_SUBST(have_openshmem)
+])


### PR DESCRIPTION
Based on the disucssions around #2684.

This PR changes `configure` such that it now ends with a summary of the build configuration and every optional dependency, showing both what was _requested_ and what was actually _found_, so a silently missing package no longer goes unnoticed. Anything requested but not found is listed in a closing warning.

An example of the output is given below:
```shell

------------------------ Configuration of Neko 1.99.8 -------------------------

  Prefix:      '/tmp/pkg'
  Host:        aarch64-apple-darwin24.6.0 (gnu)
  Fortran:     /opt/spack/darwin-sequoia-m2/gcc-15.2.0/openmpi-5.0.8-4noidyhfuxyfcjm4jicwbhfzhmlsfemh/bin/mpifort -O3 -std=f2008  -I/opt/gnu/json-fortran/9.0.3/include/
  C:           /opt/spack/darwin-sequoia-m2/gcc-15.2.0/openmpi-5.0.8-4noidyhfuxyfcjm4jicwbhfzhmlsfemh/bin/mpicc -g -O2
  C++:         /opt/spack/darwin-sequoia-m2/gcc-15.2.0/openmpi-5.0.8-4noidyhfuxyfcjm4jicwbhfzhmlsfemh/bin/mpic++ -g -O2
  Libs:        -L/opt/gnu/json-fortran/9.0.3/lib/ -ljsonfortran -llapack -lblas

  Build configuration:

    Working precision:             dp (rp = dp, xp = dp)
    Fast memory size (blk_size):   1024
    Backend:                       CPU
    Contrib tools:                 yes

  Compiler and MPI features:

    Coarray Fortran:               no
    Coarray events:                no
    MPI Fortran 2008 module:       yes
    MPI parameter datatypes:       yes
    Derived type I/O:              yes
    REAL128:                       yes

  Required dependencies:

    BLAS/LAPACK:                   -llapack -lblas
    JSON-Fortran:                  9.0.3

  Python bindings:

    Enabled:                       yes
    Interpreter:                   /usr/bin/python3 (3.9)
    Install path:                  /tmp/pkg/lib/python3.9/site-packages

  Optional dependencies:           requested   found

  Parallelism and communication
    OpenMP                         no          -
    Device-aware MPI               no          -
    NCCL                           no          -
    RCCL                           no          -
    NVSHMEM                        no          -
    uTofu                          no          -
    OpenSHMEM                      no          -

  Device backends
    CUDA                           no          -
    HIP                            no          -
    OpenCL                         no          -
    Metal                          no          -

  Math and partitioning
    libxsmm                        no          -
    ParMETIS                       yes         no

  I/O and profiling
    ADIOS2                         no          -
    ADIOS2 (Fortran)               no          -
    HDF5                           yes         no
    Darshan                        no          -
    NVTX                           no          -
    ROCTX                          no          -

  Development tools
    pFUnit                         auto        no
    Doxygen                        auto        no
    graphviz (dot)                 auto        no
    makedepf90                     auto        yes

  WARNING: requested but not found: ParMETIS HDF5

-------------------------------------------------------------------------------

```
What can be discussed is if one should throw an error instead of a warning at the end. As a rational for a warning, the user might have a script with the arguments for configure, and want to quickly test a configuration by unloading a module for a certain optional dependency. 