### PR TITLE
Add matrix/tensor cores versions of Ax for AMD and NVIDIA accelerators

### DIFF
--- a/doc/man/neko.1.in
+++ b/doc/man/neko.1.in
@@ -122,17 +122,35 @@ Indentation width used by the logger.
 Pins the kernel formulation used by the spectral element operators on the
 CUDA and HIP backends, skipping the auto-tuning search that otherwise runs
 on the first call of each operator. Accepted values are
-.BR 1D " and " KSTEP .
-When unset, each operator benchmarks both formulations, and the geometry
-parameter of each, against the running case and caches the winner.
+.BR 1D ", " KSTEP ", " DMMA " and " MFMA .
+.B DMMA
+applies to the CUDA Helmholtz operator only, scalar and vector, and needs a
+double precision build, a polynomial order with
+.BR 4 " <= " lx " <= " 8
+and an sm_80 or sm_90 device the binary was compiled for.
+.B MFMA
+is its HIP counterpart for the scalar operator, for
+.BR 4 " <= " lx " <= " 12
+on a gfx90a or gfx942 device, in either precision.
+When unset, each operator benchmarks every formulation it has, and the
+geometry parameter of each, against the running case and caches the winner.
 .TP
 .B NEKO_EB_TUNE
 Controls whether the auto-tuner sweeps the number of elements per thread
-block for the kstep kernels. Enabled by default on CUDA, where blocking
-measures a clear gain, and disabled on HIP, where the blocked kernels
-exceed the register budget and spill to scratch. Set to
-.BR 0 " or " 1
-to override the per-backend default.
+block for the kstep kernels. Enabled by default on both backends; where the
+blocked variants exceed the register budget and spill, the tuner measures that
+and rejects them. Set to
+.BR 0
+to skip the sweep.
+.TP
+.B NEKO_MFMA_TUNE
+Controls whether the auto-tuner sweeps the matrix core variant of the HIP
+Helmholtz operator. Enabled by default wherever the device and the polynomial
+order support it. Set to
+.BR 0
+to keep it out of the sweep;
+.B NEKO_AUTOTUNE=MFMA
+still pins it explicitly.
 .TP
 .B NEKO_EB
 Selects the elements-per-block candidate used when the kstep formulation
@@ -156,6 +174,28 @@ are 1024, 512, 256 and 128 threads per block; candidate
 .B 0
 is the historical value. A candidate smaller than one derivative matrix
 is invalid and falls back to 1024. Defaults to
+.BR 0 .
+.TP
+.B NEKO_DMMA_NW
+Selects the warps-per-block candidate used when the fp64 tensor core
+formulation is pinned with
+.BR NEKO_AUTOTUNE=DMMA .
+Candidates
+.BR 0 ", " 1 " and " 2
+are 2, 4 and 8 warps per block. Values outside the valid range fall back to
+.BR 0 .
+Defaults to
+.BR 0 .
+.TP
+.B NEKO_MFMA_NWF
+Selects the wavefronts-per-block candidate used when the matrix core
+formulation is pinned with
+.BR NEKO_AUTOTUNE=MFMA .
+Candidates
+.BR 0 ", " 1 " and " 2
+are 1, 2 and 4 wavefronts per block. Values outside the valid range fall back to
+.BR 0 .
+Defaults to
 .BR 0 .
 .TP
 .B NEKO_TUNE_ROUNDS

--- a/doc/man/neko.1.in
+++ b/doc/man/neko.1.in
@@ -126,8 +126,10 @@ on the first call of each operator. Accepted values are
 .B DMMA
 applies to the CUDA Helmholtz operator only, scalar and vector, and needs a
 double precision build, a polynomial order with
+.BR 2 " <= " lx " <= " 8
+for the scalar operator or
 .BR 4 " <= " lx " <= " 8
-and an sm_80 or sm_90 device the binary was compiled for.
+for the vector one, and an sm_80 or sm_90 device the binary was compiled for.
 .B MFMA
 is its HIP counterpart for the scalar operator, for
 .BR 4 " <= " lx " <= " 12
@@ -192,8 +194,10 @@ Selects the wavefronts-per-block candidate used when the matrix core
 formulation is pinned with
 .BR NEKO_AUTOTUNE=MFMA .
 Candidates
-.BR 0 ", " 1 " and " 2
-are 1, 2 and 4 wavefronts per block. Values outside the valid range fall back to
+.BR 0 " to " 3
+are 1, 2, 4 and 8 wavefronts per block. The count also fixes the elements per
+block: min(nwf, ceil(lx*lx/16)) wavefronts cooperate on one element and the
+block covers the rest. Values outside the valid range fall back to
 .BR 0 .
 Defaults to
 .BR 0 .

--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -15,10 +15,13 @@ of the code. But can be useful for users and developers alike.
 
 | Name                     | Description                                                           | Default value |
 | ------------------------ | --------------------------------------------------------------------- | ------------- |
-| `NEKO_AUTOTUNE`          | Force SEM operator kernel formulation (``'1D'``,``'KSTEP'``)          | Unset         |
-| `NEKO_EB_TUNE`           | Sweep elements per block for the kstep kernels (boolean)              | CUDA: 1, HIP: 0 |
+| `NEKO_AUTOTUNE`          | Force SEM operator kernel formulation (``'1D'``,``'KSTEP'``,``'DMMA'``,``'MFMA'``) | Unset |
+| `NEKO_EB_TUNE`           | Sweep elements per block for the kstep kernels (boolean)              | 1             |
 | `NEKO_EB`                | Elements per block candidate when `NEKO_AUTOTUNE=KSTEP` (0, 1 or 2)   | 0             |
 | `NEKO_CHUNKS`            | Chunk size candidate when `NEKO_AUTOTUNE=1D` (0 to 3)                 | 0             |
+| `NEKO_DMMA_NW`           | Warps per block candidate when `NEKO_AUTOTUNE=DMMA` (0, 1 or 2)       | 0             |
+| `NEKO_MFMA_NWF`          | Wavefronts per block candidate when `NEKO_AUTOTUNE=MFMA` (0 to 3)     | 0             |
+| `NEKO_MFMA_TUNE`         | Sweep the matrix core variant of the HIP Helmholtz operator (boolean) | 1             |
 | `NEKO_TUNE_ROUNDS`       | Interleaved sampling rounds used by the operator auto-tuner           | 3             |
 | `NEKO_TUNE_ITERS`        | Kernel launches timed per candidate per round                        | 100           |
 | `NEKO_LOG_FILE`          | Log file name, uses `stdout` if not set.                              | Unset         |
@@ -48,14 +51,35 @@ what is measured and why the defaults differ between vendors.
   given by `NEKO_CHUNKS`.
 - `NEKO_AUTOTUNE=KSTEP` : always use the kstep variant, with the
   elements per block given by `NEKO_EB`.
+- `NEKO_AUTOTUNE=DMMA`  : always use the fp64 tensor core variant of the
+  CUDA Helmholtz operator, scalar and vector, with the warps per block
+  given by `NEKO_DMMA_NW`. The other operators have no such variant and
+  keep tuning as usual.
+
+- `NEKO_AUTOTUNE=MFMA`  : the HIP counterpart of `DMMA` --- always use the
+  matrix core variant of the HIP Helmholtz operator, with the wavefronts per
+  block given by `NEKO_MFMA_NWF`.
+
+The vector Helmholtz operator has no 1d formulation, so `1D` and `KSTEP`
+both pin it to its kstep variant, and it has no matrix core variant on HIP.
 
 Any other value is reported as an error and the search runs as usual.
+`DMMA` on a build or a device without fp64 tensor cores, or at a
+polynomial order the variant does not cover, is reported the same way.
 
 `NEKO_EB_TUNE` controls whether the elements per block dimension is
-swept at all. It defaults to enabled on CUDA, where blocking measures a
-clear gain, and disabled on HIP, where the blocked kernels exceed the
-register budget and spill to scratch. Setting it to `0` or `1`
-overrides the per-backend default.
+swept at all, and defaults to enabled on both backends. It was once off
+on HIP, where the blocked kernels can exceed the register budget and
+spill to scratch, but fixing that verdict at build time also stopped the
+tuner from ever re-testing it. Where the blocked variants do spill the
+tuner rejects them, so the cost of sweeping is tuning time rather than
+run time. Set it to `0` to skip the sweep.
+
+`NEKO_MFMA_TUNE` is the equivalent switch for the matrix core variant of
+the HIP Helmholtz operator. It defaults to enabled wherever the hardware
+and the polynomial order allow the variant at all; setting it to `0`
+keeps the strategy out of the sweep while leaving
+`NEKO_AUTOTUNE=MFMA` able to pin it explicitly.
 
 `NEKO_CHUNKS` selects among the instantiated chunk sizes when the 1d
 variant is pinned with `NEKO_AUTOTUNE=1D`. Candidates `0` to `3` are
@@ -69,6 +93,12 @@ formulation is pinned with `NEKO_AUTOTUNE=KSTEP`; candidate `0` is one
 element per block, i.e. the unblocked geometry, which makes
 `NEKO_AUTOTUNE=KSTEP` on its own the A/B baseline for the blocking.
 Values outside the valid range fall back to `0`.
+
+`NEKO_DMMA_NW` selects among the instantiated warps per block candidates
+when the tensor core variant is pinned with `NEKO_AUTOTUNE=DMMA`;
+candidates `0`, `1` and `2` are 2, 4 and 8 warps. Values outside the
+valid range fall back to `0`. `NEKO_MFMA_NWF` is the HIP equivalent, with
+candidates `0`, `1` and `2` selecting 1, 2 and 4 wavefronts.
 
 `NEKO_TUNE_ROUNDS` and `NEKO_TUNE_ITERS` control the sampling, and
 apply to *both* sweeps --- they are not specific to the elements per

--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -53,19 +53,23 @@ what is measured and why the defaults differ between vendors.
   elements per block given by `NEKO_EB`.
 - `NEKO_AUTOTUNE=DMMA`  : always use the fp64 tensor core variant of the
   CUDA Helmholtz operator, scalar and vector, with the warps per block
-  given by `NEKO_DMMA_NW`. The other operators have no such variant and
+  given by `NEKO_DMMA_NW`. Double precision only, `2 <= lx <= 8` for the
+  scalar operator and `4 <= lx <= 8` for the vector one, on an sm_80 or
+  sm_90 device. The other operators have no such variant and
   keep tuning as usual.
 
 - `NEKO_AUTOTUNE=MFMA`  : the HIP counterpart of `DMMA` --- always use the
   matrix core variant of the HIP Helmholtz operator, with the wavefronts per
-  block given by `NEKO_MFMA_NWF`.
+  block given by `NEKO_MFMA_NWF`. Either precision, `4 <= lx <= 12`, on a
+  gfx90a or gfx942 device, and for the scalar operator only.
 
 The vector Helmholtz operator has no 1d formulation, so `1D` and `KSTEP`
 both pin it to its kstep variant, and it has no matrix core variant on HIP.
 
 Any other value is reported as an error and the search runs as usual.
-`DMMA` on a build or a device without fp64 tensor cores, or at a
-polynomial order the variant does not cover, is reported the same way.
+`DMMA` on a build or a device without fp64 tensor cores, or `MFMA` on one
+without matrix cores, or either at a polynomial order the variant does not
+cover, is reported the same way.
 
 `NEKO_EB_TUNE` controls whether the elements per block dimension is
 swept at all, and defaults to enabled on both backends. It was once off
@@ -98,7 +102,14 @@ Values outside the valid range fall back to `0`.
 when the tensor core variant is pinned with `NEKO_AUTOTUNE=DMMA`;
 candidates `0`, `1` and `2` are 2, 4 and 8 warps. Values outside the
 valid range fall back to `0`. `NEKO_MFMA_NWF` is the HIP equivalent, with
-candidates `0`, `1` and `2` selecting 1, 2 and 4 wavefronts.
+candidates `0` to `3` selecting 1, 2, 4 and 8 wavefronts per block.
+
+On HIP that count also fixes the elements per block, and the two cannot
+be set independently: `min(nwf, ceil(lx*lx/16))` wavefronts cooperate on
+one element --- that being all the wavefront-parallel work a contraction
+offers --- and the block covers `nwf` divided by that many elements. At
+`lx = 8` the top candidate is eight wavefronts on one element, at `lx = 4`
+it is eight elements with one wavefront each.
 
 `NEKO_TUNE_ROUNDS` and `NEKO_TUNE_ITERS` control the sampling, and
 apply to *both* sweeps --- they are not specific to the elements per

--- a/doc/pages/user-guide/performance.md
+++ b/doc/pages/user-guide/performance.md
@@ -108,7 +108,7 @@ provided (see #case-file).
 On the CUDA and HIP backends the spectral element operators --- the
 Helmholtz operator `Ax`, and `opgrad`, `dudxyz`, `cdtp`, `conv1`,
 `convect_scalar` and `lambda2` --- each ship two kernel formulations,
-and the best one depends on the polynomial order, the element count and
+and `Ax` a third, and the best one depends on the polynomial order, the element count and
 the hardware. Rather than fix a choice at build time, Neko benchmarks
 them on the first call of each operator, using the real element count of
 the running case, and caches the winner for the rest of the run.
@@ -121,32 +121,94 @@ The two formulations are:
   element and marches it in the third direction, holding the column in
   registers.
 
-On CUDA the Helmholtz operator `Ax` ships a third:
+The Helmholtz operator `Ax` ships a third on both backends, which hands
+the six tensor contractions of an element to the matrix units of the
+device rather than to the ordinary FMA pipes:
 
-- the **dmma** variant, which stages a whole element in shared memory
-  padded to `8^3` and hands each of the six tensor contractions to the
-  fp64 tensor cores as an `8 x 64 x 8` GEMM built from `8 x 8 x 4` WMMA
-  tiles. Its geometry parameter is the number of *warps per block* (2, 4
-  or 8), which stripe the eight tiles of a contraction among themselves.
+- the **dmma** variant on CUDA, which stages a cube in shared memory
+  padded to `8^3` and issues each contraction on the fp64 tensor cores as
+  an `8 x 64 x 8` GEMM built from `8 x 8 x 4` WMMA tiles. Its geometry
+  parameter is the number of *warps per block* (2, 4 or 8), which stripe
+  the eight tiles of a contraction among themselves.
+- the **mfma** variant on HIP, which stages the element in LDS and issues
+  each contraction on the matrix cores as a `D * U` GEMM with `M = lx`,
+  `N = lx^2` and `K = lx`. Double precision uses the batched `4x4x4`
+  tile, which is fully utilised in `M` for any `lx < 16`; single
+  precision uses `16x16x4`, there being no `4x4x4` instruction for it.
+  Its geometry parameter is the number of *wavefronts per block* (1, 2,
+  4 or 8).
+
+Padding the dmma cube to `8^3` keeps every tile full, so no lane ever has
+to test an index, but it is exact only at `lx = 8`: at `lx = 4` just 64
+of the 512 points are real and seven eighths of every contraction is
+spent on zeros. Where `lx` divides 8 that waste is turned back into work
+by packing `8/lx` elements along each axis --- `(8/lx)^3` per cube ---
+and making the staged derivative matrix block diagonal, one `lx * lx`
+copy per sub-cube. A contraction along any axis then couples only indices
+within the same sub-cube, so the single padded contraction computes every
+packed element independently and correctly. `lx = 8` packs one element
+and is exactly what it was, `lx = 4` packs eight and `lx = 2` sixty-four,
+none of it costing any extra shared memory. `lx = 3, 5, 6, 7` do not
+divide 8 and keep one element and the old waste. The packing is aimed at
+p-multigrid, which smooths at `lx = 4` and `lx = 2`, so low order `Ax` is
+hot rather than incidental.
+
+The mfma variant has no padding to fill, but it meets the same imbalance
+from the other side: a contraction offers only `ceil(lx^2/16)` column
+groups of wavefront-parallel work --- one at `lx = 4`, four at `lx = 8`,
+nine at `lx = 12` --- so a wavefront beyond that count has no matrix core
+work left on the element. Rather than cap the sweep there, the surplus
+wavefronts are given an element of their own: `wpe = min(nwf,
+ceil(lx^2/16))` wavefronts cooperate on one element and the block covers
+`nwf / wpe` elements, the staging, geometry and write-back passes
+parallelising over the whole block either way. At `lx = 4` with eight
+wavefronts that is eight elements, one each, with nothing idle; at
+`lx = 12` it is one element and eight cooperating wavefronts.
 
 @note The dmma variant only exists where the fp64 tensor cores do: a
-double precision build, `4 <= lx <= 8`, and an sm_80 (A100) or sm_90
-(H100 / GH200) device that the binary was actually compiled for.
-Anywhere else it is not instantiated and the tuner never offers it. It is
-also not a free win to expect: `Ax` is strongly bandwidth bound, roughly
-1.6 flop/byte at `lx = 8` against a ridge point near 9 on GH200, so the
-tensor cores can only pay by relieving shared memory and issue pressure
-rather than by adding flops. Whether they do on a given part is exactly
-what the tuner measures.
+double precision build, `2 <= lx <= 8` for the scalar operator and
+`4 <= lx <= 8` for the vector one, which does not pack, and an sm_80
+(A100) or sm_90 (H100 / GH200) device that the binary was actually
+compiled for. Both the compile time guard and the runtime check
+allow-list those two architectures rather than testing for "at least
+sm_80", because consumer sm_86 / sm_89 assemble the instruction but have
+no fp64 tensor hardware at all. A single precision build has no dmma
+variant, and that is a hardware limit rather than an omission: NVIDIA
+offers no fp32 tensor path, only TF32, whose 11 bit significand (unit
+roundoff `4.9e-4`, against fp32's `6e-8`) is not usable for the operator
+inside a Krylov solve.
+
+@note The mfma variant covers `4 <= lx <= 12` in *both* precisions, on
+gfx90a (MI250X) and gfx942 (MI300A / MI300X), and only for the scalar
+operator --- there is no vector mfma kernel. `v_mfma_f32_16x16x4f32` is
+true IEEE fp32, so a single precision build loses nothing in accuracy
+there; the upper order bound is the LDS needed to keep the staged cubes
+resident, not the instruction. Availability is confirmed by launching a
+probe kernel that reports whether the device pass really was compiled for
+a matrix core architecture, rather than by reading the device properties:
+a code object selected from a fat binary built for something else would
+otherwise turn the strategy into a silent no-op, launching, writing
+nothing, and leaving stale values in the output.
+
+@note Neither variant is a free win to expect. `Ax` is strongly bandwidth
+bound, roughly 1.6 flop/byte at `lx = 8` against a ridge point near 9 on
+GH200, so the matrix units can only pay by relieving shared memory and
+issue pressure rather than by adding flops. The AMD side has already run
+the experiment that removes precision from the argument: with a true fp32
+matrix core, and therefore no accuracy compromise whatsoever, mfma still
+measured 4.5% *behind* a plain 1d kernel at `lx = 8`. Whether either pays
+on a given part is exactly what the tuner measures.
 
 The vector (three component) Helmholtz operator runs its own two-way
 search, reported as a separate `Autotune Ax vector` section: the elements
 per block of its kstep variant against, on CUDA, the warp counts of a
 vector dmma variant. It has no 1d formulation, so `NEKO_AUTOTUNE=1D`
-selects kstep there. Blocking is not expected to pay much for the vector
-kernels --- they sit at 254-255 registers, where a wider block changes
-threads per block but not registers per thread, so it only saves the
-derivative matrix loads --- but it is swept rather than assumed. Because the three components share
+selects kstep there, and no matrix core variant on HIP, where the vector
+search is the elements per block sweep alone. Blocking is not expected
+to pay much for the vector kernels --- they sit at 254-255 registers,
+where a wider block changes threads per block but not registers per
+thread, so it only saves the derivative matrix loads --- but it is swept
+rather than assumed. Because the three components share
 one set of geometric factors, the dmma variant reads them once into
 registers and runs the components through the same staged cubes rather
 than staging twelve of them. On GH200 at `lx = 8` that loses narrowly to
@@ -183,12 +245,26 @@ visible rather than implied:
 
 The chosen line reports only the geometry that applies to the winning
 formulation: an elements-per-block count when kstep wins, a chunk size
-when the 1d variant does, and a warp count when dmma does, which for
-`Ax` on a part with fp64 tensor cores adds lines of the form
+when the 1d variant does, and a warp or wavefront count when a matrix
+core variant does, which for `Ax` on a part that has one adds lines of
+the form
 
 ```
-  DMMA  nw=2   :     10.94 us/call
+  DMMA  2w 8e  :     10.94 us/call
+  DMMA  4w 8e  :     11.62 us/call
 ```
+
+on CUDA, where the second field is the elements packed into one cube, and
+
+```
+  MFMA  4wf 1 e:    136.40 us/call
+  MFMA  8wf 1 e:    136.40 us/call
+```
+
+on HIP, where it is the elements per block that the wavefront count
+implies. The chosen line names the same pair, as
+`Chose        : 3 (DMMA, 2 warps, 8 elem/blk)` or
+`Chose        : 3 (MFMA, 4 wf, 1 elem/block)`.
 
 @note The chunk sweep measures all four sizes rather than predicting a
 best one. Thread utilisation alone suggests the smallest valid block,
@@ -217,9 +293,10 @@ turns the sweep off if the extra tuning time is not wanted.
 
 The tuning behaviour is controlled by the environment variables
 described in the @ref appendices_env-var reference: `NEKO_AUTOTUNE`
-pins a formulation and skips the search entirely, `NEKO_EB_TUNE`
-enables or disables the elements per block sweep, `NEKO_EB`,
-`NEKO_CHUNKS` and `NEKO_DMMA_NW` force a particular geometry when a
+pins a formulation and skips the search entirely, `NEKO_EB_TUNE` and
+`NEKO_MFMA_TUNE` enable or disable the elements per block and matrix
+core sweeps, `NEKO_EB`, `NEKO_CHUNKS`, `NEKO_DMMA_NW` and
+`NEKO_MFMA_NWF` force a particular geometry when a
 formulation is pinned, and
 `NEKO_TUNE_ROUNDS` / `NEKO_TUNE_ITERS` control the sampling of both
 sweeps. All

--- a/doc/pages/user-guide/performance.md
+++ b/doc/pages/user-guide/performance.md
@@ -121,6 +121,39 @@ The two formulations are:
   element and marches it in the third direction, holding the column in
   registers.
 
+On CUDA the Helmholtz operator `Ax` ships a third:
+
+- the **dmma** variant, which stages a whole element in shared memory
+  padded to `8^3` and hands each of the six tensor contractions to the
+  fp64 tensor cores as an `8 x 64 x 8` GEMM built from `8 x 8 x 4` WMMA
+  tiles. Its geometry parameter is the number of *warps per block* (2, 4
+  or 8), which stripe the eight tiles of a contraction among themselves.
+
+@note The dmma variant only exists where the fp64 tensor cores do: a
+double precision build, `4 <= lx <= 8`, and an sm_80 (A100) or sm_90
+(H100 / GH200) device that the binary was actually compiled for.
+Anywhere else it is not instantiated and the tuner never offers it. It is
+also not a free win to expect: `Ax` is strongly bandwidth bound, roughly
+1.6 flop/byte at `lx = 8` against a ridge point near 9 on GH200, so the
+tensor cores can only pay by relieving shared memory and issue pressure
+rather than by adding flops. Whether they do on a given part is exactly
+what the tuner measures.
+
+The vector (three component) Helmholtz operator runs its own two-way
+search, reported as a separate `Autotune Ax vector` section: the elements
+per block of its kstep variant against, on CUDA, the warp counts of a
+vector dmma variant. It has no 1d formulation, so `NEKO_AUTOTUNE=1D`
+selects kstep there. Blocking is not expected to pay much for the vector
+kernels --- they sit at 254-255 registers, where a wider block changes
+threads per block but not registers per thread, so it only saves the
+derivative matrix loads --- but it is swept rather than assumed. Because the three components share
+one set of geometric factors, the dmma variant reads them once into
+registers and runs the components through the same staged cubes rather
+than staging twelve of them. On GH200 at `lx = 8` that loses narrowly to
+kstep --- holding the factors costs occupancy --- so it is there for the
+low order end, where the register cost falls away and the shared memory
+footprint does not.
+
 Within each formulation the tuner also sweeps a geometry parameter. For
 the kstep kernels this is the number of *elements per thread block*: a
 single element is only half a warp at `lx = 4` and two warps at `lx = 8`,
@@ -150,7 +183,12 @@ visible rather than implied:
 
 The chosen line reports only the geometry that applies to the winning
 formulation: an elements-per-block count when kstep wins, a chunk size
-when the 1d variant does.
+when the 1d variant does, and a warp count when dmma does, which for
+`Ax` on a part with fp64 tensor cores adds lines of the form
+
+```
+  DMMA  nw=2   :     10.94 us/call
+```
 
 @note The chunk sweep measures all four sizes rather than predicting a
 best one. Thread utilisation alone suggests the smallest valid block,
@@ -167,20 +205,22 @@ order --- on a machine whose clocks move during the sweep, a fixed order
 biases the comparison by candidate position, which no amount of extra
 iterations removes.
 
-@note The measured ranking differs sharply between vendors. On an
-NVIDIA GH200 the kstep variant wins and benefits from element blocking,
-whereas on AMD MI250X and MI300A the blocked kernels overrun the
-register budget and spill to scratch, so the elements per block sweep is
-**disabled by default on HIP** and enabled on CUDA. The defaults reflect
-measurements on those parts; on a machine that behaves differently,
-`NEKO_EB_TUNE` overrides the choice either way.
+@note The measured ranking differs sharply between vendors, and by more
+than the formulations alone. On an NVIDIA GH200 the kstep variant wins
+and benefits from element blocking; on AMD gfx90a the same family
+measures far worse than the 1d variant at `lx = 8`, and the blocked
+kernels can overrun the register budget and spill to scratch. The
+elements per block sweep is nevertheless enabled on both backends: a
+verdict fixed at build time is one the tuner can never revisit, and
+where the blocked variants do spill it simply rejects them. `NEKO_EB_TUNE`
+turns the sweep off if the extra tuning time is not wanted.
 
 The tuning behaviour is controlled by the environment variables
 described in the @ref appendices_env-var reference: `NEKO_AUTOTUNE`
 pins a formulation and skips the search entirely, `NEKO_EB_TUNE`
-enables or disables the elements per block sweep, `NEKO_EB` and
-`NEKO_CHUNKS` force a particular geometry when a formulation is
-pinned, and
+enables or disables the elements per block sweep, `NEKO_EB`,
+`NEKO_CHUNKS` and `NEKO_DMMA_NW` force a particular geometry when a
+formulation is pinned, and
 `NEKO_TUNE_ROUNDS` / `NEKO_TUNE_ITERS` control the sampling of both
 sweeps. All
 of them are useful mainly for A/B testing; the defaults are intended to

--- a/doc/pages/user-guide/performance.md
+++ b/doc/pages/user-guide/performance.md
@@ -108,10 +108,11 @@ provided (see #case-file).
 On the CUDA and HIP backends the spectral element operators --- the
 Helmholtz operator `Ax`, and `opgrad`, `dudxyz`, `cdtp`, `conv1`,
 `convect_scalar` and `lambda2` --- each ship two kernel formulations,
-and `Ax` a third, and the best one depends on the polynomial order, the element count and
-the hardware. Rather than fix a choice at build time, Neko benchmarks
-them on the first call of each operator, using the real element count of
-the running case, and caches the winner for the rest of the run.
+and `Ax` a third, and the best one depends on the polynomial order, 
+the element count and the hardware. Rather than fix a choice at 
+build time, Neko benchmarks them on the first call of each operator, 
+using the real element count of the running case, and caches 
+the winner for the rest of the run.
 
 The two formulations are:
 

--- a/src/.depends_device
+++ b/src/.depends_device
@@ -12,7 +12,7 @@ math/bcknd/device/hip/opr_opgrad.lo : math/bcknd/device/hip/opr_opgrad.hip math/
 math/bcknd/device/hip/opr_lambda2.lo : math/bcknd/device/hip/opr_lambda2.hip math/bcknd/device/hip/lambda2_kernel.h math/bcknd/device/hip/elem_block.h math/bcknd/device/hip/elem_block_tune.h
 math/bcknd/device/hip/opr_cfl.lo : math/bcknd/device/hip/opr_cfl.hip math/bcknd/device/hip/cfl_kernel.h device/hip/buffer.lo
 math/bcknd/device/hip/opr_rotate_cyc.lo : math/bcknd/device/hip/opr_rotate_cyc.hip math/bcknd/device/hip/rotate_kernel.h
-math/bcknd/device/hip/ax_helm.lo : math/bcknd/device/hip/ax_helm.hip math/bcknd/device/hip/ax_helm_kernel.h math/bcknd/device/hip/elem_block.h math/bcknd/device/hip/elem_block_tune.h
+math/bcknd/device/hip/ax_helm.lo : math/bcknd/device/hip/ax_helm.hip math/bcknd/device/hip/ax_helm_kernel.h math/bcknd/device/hip/elem_block.h math/bcknd/device/hip/elem_block_tune.h math/bcknd/device/hip/mfma_kernel.h
 math/bcknd/device/hip/ax_helm_full.lo : math/bcknd/device/hip/ax_helm_full.hip math/bcknd/device/hip/ax_helm_full_kernel.h
 math/bcknd/device/hip/schwarz.lo : math/bcknd/device/hip/schwarz.hip math/bcknd/device/hip/schwarz_kernel.h
 math/bcknd/device/hip/tensor.lo : math/bcknd/device/hip/tensor.hip math/bcknd/device/hip/tensor_kernel.h
@@ -67,7 +67,7 @@ math/bcknd/device/cuda/opr_opgrad.lo : math/bcknd/device/cuda/opr_opgrad.cu math
 math/bcknd/device/cuda/opr_lambda2.lo : math/bcknd/device/cuda/opr_lambda2.cu math/bcknd/device/cuda/lambda2_kernel.h math/bcknd/device/cuda/elem_block.h math/bcknd/device/cuda/elem_block_tune.h
 math/bcknd/device/cuda/opr_cfl.lo : math/bcknd/device/cuda/opr_cfl.cu math/bcknd/device/cuda/cfl_kernel.h device/cuda/buffer.lo
 math/bcknd/device/cuda/opr_rotate_cyc.lo : math/bcknd/device/cuda/opr_rotate_cyc.cu math/bcknd/device/cuda/rotate_kernel.h
-math/bcknd/device/cuda/ax_helm.lo : math/bcknd/device/cuda/ax_helm.cu math/bcknd/device/cuda/ax_helm_kernel.h math/bcknd/device/cuda/elem_block.h math/bcknd/device/cuda/elem_block_tune.h
+math/bcknd/device/cuda/ax_helm.lo : math/bcknd/device/cuda/ax_helm.cu math/bcknd/device/cuda/ax_helm_kernel.h math/bcknd/device/cuda/elem_block.h math/bcknd/device/cuda/elem_block_tune.h math/bcknd/device/cuda/dmma_kernel.h
 math/bcknd/device/cuda/ax_helm_full.lo : math/bcknd/device/cuda/ax_helm_full.cu math/bcknd/device/cuda/ax_helm_full_kernel.h
 math/bcknd/device/cuda/schwarz.lo : math/bcknd/device/cuda/schwarz.cu math/bcknd/device/cuda/schwarz_kernel.h
 math/bcknd/device/cuda/tensor.lo : math/bcknd/device/cuda/tensor.cu math/bcknd/device/cuda/tensor_kernel.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1011,6 +1011,7 @@ EXTRA_DIST = \
 	math/bcknd/device/cuda/rotate_kernel.h\
 	math/bcknd/device/cuda/ax_helm_kernel.h\
 	math/bcknd/device/cuda/ax_helm_full_kernel.h\
+	math/bcknd/device/cuda/dmma_kernel.h\
 	math/bcknd/device/cuda/elem_block.h\
 	math/bcknd/device/cuda/elem_block_tune.h\
 	common/bcknd/device/cuda/sumab_kernel.h\
@@ -1067,6 +1068,7 @@ EXTRA_DIST = \
 	math/bcknd/device/hip/rotate_kernel.h\
 	math/bcknd/device/hip/ax_helm_kernel.h\
 	math/bcknd/device/hip/ax_helm_full_kernel.h\
+	math/bcknd/device/hip/mfma_kernel.h\
 	math/bcknd/device/hip/elem_block.h\
 	math/bcknd/device/hip/elem_block_tune.h\
 	common/bcknd/device/hip/sumab_kernel.h\

--- a/src/math/bcknd/device/cuda/ax_helm.cu
+++ b/src/math/bcknd/device/cuda/ax_helm.cu
@@ -92,7 +92,6 @@ extern "C" {
     static int autotune_nw[17] = { 0 };
 
     const dim3 nblcks_1d((*nelv), 1, 1);
-    const dim3 nblcks_dmma((*nelv), 1, 1);
     const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
 #define CASE_1D(LX, C)                                                          \
@@ -149,11 +148,11 @@ extern "C" {
 
 #define CASE_DMMA(LX, C)                                                        \
     ax_helm_kernel_dmma<real, LX, NEKO_DMMA_NW(C)>                              \
-      <<<nblcks_dmma, NEKO_DMMA_NTHRDS(C), 0, stream>>>                         \
+      <<<NEKO_DMMA_NBLCKS(*nelv, LX), NEKO_DMMA_NTHRDS(C), 0, stream>>>         \
                           ((real *) w, (real *) u,                              \
                            (real *) dx, (real *) dy, (real *) dz, (real *) h1,  \
                            (real *) g11, (real *) g22, (real *) g33,            \
-                           (real *) g12, (real *) g13, (real *) g23);           \
+                           (real *) g12, (real *) g13, (real *) g23, *nelv);    \
       CUDA_CHECK(cudaGetLastError());
 
 /* Runtime dispatch onto the tuned warps per block candidate */
@@ -445,7 +444,6 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
   }
 
   const dim3 nblcks_1d((*nelv), 1, 1);
-  const dim3 nblcks_dmma((*nelv), 1, 1);
   const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
   char *env_value = NULL;
@@ -540,7 +538,7 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
   }
 
   NEKO_TUNE_LOG(LX, time1, time2);
-  NEKO_TUNE_LOG_DMMA(time3);
+  NEKO_TUNE_LOG_DMMA(LX, time3);
 
   NEKO_TUNE_BEST(time1, best1, NEKO_CHUNKS_CANDIDATES);
   NEKO_TUNE_BEST(time2, best, NEKO_EB_CANDIDATES);
@@ -581,8 +579,8 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
     sprintf(neko_log_buf, "Chose        : 2 (KSTEP, %d elem/block)",
             NEKO_EB_SEL(LX, best));
   } else {
-    sprintf(neko_log_buf, "Chose        : 3 (DMMA, %d warps)",
-            NEKO_DMMA_NW(best3));
+    sprintf(neko_log_buf, "Chose        : 3 (DMMA, %d warps, %d elem/blk)",
+            NEKO_DMMA_NW(best3), NEKO_DMMA_PACK(LX));
   }
   log_message(neko_log_buf);
   log_end_section();
@@ -619,7 +617,6 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
   }
 
   const dim3 nblcks_1d((*nelv), 1, 1);
-  const dim3 nblcks_dmma((*nelv), 1, 1);
   const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
   char *env_value = NULL;
@@ -714,7 +711,7 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
   }
 
   NEKO_TUNE_LOG(LX, time1, time2);
-  NEKO_TUNE_LOG_DMMA(time3);
+  NEKO_TUNE_LOG_DMMA(LX, time3);
 
   NEKO_TUNE_BEST(time1, best1, NEKO_CHUNKS_CANDIDATES);
   NEKO_TUNE_BEST(time2, best, NEKO_EB_CANDIDATES);
@@ -754,8 +751,8 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
     sprintf(neko_log_buf, "Chose        : 2 (KSTEP, %d elem/block)",
             NEKO_EB_SEL(LX, best));
   } else {
-    sprintf(neko_log_buf, "Chose        : 3 (DMMA, %d warps)",
-            NEKO_DMMA_NW(best3));
+    sprintf(neko_log_buf, "Chose        : 3 (DMMA, %d warps, %d elem/blk)",
+            NEKO_DMMA_NW(best3), NEKO_DMMA_PACK(LX));
   }
   log_message(neko_log_buf);
   log_end_section();
@@ -882,7 +879,7 @@ int tune_vector(void *au, void *av, void *aw, void *u, void *v, void *w,
             NEKO_EB_SEL(LX, c), time2[c] * 10.0);
     log_message(neko_log_buf);
   }
-  NEKO_TUNE_LOG_DMMA(time3);
+  NEKO_TUNE_LOG_DMMA(LX, time3);
 
   NEKO_TUNE_BEST(time2, best2, NEKO_EB_CANDIDATES);
   NEKO_TUNE_BEST(time3, best3, NEKO_DMMA_CANDIDATES);
@@ -903,8 +900,8 @@ int tune_vector(void *au, void *av, void *aw, void *u, void *v, void *w,
             NEKO_EB_SEL(LX, best2));
   } else {
     CASE_VECTOR_DMMA_SEL(LX, best3);
-    sprintf(neko_log_buf, "Chose        : 3 (DMMA, %d warps)",
-            NEKO_DMMA_NW(best3));
+    sprintf(neko_log_buf, "Chose        : 3 (DMMA, %d warps, %d elem/blk)",
+            NEKO_DMMA_NW(best3), NEKO_DMMA_PACK(LX));
   }
   log_message(neko_log_buf);
   log_end_section();
@@ -1016,7 +1013,7 @@ int tune_vector_padded(void *au, void *av, void *aw, void *u, void *v, void *w,
             NEKO_EB_SEL(LX, c), time2[c] * 10.0);
     log_message(neko_log_buf);
   }
-  NEKO_TUNE_LOG_DMMA(time3);
+  NEKO_TUNE_LOG_DMMA(LX, time3);
 
   NEKO_TUNE_BEST(time2, best2, NEKO_EB_CANDIDATES);
   NEKO_TUNE_BEST(time3, best3, NEKO_DMMA_CANDIDATES);
@@ -1035,8 +1032,8 @@ int tune_vector_padded(void *au, void *av, void *aw, void *u, void *v, void *w,
             NEKO_EB_SEL(LX, best2));
   } else {
     CASE_VECTOR_DMMA_SEL(LX, best3);
-    sprintf(neko_log_buf, "Chose        : 3 (DMMA, %d warps)",
-            NEKO_DMMA_NW(best3));
+    sprintf(neko_log_buf, "Chose        : 3 (DMMA, %d warps, %d elem/blk)",
+            NEKO_DMMA_NW(best3), NEKO_DMMA_PACK(LX));
   }
   log_message(neko_log_buf);
   log_end_section();

--- a/src/math/bcknd/device/cuda/ax_helm.cu
+++ b/src/math/bcknd/device/cuda/ax_helm.cu
@@ -789,7 +789,7 @@ int tune_vector(void *au, void *av, void *aw, void *u, void *v, void *w,
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
   const int sweep = neko_eb_sweep();
-  const bool dmma = dmma_lx_supported<LX>() && cuda_have_dmma();
+  const bool dmma = dmma_vector_lx_supported<LX>() && cuda_have_dmma();
   int retval;
 
   for (int c = 0; c < NEKO_EB_CANDIDATES; c++) {
@@ -923,7 +923,7 @@ int tune_vector_padded(void *au, void *av, void *aw, void *u, void *v, void *w,
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
   const int sweep = neko_eb_sweep();
-  const bool dmma = dmma_lx_supported<LX>() && cuda_have_dmma();
+  const bool dmma = dmma_vector_lx_supported<LX>() && cuda_have_dmma();
   int retval;
 
   for (int c = 0; c < NEKO_EB_CANDIDATES; c++) {

--- a/src/math/bcknd/device/cuda/ax_helm.cu
+++ b/src/math/bcknd/device/cuda/ax_helm.cu
@@ -48,13 +48,29 @@ template < const int>
 int tune(void *w, void *u, void *dx, void *dy, void *dz,
          void *dxt, void *dyt, void *dzt, void *h1,
          void *g11, void *g22, void *g33, void *g12,
-         void *g13, void *g23, int *nelv, int *lx, int *eb_sel, int *ch_sel);
+         void *g13, void *g23, int *nelv, int *lx,
+         int *eb_sel, int *ch_sel, int *nw_sel);
 
 template < const int>
 int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
                 void *dxt, void *dyt, void *dzt, void *h1,
                 void *g11, void *g22, void *g33, void *g12,
-                void *g13, void *g23, int *nelv, int *lx, int *eb_sel, int *ch_sel);
+                void *g13, void *g23, int *nelv, int *lx,
+                int *eb_sel, int *ch_sel, int *nw_sel);
+
+template < const int>
+int tune_vector(void *au, void *av, void *aw, void *u, void *v, void *w,
+                void *dx, void *dy, void *dz, void *h1,
+                void *g11, void *g22, void *g33, void *g12,
+                void *g13, void *g23, int *nelv, int *lx,
+                int *eb_sel, int *nw_sel);
+
+template < const int>
+int tune_vector_padded(void *au, void *av, void *aw, void *u, void *v, void *w,
+                       void *dx, void *dy, void *dz, void *h1,
+                       void *g11, void *g22, void *g33, void *g12,
+                       void *g13, void *g23, int *nelv, int *lx,
+                int *eb_sel, int *nw_sel);
 
 extern "C" {
 
@@ -72,9 +88,11 @@ extern "C" {
     static int autotune_eb[17] = { 0 };
     /* chunk candidate chosen for the 1d variant */
     static int autotune_ch[17] = { 0 };
+    /* warps per block candidate chosen for the dmma variant */
+    static int autotune_nw[17] = { 0 };
 
-    const dim3 nthrds_1d(1024, 1, 1);
     const dim3 nblcks_1d((*nelv), 1, 1);
+    const dim3 nblcks_dmma((*nelv), 1, 1);
     const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
 #define CASE_1D(LX, C)                                                          \
@@ -129,6 +147,23 @@ extern "C" {
     default: CASE_KSTEP_PADDED(LX, 2); break;                                   \
     }
 
+#define CASE_DMMA(LX, C)                                                        \
+    ax_helm_kernel_dmma<real, LX, NEKO_DMMA_NW(C)>                              \
+      <<<nblcks_dmma, NEKO_DMMA_NTHRDS(C), 0, stream>>>                         \
+                          ((real *) w, (real *) u,                              \
+                           (real *) dx, (real *) dy, (real *) dz, (real *) h1,  \
+                           (real *) g11, (real *) g22, (real *) g33,            \
+                           (real *) g12, (real *) g13, (real *) g23);           \
+      CUDA_CHECK(cudaGetLastError());
+
+/* Runtime dispatch onto the tuned warps per block candidate */
+#define CASE_DMMA_SEL(LX, SEL)                                                  \
+    switch (SEL) {                                                              \
+    case 0:  CASE_DMMA(LX, 0); break;                                           \
+    case 1:  CASE_DMMA(LX, 1); break;                                           \
+    default: CASE_DMMA(LX, 2); break;                                           \
+    }
+
 #define CASE(LX)                                                                \
     case LX:                                                                    \
       if(autotune[LX] == 0 ) {                                                  \
@@ -137,11 +172,14 @@ extern "C" {
                                dxt, dyt, dzt,h1,                                \
                                g11, g22, g33,                                   \
                                g12, g13, g23, nelv, lx,                         \
-                               &autotune_eb[LX], &autotune_ch[LX]);             \
+                               &autotune_eb[LX], &autotune_ch[LX],              \
+                               &autotune_nw[LX]);                               \
       } else if (autotune[LX] == 1 ) {                                          \
         CASE_1D_SEL(LX, autotune_ch[LX]);                                       \
       } else if (autotune[LX] == 2 ) {                                          \
         CASE_KSTEP_SEL(LX, autotune_eb[LX]);                                    \
+      } else if (autotune[LX] == 3 ) {                                          \
+        CASE_DMMA_SEL(LX, autotune_nw[LX]);                                     \
       }                                                                         \
       break
 
@@ -153,11 +191,14 @@ extern "C" {
                                      dxt, dyt, dzt,h1,                          \
                                      g11, g22, g33,                             \
                                      g12, g13, g23,nelv,lx,                     \
-                                     &autotune_eb[LX], &autotune_ch[LX]);       \
+                                     &autotune_eb[LX], &autotune_ch[LX],        \
+                                     &autotune_nw[LX]);                         \
       } else if (autotune[LX] == 1 ) {                                          \
         CASE_1D_SEL(LX, autotune_ch[LX]);                                       \
       } else if (autotune[LX] == 2 ) {                                          \
         CASE_KSTEP_PADDED_SEL(LX, autotune_eb[LX]);                             \
+      } else if (autotune[LX] == 3 ) {                                          \
+        CASE_DMMA_SEL(LX, autotune_nw[LX]);                                     \
       }                                                                         \
       break
 
@@ -222,20 +263,31 @@ extern "C" {
                            void *g33, void *g12, void *g13,
                            void *g23, int *nelv, int *lx) {
 
+    /* Strategy chosen by the autotuner: 2 kstep, 3 dmma */
+    static int autotune_vec[17] = { 0 };
+    /* elements per block candidate chosen for the kstep variant */
+    static int autotune_vec_eb[17] = { 0 };
+    /* warps per block candidate chosen for the dmma variant */
+    static int autotune_vec_nw[17] = { 0 };
+
+    const dim3 nblcks_dmma((*nelv), 1, 1);
     const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
 /*
- * The vector kernels are not swept by the autotuner, see the note on
- * NEKO_AX_HELM_VECTOR_EB_C in ax_helm_kernel.h
+ * The vector kstep variant sweeps the same elements per block candidates as
+ * the scalar one, and the tuner picks between it and the dmma variant. The
+ * vector kernels hold three times the register blocked state -- six T[LX]
+ * arrays rather than two -- and measure at 254-255 registers on sm_90 for
+ * every lx from 8 up, spilling at 10, 12, 14 and 16, so blocking is not
+ * expected to buy much here: it does not change registers per thread, only
+ * threads per block, so it saves the derivative matrix loads and nothing
+ * else. It is swept rather than assumed because that is a measurement, and
+ * because elem_block<>'s thread clamp already keeps every candidate inside
+ * the shared memory budget at every lx.
  */
-#define AX_VEC_EB(LX) (elem_block<LX, NEKO_AX_HELM_VECTOR_EB_C>::value)
-#define AX_VEC_NTHRDS(LX) dim3((LX), (LX), AX_VEC_EB(LX))
-#define AX_VEC_NBLCKS(LX)                                                      \
-    dim3(((*nelv) + AX_VEC_EB(LX) - 1)/AX_VEC_EB(LX), 1, 1)
-
-#define CASE_VECTOR_KSTEP(LX)                                                  \
-    ax_helm_kernel_vector_kstep<real, LX, AX_VEC_EB(LX)>                       \
-    <<<AX_VEC_NBLCKS(LX), AX_VEC_NTHRDS(LX), 0, stream>>>                      \
+#define CASE_VECTOR_KSTEP(LX, C)                                               \
+    ax_helm_kernel_vector_kstep<real, LX, NEKO_EB(LX, C)>                      \
+    <<<NEKO_EB_NBLCKS(*nelv, LX, C), NEKO_EB_NTHRDS(LX, C), 0, stream>>>       \
                                     ((real *) au, (real *) av, (real *) aw,    \
                                      (real *) u, (real *) v, (real *) w,       \
                                      (real *) dx, (real *) dy, (real *) dz,    \
@@ -244,9 +296,9 @@ extern "C" {
                                      (real *) g23, *nelv);                     \
     CUDA_CHECK(cudaGetLastError());
 
-#define CASE_VECTOR_KSTEP_PADDED(LX)                                           \
-    ax_helm_kernel_vector_kstep_padded<real, LX, AX_VEC_EB(LX)>                \
-    <<<AX_VEC_NBLCKS(LX), AX_VEC_NTHRDS(LX), 0, stream>>>                      \
+#define CASE_VECTOR_KSTEP_PADDED(LX, C)                                        \
+    ax_helm_kernel_vector_kstep_padded<real, LX, NEKO_EB(LX, C)>               \
+    <<<NEKO_EB_NBLCKS(*nelv, LX, C), NEKO_EB_NTHRDS(LX, C), 0, stream>>>       \
                                     ((real *) au, (real *) av, (real *) aw,    \
                                      (real *) u, (real *) v, (real *) w,       \
                                      (real *) dx, (real *) dy, (real *) dz,    \
@@ -254,15 +306,71 @@ extern "C" {
                                      (real *) g33, (real *) g12, (real *) g13, \
                                      (real *) g23, *nelv);                     \
     CUDA_CHECK(cudaGetLastError());
+
+/* Runtime dispatch onto the tuned elements per block candidate */
+#define CASE_VECTOR_KSTEP_SEL(LX, SEL)                                         \
+    switch (SEL) {                                                             \
+    case 0:  CASE_VECTOR_KSTEP(LX, 0); break;                                  \
+    case 1:  CASE_VECTOR_KSTEP(LX, 1); break;                                  \
+    default: CASE_VECTOR_KSTEP(LX, 2); break;                                  \
+    }
+
+#define CASE_VECTOR_KSTEP_PADDED_SEL(LX, SEL)                                  \
+    switch (SEL) {                                                             \
+    case 0:  CASE_VECTOR_KSTEP_PADDED(LX, 0); break;                           \
+    case 1:  CASE_VECTOR_KSTEP_PADDED(LX, 1); break;                           \
+    default: CASE_VECTOR_KSTEP_PADDED(LX, 2); break;                           \
+    }
+
+#define CASE_VECTOR_DMMA(LX, C)                                                \
+    ax_helm_kernel_dmma_vector<real, LX, NEKO_DMMA_NW(C)>                      \
+    <<<nblcks_dmma, NEKO_DMMA_NTHRDS(C), 0, stream>>>                          \
+                                    ((real *) au, (real *) av, (real *) aw,    \
+                                     (real *) u, (real *) v, (real *) w,       \
+                                     (real *) dx, (real *) dy, (real *) dz,    \
+                                     (real *) h1, (real *) g11, (real *) g22,  \
+                                     (real *) g33, (real *) g12, (real *) g13, \
+                                     (real *) g23);                            \
+    CUDA_CHECK(cudaGetLastError());
+
+/* Runtime dispatch onto the tuned warps per block candidate */
+#define CASE_VECTOR_DMMA_SEL(LX, SEL)                                          \
+    switch (SEL) {                                                             \
+    case 0:  CASE_VECTOR_DMMA(LX, 0); break;                                   \
+    case 1:  CASE_VECTOR_DMMA(LX, 1); break;                                   \
+    default: CASE_VECTOR_DMMA(LX, 2); break;                                   \
+    }
 
 #define CASE_VECTOR(LX)                                                        \
     case LX:                                                                   \
-      CASE_VECTOR_KSTEP(LX);                                                   \
+      if (autotune_vec[LX] == 0 ) {                                            \
+        autotune_vec[LX] = tune_vector<LX>(au, av, aw, u, v, w,                \
+                                           dx, dy, dz, h1,                     \
+                                           g11, g22, g33, g12, g13, g23,       \
+                                           nelv, lx, &autotune_vec_eb[LX],     \
+                                           &autotune_vec_nw[LX]);              \
+      } else if (autotune_vec[LX] == 2 ) {                                     \
+        CASE_VECTOR_KSTEP_SEL(LX, autotune_vec_eb[LX]);                        \
+      } else if (autotune_vec[LX] == 3 ) {                                     \
+        CASE_VECTOR_DMMA_SEL(LX, autotune_vec_nw[LX]);                         \
+      }                                                                        \
        break
 
 #define CASE_VECTOR_PADDED(LX)                                                 \
     case LX:                                                                   \
-      CASE_VECTOR_KSTEP_PADDED(LX);                                            \
+      if (autotune_vec[LX] == 0 ) {                                            \
+        autotune_vec[LX] = tune_vector_padded<LX>(au, av, aw, u, v, w,         \
+                                                  dx, dy, dz, h1,              \
+                                                  g11, g22, g33,               \
+                                                  g12, g13, g23,               \
+                                                  nelv, lx,                    \
+                                                  &autotune_vec_eb[LX],        \
+                                                  &autotune_vec_nw[LX]);       \
+      } else if (autotune_vec[LX] == 2 ) {                                     \
+        CASE_VECTOR_KSTEP_PADDED_SEL(LX, autotune_vec_eb[LX]);                 \
+      } else if (autotune_vec[LX] == 3 ) {                                     \
+        CASE_VECTOR_DMMA_SEL(LX, autotune_vec_nw[LX]);                         \
+      }                                                                        \
        break
 
     switch(*lx) {
@@ -311,14 +419,18 @@ template < const int LX >
 int tune(void *w, void *u, void *dx, void *dy, void *dz,
          void *dxt, void *dyt, void *dzt, void *h1,
          void *g11, void *g22, void *g33, void *g12,
-         void *g13, void *g23, int *nelv, int *lx, int *eb_sel, int *ch_sel) {
+         void *g13, void *g23, int *nelv, int *lx,
+         int *eb_sel, int *ch_sel, int *nw_sel) {
   cudaEvent_t start,stop;
   float time1[NEKO_CHUNKS_CANDIDATES];
   int best1 = 0;
   float time2[NEKO_EB_CANDIDATES];
+  float time3[NEKO_DMMA_CANDIDATES];
+  int best3 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
   const int sweep = neko_eb_sweep();
+  const bool dmma = dmma_lx_supported<LX>() && cuda_have_dmma();
   int best = 0;
   int retval;
 
@@ -328,9 +440,12 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
   for (int c = 0; c < NEKO_CHUNKS_CANDIDATES; c++) {
     time1[c] = NEKO_TUNE_INIT;
   }
+  for (int c = 0; c < NEKO_DMMA_CANDIDATES; c++) {
+    time3[c] = NEKO_TUNE_INIT;
+  }
 
-  const dim3 nthrds_1d(1024, 1, 1);
   const dim3 nblcks_1d((*nelv), 1, 1);
+  const dim3 nblcks_dmma((*nelv), 1, 1);
   const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
   char *env_value = NULL;
@@ -362,6 +477,20 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
       log_message(neko_log_buf);
       log_end_section();
       return 2;
+    } else if( !strcmp(env_value,"DMMA") ) {
+      if (dmma) {
+        const int c = neko_dmma_env();
+        *nw_sel = c;
+        CASE_DMMA_SEL(LX, c);
+        sprintf(neko_log_buf,"Set by env   : 3 (DMMA, %d warps)",
+                NEKO_DMMA_NW(c));
+        log_message(neko_log_buf);
+        log_end_section();
+        return 3;
+      } else {
+        sprintf(neko_log_buf, "DMMA strategy not available for this config");
+        log_error(neko_log_buf);
+      }
     } else {
        sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
        log_error(neko_log_buf);
@@ -384,6 +513,11 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
       CASE_KSTEP(LX, 1);
       CASE_KSTEP(LX, 2);
     }
+    if (dmma) {
+      CASE_DMMA(LX, 0);
+      CASE_DMMA(LX, 1);
+      CASE_DMMA(LX, 2);
+    }
   }
 
   /* Interleaved rounds, best time per variant: timing them one after another
@@ -398,19 +532,33 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
       NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 1, iters);
       NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 2, iters);
     }
+    if (dmma) {
+      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 0, iters);
+      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 1, iters);
+      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 2, iters);
+    }
   }
 
   NEKO_TUNE_LOG(LX, time1, time2);
+  NEKO_TUNE_LOG_DMMA(time3);
 
   NEKO_TUNE_BEST(time1, best1, NEKO_CHUNKS_CANDIDATES);
   NEKO_TUNE_BEST(time2, best, NEKO_EB_CANDIDATES);
+  NEKO_TUNE_BEST(time3, best3, NEKO_DMMA_CANDIDATES);
   *eb_sel = best;
   *ch_sel = best1;
+  *nw_sel = best3;
 
   if (time1[best1] < time2[best]) {
-     retval = 1;
+    retval = 1;
   } else {
     retval = 2;
+  }
+
+  /* The dmma variant joins the comparison only where it exists, its
+     candidates are left at NEKO_TUNE_INIT otherwise */
+  if (time3[best3] < ((retval == 1) ? time1[best1] : time2[best])) {
+    retval = 3;
   }
 
   cudaEventDestroy(start);
@@ -420,16 +568,21 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
      sum in the same order, so leave the output of the chosen kernel in w */
   if (retval == 1) {
     CASE_1D_SEL(LX, best1);
-  } else {
+  } else if (retval == 2) {
     CASE_KSTEP_SEL(LX, best);
+  } else {
+    CASE_DMMA_SEL(LX, best3);
   }
 
   if (retval == 1) {
     sprintf(neko_log_buf, "Chose        : 1 (1D, %d chunk)",
             NEKO_CHUNKS_SEL(LX, best1));
-  } else {
+  } else if (retval == 2) {
     sprintf(neko_log_buf, "Chose        : 2 (KSTEP, %d elem/block)",
             NEKO_EB_SEL(LX, best));
+  } else {
+    sprintf(neko_log_buf, "Chose        : 3 (DMMA, %d warps)",
+            NEKO_DMMA_NW(best3));
   }
   log_message(neko_log_buf);
   log_end_section();
@@ -440,14 +593,18 @@ template < const int LX >
 int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
                 void *dxt, void *dyt, void *dzt, void *h1,
                 void *g11, void *g22, void *g33, void *g12,
-                void *g13, void *g23, int *nelv, int *lx, int *eb_sel, int *ch_sel) {
+                void *g13, void *g23, int *nelv, int *lx,
+                int *eb_sel, int *ch_sel, int *nw_sel) {
   cudaEvent_t start, stop;
   float time1[NEKO_CHUNKS_CANDIDATES];
   int best1 = 0;
   float time2[NEKO_EB_CANDIDATES];
+  float time3[NEKO_DMMA_CANDIDATES];
+  int best3 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
   const int sweep = neko_eb_sweep();
+  const bool dmma = dmma_lx_supported<LX>() && cuda_have_dmma();
   int best = 0;
   int retval;
 
@@ -457,9 +614,12 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
   for (int c = 0; c < NEKO_CHUNKS_CANDIDATES; c++) {
     time1[c] = NEKO_TUNE_INIT;
   }
+  for (int c = 0; c < NEKO_DMMA_CANDIDATES; c++) {
+    time3[c] = NEKO_TUNE_INIT;
+  }
 
-  const dim3 nthrds_1d(1024, 1, 1);
   const dim3 nblcks_1d((*nelv), 1, 1);
+  const dim3 nblcks_dmma((*nelv), 1, 1);
   const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
   char *env_value = NULL;
@@ -491,6 +651,20 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
       log_message(neko_log_buf);
       log_end_section();
       return 2;
+    } else if( !strcmp(env_value,"DMMA") ) {
+      if (dmma) {
+        const int c = neko_dmma_env();
+        *nw_sel = c;
+        CASE_DMMA_SEL(LX, c);
+        sprintf(neko_log_buf,"Set by env   : 3 (DMMA, %d warps)",
+                NEKO_DMMA_NW(c));
+        log_message(neko_log_buf);
+        log_end_section();
+        return 3;
+      } else {
+        sprintf(neko_log_buf, "DMMA strategy not available for this config");
+        log_error(neko_log_buf);
+      }
     } else {
       sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
       log_error(neko_log_buf);
@@ -513,6 +687,11 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
       CASE_KSTEP_PADDED(LX, 1);
       CASE_KSTEP_PADDED(LX, 2);
     }
+    if (dmma) {
+      CASE_DMMA(LX, 0);
+      CASE_DMMA(LX, 1);
+      CASE_DMMA(LX, 2);
+    }
   }
 
   /* Interleaved rounds, best time per variant: timing them one after another
@@ -527,19 +706,33 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
       NEKO_TUNE_TIME(time2, CASE_KSTEP_PADDED, LX, 1, iters);
       NEKO_TUNE_TIME(time2, CASE_KSTEP_PADDED, LX, 2, iters);
     }
+    if (dmma) {
+      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 0, iters);
+      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 1, iters);
+      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 2, iters);
+    }
   }
 
   NEKO_TUNE_LOG(LX, time1, time2);
+  NEKO_TUNE_LOG_DMMA(time3);
 
   NEKO_TUNE_BEST(time1, best1, NEKO_CHUNKS_CANDIDATES);
   NEKO_TUNE_BEST(time2, best, NEKO_EB_CANDIDATES);
+  NEKO_TUNE_BEST(time3, best3, NEKO_DMMA_CANDIDATES);
   *eb_sel = best;
   *ch_sel = best1;
+  *nw_sel = best3;
 
   if (time1[best1] < time2[best]) {
-    retval=1;
+    retval = 1;
   } else {
-    retval=2;
+    retval = 2;
+  }
+
+  /* The dmma variant joins the comparison only where it exists, its
+     candidates are left at NEKO_TUNE_INIT otherwise */
+  if (time3[best3] < ((retval == 1) ? time1[best1] : time2[best])) {
+    retval = 3;
   }
 
   cudaEventDestroy(start);
@@ -548,16 +741,302 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
   /* Leave the output of the chosen kernel in w, see tune() */
   if (retval == 1) {
     CASE_1D_SEL(LX, best1);
-  } else {
+  } else if (retval == 2) {
     CASE_KSTEP_PADDED_SEL(LX, best);
+  } else {
+    CASE_DMMA_SEL(LX, best3);
   }
 
   if (retval == 1) {
     sprintf(neko_log_buf, "Chose        : 1 (1D, %d chunk)",
             NEKO_CHUNKS_SEL(LX, best1));
-  } else {
+  } else if (retval == 2) {
     sprintf(neko_log_buf, "Chose        : 2 (KSTEP, %d elem/block)",
             NEKO_EB_SEL(LX, best));
+  } else {
+    sprintf(neko_log_buf, "Chose        : 3 (DMMA, %d warps)",
+            NEKO_DMMA_NW(best3));
+  }
+  log_message(neko_log_buf);
+  log_end_section();
+  return retval;
+}
+
+
+/*
+ * Autotuner for the vector Ax
+ *
+ * The vector operator has no 1d variant, so the sweep is the elements per
+ * block candidates of the kstep variant against the warps per block
+ * candidates of the dmma variant -- the same two dimensions the scalar tuner
+ * sweeps, and the same shape as the HIP vector tuner. See the note at the top
+ * of ax_helm_kernel.h for why blocking is not expected to pay here, and why
+ * it is measured rather than assumed. Sampling follows the scalar tuner:
+ * interleaved rounds, best round per candidate.
+ *
+ * @note The section title has to fit the 30 character header field in
+ * log_section(), which truncates rather than wraps -- hence "Ax vector"
+ * rather than the "Ax helm vector" it reads as.
+ */
+template < const int LX >
+int tune_vector(void *au, void *av, void *aw, void *u, void *v, void *w,
+                void *dx, void *dy, void *dz, void *h1,
+                void *g11, void *g22, void *g33, void *g12,
+                void *g13, void *g23, int *nelv, int *lx,
+                int *eb_sel, int *nw_sel) {
+  cudaEvent_t start, stop;
+  float time2[NEKO_EB_CANDIDATES];
+  int best2 = 0;
+  float time3[NEKO_DMMA_CANDIDATES];
+  int best3 = 0;
+  const int rounds = neko_tune_rounds();
+  const int iters = neko_tune_iters();
+  const int sweep = neko_eb_sweep();
+  const bool dmma = dmma_lx_supported<LX>() && cuda_have_dmma();
+  int retval;
+
+  for (int c = 0; c < NEKO_EB_CANDIDATES; c++) {
+    time2[c] = NEKO_TUNE_INIT;
+  }
+  for (int c = 0; c < NEKO_DMMA_CANDIDATES; c++) {
+    time3[c] = NEKO_TUNE_INIT;
+  }
+
+  const dim3 nblcks_dmma((*nelv), 1, 1);
+  const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
+
+  char *env_value = NULL;
+  char neko_log_buf[80];
+
+  env_value=getenv("NEKO_AUTOTUNE");
+
+  sprintf(neko_log_buf, "Autotune Ax vector (lx: %d)", *lx);
+  log_section(neko_log_buf);
+
+  *nw_sel = 0;
+
+  if(env_value) {
+    if( !strcmp(env_value,"KSTEP") || !strcmp(env_value,"1D") ) {
+      /* No 1d variant here, so either pin lands on kstep */
+      const int c = neko_eb_env();
+      *eb_sel = c;
+      CASE_VECTOR_KSTEP_SEL(LX, c);
+      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, c));
+      log_message(neko_log_buf);
+      log_end_section();
+      return 2;
+    } else if( !strcmp(env_value,"DMMA") ) {
+      if (dmma) {
+        const int c = neko_dmma_env();
+        *nw_sel = c;
+        CASE_VECTOR_DMMA_SEL(LX, c);
+        sprintf(neko_log_buf,"Set by env   : 3 (DMMA, %d warps)",
+                NEKO_DMMA_NW(c));
+        log_message(neko_log_buf);
+        log_end_section();
+        return 3;
+      } else {
+        sprintf(neko_log_buf, "DMMA strategy not available for this config");
+        log_error(neko_log_buf);
+      }
+    } else {
+      sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
+      log_error(neko_log_buf);
+    }
+  }
+
+  cudaEventCreate(&start);
+  cudaEventCreate(&stop);
+
+  /* Warm every variant before timing anything, see tune() */
+  for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
+    CASE_VECTOR_KSTEP(LX, 0);
+    if (sweep) {
+      CASE_VECTOR_KSTEP(LX, 1);
+      CASE_VECTOR_KSTEP(LX, 2);
+    }
+    if (dmma) {
+      CASE_VECTOR_DMMA(LX, 0);
+      CASE_VECTOR_DMMA(LX, 1);
+      CASE_VECTOR_DMMA(LX, 2);
+    }
+  }
+
+  for (int r = 0; r < rounds; r++) {
+    NEKO_TUNE_TIME(time2, CASE_VECTOR_KSTEP, LX, 0, iters);
+    if (sweep) {
+      NEKO_TUNE_TIME(time2, CASE_VECTOR_KSTEP, LX, 1, iters);
+      NEKO_TUNE_TIME(time2, CASE_VECTOR_KSTEP, LX, 2, iters);
+    }
+    if (dmma) {
+      NEKO_TUNE_TIME(time3, CASE_VECTOR_DMMA, LX, 0, iters);
+      NEKO_TUNE_TIME(time3, CASE_VECTOR_DMMA, LX, 1, iters);
+      NEKO_TUNE_TIME(time3, CASE_VECTOR_DMMA, LX, 2, iters);
+    }
+  }
+
+  for (int c = 0; c < NEKO_EB_CANDIDATES; c++) {
+    if (time2[c] >= NEKO_TUNE_INIT) { continue; }
+    sprintf(neko_log_buf, "KSTEP eb=%-4d: %9.2f us/call",
+            NEKO_EB_SEL(LX, c), time2[c] * 10.0);
+    log_message(neko_log_buf);
+  }
+  NEKO_TUNE_LOG_DMMA(time3);
+
+  NEKO_TUNE_BEST(time2, best2, NEKO_EB_CANDIDATES);
+  NEKO_TUNE_BEST(time3, best3, NEKO_DMMA_CANDIDATES);
+  *eb_sel = best2;
+  *nw_sel = best3;
+
+  retval = (time3[best3] < time2[best2]) ? 3 : 2;
+
+  cudaEventDestroy(start);
+  cudaEventDestroy(stop);
+
+  /* The tuner stands in for a real Ax evaluation, and the variants do not
+     sum in the same order, so leave the output of the chosen kernel in
+     au, av and aw */
+  if (retval == 2) {
+    CASE_VECTOR_KSTEP_SEL(LX, best2);
+    sprintf(neko_log_buf, "Chose        : 2 (KSTEP, %d elem/block)",
+            NEKO_EB_SEL(LX, best2));
+  } else {
+    CASE_VECTOR_DMMA_SEL(LX, best3);
+    sprintf(neko_log_buf, "Chose        : 3 (DMMA, %d warps)",
+            NEKO_DMMA_NW(best3));
+  }
+  log_message(neko_log_buf);
+  log_end_section();
+  return retval;
+}
+
+/* Padded variant of tune_vector(), see the note on bank conflicts above */
+template < const int LX >
+int tune_vector_padded(void *au, void *av, void *aw, void *u, void *v, void *w,
+                       void *dx, void *dy, void *dz, void *h1,
+                       void *g11, void *g22, void *g33, void *g12,
+                       void *g13, void *g23, int *nelv, int *lx,
+                int *eb_sel, int *nw_sel) {
+  cudaEvent_t start, stop;
+  float time2[NEKO_EB_CANDIDATES];
+  int best2 = 0;
+  float time3[NEKO_DMMA_CANDIDATES];
+  int best3 = 0;
+  const int rounds = neko_tune_rounds();
+  const int iters = neko_tune_iters();
+  const int sweep = neko_eb_sweep();
+  const bool dmma = dmma_lx_supported<LX>() && cuda_have_dmma();
+  int retval;
+
+  for (int c = 0; c < NEKO_EB_CANDIDATES; c++) {
+    time2[c] = NEKO_TUNE_INIT;
+  }
+  for (int c = 0; c < NEKO_DMMA_CANDIDATES; c++) {
+    time3[c] = NEKO_TUNE_INIT;
+  }
+
+  const dim3 nblcks_dmma((*nelv), 1, 1);
+  const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
+
+  char *env_value = NULL;
+  char neko_log_buf[80];
+
+  env_value=getenv("NEKO_AUTOTUNE");
+
+  sprintf(neko_log_buf, "Autotune Ax vector (lx: %d)", *lx);
+  log_section(neko_log_buf);
+
+  *nw_sel = 0;
+
+  if(env_value) {
+    if( !strcmp(env_value,"KSTEP") || !strcmp(env_value,"1D") ) {
+      /* No 1d variant here, so either pin lands on kstep */
+      const int c = neko_eb_env();
+      *eb_sel = c;
+      CASE_VECTOR_KSTEP_PADDED_SEL(LX, c);
+      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, c));
+      log_message(neko_log_buf);
+      log_end_section();
+      return 2;
+    } else if( !strcmp(env_value,"DMMA") ) {
+      if (dmma) {
+        const int c = neko_dmma_env();
+        *nw_sel = c;
+        CASE_VECTOR_DMMA_SEL(LX, c);
+        sprintf(neko_log_buf,"Set by env   : 3 (DMMA, %d warps)",
+                NEKO_DMMA_NW(c));
+        log_message(neko_log_buf);
+        log_end_section();
+        return 3;
+      } else {
+        sprintf(neko_log_buf, "DMMA strategy not available for this config");
+        log_error(neko_log_buf);
+      }
+    } else {
+      sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
+      log_error(neko_log_buf);
+    }
+  }
+
+  cudaEventCreate(&start);
+  cudaEventCreate(&stop);
+
+  /* Warm every variant before timing anything, see tune() */
+  for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
+    CASE_VECTOR_KSTEP_PADDED(LX, 0);
+    if (sweep) {
+      CASE_VECTOR_KSTEP_PADDED(LX, 1);
+      CASE_VECTOR_KSTEP_PADDED(LX, 2);
+    }
+    if (dmma) {
+      CASE_VECTOR_DMMA(LX, 0);
+      CASE_VECTOR_DMMA(LX, 1);
+      CASE_VECTOR_DMMA(LX, 2);
+    }
+  }
+
+  for (int r = 0; r < rounds; r++) {
+    NEKO_TUNE_TIME(time2, CASE_VECTOR_KSTEP_PADDED, LX, 0, iters);
+    if (sweep) {
+      NEKO_TUNE_TIME(time2, CASE_VECTOR_KSTEP_PADDED, LX, 1, iters);
+      NEKO_TUNE_TIME(time2, CASE_VECTOR_KSTEP_PADDED, LX, 2, iters);
+    }
+    if (dmma) {
+      NEKO_TUNE_TIME(time3, CASE_VECTOR_DMMA, LX, 0, iters);
+      NEKO_TUNE_TIME(time3, CASE_VECTOR_DMMA, LX, 1, iters);
+      NEKO_TUNE_TIME(time3, CASE_VECTOR_DMMA, LX, 2, iters);
+    }
+  }
+
+  for (int c = 0; c < NEKO_EB_CANDIDATES; c++) {
+    if (time2[c] >= NEKO_TUNE_INIT) { continue; }
+    sprintf(neko_log_buf, "KSTEP eb=%-4d: %9.2f us/call",
+            NEKO_EB_SEL(LX, c), time2[c] * 10.0);
+    log_message(neko_log_buf);
+  }
+  NEKO_TUNE_LOG_DMMA(time3);
+
+  NEKO_TUNE_BEST(time2, best2, NEKO_EB_CANDIDATES);
+  NEKO_TUNE_BEST(time3, best3, NEKO_DMMA_CANDIDATES);
+  *eb_sel = best2;
+  *nw_sel = best3;
+
+  retval = (time3[best3] < time2[best2]) ? 3 : 2;
+
+  cudaEventDestroy(start);
+  cudaEventDestroy(stop);
+
+  /* Leave the output of the chosen kernel in au, av and aw, see tune() */
+  if (retval == 2) {
+    CASE_VECTOR_KSTEP_PADDED_SEL(LX, best2);
+    sprintf(neko_log_buf, "Chose        : 2 (KSTEP, %d elem/block)",
+            NEKO_EB_SEL(LX, best2));
+  } else {
+    CASE_VECTOR_DMMA_SEL(LX, best3);
+    sprintf(neko_log_buf, "Chose        : 3 (DMMA, %d warps)",
+            NEKO_DMMA_NW(best3));
   }
   log_message(neko_log_buf);
   log_end_section();

--- a/src/math/bcknd/device/cuda/ax_helm_kernel.h
+++ b/src/math/bcknd/device/cuda/ax_helm_kernel.h
@@ -449,14 +449,16 @@ void ax_helm_dmma_elem(double * __restrict__ w,
                        const double * __restrict__ g33,
                        const double * __restrict__ g12,
                        const double * __restrict__ g13,
-                       const double * __restrict__ g23) {
+                       const double * __restrict__ g23,
+                       const int nelv) {
 
-  /* Element independent, one copy per block */
+  /* Element independent, one copy per block. Block diagonal when more than
+     one element is packed: one LX x LX copy of D per sub-cube */
   __shared__ __align__(16) double shdx[DMMA_MAT];
   __shared__ __align__(16) double shdy[DMMA_MAT];
   __shared__ __align__(16) double shdz[DMMA_MAT];
 
-  /* The element, padded to DMMA_P^3. shu carries the input and then the
+  /* The pack, padded to DMMA_P^3. shu carries the input and then the
      output, shr, shs and sht the reference derivatives */
   __shared__ __align__(16) double shu[DMMA_CUBE];
   __shared__ __align__(16) double shr[DMMA_CUBE];
@@ -473,40 +475,64 @@ void ax_helm_dmma_elem(double * __restrict__ w,
                 <= NEKO_EB_MAX_SMEM,
                 "dmma block exceeds the shared memory budget");
 
+  /* Elements per sub-cube axis, and per cube, see the note in dmma_kernel.h.
+     At LX == DMMA_P both are one and everything below constant folds back to
+     the single element kernel */
+  enum { PPA = (DMMA_P % LX == 0) ? (DMMA_P / LX) : 1,
+         PACK = PPA * PPA * PPA,
+         LX3 = LX * LX * LX,
+         NP = PACK * LX3 };
+
   const int nthrds = 32 * NW;
   const int tid = threadIdx.x;
   const int wf = tid >> 5;
-  const int ele = blockIdx.x * LX * LX * LX;
+  const int ebase = blockIdx.x * PACK;
 
-  /* The padding has to be zero for the tiles to be full without masking, see
-     dmma_kernel.h. At LX == DMMA_P there is none and this is folded away */
+  /* The padding has to be finite, see the note above. At LX == DMMA_P with
+     one element packed there is none and this is folded away */
+  if (PACK * LX3 < DMMA_CUBE) {
+    for (int p = tid; p < DMMA_CUBE; p += nthrds) {
+      shu[p] = 0.0;
+    }
+  }
   if (LX < DMMA_P) {
     for (int p = tid; p < DMMA_MAT; p += nthrds) {
       shdx[p] = 0.0;
       shdy[p] = 0.0;
       shdz[p] = 0.0;
     }
-    for (int p = tid; p < DMMA_CUBE; p += nthrds) {
-      shu[p] = 0.0;
-    }
+  }
+  if (LX < DMMA_P) {
     __syncthreads();
   }
 
+  /* One copy of D per sub-cube, down the diagonal */
   for (int p = tid; p < LX * LX; p += nthrds) {
     const int i = p % LX;
     const int l = p / LX;
-    const int m = i + DMMA_P * l;
-    shdx[m] = dx[p];
-    shdy[m] = dy[p];
-    shdz[m] = dz[p];
+#pragma unroll
+    for (int b = 0; b < PPA; b++) {
+      const int m = (b * LX + i) + DMMA_P * (b * LX + l);
+      shdx[m] = dx[p];
+      shdy[m] = dy[p];
+      shdz[m] = dz[p];
+    }
   }
 
-  for (int p = tid; p < LX * LX * LX; p += nthrds) {
-    const int i = p % LX;
-    const int jk = p / LX;
+  for (int p = tid; p < NP; p += nthrds) {
+    const int q = p / LX3;
+    const int r = p - q * LX3;
+    const int i = r % LX;
+    const int jk = r / LX;
     const int j = jk % LX;
     const int k = jk / LX;
-    shu[i + DMMA_SI * j + DMMA_SJ * k] = u[p + ele];
+    const int qa = q % PPA;
+    const int qb = (q / PPA) % PPA;
+    const int qc = q / (PPA * PPA);
+    const int c = (qa * LX + i) + DMMA_SI * (qb * LX + j)
+                + DMMA_SJ * (qc * LX + k);
+    const int eq = ebase + q;
+    shu[c] = u[r + (eq < nelv ? eq : nelv - 1) * LX3];
   }
 
   __syncthreads();
@@ -517,20 +543,28 @@ void ax_helm_dmma_elem(double * __restrict__ w,
 
   __syncthreads();
 
-  for (int p = tid; p < LX * LX * LX; p += nthrds) {
-    const int i = p % LX;
-    const int jk = p / LX;
+  for (int p = tid; p < NP; p += nthrds) {
+    const int q = p / LX3;
+    const int r = p - q * LX3;
+    const int i = r % LX;
+    const int jk = r / LX;
     const int j = jk % LX;
     const int k = jk / LX;
-    const int c = i + DMMA_SI * j + DMMA_SJ * k;
+    const int qa = q % PPA;
+    const int qb = (q / PPA) % PPA;
+    const int qc = q / (PPA * PPA);
+    const int c = (qa * LX + i) + DMMA_SI * (qb * LX + j)
+                + DMMA_SJ * (qc * LX + k);
+    const int eq = ebase + q;
+    const int gp = r + (eq < nelv ? eq : nelv - 1) * LX3;
 
-    const double G00 = g11[p + ele];
-    const double G11 = g22[p + ele];
-    const double G22 = g33[p + ele];
-    const double G01 = g12[p + ele];
-    const double G02 = g13[p + ele];
-    const double G12 = g23[p + ele];
-    const double H1  = h1[p + ele];
+    const double G00 = g11[gp];
+    const double G11 = g22[gp];
+    const double G22 = g33[gp];
+    const double G01 = g12[gp];
+    const double G02 = g13[gp];
+    const double G12 = g23[gp];
+    const double H1  = h1[gp];
 
     const double rtmp = shr[c];
     const double stmp = shs[c];
@@ -563,12 +597,23 @@ void ax_helm_dmma_elem(double * __restrict__ w,
   dmma_contract< 2, true, true, NW >(shu, shdz, sht, wf);
   __syncthreads();
 
-  for (int p = tid; p < LX * LX * LX; p += nthrds) {
-    const int i = p % LX;
-    const int jk = p / LX;
-    const int j = jk % LX;
-    const int k = jk / LX;
-    w[p + ele] = shu[i + DMMA_SI * j + DMMA_SJ * k];
+  for (int p = tid; p < NP; p += nthrds) {
+    const int q = p / LX3;
+    const int r = p - q * LX3;
+    const int eq = ebase + q;
+
+    if (eq < nelv) {
+      const int i = r % LX;
+      const int jk = r / LX;
+      const int j = jk % LX;
+      const int k = jk / LX;
+      const int qa = q % PPA;
+      const int qb = (q / PPA) % PPA;
+      const int qc = q / (PPA * PPA);
+      const int c = (qa * LX + i) + DMMA_SI * (qb * LX + j)
+                  + DMMA_SJ * (qc * LX + k);
+      w[r + eq * LX3] = shu[c];
+    }
   }
 }
 
@@ -596,7 +641,8 @@ struct ax_helm_dmma_dispatch {
                              const T * __restrict__,
                              const T * __restrict__,
                              const T * __restrict__,
-                             const T * __restrict__) { }
+                             const T * __restrict__,
+                             const int) { }
 };
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) && (__CUDA_ARCH__ < 1000)
@@ -616,12 +662,15 @@ struct ax_helm_dmma_dispatch {
                                const double * __restrict__ g33,                \
                                const double * __restrict__ g12,                \
                                const double * __restrict__ g13,                \
-                               const double * __restrict__ g23) {              \
+                               const double * __restrict__ g23,               \
+                               const int nelv) {                               \
       ax_helm_dmma_elem< LXV, NW >(w, u, dx, dy, dz, h1,                       \
-                                   g11, g22, g33, g12, g13, g23);              \
+                                   g11, g22, g33, g12, g13, g23, nelv);        \
     }                                                                          \
   }
 
+NEKO_AX_HELM_DMMA_DISPATCH(2);
+NEKO_AX_HELM_DMMA_DISPATCH(3);
 NEKO_AX_HELM_DMMA_DISPATCH(4);
 NEKO_AX_HELM_DMMA_DISPATCH(5);
 NEKO_AX_HELM_DMMA_DISPATCH(6);
@@ -643,10 +692,11 @@ ax_helm_kernel_dmma(T * __restrict__ w,
                     const T * __restrict__ g33,
                     const T * __restrict__ g12,
                     const T * __restrict__ g13,
-                    const T * __restrict__ g23) {
+                    const T * __restrict__ g23,
+                    const int nelv) {
 
   ax_helm_dmma_dispatch< T, LX, NW >::run(w, u, dx, dy, dz, h1,
-                                          g11, g22, g33, g12, g13, g23);
+                                          g11, g22, g33, g12, g13, g23, nelv);
 }
 
 /*

--- a/src/math/bcknd/device/cuda/ax_helm_kernel.h
+++ b/src/math/bcknd/device/cuda/ax_helm_kernel.h
@@ -1338,7 +1338,8 @@ struct ax_helm_dmma_vector_dispatch {
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) && (__CUDA_ARCH__ < 1000)
 
-/* Keep in sync with dmma_lx_supported() in dmma_kernel.h */
+/* Keep in sync with dmma_vector_lx_supported() in dmma_kernel.h, which is
+   4 <= LX <= 8 and not the 2 <= LX <= 8 of the packed scalar kernel */
 #define NEKO_AX_HELM_DMMA_VECTOR_DISPATCH(LXV)                                 \
   template< const int NW >                                                     \
   struct ax_helm_dmma_vector_dispatch< double, LXV, NW > {                     \

--- a/src/math/bcknd/device/cuda/ax_helm_kernel.h
+++ b/src/math/bcknd/device/cuda/ax_helm_kernel.h
@@ -476,17 +476,20 @@ void ax_helm_dmma_elem(double * __restrict__ w,
                 "dmma block exceeds the shared memory budget");
 
   /* Elements per sub-cube axis, and per cube, see the note in dmma_kernel.h.
-     At LX == DMMA_P both are one and everything below constant folds back to
-     the single element kernel */
+     At PPA == 1 the addressing is not left to constant fold -- dmma_pack is
+     specialised so the tail clamp and the guarded store are never emitted at
+     all, see the note there */
   enum { PPA = (DMMA_P % LX == 0) ? (DMMA_P / LX) : 1,
          PACK = PPA * PPA * PPA,
          LX3 = LX * LX * LX,
          NP = PACK * LX3 };
 
+  typedef dmma_pack< LX, PPA > pack;
+
   const int nthrds = 32 * NW;
   const int tid = threadIdx.x;
   const int wf = tid >> 5;
-  const int ebase = blockIdx.x * PACK;
+  const int ebase = pack::ebase();
 
   /* The padding has to be finite, see the note above. At LX == DMMA_P with
      one element packed there is none and this is folded away */
@@ -520,19 +523,9 @@ void ax_helm_dmma_elem(double * __restrict__ w,
   }
 
   for (int p = tid; p < NP; p += nthrds) {
-    const int q = p / LX3;
-    const int r = p - q * LX3;
-    const int i = r % LX;
-    const int jk = r / LX;
-    const int j = jk % LX;
-    const int k = jk / LX;
-    const int qa = q % PPA;
-    const int qb = (q / PPA) % PPA;
-    const int qc = q / (PPA * PPA);
-    const int c = (qa * LX + i) + DMMA_SI * (qb * LX + j)
-                + DMMA_SJ * (qc * LX + k);
-    const int eq = ebase + q;
-    shu[c] = u[r + (eq < nelv ? eq : nelv - 1) * LX3];
+    const dmma_idx x = pack::map(p, ebase, nelv);
+
+    shu[x.c] = u[x.g];
   }
 
   __syncthreads();
@@ -544,19 +537,9 @@ void ax_helm_dmma_elem(double * __restrict__ w,
   __syncthreads();
 
   for (int p = tid; p < NP; p += nthrds) {
-    const int q = p / LX3;
-    const int r = p - q * LX3;
-    const int i = r % LX;
-    const int jk = r / LX;
-    const int j = jk % LX;
-    const int k = jk / LX;
-    const int qa = q % PPA;
-    const int qb = (q / PPA) % PPA;
-    const int qc = q / (PPA * PPA);
-    const int c = (qa * LX + i) + DMMA_SI * (qb * LX + j)
-                + DMMA_SJ * (qc * LX + k);
-    const int eq = ebase + q;
-    const int gp = r + (eq < nelv ? eq : nelv - 1) * LX3;
+    const dmma_idx x = pack::map(p, ebase, nelv);
+    const int c = x.c;
+    const int gp = x.g;
 
     const double G00 = g11[gp];
     const double G11 = g22[gp];
@@ -598,21 +581,10 @@ void ax_helm_dmma_elem(double * __restrict__ w,
   __syncthreads();
 
   for (int p = tid; p < NP; p += nthrds) {
-    const int q = p / LX3;
-    const int r = p - q * LX3;
-    const int eq = ebase + q;
+    const dmma_idx x = pack::map(p, ebase, nelv);
 
-    if (eq < nelv) {
-      const int i = r % LX;
-      const int jk = r / LX;
-      const int j = jk % LX;
-      const int k = jk / LX;
-      const int qa = q % PPA;
-      const int qb = (q / PPA) % PPA;
-      const int qc = q / (PPA * PPA);
-      const int c = (qa * LX + i) + DMMA_SI * (qb * LX + j)
-                  + DMMA_SJ * (qc * LX + k);
-      w[r + eq * LX3] = shu[c];
+    if (x.live) {
+      w[x.g] = shu[x.c];
     }
   }
 }

--- a/src/math/bcknd/device/cuda/ax_helm_kernel.h
+++ b/src/math/bcknd/device/cuda/ax_helm_kernel.h
@@ -634,7 +634,7 @@ struct ax_helm_dmma_dispatch {
                                const double * __restrict__ g33,                \
                                const double * __restrict__ g12,                \
                                const double * __restrict__ g13,                \
-                               const double * __restrict__ g23,               \
+                               const double * __restrict__ g23,                \
                                const int nelv) {                               \
       ax_helm_dmma_elem< LXV, NW >(w, u, dx, dy, dz, h1,                       \
                                    g11, g22, g33, g12, g13, g23, nelv);        \

--- a/src/math/bcknd/device/cuda/ax_helm_kernel.h
+++ b/src/math/bcknd/device/cuda/ax_helm_kernel.h
@@ -1,7 +1,7 @@
 #ifndef __MATH_AX_HELM_KERNEL_H__
 #define __MATH_AX_HELM_KERNEL_H__
 /*
- Copyright (c) 2021-2024, The Neko Authors
+ Copyright (c) 2021-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -35,19 +35,26 @@
 */
 
 #include "elem_block.h"
+#include "dmma_kernel.h"
 
 /*
- * Elements per block for the vector kstep kernels, pinned rather than swept.
+ * A note on elements per block for the vector kstep kernels.
  *
  * These hold three times the register blocked state of the scalar ones -- six
  * T[LX] arrays rather than two -- and measure at 254-255 registers on sm_90
- * for every lx from 8 up, spilling at 10, 12, 14 and 16. There is no headroom
- * for a wider block, so they keep one element per block. Override with
- * -DNEKO_AX_HELM_VECTOR_EB_C=<0|1|2> if that ever changes.
+ * for every lx from 8 up, spilling at 10, 12, 14 and 16. Blocking is therefore
+ * not expected to buy much: it does not change registers per thread, only
+ * threads per block, so at 255 registers the occupancy is the same either way
+ * and all it saves is loading the derivative matrices once per block instead
+ * of once per element.
+ *
+ * They are swept anyway, over the same elem_block<> candidates as the scalar
+ * kernels. "Not expected to buy much" is a prediction, and pinning it at build
+ * time is a prediction the tuner can never check. elem_block<>'s thread clamp
+ * keeps every candidate inside the shared memory budget at every lx -- the
+ * widest case, lx = 11 at four elements per block, comes to 37 kB against the
+ * 48 kB cap -- so nothing here needs a bound of its own.
  */
-#ifndef NEKO_AX_HELM_VECTOR_EB_C
-#define NEKO_AX_HELM_VECTOR_EB_C 0
-#endif
 
 /**
  * Device kernel for axhelm
@@ -412,6 +419,234 @@ ax_helm_kernel_kstep_padded(T * __restrict__ w,
       w[ij + k*LX*LX + ele] = rw[k];
     }
   }
+}
+
+
+/**
+ * Device kernel for axhelm on the fp64 tensor cores
+ *
+ * One element per block, NW warps, and the whole element resident in shared
+ * memory as four DMMA_P^3 cubes: the staged input (reused as the output), and
+ * the three reference derivatives. Unlike the kstep variants, which stream a
+ * k plane at a time and keep the k contraction in registers, all six
+ * contractions here are full D * U GEMMs handed to dmma_contract(), with the
+ * geometric factors applied pointwise in between. See dmma_kernel.h for the
+ * padded staging, the per axis matrix views and the arch and LX bounds.
+ */
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) && (__CUDA_ARCH__ < 1000)
+
+template< const int LX, const int NW >
+__device__ __forceinline__
+void ax_helm_dmma_elem(double * __restrict__ w,
+                       const double * __restrict__ u,
+                       const double * __restrict__ dx,
+                       const double * __restrict__ dy,
+                       const double * __restrict__ dz,
+                       const double * __restrict__ h1,
+                       const double * __restrict__ g11,
+                       const double * __restrict__ g22,
+                       const double * __restrict__ g33,
+                       const double * __restrict__ g12,
+                       const double * __restrict__ g13,
+                       const double * __restrict__ g23) {
+
+  /* Element independent, one copy per block */
+  __shared__ __align__(16) double shdx[DMMA_MAT];
+  __shared__ __align__(16) double shdy[DMMA_MAT];
+  __shared__ __align__(16) double shdz[DMMA_MAT];
+
+  /* The element, padded to DMMA_P^3. shu carries the input and then the
+     output, shr, shs and sht the reference derivatives */
+  __shared__ __align__(16) double shu[DMMA_CUBE];
+  __shared__ __align__(16) double shr[DMMA_CUBE];
+  __shared__ __align__(16) double shs[DMMA_CUBE];
+  __shared__ __align__(16) double sht[DMMA_CUBE];
+
+  static_assert(sizeof(shdx) +
+                sizeof(shdy) +
+                sizeof(shdz) +
+                sizeof(shu) +
+                sizeof(shr) +
+                sizeof(shs) +
+                sizeof(sht)
+                <= NEKO_EB_MAX_SMEM,
+                "dmma block exceeds the shared memory budget");
+
+  const int nthrds = 32 * NW;
+  const int tid = threadIdx.x;
+  const int wf = tid >> 5;
+  const int ele = blockIdx.x * LX * LX * LX;
+
+  /* The padding has to be zero for the tiles to be full without masking, see
+     dmma_kernel.h. At LX == DMMA_P there is none and this is folded away */
+  if (LX < DMMA_P) {
+    for (int p = tid; p < DMMA_MAT; p += nthrds) {
+      shdx[p] = 0.0;
+      shdy[p] = 0.0;
+      shdz[p] = 0.0;
+    }
+    for (int p = tid; p < DMMA_CUBE; p += nthrds) {
+      shu[p] = 0.0;
+    }
+    __syncthreads();
+  }
+
+  for (int p = tid; p < LX * LX; p += nthrds) {
+    const int i = p % LX;
+    const int l = p / LX;
+    const int m = i + DMMA_P * l;
+    shdx[m] = dx[p];
+    shdy[m] = dy[p];
+    shdz[m] = dz[p];
+  }
+
+  for (int p = tid; p < LX * LX * LX; p += nthrds) {
+    const int i = p % LX;
+    const int jk = p / LX;
+    const int j = jk % LX;
+    const int k = jk / LX;
+    shu[i + DMMA_SI * j + DMMA_SJ * k] = u[p + ele];
+  }
+
+  __syncthreads();
+
+  dmma_contract< 0, false, false, NW >(shr, shdx, shu, wf);
+  dmma_contract< 1, false, false, NW >(shs, shdy, shu, wf);
+  dmma_contract< 2, false, false, NW >(sht, shdz, shu, wf);
+
+  __syncthreads();
+
+  for (int p = tid; p < LX * LX * LX; p += nthrds) {
+    const int i = p % LX;
+    const int jk = p / LX;
+    const int j = jk % LX;
+    const int k = jk / LX;
+    const int c = i + DMMA_SI * j + DMMA_SJ * k;
+
+    const double G00 = g11[p + ele];
+    const double G11 = g22[p + ele];
+    const double G22 = g33[p + ele];
+    const double G01 = g12[p + ele];
+    const double G02 = g13[p + ele];
+    const double G12 = g23[p + ele];
+    const double H1  = h1[p + ele];
+
+    const double rtmp = shr[c];
+    const double stmp = shs[c];
+    const double ttmp = sht[c];
+
+    shr[c] = H1
+           * (G00 * rtmp
+              + G01 * stmp
+              + G02 * ttmp);
+    shs[c] = H1
+           * (G01 * rtmp
+              + G11 * stmp
+              + G12 * ttmp);
+    sht[c] = H1
+           * (G02 * rtmp
+              + G12 * stmp
+              + G22 * ttmp);
+  }
+
+  __syncthreads();
+
+  /* The result overwrites the staged input; the first contraction writes
+     every tile of the cube, so nothing has to be cleared first. The barriers
+     are needed because the j slab tiles of axis 2 span what every warp wrote
+     along axis 0 and 1 */
+  dmma_contract< 0, true, false, NW >(shu, shdx, shr, wf);
+  __syncthreads();
+  dmma_contract< 1, true, true, NW >(shu, shdy, shs, wf);
+  __syncthreads();
+  dmma_contract< 2, true, true, NW >(shu, shdz, sht, wf);
+  __syncthreads();
+
+  for (int p = tid; p < LX * LX * LX; p += nthrds) {
+    const int i = p % LX;
+    const int jk = p / LX;
+    const int j = jk % LX;
+    const int k = jk / LX;
+    w[p + ele] = shu[i + DMMA_SI * j + DMMA_SJ * k];
+  }
+}
+
+#endif // __CUDA_ARCH__ in [800, 1000)
+
+/*
+ * Compile-time dispatch onto the DMMA element kernel. The launch macros in
+ * ax_helm.cu are written for every LX the operator dispatches and for whatever
+ * `real` is, so every combination has to compile; the ones the strategy does
+ * not cover -- single precision, LX outside the supported range, a build
+ * without an fp64 tensor core arch -- resolve to this no-op. The autotuner
+ * never selects the strategy for them, so the no-op is unreachable at runtime,
+ * see dmma_lx_supported() and cuda_have_dmma() in dmma_kernel.h.
+ */
+template< typename T, const int LX, const int NW >
+struct ax_helm_dmma_dispatch {
+  __device__ static void run(T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__) { }
+};
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) && (__CUDA_ARCH__ < 1000)
+
+/* Keep in sync with dmma_lx_supported() in dmma_kernel.h */
+#define NEKO_AX_HELM_DMMA_DISPATCH(LXV)                                        \
+  template< const int NW >                                                     \
+  struct ax_helm_dmma_dispatch< double, LXV, NW > {                            \
+    __device__ static void run(double * __restrict__ w,                        \
+                               const double * __restrict__ u,                  \
+                               const double * __restrict__ dx,                 \
+                               const double * __restrict__ dy,                 \
+                               const double * __restrict__ dz,                 \
+                               const double * __restrict__ h1,                 \
+                               const double * __restrict__ g11,                \
+                               const double * __restrict__ g22,                \
+                               const double * __restrict__ g33,                \
+                               const double * __restrict__ g12,                \
+                               const double * __restrict__ g13,                \
+                               const double * __restrict__ g23) {              \
+      ax_helm_dmma_elem< LXV, NW >(w, u, dx, dy, dz, h1,                       \
+                                   g11, g22, g33, g12, g13, g23);              \
+    }                                                                          \
+  }
+
+NEKO_AX_HELM_DMMA_DISPATCH(4);
+NEKO_AX_HELM_DMMA_DISPATCH(5);
+NEKO_AX_HELM_DMMA_DISPATCH(6);
+NEKO_AX_HELM_DMMA_DISPATCH(7);
+NEKO_AX_HELM_DMMA_DISPATCH(8);
+
+#endif // __CUDA_ARCH__ in [800, 1000)
+
+template< typename T, const int LX, const int NW >
+__global__ void NEKO_EB_BOUNDS(32 * NW)
+ax_helm_kernel_dmma(T * __restrict__ w,
+                    const T * __restrict__ u,
+                    const T * __restrict__ dx,
+                    const T * __restrict__ dy,
+                    const T * __restrict__ dz,
+                    const T * __restrict__ h1,
+                    const T * __restrict__ g11,
+                    const T * __restrict__ g22,
+                    const T * __restrict__ g33,
+                    const T * __restrict__ g12,
+                    const T * __restrict__ g13,
+                    const T * __restrict__ g23) {
+
+  ax_helm_dmma_dispatch< T, LX, NW >::run(w, u, dx, dy, dz, h1,
+                                          g11, g22, g33, g12, g13, g23);
 }
 
 /*
@@ -844,6 +1079,299 @@ ax_helm_kernel_vector_kstep_padded(T * __restrict__ au,
       aw[ij + k*LX*LX + ele] = rww[k];
     }
   }
+}
+
+
+/**
+ * Device kernel for the vector axhelm on the fp64 tensor cores
+ *
+ * The three components share one set of geometric factors, which is the whole
+ * point of the vector operator: reading them once and applying them to u, v
+ * and w moves 13 arrays per element instead of the 27 that three scalar calls
+ * would. Twelve staged cubes will not fit in a block's shared memory, so the
+ * components are run one after another through the same four cubes and the
+ * factors are hoisted into registers instead -- PPT points per thread, held
+ * across all three passes. Everything else is the scalar kernel; see
+ * dmma_kernel.h for the padded staging and the per axis matrix views.
+ *
+ * Note the padded entries of a staged cube only have to be *finite*, not zero.
+ * A padded row of the derivative matrix is zero and kills the contribution of
+ * a padded row of the cube, but 0 * NaN would not, so the cube is zeroed once
+ * before its first use and then left to carry whatever the contractions put
+ * there. That is why the component loop below re-stages only the LX^3 real
+ * points and never clears the padding again.
+ *
+ * Measured on GH200 at lx = 8 this loses to the kstep variant: holding the
+ * factors costs enough occupancy (~60 registers of metrics at nw = 4, against
+ * the scalar kernel's handful) to give back more than the access pattern wins.
+ * It is kept for the low order end, where PPT falls to 1 and the register cost
+ * with it, while the shared memory footprint stays flat. The autotuner decides.
+ */
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) && (__CUDA_ARCH__ < 1000)
+
+template< const int LX, const int NW >
+__device__ __forceinline__
+void ax_helm_dmma_vector_elem(double * __restrict__ au,
+                              double * __restrict__ av,
+                              double * __restrict__ aw,
+                              const double * __restrict__ u,
+                              const double * __restrict__ v,
+                              const double * __restrict__ w,
+                              const double * __restrict__ dx,
+                              const double * __restrict__ dy,
+                              const double * __restrict__ dz,
+                              const double * __restrict__ h1,
+                              const double * __restrict__ g11,
+                              const double * __restrict__ g22,
+                              const double * __restrict__ g33,
+                              const double * __restrict__ g12,
+                              const double * __restrict__ g13,
+                              const double * __restrict__ g23) {
+
+  /* Element independent, one copy per block */
+  __shared__ __align__(16) double shdx[DMMA_MAT];
+  __shared__ __align__(16) double shdy[DMMA_MAT];
+  __shared__ __align__(16) double shdz[DMMA_MAT];
+
+  /* One component at a time: shc carries it in and the result out, shr, shs
+     and sht its reference derivatives */
+  __shared__ __align__(16) double shc[DMMA_CUBE];
+  __shared__ __align__(16) double shr[DMMA_CUBE];
+  __shared__ __align__(16) double shs[DMMA_CUBE];
+  __shared__ __align__(16) double sht[DMMA_CUBE];
+
+  static_assert(sizeof(shdx) +
+                sizeof(shdy) +
+                sizeof(shdz) +
+                sizeof(shc) +
+                sizeof(shr) +
+                sizeof(shs) +
+                sizeof(sht)
+                <= NEKO_EB_MAX_SMEM,
+                "dmma vector block exceeds the shared memory budget");
+
+  enum { NTHRDS = 32 * NW,
+         LX3 = LX * LX * LX,
+         PPT = (LX3 + NTHRDS - 1) / NTHRDS };
+
+  const int tid = threadIdx.x;
+  const int wf = tid >> 5;
+  const int ele = blockIdx.x * LX3;
+
+  /* The geometric factors, read once and reused by all three components */
+  double rG00[PPT], rG11[PPT], rG22[PPT];
+  double rG01[PPT], rG02[PPT], rG12[PPT];
+  double rH1[PPT];
+  int rc[PPT];
+
+  /* The padding only has to be finite, see the note above. At LX == DMMA_P
+     there is none and this is folded away */
+  if (LX < DMMA_P) {
+    for (int p = tid; p < DMMA_MAT; p += NTHRDS) {
+      shdx[p] = 0.0;
+      shdy[p] = 0.0;
+      shdz[p] = 0.0;
+    }
+    for (int p = tid; p < DMMA_CUBE; p += NTHRDS) {
+      shc[p] = 0.0;
+    }
+    __syncthreads();
+  }
+
+  for (int p = tid; p < LX * LX; p += NTHRDS) {
+    const int i = p % LX;
+    const int l = p / LX;
+    const int m = i + DMMA_P * l;
+    shdx[m] = dx[p];
+    shdy[m] = dy[p];
+    shdz[m] = dz[p];
+  }
+
+#pragma unroll
+  for (int q = 0; q < PPT; q++) {
+    const int p = tid + q * NTHRDS;
+
+    if (p < LX3) {
+      const int i = p % LX;
+      const int jk = p / LX;
+      const int j = jk % LX;
+      const int k = jk / LX;
+      rc[q]   = i + DMMA_SI * j + DMMA_SJ * k;
+      rG00[q] = g11[p + ele];
+      rG11[q] = g22[p + ele];
+      rG22[q] = g33[p + ele];
+      rG01[q] = g12[p + ele];
+      rG02[q] = g13[p + ele];
+      rG12[q] = g23[p + ele];
+      rH1[q]  = h1[p + ele];
+    } else {
+      rc[q]   = 0;
+      rG00[q] = 0.0;
+      rG11[q] = 0.0;
+      rG22[q] = 0.0;
+      rG01[q] = 0.0;
+      rG02[q] = 0.0;
+      rG12[q] = 0.0;
+      rH1[q]  = 0.0;
+    }
+  }
+
+  __syncthreads();
+
+  const double * const cin[3]  = { u, v, w };
+  double * const       cout[3] = { au, av, aw };
+
+#pragma unroll
+  for (int c = 0; c < 3; c++) {
+
+    for (int p = tid; p < LX3; p += NTHRDS) {
+      const int i = p % LX;
+      const int jk = p / LX;
+      const int j = jk % LX;
+      const int k = jk / LX;
+      shc[i + DMMA_SI * j + DMMA_SJ * k] = cin[c][p + ele];
+    }
+
+    __syncthreads();
+
+    dmma_contract< 0, false, false, NW >(shr, shdx, shc, wf);
+    dmma_contract< 1, false, false, NW >(shs, shdy, shc, wf);
+    dmma_contract< 2, false, false, NW >(sht, shdz, shc, wf);
+
+    __syncthreads();
+
+#pragma unroll
+    for (int q = 0; q < PPT; q++) {
+      const int p = tid + q * NTHRDS;
+
+      if (p < LX3) {
+        const int idx = rc[q];
+        const double rtmp = shr[idx];
+        const double stmp = shs[idx];
+        const double ttmp = sht[idx];
+
+        shr[idx] = rH1[q]
+                 * (rG00[q] * rtmp
+                    + rG01[q] * stmp
+                    + rG02[q] * ttmp);
+        shs[idx] = rH1[q]
+                 * (rG01[q] * rtmp
+                    + rG11[q] * stmp
+                    + rG12[q] * ttmp);
+        sht[idx] = rH1[q]
+                 * (rG02[q] * rtmp
+                    + rG12[q] * stmp
+                    + rG22[q] * ttmp);
+      }
+    }
+
+    __syncthreads();
+
+    dmma_contract< 0, true, false, NW >(shc, shdx, shr, wf);
+    __syncthreads();
+    dmma_contract< 1, true, true, NW >(shc, shdy, shs, wf);
+    __syncthreads();
+    dmma_contract< 2, true, true, NW >(shc, shdz, sht, wf);
+    __syncthreads();
+
+    for (int p = tid; p < LX3; p += NTHRDS) {
+      const int i = p % LX;
+      const int jk = p / LX;
+      const int j = jk % LX;
+      const int k = jk / LX;
+      cout[c][p + ele] = shc[i + DMMA_SI * j + DMMA_SJ * k];
+    }
+
+    /* shc is restaged by the next component */
+    __syncthreads();
+  }
+}
+
+#endif // __CUDA_ARCH__ in [800, 1000)
+
+/*
+ * Compile-time dispatch onto the vector DMMA element kernel, see the note on
+ * ax_helm_dmma_dispatch above.
+ */
+template< typename T, const int LX, const int NW >
+struct ax_helm_dmma_vector_dispatch {
+  __device__ static void run(T * __restrict__,
+                             T * __restrict__,
+                             T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__,
+                             const T * __restrict__) { }
+};
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) && (__CUDA_ARCH__ < 1000)
+
+/* Keep in sync with dmma_lx_supported() in dmma_kernel.h */
+#define NEKO_AX_HELM_DMMA_VECTOR_DISPATCH(LXV)                                 \
+  template< const int NW >                                                     \
+  struct ax_helm_dmma_vector_dispatch< double, LXV, NW > {                     \
+    __device__ static void run(double * __restrict__ au,                       \
+                               double * __restrict__ av,                       \
+                               double * __restrict__ aw,                       \
+                               const double * __restrict__ u,                  \
+                               const double * __restrict__ v,                  \
+                               const double * __restrict__ w,                  \
+                               const double * __restrict__ dx,                 \
+                               const double * __restrict__ dy,                 \
+                               const double * __restrict__ dz,                 \
+                               const double * __restrict__ h1,                 \
+                               const double * __restrict__ g11,                \
+                               const double * __restrict__ g22,                \
+                               const double * __restrict__ g33,                \
+                               const double * __restrict__ g12,                \
+                               const double * __restrict__ g13,                \
+                               const double * __restrict__ g23) {              \
+      ax_helm_dmma_vector_elem< LXV, NW >(au, av, aw, u, v, w, dx, dy, dz, h1, \
+                                          g11, g22, g33, g12, g13, g23);       \
+    }                                                                          \
+  }
+
+NEKO_AX_HELM_DMMA_VECTOR_DISPATCH(4);
+NEKO_AX_HELM_DMMA_VECTOR_DISPATCH(5);
+NEKO_AX_HELM_DMMA_VECTOR_DISPATCH(6);
+NEKO_AX_HELM_DMMA_VECTOR_DISPATCH(7);
+NEKO_AX_HELM_DMMA_VECTOR_DISPATCH(8);
+
+#endif // __CUDA_ARCH__ in [800, 1000)
+
+template< typename T, const int LX, const int NW >
+__global__ void NEKO_EB_BOUNDS(32 * NW)
+ax_helm_kernel_dmma_vector(T * __restrict__ au,
+                           T * __restrict__ av,
+                           T * __restrict__ aw,
+                           const T * __restrict__ u,
+                           const T * __restrict__ v,
+                           const T * __restrict__ w,
+                           const T * __restrict__ dx,
+                           const T * __restrict__ dy,
+                           const T * __restrict__ dz,
+                           const T * __restrict__ h1,
+                           const T * __restrict__ g11,
+                           const T * __restrict__ g22,
+                           const T * __restrict__ g33,
+                           const T * __restrict__ g12,
+                           const T * __restrict__ g13,
+                           const T * __restrict__ g23) {
+
+  ax_helm_dmma_vector_dispatch< T, LX, NW >::run(au, av, aw, u, v, w,
+                                                 dx, dy, dz, h1,
+                                                 g11, g22, g33,
+                                                 g12, g13, g23);
 }
 
 template< typename T >

--- a/src/math/bcknd/device/cuda/dmma_kernel.h
+++ b/src/math/bcknd/device/cuda/dmma_kernel.h
@@ -56,7 +56,8 @@
  * That fixed tile is also what bounds the strategy: LX > DMMA_P would need
  * the cubes padded to 16^3, i.e. 4 * 16^3 * 8 = 128 kB of shared memory for
  * the four cubes, well past the 48 kB a block gets without the opt-in dynamic
- * path. Supported for double precision and 4 <= LX <= 8 only, see
+ * path. Supported for double precision and 2 <= LX <= 8 only -- the lower
+ * bound is 2 rather than 4 because of the packing below, see
  * dmma_lx_supported(); note that fp32 has no tensor core equivalent, only
  * TF32 with an 11 bit significand, which is not usable for the operator
  * inside a Krylov solve, so a single precision build has no DMMA strategy.
@@ -271,6 +272,28 @@ template< const int LX >
 static inline bool dmma_lx_supported()
 {
   return (sizeof(real) == 8) && (LX >= 2) && (LX <= DMMA_P);
+}
+
+/**
+ * The same predicate for the vector operator, whose supported range is not the
+ * same and must not be assumed to be.
+ *
+ * The vector kernel stages one element per block and does not pack, so the
+ * lower bound stays at 4: below it the padding waste that packing removes for
+ * the scalar kernel is still there, and there is nothing to gain. That is a
+ * performance argument, but the predicate is a correctness one -- the tuner
+ * launches whatever it is told is supported, and an LX the vector dispatch
+ * does not specialise resolves to the no-op primary template, which times as
+ * free, wins the comparison and leaves stale values in au/av/aw. Lowering
+ * dmma_lx_supported() to 2 for the packed scalar kernel is exactly how that
+ * happened.
+ *
+ * MUST match NEKO_AX_HELM_DMMA_VECTOR_DISPATCH in ax_helm_kernel.h.
+ */
+template< const int LX >
+static inline bool dmma_vector_lx_supported()
+{
+  return (sizeof(real) == 8) && (LX >= 4) && (LX <= DMMA_P);
 }
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) && (__CUDA_ARCH__ < 1000)

--- a/src/math/bcknd/device/cuda/dmma_kernel.h
+++ b/src/math/bcknd/device/cuda/dmma_kernel.h
@@ -162,13 +162,17 @@ static int neko_dmma_env()
 }
 
 /* Report every measured DMMA candidate, see NEKO_TUNE_LOG in
-   elem_block_tune.h */
+   elem_block_tune.h. The label is padded to 13 as a whole rather than by
+   hand counted field widths, so it stays column aligned with the 1D, KSTEP
+   and Chose lines whatever the warp and element counts render as */
 #define NEKO_TUNE_LOG_DMMA(LX, T3)                                            \
   do {                                                                        \
     for (int c = 0; c < NEKO_DMMA_CANDIDATES; c++) {                          \
       if ((T3)[c] >= NEKO_TUNE_INIT) { continue; }                            \
-      sprintf(neko_log_buf, "DMMA  %dw %-2de: %9.2f us/call",                 \
-              NEKO_DMMA_NW(c), NEKO_DMMA_PACK(LX), (T3)[c] * 10.0);           \
+      char lbl_[16];                                                          \
+      sprintf(lbl_, "DMMA  %dw %de",                                          \
+              NEKO_DMMA_NW(c), NEKO_DMMA_PACK(LX));                           \
+      sprintf(neko_log_buf, "%-13s: %9.2f us/call", lbl_, (T3)[c] * 10.0);    \
       log_message(neko_log_buf);                                              \
     }                                                                         \
   } while (0)

--- a/src/math/bcknd/device/cuda/dmma_kernel.h
+++ b/src/math/bcknd/device/cuda/dmma_kernel.h
@@ -1,0 +1,374 @@
+#ifndef __MATH_DMMA_KERNEL_H__
+#define __MATH_DMMA_KERNEL_H__
+/*
+ Copyright (c) 2026, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/**
+ * Double precision matrix-core (DMMA) primitives for the spectral element
+ * tensor contractions, the CUDA counterpart of the AMD MFMA strategies.
+ *
+ * Maps a reference derivative matrix * field contraction onto the fp64 tensor
+ * cores, which are exposed as a single fixed 8x8x4 WMMA tile lowering to
+ * mma.sync.aligned.m8n8k4.f64. Each contraction is a D * U GEMM with M = LX,
+ * N = LX^2, K = LX, and rather than mask the partial M, N and K tiles that a
+ * general LX would leave, every cube is staged into shared memory padded to
+ * DMMA_P^3 and every derivative matrix to DMMA_P^2, with the padding zero
+ * filled. The GEMM is then always 8 x 64 x 8 and every tile is full:
+ *
+ *   - zero rows of D contribute nothing to a padded output row,
+ *   - zero rows of the staged cube contribute nothing to any output,
+ *   - padded output entries are never read back out of shared memory,
+ *
+ * so no lane ever has to test an index. At LX = 8 the padding is empty and
+ * the staging is a straight copy, which is the case the strategy is aimed at.
+ *
+ * That fixed tile is also what bounds the strategy: LX > DMMA_P would need
+ * the cubes padded to 16^3, i.e. 4 * 16^3 * 8 = 128 kB of shared memory for
+ * the four cubes, well past the 48 kB a block gets without the opt-in dynamic
+ * path. Supported for double precision and 4 <= LX <= 8 only, see
+ * dmma_lx_supported(); note that fp32 has no tensor core equivalent, only
+ * TF32 with an 11 bit significand, which is not usable for the operator
+ * inside a Krylov solve, so a single precision build has no DMMA strategy.
+ *
+ * The fp64 tensor cores themselves only exist on the data centre parts:
+ * sm_80 (A100) and sm_90 (H100 / GH200), where they run at twice the fp64
+ * FMA rate. Consumer sm_86 / sm_89 assemble the instruction but have no fp64
+ * tensor hardware at all, and Blackwell moves the fp64 rates again, so both
+ * the compile time guard and cuda_have_dmma() below allow-list [sm_80, sm_90]
+ * rather than testing for "at least sm_80". Widen both together if a later
+ * part turns out to be worth measuring.
+ *
+ * The result is bit-for-bit an fp64 computation -- mma.m8n8k4.f64 is IEEE
+ * double throughout, unlike the reduced precision tensor tiles -- but the
+ * summation order differs from the scalar variants, so the Ax output differs
+ * in the last bits, exactly as it already does between the 1d and kstep
+ * variants.
+ *
+ * Cube and matrix layout. A staged cube is
+ *
+ *   cube[i + DMMA_SI * j + DMMA_SJ * k],  i, j, k < DMMA_P
+ *
+ * and a staged derivative matrix is dmat[m + DMMA_P * l] = D(m, l), matching
+ * the dx[i + l*LX] = D(i,l) convention of the scalar kernels. Contracting
+ * axis AXIS turns the cube into an M x N matrix whose (m, n) element sits at a
+ * constant stride, which is all load_matrix_sync() needs:
+ *
+ *   AXIS = 0: m = i, n = (j,k), element at m + DMMA_SI * n -> column major,
+ *             ldm = DMMA_SI, one tile per group of 8 (j,k) pairs
+ *   AXIS = 1: m = j, n = i, element at n + DMMA_SI * m + DMMA_SJ * k -> row
+ *             major, ldm = DMMA_SI, one tile per k slab
+ *   AXIS = 2: m = k, n = i, element at n + DMMA_SI * j + DMMA_SJ * m -> row
+ *             major, ldm = DMMA_SJ, one tile per j slab
+ *
+ * Each view has DMMA_P tiles and the same view describes the input and the
+ * output of a contraction, so one traits struct covers both.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <cuda_runtime.h>
+#include <mma.h>
+#include <device/device_config.h>
+
+enum {
+  DMMA_P = 8,                    /* Tile M and N, and the padded cube extent */
+  DMMA_KS = 4,                   /* Tile K */
+  DMMA_SI = DMMA_P,              /* Padded cube stride between j */
+  DMMA_SJ = DMMA_P * DMMA_P,     /* Padded cube stride between k */
+  DMMA_CUBE = DMMA_P * DMMA_P * DMMA_P,
+  DMMA_MAT = DMMA_P * DMMA_P,
+  DMMA_NTILES = DMMA_P,          /* Tiles (or slabs) per contraction */
+  DMMA_KSTEPS = DMMA_P / DMMA_KS
+};
+
+/*
+ * Warps per block for the DMMA kernels. Candidate C selects 2^(C+1) warps,
+ * which stripe the DMMA_NTILES tiles of every contraction among themselves;
+ * at the top candidate each warp owns exactly one tile. Picked between at
+ * runtime by the operator's autotuner, like the elements per block candidates
+ * of the kstep variants.
+ */
+#define NEKO_DMMA_CANDIDATES 3
+#define NEKO_DMMA_NW(C) (1 << ((C) + 1))
+#define NEKO_DMMA_NTHRDS(C) dim3(32 * NEKO_DMMA_NW(C), 1, 1)
+
+/* Forced candidate, used when NEKO_AUTOTUNE pins the DMMA variant */
+static int neko_dmma_env()
+{
+  const char *v = getenv("NEKO_DMMA_NW");
+  int c = (v != NULL) ? atoi(v) : 0;
+
+  if (c < 0 || c >= NEKO_DMMA_CANDIDATES) {
+    c = 0;
+  }
+  return c;
+}
+
+/* Report every measured DMMA candidate, see NEKO_TUNE_LOG in
+   elem_block_tune.h */
+#define NEKO_TUNE_LOG_DMMA(T3)                                                \
+  do {                                                                        \
+    for (int c = 0; c < NEKO_DMMA_CANDIDATES; c++) {                          \
+      if ((T3)[c] >= NEKO_TUNE_INIT) { continue; }                            \
+      sprintf(neko_log_buf, "DMMA  nw=%-4d: %9.2f us/call",                   \
+              NEKO_DMMA_NW(c), (T3)[c] * 10.0);                               \
+      log_message(neko_log_buf);                                              \
+    }                                                                         \
+  } while (0)
+
+/*
+ * Was any architecture with fp64 tensor cores among the ones this translation
+ * unit was compiled for? Unlike HIP, a binary built for an older arch still
+ * runs on a newer device by JIT compiling its PTX, and the kernel body below
+ * is guarded on __CUDA_ARCH__ -- so a build for, say, sm_70 running on an
+ * H100 would JIT the *no-op* body and silently return a zero Ax. Checking the
+ * compiled arch list keeps the strategy from ever being offered in that case.
+ *
+ * __CUDA_ARCH_LIST__ needs CUDA >= 11.5; on an older toolkit the strategy is
+ * off unless forced with -DNEKO_DMMA_ARCH_COMPILED=1.
+ */
+#ifndef NEKO_DMMA_ARCH_COMPILED
+#if defined(__CUDA_ARCH_LIST__)
+static inline bool dmma_arch_compiled()
+{
+  const int arch[] = { __CUDA_ARCH_LIST__ };
+
+  for (int i = 0; i < (int) (sizeof(arch)/sizeof(arch[0])); i++) {
+    if (arch[i] >= 800 && arch[i] < 1000) {
+      return true;
+    }
+  }
+  return false;
+}
+#else
+static inline bool dmma_arch_compiled()
+{
+  return false;
+}
+#endif
+#else
+static inline bool dmma_arch_compiled()
+{
+  return (NEKO_DMMA_ARCH_COMPILED != 0);
+}
+#endif
+
+/**
+ * Returns true if the current device exposes the fp64 tensor cores used by the
+ * DMMA strategies and this build can actually reach them. Result is cached
+ * after the first query.
+ */
+static inline bool cuda_have_dmma()
+{
+  static int cached = -1;
+
+  if (cached < 0) {
+    int dev = 0;
+    cudaDeviceProp prop;
+
+    if (!dmma_arch_compiled()) {
+      cached = 0;
+    } else if (cudaGetDevice(&dev) == cudaSuccess &&
+               cudaGetDeviceProperties(&prop, dev) == cudaSuccess) {
+      cached = ((prop.major == 8 && prop.minor == 0) ||
+                (prop.major == 9)) ? 1 : 0;
+    } else {
+      cached = 0;
+    }
+  }
+  return cached == 1;
+}
+
+/**
+ * Compile-time predicate for the LX values that the DMMA strategy supports.
+ * Double precision and 4 <= LX <= DMMA_P, see the note on the padded staging
+ * above. MUST match the dispatch specialisations in each operator's kernel
+ * header.
+ *
+ * The double precision requirement is deliberate and is NOT an oversight to
+ * be brought in line with the HIP side, which does offer both precisions.
+ * That difference is hardware: AMD's v_mfma_f32_16x16x4f32 is true IEEE fp32,
+ * so an sp build there loses nothing, while NVIDIA has no fp32 tensor path at
+ * all -- only TF32, whose 11 bit significand (unit roundoff 4.9e-4, against
+ * fp32's 6e-8) is not usable for the operator inside a Krylov solve. The
+ * accuracy preserving alternative, 3xTF32 splitting, costs three MMAs to buy
+ * back precision in a kernel that is bandwidth bound with flops to spare.
+ *
+ * The empirical argument is stronger than the roofline one. AMD ran the
+ * experiment NVIDIA cannot: with a true fp32 matrix core and therefore no
+ * accuracy compromise whatsoever, MFMA still measured 4.5% BEHIND a plain 1d
+ * kernel at lx = 8, and the whole fp32 speedup over fp64 (2.05x) came from
+ * moving half the bytes at identical achieved bandwidth. A path that loses
+ * where it is free will not win where it is lossy.
+ */
+template< const int LX >
+static inline bool dmma_lx_supported()
+{
+  return (sizeof(real) == 8) && (LX >= 4) && (LX <= DMMA_P);
+}
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) && (__CUDA_ARCH__ < 1000)
+
+/*
+ * How the staged cube is read as an M x N matrix when contracting axis AXIS,
+ * see the layout note above. COL_MAJOR is carried alongside the layout tag
+ * because the pointer offset of a K step depends on it: the contraction index
+ * is the row index of B, so it advances by one element in a column major view
+ * and by ldm in a row major one.
+ */
+template< const int AXIS >
+struct dmma_view;
+
+template< >
+struct dmma_view< 0 > {
+  typedef nvcuda::wmma::col_major layout;
+  enum { LDM = DMMA_SI, COL_MAJOR = 1 };
+  __device__ __forceinline__ static int base(const int t) {
+    return DMMA_SI * DMMA_P * t;
+  }
+};
+
+template< >
+struct dmma_view< 1 > {
+  typedef nvcuda::wmma::row_major layout;
+  enum { LDM = DMMA_SI, COL_MAJOR = 0 };
+  __device__ __forceinline__ static int base(const int t) {
+    return DMMA_SJ * t;
+  }
+};
+
+template< >
+struct dmma_view< 2 > {
+  typedef nvcuda::wmma::row_major layout;
+  enum { LDM = DMMA_SJ, COL_MAJOR = 0 };
+  __device__ __forceinline__ static int base(const int t) {
+    return DMMA_SI * t;
+  }
+};
+
+/*
+ * The A operand is the staged derivative matrix, D(m,l) = dmat[m + DMMA_P*l].
+ * Untransposed that is a column major 8x8 with ldm = DMMA_P; transposed it is
+ * the same storage read row major. Here the contraction index is the column
+ * index of A, so the K step offset is the mirror of the B one above.
+ */
+template< const bool TRANSPOSE >
+struct dmma_amat;
+
+template< >
+struct dmma_amat< false > {
+  typedef nvcuda::wmma::col_major layout;
+  __device__ __forceinline__ static int koff(const int l0) {
+    return DMMA_P * l0;
+  }
+};
+
+template< >
+struct dmma_amat< true > {
+  typedef nvcuda::wmma::row_major layout;
+  __device__ __forceinline__ static int koff(const int l0) {
+    return l0;
+  }
+};
+
+/*
+ * NW cooperating warps (wf = threadIdx.x / 32) contract the staged derivative
+ * matrix 'dmat' with the staged cube 'in' along axis AXIS into the staged cube
+ * 'out':
+ *
+ *   out[idx(m,n)] (+)= sum_l  D(m,l) * in[idx(l,n)]   (TRANSPOSE = false)
+ *   out[idx(m,n)] (+)= sum_l  D(l,m) * in[idx(l,n)]   (TRANSPOSE = true)
+ *
+ * ACCUM selects += over =. Warp wf takes tiles wf, wf+NW, ..., so every lane
+ * of a warp follows the same tile sequence and the warp wide WMMA operations
+ * are never reached divergently.
+ */
+template< const int AXIS, const bool TRANSPOSE, const bool ACCUM,
+          const int NW >
+__device__ __forceinline__
+void dmma_contract(double * __restrict__ out,
+                   const double * __restrict__ dmat,
+                   const double * __restrict__ in,
+                   const int wf)
+{
+  namespace wmma = nvcuda::wmma;
+  typedef dmma_view< AXIS > view;
+  typedef dmma_amat< TRANSPOSE > amat;
+
+  const wmma::layout_t mem_layout =
+    view::COL_MAJOR ? wmma::mem_col_major : wmma::mem_row_major;
+
+  /* A is the same for every tile of the contraction, so it is loaded once
+     rather than once per tile */
+  wmma::fragment< wmma::matrix_a, DMMA_P, DMMA_P, DMMA_KS, double,
+                  typename amat::layout > a[DMMA_KSTEPS];
+#pragma unroll
+  for (int ks = 0; ks < DMMA_KSTEPS; ks++) {
+    wmma::load_matrix_sync(a[ks], dmat + amat::koff(ks * DMMA_KS), DMMA_P);
+  }
+
+  const int npass = (DMMA_NTILES + NW - 1) / NW;
+
+#pragma unroll
+  for (int p = 0; p < npass; p++) {
+    const int t = wf + p * NW;
+
+    if (t < DMMA_NTILES) {
+      wmma::fragment< wmma::accumulator, DMMA_P, DMMA_P, DMMA_KS, double > acc;
+
+      if (ACCUM) {
+        wmma::load_matrix_sync(acc, out + view::base(t), view::LDM, mem_layout);
+      } else {
+        wmma::fill_fragment(acc, 0.0);
+      }
+
+#pragma unroll
+      for (int ks = 0; ks < DMMA_KSTEPS; ks++) {
+        const int l0 = ks * DMMA_KS;
+        const int koff = view::COL_MAJOR ? l0 : (l0 * (int) view::LDM);
+        wmma::fragment< wmma::matrix_b, DMMA_P, DMMA_P, DMMA_KS, double,
+                        typename view::layout > b;
+
+        wmma::load_matrix_sync(b, in + view::base(t) + koff, view::LDM);
+        wmma::mma_sync(acc, a[ks], b, acc);
+      }
+
+      wmma::store_matrix_sync(out + view::base(t), acc, view::LDM, mem_layout);
+    }
+  }
+}
+
+#endif // __CUDA_ARCH__ in [800, 1000)
+
+#endif // __MATH_DMMA_KERNEL_H__

--- a/src/math/bcknd/device/cuda/dmma_kernel.h
+++ b/src/math/bcknd/device/cuda/dmma_kernel.h
@@ -272,6 +272,91 @@ static inline bool dmma_lx_supported()
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) && (__CUDA_ARCH__ < 1000)
 
 /*
+ * Index map from the flat staging loop counter p to the padded cube offset and
+ * the global element offset, specialised on whether the cube holds more than
+ * one element.
+ *
+ * The two cases have to *generate* different code, not merely fold to it. With
+ * PACK > 1 the grid is ceil(nelv/PACK) blocks, so the last block can own slots
+ * past nelv: those are clamped on the way in -- the cube has to be finite, see
+ * the note above -- and dropped on the way out. With PACK == 1 the grid is
+ * exactly nelv blocks and neither is needed, but leaving that to the optimiser
+ * does NOT work: nvcc cannot prove blockIdx.x < nelv, so the select survives on
+ * every staging and metric load where the unpacked kernel had a single hoisted
+ * blockIdx.x * LX3, and the guarded store keeps its branch. Hence the explicit
+ * PPA == 1 specialisation below, which restores that addressing verbatim and
+ * makes `live` a compile time true.
+ */
+struct dmma_idx {
+  int c;                     /* offset into the padded cube */
+  int g;                     /* offset into the global element arrays */
+  bool live;                 /* false only for a padded tail slot, PACK > 1 */
+};
+
+template< const int LX, const int PPA >
+struct dmma_pack {
+  enum { PACK = PPA * PPA * PPA,
+         LX3 = LX * LX * LX,
+         NP = PACK * LX3 };
+
+  /* Loop invariant part of the addressing, hoisted by the caller */
+  __device__ __forceinline__ static int ebase() {
+    return blockIdx.x * PACK;
+  }
+
+  __device__ __forceinline__ static dmma_idx map(const int p, const int ebase,
+                                                 const int nelv) {
+    const int q = p / LX3;
+    const int r = p - q * LX3;
+    const int i = r % LX;
+    const int jk = r / LX;
+    const int j = jk % LX;
+    const int k = jk / LX;
+    const int qa = q % PPA;
+    const int qb = (q / PPA) % PPA;
+    const int qc = q / (PPA * PPA);
+    const int eq = ebase + q;
+    dmma_idx x;
+
+    x.c = (qa * LX + i) + DMMA_SI * (qb * LX + j) + DMMA_SJ * (qc * LX + k);
+    x.g = r + (eq < nelv ? eq : nelv - 1) * LX3;
+    x.live = (eq < nelv);
+    return x;
+  }
+};
+
+/*
+ * One element per cube: the grid covers nelv exactly, so there is no tail to
+ * clamp, no store to predicate, and ebase() is the element's base offset
+ * outright rather than an element index. This is the addressing the kernel had
+ * before packing existed, and at LX == DMMA_P the cube offset reduces to p.
+ */
+template< const int LX >
+struct dmma_pack< LX, 1 > {
+  enum { PACK = 1,
+         LX3 = LX * LX * LX,
+         NP = LX3 };
+
+  __device__ __forceinline__ static int ebase() {
+    return blockIdx.x * LX3;
+  }
+
+  __device__ __forceinline__ static dmma_idx map(const int p, const int ebase,
+                                                 const int) {
+    const int i = p % LX;
+    const int jk = p / LX;
+    const int j = jk % LX;
+    const int k = jk / LX;
+    dmma_idx x;
+
+    x.c = i + DMMA_SI * j + DMMA_SJ * k;
+    x.g = ebase + p;
+    x.live = true;
+    return x;
+  }
+};
+
+/*
  * How the staged cube is read as an M x N matrix when contracting axis AXIS,
  * see the layout note above. COL_MAJOR is carried alongside the layout tag
  * because the pointer offset of a K step depends on it: the contraction index

--- a/src/math/bcknd/device/cuda/dmma_kernel.h
+++ b/src/math/bcknd/device/cuda/dmma_kernel.h
@@ -123,6 +123,32 @@ enum {
 #define NEKO_DMMA_NW(C) (1 << ((C) + 1))
 #define NEKO_DMMA_NTHRDS(C) dim3(32 * NEKO_DMMA_NW(C), 1, 1)
 
+/*
+ * Elements packed into one padded cube.
+ *
+ * The staging pads every cube to DMMA_P^3 so that the fixed 8x8x4 tile is
+ * always full, which at LX = DMMA_P is exact and below it is waste: at LX = 4
+ * only 64 of 512 points are real, so seven eighths of every contraction is
+ * spent on zeros. Where LX divides DMMA_P that waste can be turned back into
+ * work by packing DMMA_P/LX elements along each axis -- one per sub-cube --
+ * and making the staged derivative matrix block diagonal, one LX x LX copy of
+ * D per sub-cube. Because D is then block diagonal, the contraction along any
+ * axis couples only indices within the same sub-cube, so the single padded
+ * contraction computes every packed element independently and correctly.
+ *
+ * LX = 8 packs one element and is exactly what it was; LX = 4 packs eight,
+ * LX = 2 packs sixty-four. LX = 3, 5, 6 and 7 do not divide DMMA_P and keep
+ * one element with the old padding waste. This matters because p-multigrid
+ * smooths at LX = 4 and 2, so low order Ax is hot rather than incidental --
+ * and note the packing costs no extra shared memory at all, the cube is
+ * DMMA_P^3 either way.
+ */
+#define NEKO_DMMA_PPA(LX) ((DMMA_P % (LX) == 0) ? (DMMA_P / (LX)) : 1)
+#define NEKO_DMMA_PACK(LX)                                                    \
+  (NEKO_DMMA_PPA(LX) * NEKO_DMMA_PPA(LX) * NEKO_DMMA_PPA(LX))
+#define NEKO_DMMA_NBLCKS(NELV, LX)                                            \
+  dim3(((NELV) + NEKO_DMMA_PACK(LX) - 1) / NEKO_DMMA_PACK(LX), 1, 1)
+
 /* Forced candidate, used when NEKO_AUTOTUNE pins the DMMA variant */
 static int neko_dmma_env()
 {
@@ -137,12 +163,12 @@ static int neko_dmma_env()
 
 /* Report every measured DMMA candidate, see NEKO_TUNE_LOG in
    elem_block_tune.h */
-#define NEKO_TUNE_LOG_DMMA(T3)                                                \
+#define NEKO_TUNE_LOG_DMMA(LX, T3)                                            \
   do {                                                                        \
     for (int c = 0; c < NEKO_DMMA_CANDIDATES; c++) {                          \
       if ((T3)[c] >= NEKO_TUNE_INIT) { continue; }                            \
-      sprintf(neko_log_buf, "DMMA  nw=%-4d: %9.2f us/call",                   \
-              NEKO_DMMA_NW(c), (T3)[c] * 10.0);                               \
+      sprintf(neko_log_buf, "DMMA  %dw %-2de: %9.2f us/call",                 \
+              NEKO_DMMA_NW(c), NEKO_DMMA_PACK(LX), (T3)[c] * 10.0);           \
       log_message(neko_log_buf);                                              \
     }                                                                         \
   } while (0)
@@ -212,8 +238,13 @@ static inline bool cuda_have_dmma()
 
 /**
  * Compile-time predicate for the LX values that the DMMA strategy supports.
- * Double precision and 4 <= LX <= DMMA_P, see the note on the padded staging
- * above. MUST match the dispatch specialisations in each operator's kernel
+ * Double precision and 2 <= LX <= DMMA_P, see the note on the padded staging
+ * above. The lower bound is 2 rather than 4 because packing makes LX = 2
+ * useful rather than absurd -- sixty-four elements to a cube, and it is a
+ * p-multigrid level. LX = 3 is supported but packs one element and wastes
+ * 95% of every contraction; the tuner will reject it.
+ *
+ * MUST match the dispatch specialisations in each operator's kernel
  * header.
  *
  * The double precision requirement is deliberate and is NOT an oversight to
@@ -235,7 +266,7 @@ static inline bool cuda_have_dmma()
 template< const int LX >
 static inline bool dmma_lx_supported()
 {
-  return (sizeof(real) == 8) && (LX >= 4) && (LX <= DMMA_P);
+  return (sizeof(real) == 8) && (LX >= 2) && (LX <= DMMA_P);
 }
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) && (__CUDA_ARCH__ < 1000)

--- a/src/math/bcknd/device/cuda/tensor.cu
+++ b/src/math/bcknd/device/cuda/tensor.cu
@@ -54,12 +54,42 @@ static void set_tnsr3d_large_shmem_attr(const size_t shmem_size) {
   }
 }
 
+/*
+ * Threads per block for tnsr3d.
+ *
+ * One thread per output point of the widest of the three phases, rounded up
+ * to whole warps and capped at the block maximum. The three phases
+ * produce nu*nu*nv, nu*nv*nv and nv*nv*nv points, so the widest is nu*nu*nv
+ * when restricting and nv*nv*nv when prolonging.
+ *
+ * This used to be a flat 1024 regardless, which on a p-transfer left most of
+ * the block with nothing to do: an 8 -> 4 restriction has 256, 128 and 64
+ * points in its phases, so three quarters to fifteen sixteenths of the
+ * threads idled. p-multigrid transfers between adjacent levels constantly,
+ * which is where that showed up.
+ *
+ * Any block size is correct here: the phases are grid stride loops and the
+ * barriers between them sit outside the loop bodies, so a thread with no
+ * iterations still reaches every barrier.
+ */
+static int cuda_tnsr3d_nthrds(const int nu, const int nv)
+{
+  const int w1 = nu * nu * nv;
+  const int w3 = nv * nv * nv;
+  int work = (w1 > w3) ? w1 : w3;
+
+  work = ((work + 32 - 1) / 32) * 32;
+  if (work > 1024) work = 1024;
+  if (work < 32) work = 32;
+  return work;
+}
+
 extern "C" {
 
   /** Fortran wrapper for tnsr3d **/
   void cuda_tnsr3d(void *v, int *nv, void *u, int *nu,
 		   void *A, void *Bt, void *Ct, int *nel) {
-    const dim3 nthrds(1024, 1, 1);
+    const dim3 nthrds(cuda_tnsr3d_nthrds(*nu, *nv), 1, 1);
     const dim3 nblcks(*nel, 1, 1);
     const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
@@ -113,7 +143,7 @@ extern "C" {
   /** Fortran wrapper for tnsr3d **/
   void cuda_tnsr3d_el_list(void *v, int *nv, void *u, int *nu,
 		   void *A, void *Bt, void *Ct, int * elements, int* n_points) {
-    const dim3 nthrds(1024, 1, 1);
+    const dim3 nthrds(cuda_tnsr3d_nthrds(*nu, *nv), 1, 1);
     const dim3 nblcks(*n_points, 1, 1);
     const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 

--- a/src/math/bcknd/device/cuda/tensor_kernel.h
+++ b/src/math/bcknd/device/cuda/tensor_kernel.h
@@ -51,12 +51,25 @@ __global__ void tnsr3d_el_kernel(T  * __restrict__  v,
   const int pt = blockIdx.x;
   const int e = elements[pt];
   
+  /* Stage the element into shared memory before the first contraction.
+     Read straight from global, phase 1 fetches every value of u nv times --
+     once per output row i -- and fetches them badly: with ii decomposing as
+     i + j*nv, consecutive threads vary i and share j, so a warp asks for
+     values nu apart and pulls a whole sector for each one. Staged, the global
+     read is a single contiguous pass and the redundancy is served from shared
+     memory. shwork2 is unused until phase 2 writes it, by which point u is
+     dead, so this costs no extra shared memory. */
+  for (int p = idx; p < nu*nu*nu; p += str)
+    shwork2[p] = u[p + e*nu*nu*nu];
+
+  __syncthreads();
+
   for (int ii = idx; ii< nu*nu*nv; ii += str) {
     T tmp = 0.0;
     int j = ii/nv;
     int i = ii - j*nv;
     for( int l = 0; l < nu; l++){
-      tmp += A[i+l*nv+pt*nv*nu]*u[l+nu*j+e*nu*nu*nu];
+      tmp += A[i+l*nv+pt*nv*nu]*shwork2[l+nu*j];
     }
     shwork[ii] = tmp;
   }
@@ -110,12 +123,25 @@ __global__ void tnsr3d_kernel(T  * __restrict__  v,
   const int str = blockDim.x;
   const int e = blockIdx.x;
   
+  /* Stage the element into shared memory before the first contraction.
+     Read straight from global, phase 1 fetches every value of u nv times --
+     once per output row i -- and fetches them badly: with ii decomposing as
+     i + j*nv, consecutive threads vary i and share j, so a warp asks for
+     values nu apart and pulls a whole sector for each one. Staged, the global
+     read is a single contiguous pass and the redundancy is served from shared
+     memory. shwork2 is unused until phase 2 writes it, by which point u is
+     dead, so this costs no extra shared memory. */
+  for (int p = idx; p < nu*nu*nu; p += str)
+    shwork2[p] = u[p + e*nu*nu*nu];
+
+  __syncthreads();
+
   for (int ii = idx; ii< nu*nu*nv; ii += str) {
     T tmp = 0.0;
     int j = ii/nv;
     int i = ii - j*nv;
     for( int l = 0; l < nu; l++){
-      tmp += A[i+l*nv]*u[l+nu*j+e*nu*nu*nu];
+      tmp += A[i+l*nv]*shwork2[l+nu*j];
     }
     shwork[ii] = tmp;
   }
@@ -167,12 +193,25 @@ __global__ void tnsr3d_kernel_large(T  * __restrict__  v,
   const int str = blockDim.x;
   const int e = blockIdx.x;
   
+  /* Stage the element into shared memory before the first contraction.
+     Read straight from global, phase 1 fetches every value of u nv times --
+     once per output row i -- and fetches them badly: with ii decomposing as
+     i + j*nv, consecutive threads vary i and share j, so a warp asks for
+     values nu apart and pulls a whole sector for each one. Staged, the global
+     read is a single contiguous pass and the redundancy is served from shared
+     memory. shwork2 is unused until phase 2 writes it, by which point u is
+     dead, so this costs no extra shared memory. */
+  for (int p = idx; p < nu*nu*nu; p += str)
+    shwork2[p] = u[p + e*nu*nu*nu];
+
+  __syncthreads();
+
   for (int ii = idx; ii< nu*nu*nv; ii += str) {
     T tmp = 0.0;
     int j = ii/nv;
     int i = ii - j*nv;
     for( int l = 0; l < nu; l++){
-      tmp += A[i+l*nv]*u[l+nu*j+e*nu*nu*nu];
+      tmp += A[i+l*nv]*shwork2[l+nu*j];
     }
     shwork[ii] = tmp;
   }

--- a/src/math/bcknd/device/hip/ax_helm.hip
+++ b/src/math/bcknd/device/hip/ax_helm.hip
@@ -140,12 +140,12 @@ extern "C" {
 #define CASE_MFMA(LX, C)                                                        \
     hipLaunchKernelGGL( HIP_KERNEL_NAME(                                        \
                           ax_helm_kernel_mfma<real, LX, NEKO_MFMA_NWF(C)> ),    \
-                        dim3((*nelv), 1, 1), NEKO_MFMA_NTHRDS(C), 0,            \
+                        NEKO_MFMA_NBLCKS(*nelv, LX, C), NEKO_MFMA_NTHRDS(C), 0, \
                         (hipStream_t) glb_cmd_queue,                            \
                         (real *) w, (real *) u,                                 \
                         (real *) dx, (real *) dy, (real *) dz,  (real *) h1,    \
                         (real *) g11, (real *) g22, (real *) g33,               \
-                        (real *) g12, (real *) g13, (real *) g23);              \
+                        (real *) g12, (real *) g13, (real *) g23, *nelv);       \
     HIP_CHECK(hipGetLastError());
 
 /* Runtime dispatch onto the tuned wavefronts per block candidate */
@@ -453,8 +453,8 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
         const int c = neko_mfma_env();
         *nwf_sel = c;
         CASE_MFMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 3 (MFMA, %d wavefronts)",
-                NEKO_MFMA_NWF(c));
+        sprintf(neko_log_buf,"Set by env   : 3 (MFMA, %d wf, %d elem/block)",
+                NEKO_MFMA_NWF(c), NEKO_MFMA_EB(LX, c));
         log_message(neko_log_buf);
         log_end_section();
         return 3;
@@ -486,9 +486,9 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
     }
     if (mfma_tune) {
       CASE_MFMA(LX, 0);
-      if (NEKO_MFMA_NWF_USEFUL(LX, 1)) { CASE_MFMA(LX, 1); }
-      if (NEKO_MFMA_NWF_USEFUL(LX, 2)) { CASE_MFMA(LX, 2); }
-      if (NEKO_MFMA_NWF_USEFUL(LX, 3)) { CASE_MFMA(LX, 3); }
+      CASE_MFMA(LX, 1);
+      CASE_MFMA(LX, 2);
+      CASE_MFMA(LX, 3);
     }
   }
 
@@ -506,20 +506,14 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
     }
     if (mfma_tune) {
       NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 0, iters);
-      if (NEKO_MFMA_NWF_USEFUL(LX, 1)) {
-        NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 1, iters);
-      }
-      if (NEKO_MFMA_NWF_USEFUL(LX, 2)) {
-        NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 2, iters);
-      }
-      if (NEKO_MFMA_NWF_USEFUL(LX, 3)) {
-        NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 3, iters);
-      }
+      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 1, iters);
+      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 2, iters);
+      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 3, iters);
     }
   }
 
   NEKO_TUNE_LOG(LX, time1, time2);
-  NEKO_TUNE_LOG_MFMA(time3);
+  NEKO_TUNE_LOG_MFMA(LX, time3);
 
   NEKO_TUNE_BEST(time1, best1, NEKO_CHUNKS_CANDIDATES);
   NEKO_TUNE_BEST(time2, best, NEKO_EB_CANDIDATES);
@@ -560,8 +554,8 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
     sprintf(neko_log_buf, "Chose        : 2 (KSTEP, %d elem/block)",
             NEKO_EB_SEL(LX, best));
   } else {
-    sprintf(neko_log_buf, "Chose        : 3 (MFMA, %d wavefronts)",
-            NEKO_MFMA_NWF(best3));
+    sprintf(neko_log_buf, "Chose        : 3 (MFMA, %d wf, %d elem/block)",
+            NEKO_MFMA_NWF(best3), NEKO_MFMA_EB(LX, best3));
   }
   log_message(neko_log_buf);
   log_end_section();
@@ -638,8 +632,8 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
         const int c = neko_mfma_env();
         *nwf_sel = c;
         CASE_MFMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 3 (MFMA, %d wavefronts)",
-                NEKO_MFMA_NWF(c));
+        sprintf(neko_log_buf,"Set by env   : 3 (MFMA, %d wf, %d elem/block)",
+                NEKO_MFMA_NWF(c), NEKO_MFMA_EB(LX, c));
         log_message(neko_log_buf);
         log_end_section();
         return 3;
@@ -671,9 +665,9 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
     }
     if (mfma_tune) {
       CASE_MFMA(LX, 0);
-      if (NEKO_MFMA_NWF_USEFUL(LX, 1)) { CASE_MFMA(LX, 1); }
-      if (NEKO_MFMA_NWF_USEFUL(LX, 2)) { CASE_MFMA(LX, 2); }
-      if (NEKO_MFMA_NWF_USEFUL(LX, 3)) { CASE_MFMA(LX, 3); }
+      CASE_MFMA(LX, 1);
+      CASE_MFMA(LX, 2);
+      CASE_MFMA(LX, 3);
     }
   }
 
@@ -691,20 +685,14 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
     }
     if (mfma_tune) {
       NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 0, iters);
-      if (NEKO_MFMA_NWF_USEFUL(LX, 1)) {
-        NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 1, iters);
-      }
-      if (NEKO_MFMA_NWF_USEFUL(LX, 2)) {
-        NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 2, iters);
-      }
-      if (NEKO_MFMA_NWF_USEFUL(LX, 3)) {
-        NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 3, iters);
-      }
+      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 1, iters);
+      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 2, iters);
+      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 3, iters);
     }
   }
 
   NEKO_TUNE_LOG(LX, time1, time2);
-  NEKO_TUNE_LOG_MFMA(time3);
+  NEKO_TUNE_LOG_MFMA(LX, time3);
 
   NEKO_TUNE_BEST(time1, best1, NEKO_CHUNKS_CANDIDATES);
   NEKO_TUNE_BEST(time2, best, NEKO_EB_CANDIDATES);
@@ -744,8 +732,8 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
     sprintf(neko_log_buf, "Chose        : 2 (KSTEP, %d elem/block)",
             NEKO_EB_SEL(LX, best));
   } else {
-    sprintf(neko_log_buf, "Chose        : 3 (MFMA, %d wavefronts)",
-            NEKO_MFMA_NWF(best3));
+    sprintf(neko_log_buf, "Chose        : 3 (MFMA, %d wf, %d elem/block)",
+            NEKO_MFMA_NWF(best3), NEKO_MFMA_EB(LX, best3));
   }
   log_message(neko_log_buf);
   log_end_section();

--- a/src/math/bcknd/device/hip/ax_helm.hip
+++ b/src/math/bcknd/device/hip/ax_helm.hip
@@ -49,14 +49,15 @@ template < const int>
 int tune(void *w, void *u, void *dx, void *dy, void *dz,
          void *dxt, void *dyt, void *dzt, void *h1,
          void *g11, void *g22, void *g33, void *g12,
-         void *g13, void *g23, int *nelv, int *lx, int *eb_sel, int *ch_sel);
+         void *g13, void *g23, int *nelv, int *lx, int *eb_sel, int *ch_sel,
+         int *nwf_sel);
 
 template < const int>
 int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
                 void *dxt, void *dyt, void *dzt, void *h1,
                 void *g11, void *g22, void *g33, void *g12,
                 void *g13, void *g23, int *nelv, int *lx, int *eb_sel,
-                int *ch_sel);
+                int *ch_sel, int *nwf_sel);
 
 template < const int>
 int tune_vector(void *au, void *av, void *aw, void *u, void *v, void *w,
@@ -87,6 +88,8 @@ extern "C" {
     static int autotune_eb[13] = { 0 };
     /* chunk candidate chosen for the 1d variant */
     static int autotune_ch[13] = { 0 };
+    /* wavefronts per block candidate chosen for the mfma variant */
+    static int autotune_nwf[13] = { 0 };
 
     const dim3 nthrds_1d(1024, 1, 1);
     const dim3 nblcks_1d((*nelv), 1, 1);
@@ -134,6 +137,26 @@ extern "C" {
                         (real *) g12, (real *) g13, (real *) g23, *nelv);       \
     HIP_CHECK(hipGetLastError());
 
+#define CASE_MFMA(LX, C)                                                        \
+    hipLaunchKernelGGL( HIP_KERNEL_NAME(                                        \
+                          ax_helm_kernel_mfma<real, LX, NEKO_MFMA_NWF(C)> ),    \
+                        dim3((*nelv), 1, 1), NEKO_MFMA_NTHRDS(C), 0,            \
+                        (hipStream_t) glb_cmd_queue,                            \
+                        (real *) w, (real *) u,                                 \
+                        (real *) dx, (real *) dy, (real *) dz,  (real *) h1,    \
+                        (real *) g11, (real *) g22, (real *) g33,               \
+                        (real *) g12, (real *) g13, (real *) g23);              \
+    HIP_CHECK(hipGetLastError());
+
+/* Runtime dispatch onto the tuned wavefronts per block candidate */
+#define CASE_MFMA_SEL(LX, SEL)                                                  \
+    switch (SEL) {                                                              \
+    case 0:  CASE_MFMA(LX, 0); break;                                           \
+    case 1:  CASE_MFMA(LX, 1); break;                                           \
+    case 2:  CASE_MFMA(LX, 2); break;                                           \
+    default: CASE_MFMA(LX, 3); break;                                           \
+    }
+
 /* Runtime dispatch onto the tuned elements per block candidate */
 #define CASE_KSTEP_SEL(LX, SEL)                                                 \
     switch (SEL) {                                                              \
@@ -157,11 +180,14 @@ extern "C" {
                                dxt, dyt, dzt,h1,                                \
                                g11, g22, g33,                                   \
                                g12, g13, g23, nelv, lx,                         \
-                               &autotune_eb[LX], &autotune_ch[LX]);             \
+                               &autotune_eb[LX], &autotune_ch[LX],              \
+                               &autotune_nwf[LX]);                              \
       } else if (autotune[LX] == 1 ) {                                          \
         CASE_1D_SEL(LX, autotune_ch[LX]);                                       \
       } else if (autotune[LX] == 2 ) {                                          \
         CASE_KSTEP_SEL(LX, autotune_eb[LX]);                                    \
+      } else if (autotune[LX] == 3 ) {                                          \
+        CASE_MFMA_SEL(LX, autotune_nwf[LX]);                                    \
       }                                                                         \
       break
 
@@ -173,11 +199,14 @@ extern "C" {
                                      dxt, dyt, dzt,h1,                          \
                                      g11, g22, g33,                             \
                                      g12, g13, g23,nelv,lx,                     \
-                                     &autotune_eb[LX], &autotune_ch[LX]);       \
+                                     &autotune_eb[LX], &autotune_ch[LX],        \
+                                     &autotune_nwf[LX]);                        \
       } else if (autotune[LX] == 1 ) {                                          \
         CASE_1D_SEL(LX, autotune_ch[LX]);                                       \
       } else if (autotune[LX] == 2 ) {                                          \
         CASE_KSTEP_PADDED_SEL(LX, autotune_eb[LX]);                             \
+      } else if (autotune[LX] == 3 ) {                                          \
+        CASE_MFMA_SEL(LX, autotune_nwf[LX]);                                    \
       }                                                                         \
       break
 
@@ -358,14 +387,21 @@ template < const int LX >
 int tune(void *w, void *u, void *dx, void *dy, void *dz,
          void *dxt, void *dyt, void *dzt, void *h1,
          void *g11, void *g22, void *g33, void *g12,
-         void *g13, void *g23, int *nelv, int *lx, int *eb_sel, int *ch_sel) {
+         void *g13, void *g23, int *nelv, int *lx, int *eb_sel, int *ch_sel,
+         int *nwf_sel) {
   hipEvent_t start,stop;
   float time1[NEKO_CHUNKS_CANDIDATES];
   int best1 = 0;
   float time2[NEKO_EB_CANDIDATES];
+  float time3[NEKO_MFMA_CANDIDATES];
+  int best3 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
   const int sweep = neko_eb_sweep();
+  /* Hardware capability, which the explicit NEKO_AUTOTUNE=MFMA pin needs */
+  const bool mfma = mfma_lx_supported<LX>() && hip_have_mfma();
+  /* Whether the sweep may pick it on its own, see neko_mfma_sweep() */
+  const bool mfma_tune = mfma && neko_mfma_sweep();
   int best = 0;
   int retval;
 
@@ -374,6 +410,9 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
   }
   for (int c = 0; c < NEKO_CHUNKS_CANDIDATES; c++) {
     time1[c] = NEKO_TUNE_INIT;
+  }
+  for (int c = 0; c < NEKO_MFMA_CANDIDATES; c++) {
+    time3[c] = NEKO_TUNE_INIT;
   }
 
   const dim3 nthrds_1d(1024, 1, 1);
@@ -409,6 +448,20 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
       log_message(neko_log_buf);
       log_end_section();
       return 2;
+    } else if( !strcmp(env_value,"MFMA") ) {
+      if (mfma) {
+        const int c = neko_mfma_env();
+        *nwf_sel = c;
+        CASE_MFMA_SEL(LX, c);
+        sprintf(neko_log_buf,"Set by env   : 3 (MFMA, %d wavefronts)",
+                NEKO_MFMA_NWF(c));
+        log_message(neko_log_buf);
+        log_end_section();
+        return 3;
+      } else {
+        sprintf(neko_log_buf, "MFMA strategy not available for this config");
+        log_error(neko_log_buf);
+      }
     } else {
        sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
        log_error(neko_log_buf);
@@ -431,6 +484,12 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
       CASE_KSTEP(LX, 1);
       CASE_KSTEP(LX, 2);
     }
+    if (mfma_tune) {
+      CASE_MFMA(LX, 0);
+      if (NEKO_MFMA_NWF_USEFUL(LX, 1)) { CASE_MFMA(LX, 1); }
+      if (NEKO_MFMA_NWF_USEFUL(LX, 2)) { CASE_MFMA(LX, 2); }
+      if (NEKO_MFMA_NWF_USEFUL(LX, 3)) { CASE_MFMA(LX, 3); }
+    }
   }
 
   /* Interleaved rounds, best time per variant: timing them one after another
@@ -445,19 +504,40 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
       NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 1, iters);
       NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 2, iters);
     }
+    if (mfma_tune) {
+      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 0, iters);
+      if (NEKO_MFMA_NWF_USEFUL(LX, 1)) {
+        NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 1, iters);
+      }
+      if (NEKO_MFMA_NWF_USEFUL(LX, 2)) {
+        NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 2, iters);
+      }
+      if (NEKO_MFMA_NWF_USEFUL(LX, 3)) {
+        NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 3, iters);
+      }
+    }
   }
 
   NEKO_TUNE_LOG(LX, time1, time2);
+  NEKO_TUNE_LOG_MFMA(time3);
 
   NEKO_TUNE_BEST(time1, best1, NEKO_CHUNKS_CANDIDATES);
   NEKO_TUNE_BEST(time2, best, NEKO_EB_CANDIDATES);
+  NEKO_TUNE_BEST(time3, best3, NEKO_MFMA_CANDIDATES);
   *eb_sel = best;
   *ch_sel = best1;
+  *nwf_sel = best3;
 
   if (time1[best1] < time2[best]) {
-     retval = 1;
+    retval = 1;
   } else {
     retval = 2;
+  }
+
+  /* The mfma variant joins the comparison only where it exists, its
+     candidates are left at NEKO_TUNE_INIT otherwise */
+  if (time3[best3] < ((retval == 1) ? time1[best1] : time2[best])) {
+    retval = 3;
   }
 
   HIP_CHECK(hipEventDestroy(start));
@@ -467,16 +547,21 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
      sum in the same order, so leave the output of the chosen kernel in w */
   if (retval == 1) {
     CASE_1D_SEL(LX, best1);
-  } else {
+  } else if (retval == 2) {
     CASE_KSTEP_SEL(LX, best);
+  } else {
+    CASE_MFMA_SEL(LX, best3);
   }
 
   if (retval == 1) {
     sprintf(neko_log_buf, "Chose        : 1 (1D, %d chunk)",
             NEKO_CHUNKS_SEL(LX, best1));
-  } else {
+  } else if (retval == 2) {
     sprintf(neko_log_buf, "Chose        : 2 (KSTEP, %d elem/block)",
             NEKO_EB_SEL(LX, best));
+  } else {
+    sprintf(neko_log_buf, "Chose        : 3 (MFMA, %d wavefronts)",
+            NEKO_MFMA_NWF(best3));
   }
   log_message(neko_log_buf);
   log_end_section();
@@ -487,14 +572,21 @@ template < const int LX >
 int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
                 void *dxt, void *dyt, void *dzt, void *h1,
                 void *g11, void *g22, void *g33, void *g12,
-                void *g13, void *g23, int *nelv, int *lx, int *eb_sel, int *ch_sel) {
+                void *g13, void *g23, int *nelv, int *lx,
+                int *eb_sel, int *ch_sel, int *nwf_sel) {
   hipEvent_t start, stop;
   float time1[NEKO_CHUNKS_CANDIDATES];
   int best1 = 0;
   float time2[NEKO_EB_CANDIDATES];
+  float time3[NEKO_MFMA_CANDIDATES];
+  int best3 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
   const int sweep = neko_eb_sweep();
+  /* Hardware capability, which the explicit NEKO_AUTOTUNE=MFMA pin needs */
+  const bool mfma = mfma_lx_supported<LX>() && hip_have_mfma();
+  /* Whether the sweep may pick it on its own, see neko_mfma_sweep() */
+  const bool mfma_tune = mfma && neko_mfma_sweep();
   int best = 0;
   int retval;
 
@@ -503,6 +595,9 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
   }
   for (int c = 0; c < NEKO_CHUNKS_CANDIDATES; c++) {
     time1[c] = NEKO_TUNE_INIT;
+  }
+  for (int c = 0; c < NEKO_MFMA_CANDIDATES; c++) {
+    time3[c] = NEKO_TUNE_INIT;
   }
 
   const dim3 nthrds_1d(1024, 1, 1);
@@ -538,6 +633,20 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
       log_message(neko_log_buf);
       log_end_section();
       return 2;
+    } else if( !strcmp(env_value,"MFMA") ) {
+      if (mfma) {
+        const int c = neko_mfma_env();
+        *nwf_sel = c;
+        CASE_MFMA_SEL(LX, c);
+        sprintf(neko_log_buf,"Set by env   : 3 (MFMA, %d wavefronts)",
+                NEKO_MFMA_NWF(c));
+        log_message(neko_log_buf);
+        log_end_section();
+        return 3;
+      } else {
+        sprintf(neko_log_buf, "MFMA strategy not available for this config");
+        log_error(neko_log_buf);
+      }
     } else {
       sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
       log_error(neko_log_buf);
@@ -560,6 +669,12 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
       CASE_KSTEP_PADDED(LX, 1);
       CASE_KSTEP_PADDED(LX, 2);
     }
+    if (mfma_tune) {
+      CASE_MFMA(LX, 0);
+      if (NEKO_MFMA_NWF_USEFUL(LX, 1)) { CASE_MFMA(LX, 1); }
+      if (NEKO_MFMA_NWF_USEFUL(LX, 2)) { CASE_MFMA(LX, 2); }
+      if (NEKO_MFMA_NWF_USEFUL(LX, 3)) { CASE_MFMA(LX, 3); }
+    }
   }
 
   /* Interleaved rounds, best time per variant: timing them one after another
@@ -574,19 +689,40 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
       NEKO_TUNE_TIME(time2, CASE_KSTEP_PADDED, LX, 1, iters);
       NEKO_TUNE_TIME(time2, CASE_KSTEP_PADDED, LX, 2, iters);
     }
+    if (mfma_tune) {
+      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 0, iters);
+      if (NEKO_MFMA_NWF_USEFUL(LX, 1)) {
+        NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 1, iters);
+      }
+      if (NEKO_MFMA_NWF_USEFUL(LX, 2)) {
+        NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 2, iters);
+      }
+      if (NEKO_MFMA_NWF_USEFUL(LX, 3)) {
+        NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 3, iters);
+      }
+    }
   }
 
   NEKO_TUNE_LOG(LX, time1, time2);
+  NEKO_TUNE_LOG_MFMA(time3);
 
   NEKO_TUNE_BEST(time1, best1, NEKO_CHUNKS_CANDIDATES);
   NEKO_TUNE_BEST(time2, best, NEKO_EB_CANDIDATES);
+  NEKO_TUNE_BEST(time3, best3, NEKO_MFMA_CANDIDATES);
   *eb_sel = best;
   *ch_sel = best1;
+  *nwf_sel = best3;
 
   if (time1[best1] < time2[best]) {
-    retval=1;
+    retval = 1;
   } else {
-    retval=2;
+    retval = 2;
+  }
+
+  /* The mfma variant joins the comparison only where it exists, its
+     candidates are left at NEKO_TUNE_INIT otherwise */
+  if (time3[best3] < ((retval == 1) ? time1[best1] : time2[best])) {
+    retval = 3;
   }
 
   HIP_CHECK(hipEventDestroy(start));
@@ -595,16 +731,21 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
   /* Leave the output of the chosen kernel in w, see tune() */
   if (retval == 1) {
     CASE_1D_SEL(LX, best1);
-  } else {
+  } else if (retval == 2) {
     CASE_KSTEP_PADDED_SEL(LX, best);
+  } else {
+    CASE_MFMA_SEL(LX, best3);
   }
 
   if (retval == 1) {
     sprintf(neko_log_buf, "Chose        : 1 (1D, %d chunk)",
             NEKO_CHUNKS_SEL(LX, best1));
-  } else {
+  } else if (retval == 2) {
     sprintf(neko_log_buf, "Chose        : 2 (KSTEP, %d elem/block)",
             NEKO_EB_SEL(LX, best));
+  } else {
+    sprintf(neko_log_buf, "Chose        : 3 (MFMA, %d wavefronts)",
+            NEKO_MFMA_NWF(best3));
   }
   log_message(neko_log_buf);
   log_end_section();
@@ -616,6 +757,10 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
  * block candidates. Setting NEKO_AUTOTUNE to anything pins candidate 0,
  * i.e. the one element per block shape these kernels have always had,
  * which is the A/B baseline for the blocking.
+ *
+ * @note The section title has to fit the 30 character header field in
+ * log_section(), which truncates rather than wraps -- hence "Ax vector"
+ * rather than the "Ax helm vector" it reads as. It matches the CUDA copy.
  */
 template < const int LX >
 int tune_vector(void *au, void *av, void *aw, void *u, void *v, void *w,
@@ -636,7 +781,7 @@ int tune_vector(void *au, void *av, void *aw, void *u, void *v, void *w,
   const hipStream_t stream = (hipStream_t) glb_cmd_queue;
   char neko_log_buf[80];
 
-  sprintf(neko_log_buf, "Autotune Ax helm vector (lx: %d)", *lx);
+  sprintf(neko_log_buf, "Autotune Ax vector (lx: %d)", *lx);
   log_section(neko_log_buf);
 
   /*
@@ -712,7 +857,7 @@ int tune_vector_padded(void *au, void *av, void *aw,
   const hipStream_t stream = (hipStream_t) glb_cmd_queue;
   char neko_log_buf[80];
 
-  sprintf(neko_log_buf, "Autotune Ax helm vector (lx: %d)", *lx);
+  sprintf(neko_log_buf, "Autotune Ax vector (lx: %d)", *lx);
   log_section(neko_log_buf);
 
   /*

--- a/src/math/bcknd/device/hip/ax_helm_kernel.h
+++ b/src/math/bcknd/device/hip/ax_helm_kernel.h
@@ -445,17 +445,26 @@ __device__ void ax_helm_mfma_elem(T * __restrict__ w,
                                   const T * __restrict__ g33,
                                   const T * __restrict__ g12,
                                   const T * __restrict__ g13,
-                                  const T * __restrict__ g23) {
+                                  const T * __restrict__ g23,
+                                  const int nelv) {
   const int LX2 = LX * LX;
   const int LX3 = LX * LX * LX;
+
+  /* NWF wavefronts per block, WPE of them cooperating on one element and the
+     block covering EB elements, see the note in mfma_kernel.h. At LX = 4 the
+     contraction offers one column group, so WPE is 1 and every wavefront gets
+     an element of its own rather than idling. */
+  enum { NGROUPS = (LX * LX + 15) / 16,
+         WPE = (NWF < NGROUPS) ? NWF : NGROUPS,
+         EB = NWF / WPE };
 
   __shared__ T shdx[LX * LX];
   __shared__ T shdy[LX * LX];
   __shared__ T shdz[LX * LX];
-  __shared__ T shu[LX * LX * LX];   // input u, later reused as output w
-  __shared__ T shr[LX * LX * LX];   // d/dr -> Sr
-  __shared__ T shs[LX * LX * LX];   // d/ds -> Ss
-  __shared__ T sht[LX * LX * LX];   // d/dt -> St
+  __shared__ T shu[EB * LX * LX * LX];   // input u, later reused as output w
+  __shared__ T shr[EB * LX * LX * LX];   // d/dr -> Sr
+  __shared__ T shs[EB * LX * LX * LX];   // d/ds -> Ss
+  __shared__ T sht[EB * LX * LX * LX];   // d/dt -> St
 
   static_assert(sizeof(shdx) + sizeof(shdy) + sizeof(shdz) +
                 sizeof(shu) + sizeof(shr) + sizeof(shs) + sizeof(sht)
@@ -466,55 +475,77 @@ __device__ void ax_helm_mfma_elem(T * __restrict__ w,
   const int wf   = threadIdx.y;          // 0..NWF-1 : which wavefront
   const int tid  = wf * 64 + lane;       // 0..NWF*64-1 : block-wide thread id
   const int nthr = NWF * 64;
-  const int ele  = blockIdx.x * LX3;
 
-  /* Reference derivative matrices (identical for every element). */
+  const int eb  = wf / WPE;              // which element this wavefront serves
+  const int sub = wf % WPE;              // its rank among that element's waves
+  const int gtid = sub * 64 + lane;      // thread id within the element group
+  const int gnthr = WPE * 64;
+
+  /* Threads past the last element still have to reach the block wide
+     barriers, so clamp their reads and drop their stores rather than
+     returning early. At EB == 1 the grid covers nelv exactly and this is
+     constant folded away */
+  const int e_blk = blockIdx.x * EB + eb;
+  const bool active = (EB == 1) ? true : (e_blk < nelv);
+  const int e = active ? e_blk : (nelv - 1);
+  const int ele = e * LX3;
+  const int sh = eb * LX3;
+
+  /* Reference derivative matrices, one copy shared by every element */
   for (int p = tid; p < LX2; p += nthr) {
     shdx[p] = dx[p];
     shdy[p] = dy[p];
     shdz[p] = dz[p];
   }
-  /* Element-local field. */
-  for (int p = tid; p < LX3; p += nthr)
-    shu[p] = u[p + ele];
+  /* Element-local field, staged by the wavefronts that own it */
+  for (int p = gtid; p < LX3; p += gnthr)
+    shu[sh + p] = u[p + ele];
 
   __syncthreads();
 
   /* Gradient: ur, us, ut in canonical i + LX*j + LX*LX*k layout. */
-  mfma_contract_sel<T, LX, 0, false, false, NWF>::run(shr, shdx, shu, lane, wf);
-  mfma_contract_sel<T, LX, 1, false, false, NWF>::run(shs, shdy, shu, lane, wf);
-  mfma_contract_sel<T, LX, 2, false, false, NWF>::run(sht, shdz, shu, lane, wf);
+  mfma_contract_sel<T, LX, 0, false, false, WPE>::run(shr + sh, shdx,
+                                                      shu + sh, lane, sub);
+  mfma_contract_sel<T, LX, 1, false, false, WPE>::run(shs + sh, shdy,
+                                                      shu + sh, lane, sub);
+  mfma_contract_sel<T, LX, 2, false, false, WPE>::run(sht + sh, shdz,
+                                                      shu + sh, lane, sub);
 
   __syncthreads();
 
   /* Geometry (pointwise): (ur,us,ut) -> (Sr,Ss,St), reusing shr/shs/sht. */
-  for (int p = tid; p < LX3; p += nthr) {
+  for (int p = gtid; p < LX3; p += gnthr) {
     const int gp = p + ele;
     const T G00 = g11[gp], G11 = g22[gp], G22 = g33[gp];
     const T G01 = g12[gp], G02 = g13[gp], G12 = g23[gp];
     const T H1  = h1[gp];
-    const T rr = shr[p], ss = shs[p], tt = sht[p];
-    shr[p] = H1 * (G00 * rr + G01 * ss + G02 * tt);
-    shs[p] = H1 * (G01 * rr + G11 * ss + G12 * tt);
-    sht[p] = H1 * (G02 * rr + G12 * ss + G22 * tt);
+    const T rr = shr[sh + p], ss = shs[sh + p], tt = sht[sh + p];
+    shr[sh + p] = H1 * (G00 * rr + G01 * ss + G02 * tt);
+    shs[sh + p] = H1 * (G01 * rr + G11 * ss + G12 * tt);
+    sht[sh + p] = H1 * (G02 * rr + G12 * ss + G22 * tt);
   }
 
   __syncthreads();
 
   /* Divergence: w = Dr^T Sr + Ds^T Ss + Dt^T St, accumulated in shu (= w). */
-  for (int p = tid; p < LX3; p += nthr)
-    shu[p] = 0.0;
+  for (int p = gtid; p < LX3; p += gnthr)
+    shu[sh + p] = 0.0;
   __syncthreads();
 
-  mfma_contract_sel<T, LX, 0, true, true, NWF>::run(shu, shdx, shr, lane, wf);
+  mfma_contract_sel<T, LX, 0, true, true, WPE>::run(shu + sh, shdx,
+                                                    shr + sh, lane, sub);
   __syncthreads();
-  mfma_contract_sel<T, LX, 1, true, true, NWF>::run(shu, shdy, shs, lane, wf);
+  mfma_contract_sel<T, LX, 1, true, true, WPE>::run(shu + sh, shdy,
+                                                    shs + sh, lane, sub);
   __syncthreads();
-  mfma_contract_sel<T, LX, 2, true, true, NWF>::run(shu, shdz, sht, lane, wf);
+  mfma_contract_sel<T, LX, 2, true, true, WPE>::run(shu + sh, shdz,
+                                                    sht + sh, lane, sub);
   __syncthreads();
 
-  for (int p = tid; p < LX3; p += nthr)
-    w[p + ele] = shu[p];
+  if (active) {
+    for (int p = gtid; p < LX3; p += gnthr)
+      w[p + ele] = shu[sh + p];
+  }
 }
 #endif // __gfx90a__ || __gfx942__
 
@@ -531,7 +562,7 @@ template< typename T, const int LX, const int NWF >
 struct ax_helm_mfma_dispatch {
   __device__ static void run(T *, const T *, const T *, const T *, const T *,
                              const T *, const T *, const T *, const T *,
-                             const T *, const T *, const T *) {}
+                             const T *, const T *, const T *, const int) {}
 };
 
 #if defined(__gfx90a__) || defined(__gfx942__)
@@ -545,9 +576,11 @@ struct ax_helm_mfma_dispatch {
                                const TYPE *dz, const TYPE *h1,                 \
                                const TYPE *g11, const TYPE *g22,               \
                                const TYPE *g33, const TYPE *g12,               \
-                               const TYPE *g13, const TYPE *g23) {             \
+                               const TYPE *g13, const TYPE *g23,              \
+                               const int nelv) {                               \
       ax_helm_mfma_elem< TYPE, LXV, NWF >(w, u, dx, dy, dz, h1,                \
-                                          g11, g22, g33, g12, g13, g23);       \
+                                          g11, g22, g33, g12, g13, g23,        \
+                                          nelv);                               \
     }                                                                          \
   }
 
@@ -591,10 +624,11 @@ ax_helm_kernel_mfma(T * __restrict__ w,
                     const T * __restrict__ g33,
                     const T * __restrict__ g12,
                     const T * __restrict__ g13,
-                    const T * __restrict__ g23) {
+                    const T * __restrict__ g23,
+                    const int nelv) {
 
   ax_helm_mfma_dispatch< T, LX, NWF >::run(w, u, dx, dy, dz, h1,
-                                           g11, g22, g33, g12, g13, g23);
+                                           g11, g22, g33, g12, g13, g23, nelv);
 }
 
 /*

--- a/src/math/bcknd/device/hip/ax_helm_kernel.h
+++ b/src/math/bcknd/device/hip/ax_helm_kernel.h
@@ -576,7 +576,7 @@ struct ax_helm_mfma_dispatch {
                                const TYPE *dz, const TYPE *h1,                 \
                                const TYPE *g11, const TYPE *g22,               \
                                const TYPE *g33, const TYPE *g12,               \
-                               const TYPE *g13, const TYPE *g23,              \
+                               const TYPE *g13, const TYPE *g23,               \
                                const int nelv) {                               \
       ax_helm_mfma_elem< TYPE, LXV, NWF >(w, u, dx, dy, dz, h1,                \
                                           g11, g22, g33, g12, g13, g23,        \

--- a/src/math/bcknd/device/hip/ax_helm_kernel.h
+++ b/src/math/bcknd/device/hip/ax_helm_kernel.h
@@ -36,6 +36,7 @@
 */
 
 #include "elem_block.h"
+#include "mfma_kernel.h"
 
 /**
  * Device kernels for Ax helm
@@ -400,6 +401,200 @@ ax_helm_kernel_kstep_padded(T * __restrict__ w,
       w[ij + k*LX*LX + ele] = rw[k];
     }
   }
+}
+
+
+/**
+ * Matrix-core (MFMA) device kernel for axhelm.
+ *
+ * Additional autotuner strategy that maps the six spectral-element tensor
+ * contractions (3 gradient + 3 divergence) onto the AMD matrix cores via the
+ * precision-dispatched mfma_contract_sel primitive -- double precision uses the
+ * batched 4x4x4 matrix core (full M-utilisation), single precision the 16x16x4
+ * tile (see mfma_kernel.h for the precision traits, lane layout and supported
+ * (precision, LX) set).  AX_HELM_MFMA_NWF cooperating wavefronts process one
+ * element, sharing the LX^3 field staged in LDS; decoupling the block shape
+ * from LX lets one implementation cover 4 <= LX <= 12 rather than only LX = 8.
+ * Unsupported (T, LX) instantiate to a no-op; the autotuner only launches this
+ * kernel for the supported set (see mfma_lx_supported() and hip_have_mfma() in
+ * mfma_kernel.h), so the no-op is never reached at runtime.
+ */
+#if defined(__gfx90a__) || defined(__gfx942__)
+
+/* Matrix-core axhelm for one element of order LX-1 (T = float or double).
+ *
+ * NWF cooperating wavefronts (blockDim = (64, NWF, 1)) process one element,
+ * sharing a single staged cube in LDS.  The matrix-core column tiles are
+ * striped across the wavefronts (wf = threadIdx.y) via mfma_contract_sel, while
+ * the staging, geometry and write-back passes parallelise over all NWF*64
+ * threads (tid).  The three accumulating divergence contractions stay separated
+ * by __syncthreads and each wavefront owns disjoint output columns, so the
+ * accumulation is race-free.  NWF = 1 reproduces the single-wavefront kernel.
+ *
+ * mfma_contract_sel routes double precision through the batched 4x4x4 matrix
+ * core (full M-utilisation) and single precision through the 16x16x4 tile. */
+template< typename T, const int LX, const int NWF >
+__device__ void ax_helm_mfma_elem(T * __restrict__ w,
+                                  const T * __restrict__ u,
+                                  const T * __restrict__ dx,
+                                  const T * __restrict__ dy,
+                                  const T * __restrict__ dz,
+                                  const T * __restrict__ h1,
+                                  const T * __restrict__ g11,
+                                  const T * __restrict__ g22,
+                                  const T * __restrict__ g33,
+                                  const T * __restrict__ g12,
+                                  const T * __restrict__ g13,
+                                  const T * __restrict__ g23) {
+  const int LX2 = LX * LX;
+  const int LX3 = LX * LX * LX;
+
+  __shared__ T shdx[LX * LX];
+  __shared__ T shdy[LX * LX];
+  __shared__ T shdz[LX * LX];
+  __shared__ T shu[LX * LX * LX];   // input u, later reused as output w
+  __shared__ T shr[LX * LX * LX];   // d/dr -> Sr
+  __shared__ T shs[LX * LX * LX];   // d/ds -> Ss
+  __shared__ T sht[LX * LX * LX];   // d/dt -> St
+
+  static_assert(sizeof(shdx) + sizeof(shdy) + sizeof(shdz) +
+                sizeof(shu) + sizeof(shr) + sizeof(shs) + sizeof(sht)
+                <= NEKO_EB_MAX_LDS,
+                "mfma block exceeds the shared memory budget");
+
+  const int lane = threadIdx.x;          // 0..63 : lane within a wavefront
+  const int wf   = threadIdx.y;          // 0..NWF-1 : which wavefront
+  const int tid  = wf * 64 + lane;       // 0..NWF*64-1 : block-wide thread id
+  const int nthr = NWF * 64;
+  const int ele  = blockIdx.x * LX3;
+
+  /* Reference derivative matrices (identical for every element). */
+  for (int p = tid; p < LX2; p += nthr) {
+    shdx[p] = dx[p];
+    shdy[p] = dy[p];
+    shdz[p] = dz[p];
+  }
+  /* Element-local field. */
+  for (int p = tid; p < LX3; p += nthr)
+    shu[p] = u[p + ele];
+
+  __syncthreads();
+
+  /* Gradient: ur, us, ut in canonical i + LX*j + LX*LX*k layout. */
+  mfma_contract_sel<T, LX, 0, false, false, NWF>::run(shr, shdx, shu, lane, wf);
+  mfma_contract_sel<T, LX, 1, false, false, NWF>::run(shs, shdy, shu, lane, wf);
+  mfma_contract_sel<T, LX, 2, false, false, NWF>::run(sht, shdz, shu, lane, wf);
+
+  __syncthreads();
+
+  /* Geometry (pointwise): (ur,us,ut) -> (Sr,Ss,St), reusing shr/shs/sht. */
+  for (int p = tid; p < LX3; p += nthr) {
+    const int gp = p + ele;
+    const T G00 = g11[gp], G11 = g22[gp], G22 = g33[gp];
+    const T G01 = g12[gp], G02 = g13[gp], G12 = g23[gp];
+    const T H1  = h1[gp];
+    const T rr = shr[p], ss = shs[p], tt = sht[p];
+    shr[p] = H1 * (G00 * rr + G01 * ss + G02 * tt);
+    shs[p] = H1 * (G01 * rr + G11 * ss + G12 * tt);
+    sht[p] = H1 * (G02 * rr + G12 * ss + G22 * tt);
+  }
+
+  __syncthreads();
+
+  /* Divergence: w = Dr^T Sr + Ds^T Ss + Dt^T St, accumulated in shu (= w). */
+  for (int p = tid; p < LX3; p += nthr)
+    shu[p] = 0.0;
+  __syncthreads();
+
+  mfma_contract_sel<T, LX, 0, true, true, NWF>::run(shu, shdx, shr, lane, wf);
+  __syncthreads();
+  mfma_contract_sel<T, LX, 1, true, true, NWF>::run(shu, shdy, shs, lane, wf);
+  __syncthreads();
+  mfma_contract_sel<T, LX, 2, true, true, NWF>::run(shu, shdz, sht, lane, wf);
+  __syncthreads();
+
+  for (int p = tid; p < LX3; p += nthr)
+    w[p + ele] = shu[p];
+}
+#endif // __gfx90a__ || __gfx942__
+
+/*
+ * Compile-time dispatch onto the MFMA element kernel. The launch macros in
+ * ax_helm.hip are written for every LX the operator dispatches and for
+ * whatever `real` is, so every combination has to compile; the ones the
+ * strategy does not cover -- LX outside the supported range, a build without
+ * a matrix-core arch -- resolve to this no-op. The autotuner never selects
+ * the strategy for them, so the no-op is unreachable at runtime, see
+ * mfma_lx_supported() and hip_have_mfma() in mfma_kernel.h.
+ */
+template< typename T, const int LX, const int NWF >
+struct ax_helm_mfma_dispatch {
+  __device__ static void run(T *, const T *, const T *, const T *, const T *,
+                             const T *, const T *, const T *, const T *,
+                             const T *, const T *, const T *) {}
+};
+
+#if defined(__gfx90a__) || defined(__gfx942__)
+
+/* Keep in sync with mfma_lx_supported() in mfma_kernel.h */
+#define NEKO_AX_HELM_MFMA_DISPATCH(TYPE, LXV)                                  \
+  template< const int NWF >                                                    \
+  struct ax_helm_mfma_dispatch< TYPE, LXV, NWF > {                             \
+    __device__ static void run(TYPE *w, const TYPE *u,                         \
+                               const TYPE *dx, const TYPE *dy,                 \
+                               const TYPE *dz, const TYPE *h1,                 \
+                               const TYPE *g11, const TYPE *g22,               \
+                               const TYPE *g33, const TYPE *g12,               \
+                               const TYPE *g13, const TYPE *g23) {             \
+      ax_helm_mfma_elem< TYPE, LXV, NWF >(w, u, dx, dy, dz, h1,                \
+                                          g11, g22, g33, g12, g13, g23);       \
+    }                                                                          \
+  }
+
+NEKO_AX_HELM_MFMA_DISPATCH(double, 4);
+NEKO_AX_HELM_MFMA_DISPATCH(double, 5);
+NEKO_AX_HELM_MFMA_DISPATCH(double, 6);
+NEKO_AX_HELM_MFMA_DISPATCH(double, 7);
+NEKO_AX_HELM_MFMA_DISPATCH(double, 8);
+NEKO_AX_HELM_MFMA_DISPATCH(double, 9);
+NEKO_AX_HELM_MFMA_DISPATCH(double, 10);
+NEKO_AX_HELM_MFMA_DISPATCH(double, 11);
+NEKO_AX_HELM_MFMA_DISPATCH(double, 12);
+NEKO_AX_HELM_MFMA_DISPATCH(float, 4);
+NEKO_AX_HELM_MFMA_DISPATCH(float, 5);
+NEKO_AX_HELM_MFMA_DISPATCH(float, 6);
+NEKO_AX_HELM_MFMA_DISPATCH(float, 7);
+NEKO_AX_HELM_MFMA_DISPATCH(float, 8);
+NEKO_AX_HELM_MFMA_DISPATCH(float, 9);
+NEKO_AX_HELM_MFMA_DISPATCH(float, 10);
+NEKO_AX_HELM_MFMA_DISPATCH(float, 11);
+NEKO_AX_HELM_MFMA_DISPATCH(float, 12);
+
+#endif // __gfx90a__ || __gfx942__
+
+/*
+ * Note the bare __launch_bounds__ rather than NEKO_EB_BOUNDS: the kstep
+ * kernels ask for three waves per SIMD, and this kernel was validated on
+ * gfx90a/gfx942 without that constraint. Keep it byte-identical to the
+ * configuration that was confirmed on hardware.
+ */
+template< typename T, const int LX, const int NWF >
+__global__ void __launch_bounds__(64 * NWF)
+ax_helm_kernel_mfma(T * __restrict__ w,
+                    const T * __restrict__ u,
+                    const T * __restrict__ dx,
+                    const T * __restrict__ dy,
+                    const T * __restrict__ dz,
+                    const T * __restrict__ h1,
+                    const T * __restrict__ g11,
+                    const T * __restrict__ g22,
+                    const T * __restrict__ g33,
+                    const T * __restrict__ g12,
+                    const T * __restrict__ g13,
+                    const T * __restrict__ g23) {
+
+  ax_helm_mfma_dispatch< T, LX, NWF >::run(w, u, dx, dy, dz, h1,
+                                           g11, g22, g33, g12, g13, g23);
 }
 
 /*

--- a/src/math/bcknd/device/hip/elem_block.h
+++ b/src/math/bcknd/device/hip/elem_block.h
@@ -45,10 +45,17 @@
  * MEASURED TO LOSE on gfx90a and gfx942 for ax_helm: the blocked
  * specialisations roughly double VGPR usage and spill to scratch
  * (kstep_padded<double,8,4>: 168 VGPRs, 2596 B/lane scratch, against 110/0
- * unblocked). The sweep therefore defaults off on this backend. The
- * machinery is kept because the ranking inverts on NVIDIA, where blocking
- * measures a 1.6x win, and because the cause of the AMD register blow-up is
- * not yet understood.
+ * unblocked), and the cause of the register blow-up is still not understood.
+ * A single precision run at lx = 8 puts numbers on it: 130.7 us/call at one
+ * element per block against 1212 us at four and 1213 at eight, a factor of
+ * 9.3.
+ *
+ * The sweep is nevertheless on by default here as of 2026-08-22, as it is on
+ * CUDA. Encoding the verdict in a default meant the tuner could never
+ * re-measure it, and the ranking does invert on NVIDIA, where blocking
+ * measures a 1.6x win. The tuner rejects the blocked variants on its own; the
+ * price is tuning time, and at 9.3x slower those two candidates are most of
+ * it -- roughly 0.7 s per polynomial order at the default sampling.
  *
  * Candidate 0 is one element per block. Candidate C > 0 fits as many whole
  * elements as it can into 2^(C+1) wavefronts.

--- a/src/math/bcknd/device/hip/elem_block_tune.h
+++ b/src/math/bcknd/device/hip/elem_block_tune.h
@@ -52,15 +52,19 @@
 #include <stdlib.h>
 
 /* Sweep the elements per block candidates?
-   Measured a LOSS on MI250X and MI300A
-   (the blocked variants spill), hence off by default here; the CUDA copy
-   defaults on, where it measures a 1.6x win
+   On by default, as on CUDA. It was off here because the blocked variants
+   measured a loss on MI250X and MI300A, where they spill -- but baking that
+   in also stopped the tuner from ever re-testing it, and the kstep family has
+   since measured badly enough on gfx90a (788 us/call at lx = 8 against 268
+   for the 1d variant) that its geometry is worth measuring per case rather
+   than assuming. Where the blocked variants still spill the tuner simply
+   rejects them; the cost is tuning time, not run time.
 
    Note NEKO_TUNE_ROUNDS and NEKO_TUNE_ITERS below are not specific to
    this sweep: they control the sampling of every candidate the tuner
    times, chunk sizes included. */
 #ifndef NEKO_EB_SWEEP_DEFAULT
-#define NEKO_EB_SWEEP_DEFAULT 0
+#define NEKO_EB_SWEEP_DEFAULT 1
 #endif
 
 #define NEKO_TUNE_INIT 1.0e30f

--- a/src/math/bcknd/device/hip/mfma_kernel.h
+++ b/src/math/bcknd/device/hip/mfma_kernel.h
@@ -189,20 +189,31 @@ static inline bool mfma_lx_supported() {
 #define NEKO_MFMA_NTHRDS(C) dim3(64, NEKO_MFMA_NWF(C), 1)
 
 /*
- * Column groups per contraction -- the wavefront-parallel work that actually
- * exists. Both tiles group N the same way, 16 columns at a time, so this is
- * ceil(LX^2/16) either way: 1 at LX = 4, 4 at LX = 8, 9 at LX = 12. A
- * wavefront beyond this one can only idle through the matrix core work; it
- * still helps the staging and pointwise loops, but measurement says not
- * enough to pay. At LX = 4 in single precision the four candidates ran
- * 20.5 / 23.6 / 34.0 / 60.2 us, monotonically worse, while at LX = 8 they ran
- * 218 / 157 / 136.4 / 136.4, improving up to four and then flat. Capping the
- * sweep here costs nothing measurable and skips the candidates that cannot
- * win -- which at low order are also the slowest to time.
+ * Column groups per contraction -- the wavefront-parallel work one element
+ * offers. Both tiles group N the same way, 16 columns at a time, so this is
+ * ceil(LX^2/16) either way: 1 at LX = 4, 4 at LX = 8, 9 at LX = 12.
+ *
+ * A wavefront beyond that count has no matrix core work left on that element,
+ * which is what the LX = 4 single precision sweep measured: 20.5 / 23.6 /
+ * 34.0 / 60.2 us as NWF went 1, 2, 4, 8, monotonically worse, against
+ * 218 / 157 / 136.4 / 136.4 at LX = 8 where four groups exist. Rather than
+ * cap the sweep, the surplus wavefronts are given their own element: NWF is
+ * read as wavefronts per block, WPE = min(NWF, NGROUPS) of them cooperate on
+ * one element, and the block covers EB = NWF/WPE elements. At LX = 4 with
+ * eight wavefronts that is eight elements, one each, with nothing idle; at
+ * LX = 12 it is one element and eight cooperating wavefronts, exactly as
+ * before. This matters because p-multigrid smooths at LX = 4 and 2, so low
+ * order Ax is hot rather than incidental.
  */
 #define NEKO_MFMA_NGROUPS(LX) (((LX) * (LX) + 15) / 16)
-#define NEKO_MFMA_NWF_USEFUL(LX, C) \
-  (NEKO_MFMA_NWF(C) <= NEKO_MFMA_NGROUPS(LX))
+/* Wavefronts cooperating on one element */
+#define NEKO_MFMA_WPE(LX, C)                                                  \
+  (NEKO_MFMA_NWF(C) < NEKO_MFMA_NGROUPS(LX) ? NEKO_MFMA_NWF(C)                \
+                                            : NEKO_MFMA_NGROUPS(LX))
+/* Elements per block */
+#define NEKO_MFMA_EB(LX, C) (NEKO_MFMA_NWF(C) / NEKO_MFMA_WPE(LX, C))
+#define NEKO_MFMA_NBLCKS(NELV, LX, C)                                         \
+  dim3(((NELV) + NEKO_MFMA_EB(LX, C) - 1) / NEKO_MFMA_EB(LX, C), 1, 1)
 
 /*
  * Whether the autotuner sweeps the MFMA strategy, on by default wherever the
@@ -241,12 +252,12 @@ static int neko_mfma_env()
 
 /* Report every measured MFMA candidate, see NEKO_TUNE_LOG in
    elem_block_tune.h */
-#define NEKO_TUNE_LOG_MFMA(T3)                                                \
+#define NEKO_TUNE_LOG_MFMA(LX, T3)                                            \
   do {                                                                        \
     for (int c = 0; c < NEKO_MFMA_CANDIDATES; c++) {                          \
       if ((T3)[c] >= NEKO_TUNE_INIT) { continue; }                            \
-      sprintf(neko_log_buf, "MFMA  nwf=%-3d: %9.2f us/call",                  \
-              NEKO_MFMA_NWF(c), (T3)[c] * 10.0);                              \
+      sprintf(neko_log_buf, "MFMA  %dwf %-2de: %9.2f us/call",                \
+              NEKO_MFMA_NWF(c), NEKO_MFMA_EB(LX, c), (T3)[c] * 10.0);         \
       log_message(neko_log_buf);                                              \
     }                                                                         \
   } while (0)

--- a/src/math/bcknd/device/hip/mfma_kernel.h
+++ b/src/math/bcknd/device/hip/mfma_kernel.h
@@ -1,0 +1,498 @@
+#ifndef __MATH_MFMA_KERNEL_H__
+#define __MATH_MFMA_KERNEL_H__
+/*
+ Copyright (c) 2026, The Neko Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   * Neither the name of the authors nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/**
+ * Shared matrix-core (MFMA) primitives for the spectral-element tensor
+ * contractions, used by the Ax-helm autotuner strategy.
+ *
+ * Recovered onto develop 2026-08-22 from the feature/mfma branch, scoped down
+ * to Ax-helm: the other operators it covered (dudxyz, cdtp, conv1,
+ * convect_scalar) are the four worst placed in the arithmetic intensity
+ * ranking and are not worth carrying without a measurement. The contraction
+ * primitives below are unchanged from the hardware-validated versions -- see
+ * the layout note on mfma_contract_4x4 for why they must not be re-derived
+ * from host simulation alone.
+ *
+ * Maps a reference derivative-matrix * field contraction onto the AMD matrix
+ * cores on CDNA2 (MI250X / gfx90a) and CDNA3 (MI300A / MI300X / gfx942).  Double
+ * precision defaults to the batched 4x4x4 tile (v_mfma_f64_4x4x4f64, full
+ * M-utilisation for M = LX < 16; see mfma_contract_4x4), single precision uses
+ * the 16x16x4 tile (v_mfma_f32_16x16x4f32; no f32 4x4x4 equivalent).  Double
+ * precision can be forced back onto 16x16x4 with -DMFMA_F64_USE_16X16.  One
+ * thread block is launched as a single 64-lane wavefront (blockDim = (64,1,1),
+ * or (64, NWF, 1) for the multi-wavefront Ax-helm) and processes one element;
+ * each contraction is a D * U GEMM with M = LX, N = LX^2, K = LX, the partial
+ * tiles masked off.
+ *
+ * Supported for single and double precision and 4 <= LX <= 12; the upper
+ * bound is set by the LDS needed to keep the cubes resident (operators stage
+ * up to 4*LX^3 + 3*LX^2 elements, ~57 KB of f64 at LX = 12).
+ *
+ * 16x16x4 register/lane layout (used by the f32 tile and the f64 16x16x4
+ * fallback; the 4x4x4 layout is documented at mfma_contract_4x4).
+ *
+ * Verification status, since this tile came from the same source that got the
+ * 4x4x4 block selector and contraction index the wrong way round: CONFIRMED
+ * on gfx90a 2026-08-22, both accumulator packings. The f32 sweep of mfma_probe
+ * covers the A and B layouts (shared between precisions) and the i = 4*g + r
+ * packing at ~1e-7, fp32 epsilon; a second run with -DMFMA_F64_USE_16X16
+ * covers the i = g + 4*r packing at ~1e-16. A layout error reads as O(1) here,
+ * so neither pass rests on a loose tolerance.
+ *
+ * Note the f64 results are bit-identical between this tile and the 4x4x4 one.
+ * That is expected rather than suspicious: both decompose K into chunks of
+ * four with one MFMA per chunk accumulated in sequence, so the summation order
+ * is the same. It is not the signature of dead code, which is what identical
+ * results across NWF would be -- NWF changes which wavefront takes which
+ * column group and so must perturb the schedule.  D = A*B + C,
+ * wave of 64 lanes, g = lane/16 in 0..3, c = lane%16 in 0..15.  A and B share
+ * the same layout for both precisions; only the accumulator packing of the
+ * 16x16 result differs:
+ *   A[i][k] : lane holds A[i = c][k = g]
+ *   B[k][j] : lane holds B[k = g][j = c]
+ *   D[i][j] : lane holds D[j = c] in accumulator slot r = 0..3, with row
+ *             i = g + 4*r for f64 (rows spread with stride 4) and
+ *             i = 4*g + r for f32 (four contiguous rows per lane group)
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <hip/hip_runtime.h>
+#include <device/device_config.h>
+
+/*
+ * Reports whether the device code really was compiled for a matrix core
+ * architecture, i.e. whether the __gfx90a__ / __gfx942__ guard below was true
+ * in the device pass.
+ *
+ * This is not the same question as "does the device have matrix cores". The
+ * contraction primitives and their call sites are all guarded on those
+ * macros, so a build whose offload arch does not include the running device's
+ * -- or a code object selected from a fat binary built for something else --
+ * turns the whole strategy into a silent no-op: the kernel launches, writes
+ * nothing, and leaves stale values in the output. That fails as bad results
+ * rather than as an error, which is the worst way for it to fail. Checking it
+ * from the device removes the guesswork.
+ */
+__global__ void hip_mfma_arch_probe(int * flag) {
+#if defined(__gfx90a__) || defined(__gfx942__)
+  *flag = 1;
+#else
+  *flag = 0;
+#endif
+}
+
+/**
+ * Returns true if the current device exposes the matrix cores used by the
+ * MFMA strategies (currently gfx90a / MI250X and gfx942 / MI300A / MI300X)
+ * *and* this build actually compiled the device code for them.  The f64
+ * 4x4x4 / 16x16x4 and f32 16x16x4 instructions are all available on these
+ * arches, so a single check gates either precision.  Result is cached after
+ * the first query.
+ */
+static inline bool hip_have_mfma() {
+  static int cached = -1;
+  if (cached < 0) {
+    int dev = 0;
+    hipDeviceProp_t prop;
+    cached = 0;
+    if (hipGetDevice(&dev) == hipSuccess &&
+        hipGetDeviceProperties(&prop, dev) == hipSuccess &&
+        (strstr(prop.gcnArchName, "gfx90a") != NULL ||
+         strstr(prop.gcnArchName, "gfx942") != NULL)) {
+      int *d_flag = NULL;
+      int flag = 0;
+      if (hipMalloc(&d_flag, sizeof(int)) == hipSuccess) {
+        if (hipMemcpy(d_flag, &flag, sizeof(int),
+                      hipMemcpyHostToDevice) == hipSuccess) {
+          hipLaunchKernelGGL(hip_mfma_arch_probe, dim3(1), dim3(1), 0, 0,
+                             d_flag);
+          if (hipGetLastError() == hipSuccess &&
+              hipMemcpy(&flag, d_flag, sizeof(int),
+                        hipMemcpyDeviceToHost) == hipSuccess) {
+            cached = flag;
+          }
+        }
+        hipFree(d_flag);
+      }
+    }
+  }
+  return cached == 1;
+}
+
+/**
+ * Compile-time predicate for the LX values that the MFMA strategy supports.
+ * Single or double precision and 4 <= LX <= 12 (bounded above by the LDS
+ * needed to keep one element resident).  MUST match the dispatch
+ * specialisations in each operator's kernel header.
+ */
+/*
+ * Both precisions are offered, and both are verified against a reference on
+ * gfx90a (mfma_probe, 144 configurations, 2026-08-22). They do not share a
+ * code path: f64 goes through the batched 4x4x4 tile, f32 has no 4x4x4
+ * instruction and uses the 16x16x4 one. If a future part disagrees, excluding
+ * a precision here is a one-line change.
+ */
+template < const int LX >
+static inline bool mfma_lx_supported() {
+  return (sizeof(real) == 8 || sizeof(real) == 4) && (LX >= 4) && (LX <= 12);
+}
+
+/*
+ * Wavefronts per block for the MFMA kernels. Candidate C selects 2^C
+ * wavefronts, i.e. 1, 2, 4 or 8.
+ *
+ * Two things are being traded. The contraction stripes its N column groups
+ * across wavefronts, and there are only NGROUPS = ceil(LX^2/16) of them --
+ * one at LX = 4, four at LX = 8 -- so past that count the extra wavefronts
+ * idle through the matrix core work. The staging and pointwise loops, on the
+ * other hand, keep scaling: at LX = 8, eight wavefronts is 512 threads for
+ * 512 points, one each, which is why the branch this came from defaulted to
+ * eight. The measured LX = 8 curve was still improving at four, hence the
+ * fourth candidate.
+ */
+#define NEKO_MFMA_CANDIDATES 4
+#define NEKO_MFMA_NWF(C) (1 << (C))
+#define NEKO_MFMA_NTHRDS(C) dim3(64, NEKO_MFMA_NWF(C), 1)
+
+/*
+ * Column groups per contraction -- the wavefront-parallel work that actually
+ * exists. Both tiles group N the same way, 16 columns at a time, so this is
+ * ceil(LX^2/16) either way: 1 at LX = 4, 4 at LX = 8, 9 at LX = 12. A
+ * wavefront beyond this one can only idle through the matrix core work; it
+ * still helps the staging and pointwise loops, but measurement says not
+ * enough to pay. At LX = 4 in single precision the four candidates ran
+ * 20.5 / 23.6 / 34.0 / 60.2 us, monotonically worse, while at LX = 8 they ran
+ * 218 / 157 / 136.4 / 136.4, improving up to four and then flat. Capping the
+ * sweep here costs nothing measurable and skips the candidates that cannot
+ * win -- which at low order are also the slowest to time.
+ */
+#define NEKO_MFMA_NGROUPS(LX) (((LX) * (LX) + 15) / 16)
+#define NEKO_MFMA_NWF_USEFUL(LX, C) \
+  (NEKO_MFMA_NWF(C) <= NEKO_MFMA_NGROUPS(LX))
+
+/*
+ * Whether the autotuner sweeps the MFMA strategy, on by default wherever the
+ * hardware and the polynomial order allow it.
+ *
+ * It was briefly off while the matrix core contraction was known broken -- the
+ * lane layout had the block selector and the contraction index interchanged,
+ * which a "the solver converges" check had failed to catch for a long time.
+ * The layout was measured on gfx90a, corrected, and mfma_contract_4x4 now
+ * reproduces a CPU reference to ~1e-16 over every supported order, axis,
+ * transpose/accumulate mode and wavefront count, so there is no reason to
+ * withhold it from the sweep. Kept as an off switch in the shape of
+ * NEKO_EB_TUNE, for A/B work.
+ */
+static int neko_mfma_sweep()
+{
+  const char *v = getenv("NEKO_MFMA_TUNE");
+
+  if (v != NULL) {
+    return (atoi(v) != 0);
+  }
+  return 1;
+}
+
+/* Forced candidate, used when NEKO_AUTOTUNE pins the MFMA variant */
+static int neko_mfma_env()
+{
+  const char *v = getenv("NEKO_MFMA_NWF");
+  int c = (v != NULL) ? atoi(v) : 0;
+
+  if (c < 0 || c >= NEKO_MFMA_CANDIDATES) {
+    c = 0;
+  }
+  return c;
+}
+
+/* Report every measured MFMA candidate, see NEKO_TUNE_LOG in
+   elem_block_tune.h */
+#define NEKO_TUNE_LOG_MFMA(T3)                                                \
+  do {                                                                        \
+    for (int c = 0; c < NEKO_MFMA_CANDIDATES; c++) {                          \
+      if ((T3)[c] >= NEKO_TUNE_INIT) { continue; }                            \
+      sprintf(neko_log_buf, "MFMA  nwf=%-3d: %9.2f us/call",                  \
+              NEKO_MFMA_NWF(c), (T3)[c] * 10.0);                              \
+      log_message(neko_log_buf);                                              \
+    }                                                                         \
+  } while (0)
+
+#if defined(__gfx90a__) || defined(__gfx942__)
+
+/* 4-wide accumulators for the gfx90a / gfx942 matrix cores. */
+typedef double mfma_f64x4 __attribute__((ext_vector_type(4)));
+typedef float  mfma_f32x4 __attribute__((ext_vector_type(4)));
+
+/*
+ * Per-precision matrix-core traits: the 4-wide accumulator type, the MFMA
+ * builtin, and the accumulator-slot -> output-row mapping (see the layout
+ * note above; f64 spreads rows with stride 4, f32 packs four contiguous rows).
+ */
+template< typename T >
+struct mfma_traits;
+
+template< >
+struct mfma_traits< double > {
+  typedef mfma_f64x4 acc_t;
+  __device__ __forceinline__ static acc_t mma(double a, double b, acc_t c) {
+    return __builtin_amdgcn_mfma_f64_16x16x4f64(a, b, c, 0, 0, 0);
+  }
+  __device__ __forceinline__ static int out_row(const int g, const int r) {
+    return g + 4 * r;
+  }
+};
+
+template< >
+struct mfma_traits< float > {
+  typedef mfma_f32x4 acc_t;
+  __device__ __forceinline__ static acc_t mma(float a, float b, acc_t c) {
+    return __builtin_amdgcn_mfma_f32_16x16x4f32(a, b, c, 0, 0, 0);
+  }
+  __device__ __forceinline__ static int out_row(const int g, const int r) {
+    return 4 * g + r;
+  }
+};
+
+/*
+ * Linearised index into an LX^3 cube stored as i + LX*j + LX*LX*k, where the
+ * coordinate 'p' lies on contraction axis AXIS and 'n' enumerates the two
+ * remaining axes as n = a + LX*b.
+ */
+template< const int LX, const int AXIS >
+__device__ __forceinline__ int mfma_cube_idx(const int p, const int n) {
+  const int a = n % LX;
+  const int b = n / LX;
+  if (AXIS == 0) return p + LX * a + LX * LX * b;   // contract i; n = (j,k)
+  if (AXIS == 1) return a + LX * p + LX * LX * b;   // contract j; n = (i,k)
+  return a + LX * b + LX * LX * p;                  // contract k; n = (i,j)
+}
+
+/*
+ * One wavefront contracts the reference derivative matrix 'dmat' (LX x LX,
+ * stored column-major: D(row,col) = dmat[row + LX*col]) with the cube 'in'
+ * along axis AXIS, writing the cube 'out':
+ *
+ *   out[idx(m,n)] (+)= sum_l  D(m,l) * in[idx(l,n)]   (TRANSPOSE = false)
+ *   out[idx(m,n)] (+)= sum_l  D(l,m) * in[idx(l,n)]   (TRANSPOSE = true)
+ *
+ * GEMM dimensions M = LX, N = LX*LX, K = LX, tiled over 16x16x4 MFMA tiles
+ * with the partial M/N/K tiles masked.  ACCUM selects += over = .
+ */
+/*
+ * NWF cooperating wavefronts (wf = 0..NWF-1) stripe the NTILES N-tiles among
+ * themselves -- wavefront wf handles nt = wf, wf+NWF, ...  NWF = 1, wf = 0
+ * (the defaults) reproduces the single-wavefront contraction.
+ */
+template< typename T, const int LX, const int AXIS,
+          const bool TRANSPOSE, const bool ACCUM, const int NWF = 1 >
+__device__ __forceinline__
+void mfma_contract(T * __restrict__ out,
+                   const T * __restrict__ dmat,
+                   const T * __restrict__ in,
+                   const int lane, const int wf = 0) {
+  typedef mfma_traits<T> mma_t;
+  const int g = lane >> 4;             // lane / 16 -> 0..3
+  const int c = lane & 15;             // lane % 16 -> 0..15
+  const int NTILES = (LX * LX + 15) / 16;
+  const int KSTEPS = (LX + 3) / 4;
+  const int NPASS  = (NTILES + NWF - 1) / NWF;  // N-tiles handled by this wave
+
+#pragma unroll
+  for (int p = 0; p < NPASS; ++p) {
+    const int nt = wf + p * NWF;                // this wavefront's N-tile
+    if (nt < NTILES) {
+      const int n = nt * 16 + c;                // free (column) index
+      typename mma_t::acc_t acc = {0, 0, 0, 0};
+#pragma unroll
+      for (int ks = 0; ks < KSTEPS; ++ks) {
+        const int l = ks * 4 + g;               // contraction index
+        T a = 0;
+        if (c < LX && l < LX)
+          a = TRANSPOSE ? dmat[l + c * LX]      // D(l,c) = D^T(c,l)
+                        : dmat[c + l * LX];     // D(c,l)
+        T b = 0;
+        if (l < LX && n < LX * LX)
+          b = in[mfma_cube_idx<LX, AXIS>(l, n)];
+        acc = mma_t::mma(a, b, acc);
+      }
+      const T dvals[4] = { acc[0], acc[1], acc[2], acc[3] };
+#pragma unroll
+      for (int r = 0; r < 4; ++r) {
+        const int m = mma_t::out_row(g, r);     // output coordinate on AXIS
+        if (m < LX && n < LX * LX) {
+          const int idx = mfma_cube_idx<LX, AXIS>(m, n);
+          if (ACCUM) out[idx] += dvals[r];
+          else       out[idx]  = dvals[r];
+        }
+      }
+    }
+  }
+}
+
+/*
+ * Double-precision batched matrix-core contraction using v_mfma_f64_4x4x4f64.
+ *
+ * Same contract as mfma_contract() -- out(m,n) (+)= sum_l D(m,l) in(l,n), with
+ * D(l,m) when TRANSPOSE -- but tiled with 4x4x4 MFMA tiles and the
+ * instruction's four blocks assigned to four consecutive 4-column N-subtiles.
+ * GEMM M = LX, N = LX*LX, K = LX, tiled as MT = ceil(LX/4) M-tiles,
+ * KSTEPS = ceil(LX/4) K-steps and NGROUPS = ceil(LX^2/16) column groups (each
+ * group = 4 blocks x 4 columns); partial M/N/K masked with zeros.
+ *
+ * Versus the 16x16x4 tile, the 4-wide M granularity fills M = LX < 16 exactly
+ * (LX = 8 runs the matrix core at 100% M-utilisation instead of 50%), at the
+ * cost of 4x as many, 1/4-sized MFMA issues that feed the same f64 matrix
+ * pipeline.  Double precision only: the f32 4x4 instruction has K = 1, so there
+ * is no single-precision counterpart -- single precision keeps the 16x16x4 tile
+ * (see mfma_contract_sel below).
+ *
+ * Wave of 64 lanes = 4 blocks x 16 lanes.  v_mfma_f64_4x4x4f64 lane layout,
+ * with lo = lane%4, gemm = (lane/4)%4 and kq = lane/16:
+ *   A[i][k] : lane holds A[i = lo ][k = kq]
+ *   B[k][j] : lane holds B[k = kq ][j = lo]
+ *   D[i][j] : lane holds D[i = kq ][j = lo]   (scalar f64 accumulator)
+ * and the four independent 4x4x4 blocks are selected by 'gemm', not by
+ * lane/16.
+ *
+ * This was MEASURED on gfx90a, not assumed: a one-hot read-out of which lane
+ * receives which element (128 launches, no assumptions) produced exactly this
+ * mapping.  The previous version had 'gemm' and 'kq' interchanged -- it used
+ * lane/16 as the block selector and (lane/4)%4 as the contraction index -- and
+ * every one of 72 probe configurations disagreed with a CPU reference.
+ *
+ * It had been believed validated because the Ax-helm fluid solver converged
+ * with it.  It does: a wrong but symmetric operator makes CG converge happily
+ * to the solution of a different system.  Convergence is not correctness, and
+ * only a diff against a reference settles a layout.  Any future correction
+ * stays localised to the four index expressions (m_a, l, n, m_d).
+ *
+ * NWF cooperating wavefronts (wf = 0..NWF-1) stripe the NGROUPS column groups
+ * among themselves -- wavefront wf handles ng = wf, wf+NWF, ...  NWF = 1,
+ * wf = 0 (the defaults) reproduces the single-wavefront contraction.
+ */
+template< const int LX, const int AXIS,
+          const bool TRANSPOSE, const bool ACCUM, const int NWF = 1 >
+__device__ __forceinline__
+void mfma_contract_4x4(double * __restrict__ out,
+                       const double * __restrict__ dmat,
+                       const double * __restrict__ in,
+                       const int lane, const int wf = 0) {
+  const int lo   = lane & 3;           // 0..3 : A row, B column, D column
+  const int gemm = (lane >> 2) & 3;    // 0..3 : which of the four 4x4x4 blocks
+  const int kq   = lane >> 4;          // 0..3 : contraction index within a step
+  const int MT      = (LX + 3) / 4;
+  const int KSTEPS  = (LX + 3) / 4;
+  const int NGROUPS = (LX * LX + 15) / 16;
+  const int NPASS   = (NGROUPS + NWF - 1) / NWF; // groups handled by this wave
+
+#pragma unroll
+  for (int mt = 0; mt < MT; ++mt) {
+    const int m_a = mt * 4 + lo;       // A row (input lane layout: i = lo)
+    const int m_d = mt * 4 + kq;       // D row (output lane layout: i = kq)
+#pragma unroll
+    for (int gp = 0; gp < NPASS; ++gp) {
+      const int ng = wf + gp * NWF;    // this wavefront's column group
+      if (ng < NGROUPS) {
+        /* the four blocks take four consecutive 4-column N-subtiles */
+        const int n = ng * 16 + gemm * 4 + lo;  // column (N) for B in / D out
+        double acc = 0.0;
+#pragma unroll
+        for (int ks = 0; ks < KSTEPS; ++ks) {
+          const int l = ks * 4 + kq;   // contraction index (k = kq for A and B)
+          double a = 0.0;
+          if (m_a < LX && l < LX)
+            a = TRANSPOSE ? dmat[l + m_a * LX]  // D(l,m) = D^T(m,l)
+                          : dmat[m_a + l * LX]; // D(m,l)
+          double b = 0.0;
+          if (l < LX && n < LX * LX)
+            b = in[mfma_cube_idx<LX, AXIS>(l, n)];
+          acc = __builtin_amdgcn_mfma_f64_4x4x4f64(a, b, acc, 0, 0, 0);
+        }
+        if (m_d < LX && n < LX * LX) {
+          const int idx = mfma_cube_idx<LX, AXIS>(m_d, n);
+          if (ACCUM) out[idx] += acc;
+          else       out[idx]  = acc;
+        }
+      }
+    }
+  }
+}
+
+/*
+ * Precision-dispatched tensor contraction: double precision uses the batched
+ * 4x4x4 matrix core (full M-utilisation for M = LX < 16), single precision the
+ * 16x16x4 tile (no f32 4x4x4 equivalent).  Lets one call site cover both.
+ */
+template< typename T, const int LX, const int AXIS,
+          const bool TRANSPOSE, const bool ACCUM, const int NWF = 1 >
+struct mfma_contract_sel {
+  __device__ __forceinline__
+  static void run(T * __restrict__ out, const T * __restrict__ dmat,
+                  const T * __restrict__ in, const int lane,
+                  const int wf = 0) {
+    mfma_contract<T, LX, AXIS, TRANSPOSE, ACCUM, NWF>(out, dmat, in, lane, wf);
+  }
+};
+
+template< const int LX, const int AXIS, const bool TRANSPOSE, const bool ACCUM,
+          const int NWF >
+struct mfma_contract_sel<double, LX, AXIS, TRANSPOSE, ACCUM, NWF> {
+  __device__ __forceinline__
+  static void run(double * __restrict__ out, const double * __restrict__ dmat,
+                  const double * __restrict__ in, const int lane,
+                  const int wf = 0) {
+#ifdef MFMA_F64_USE_16X16
+    /*
+     * Opt-out fallback: the original 16x16x4 tile (M-utilisation 50% at LX=8,
+     * 75% at LX=12).  Kept as an escape hatch behind -DMFMA_F64_USE_16X16; the
+     * batched 4x4x4 path below is the hardware-validated default.
+     */
+    mfma_contract<double, LX, AXIS, TRANSPOSE, ACCUM, NWF>(out, dmat, in,
+                                                           lane, wf);
+#else
+    /*
+     * Default f64 path: batched 4x4x4 matrix-core tile, full M-utilisation.
+     * Hardware-validated -- the ax_helm fluid solver converges on gfx90a/
+     * gfx942.  Still multi-wavefront via NWF.
+     */
+    mfma_contract_4x4<LX, AXIS, TRANSPOSE, ACCUM, NWF>(out, dmat, in, lane, wf);
+#endif
+  }
+};
+
+#endif // __gfx90a__ || __gfx942__
+#endif // __MATH_MFMA_KERNEL_H__

--- a/src/math/bcknd/device/hip/tensor.hip
+++ b/src/math/bcknd/device/hip/tensor.hip
@@ -44,13 +44,43 @@
      _a > _b ? _a : _b; })
 
 
+/*
+ * Threads per block for tnsr3d.
+ *
+ * One thread per output point of the widest of the three phases, rounded up
+ * to whole wavefronts and capped at the block maximum. The three phases
+ * produce nu*nu*nv, nu*nv*nv and nv*nv*nv points, so the widest is nu*nu*nv
+ * when restricting and nv*nv*nv when prolonging.
+ *
+ * This used to be a flat 1024 regardless, which on a p-transfer left most of
+ * the block with nothing to do: an 8 -> 4 restriction has 256, 128 and 64
+ * points in its phases, so three quarters to fifteen sixteenths of the
+ * threads idled. p-multigrid transfers between adjacent levels constantly,
+ * which is where that showed up.
+ *
+ * Any block size is correct here: the phases are grid stride loops and the
+ * barriers between them sit outside the loop bodies, so a thread with no
+ * iterations still reaches every barrier.
+ */
+static int hip_tnsr3d_nthrds(const int nu, const int nv)
+{
+  const int w1 = nu * nu * nv;
+  const int w3 = nv * nv * nv;
+  int work = (w1 > w3) ? w1 : w3;
+
+  work = ((work + 64 - 1) / 64) * 64;
+  if (work > 1024) work = 1024;
+  if (work < 64) work = 64;
+  return work;
+}
+
 extern "C" {
 
   /** Fortran wrapper for tnsr3d **/
   void hip_tnsr3d(void *v, int *nv, void *u, int *nu,
 		  void *A, void *Bt, void *Ct, int *nel) {
     
-    const dim3 nthrds(1024, 1, 1);
+    const dim3 nthrds(hip_tnsr3d_nthrds(*nu, *nv), 1, 1);
     const dim3 nblcks(*nel, 1, 1);
 
     int n = max(*nu,*nv);
@@ -92,7 +122,7 @@ extern "C" {
  /** Fortran wrapper for tnsr3d **/
   void hip_tnsr3d_el_list(void *v, int *nv, void *u, int *nu,
 		   void *A, void *Bt, void *Ct, int * elements, int* n_points) {
-    const dim3 nthrds(1024, 1, 1);
+    const dim3 nthrds(hip_tnsr3d_nthrds(*nu, *nv), 1, 1);
     const dim3 nblcks(*n_points, 1, 1);
 
     int n = max(*nu,*nv);

--- a/src/math/bcknd/device/hip/tensor_kernel.h
+++ b/src/math/bcknd/device/hip/tensor_kernel.h
@@ -51,12 +51,25 @@ __global__ void tnsr3d_el_kernel(T  * __restrict__  v,
   const int pt = blockIdx.x;
   const int e = elements[pt];
 
+  /* Stage the element into shared memory before the first contraction.
+     Read straight from global, phase 1 fetches every value of u nv times --
+     once per output row i -- and fetches them badly: with ii decomposing as
+     i + j*nv, consecutive threads vary i and share j, so a warp asks for
+     values nu apart and pulls a whole sector for each one. Staged, the global
+     read is a single contiguous pass and the redundancy is served from shared
+     memory. shwork2 is unused until phase 2 writes it, by which point u is
+     dead, so this costs no extra shared memory. */
+  for (int p = idx; p < nu*nu*nu; p += str)
+    shwork2[p] = u[p + e*nu*nu*nu];
+
+  __syncthreads();
+
   for (int ii = idx; ii< nu*nu*nv; ii += str) {
     T tmp = 0.0;
     int j = ii/nv;
     int i = ii - j*nv;
     for( int l = 0; l < nu; l++){
-      tmp += A[i+l*nv+pt*nv*nu]*u[l+nu*j+e*nu*nu*nu];
+      tmp += A[i+l*nv+pt*nv*nu]*shwork2[l+nu*j];
     }
     shwork[ii] = tmp;
   }
@@ -109,12 +122,25 @@ __global__ void tnsr3d_kernel(T  * __restrict__  v,
   const int str = blockDim.x;
   const int e = blockIdx.x;
   
+  /* Stage the element into shared memory before the first contraction.
+     Read straight from global, phase 1 fetches every value of u nv times --
+     once per output row i -- and fetches them badly: with ii decomposing as
+     i + j*nv, consecutive threads vary i and share j, so a warp asks for
+     values nu apart and pulls a whole sector for each one. Staged, the global
+     read is a single contiguous pass and the redundancy is served from shared
+     memory. shwork2 is unused until phase 2 writes it, by which point u is
+     dead, so this costs no extra shared memory. */
+  for (int p = idx; p < nu*nu*nu; p += str)
+    shwork2[p] = u[p + e*nu*nu*nu];
+
+  __syncthreads();
+
   for (int ii = idx; ii< nu*nu*nv; ii += str) {
     T tmp = 0.0;
     int j = ii/nv;
     int i = ii - j*nv;
     for( int l = 0; l < nu; l++){
-      tmp += A[i+l*nv]*u[l+nu*j+e*nu*nu*nu];
+      tmp += A[i+l*nv]*shwork2[l+nu*j];
     }
     shwork[ii] = tmp;
   }


### PR DESCRIPTION
This PR adds matrix/tensor core variants of Ax to the autotune. On AMD the kernels utilise MFMA and on NVIDIA it uses DMMA. Furthermore, both MFMA and DMMA sweeps various element packing and warp/wavefront variants during each autotune invocation. 

Example on a GH200,

```shell
    ---Autotune Ax helm (lx: 8)---
    1D    ch=1024:    138.30 us/call
    1D    ch=512 :    108.47 us/call
    1D    ch=256 :    100.68 us/call
    1D    ch=128 :    107.62 us/call
    KSTEP eb=1   :    114.23 us/call
    KSTEP eb=2   :    121.32 us/call
    KSTEP eb=4   :    129.73 us/call
    DMMA  2w 1e  :    100.14 us/call
    DMMA  4w 1e  :     91.31 us/call
    DMMA  8w 1e  :     95.63 us/call
    Chose        : 3 (DMMA, 4 warps, 1 elem/blk)
```
