### PR TITLE
Add templates for user-defined types

### DIFF
--- a/doc/pages/user-guide/extension.md
+++ b/doc/pages/user-guide/extension.md
@@ -33,9 +33,10 @@ supports this. Here is a list of things you can implement.
 - Point zones (`point_zone_t` descendants).
 - Preconditioners (`pc_t` descendants).
 - Krylov solvers (`ksp_t` descendants).
+- Scalar schemes (`scalar_scheme_t` descendants).
 
-This list will hopefully be extended later. Notable omissions are scalar and
-fluid schemes.
+This list will hopefully be extended later. Fluid schemes are a notable
+omission.
 
 To implement a new type, the easiest thing is to start by copying over the
 `.f90` of an already existing type, renaming things inside and then adding the

--- a/examples/programming/user_type_templates/README.md
+++ b/examples/programming/user_type_templates/README.md
@@ -1,0 +1,33 @@
+# User-type templates
+
+Each file is a standalone module that demonstrates one of Neko's supported
+user-type injection points.  Copy the file for the type you need, rename the
+file, module, derived type, JSON type name, and registration routine together,
+then add it to your `makeneko` command alongside the user file.
+
+For example:
+
+```sh
+makeneko user.f90 my_source_term.f90
+```
+
+`makeneko` discovers each `module_name_register_types` routine and calls it at
+startup.  The registration routine in every template is deliberately kept at
+the end of its module so it is easy to find.
+
+The templates cover every type currently supported by factory-based injection:
+
+- `les_model_template.f90` — `les_model_t`
+- `wall_model_template.f90` — `wall_model_t`
+- `simulation_component_template.f90` — `simulation_component_t`
+- `source_term_template.f90` — `source_term_t`
+- `point_zone_template.f90` — `point_zone_t`
+- `preconditioner_template.f90` — `pc_t`
+- `krylov_solver_template.f90` — `ksp_t`
+- `scalar_scheme_template.f90` — `scalar_scheme_t`
+
+The executable bodies are safe, minimal starting points rather than useful
+models: the LES and wall-model templates produce zero additional effects; the
+preconditioner is the identity; and the Krylov template stops with an explicit
+error until its solve routine is implemented.  Replace the marked `TODO`
+sections with the actual algorithm.

--- a/examples/programming/user_type_templates/krylov_solver_template.f90
+++ b/examples/programming/user_type_templates/krylov_solver_template.f90
@@ -1,0 +1,105 @@
+!> Template for a user-defined Krylov solver.
+module krylov_solver_template
+  use ax_product, only : ax_t
+  use bc_list, only : bc_list_t
+  use coefs, only : coef_t
+  use field, only : field_t
+  use gather_scatter, only : gs_t
+  use krylov, only : ksp_t, ksp_monitor_t, krylov_allocate, register_krylov
+  use num_types, only : rp
+  use precon, only : pc_t
+  use utils, only : neko_error
+  implicit none
+  private
+
+  type, extends(ksp_t) :: krylov_solver_template_t
+   contains
+     procedure :: init => krylov_solver_template_init
+     procedure :: free => krylov_solver_template_free
+     procedure :: solve => krylov_solver_template_solve
+     procedure :: solve_coupled => krylov_solver_template_solve_coupled
+  end type krylov_solver_template_t
+
+  public :: krylov_solver_template_register_types
+
+contains
+
+  subroutine krylov_solver_template_init(this, n, max_iter, M, rel_tol, &
+       abs_tol, monitor)
+    class(krylov_solver_template_t), target, intent(inout) :: this
+    integer, intent(in) :: n, max_iter
+    class(pc_t), target, optional, intent(in) :: M
+    real(kind=rp), optional, intent(in) :: rel_tol, abs_tol
+    logical, optional, intent(in) :: monitor
+
+    call this%free()
+    if (present(M)) call this%set_pc(M)
+    if (present(rel_tol) .and. present(abs_tol) .and. present(monitor)) then
+       call this%ksp_init(max_iter, rel_tol, abs_tol, monitor = monitor)
+    else if (present(rel_tol) .and. present(abs_tol)) then
+       call this%ksp_init(max_iter, rel_tol, abs_tol)
+    else if (present(rel_tol)) then
+       call this%ksp_init(max_iter, rel_tol = rel_tol)
+    else if (present(abs_tol)) then
+       call this%ksp_init(max_iter, abs_tol = abs_tol)
+    else if (present(monitor)) then
+       call this%ksp_init(max_iter, monitor = monitor)
+    else
+       call this%ksp_init(max_iter)
+    end if
+    ! TODO: Allocate work arrays of length n.
+  end subroutine krylov_solver_template_init
+
+  subroutine krylov_solver_template_free(this)
+    class(krylov_solver_template_t), intent(inout) :: this
+    ! TODO: Deallocate work arrays and other derived-type state.
+    call this%ksp_free()
+  end subroutine krylov_solver_template_free
+
+  function krylov_solver_template_solve(this, Ax, x, f, n, coef, blst, gs_h, &
+       niter) result(ksp_results)
+    class(krylov_solver_template_t), intent(inout) :: this
+    class(ax_t), intent(in) :: Ax
+    type(field_t), intent(inout) :: x
+    integer, intent(in) :: n
+    real(kind=rp), intent(in) :: f(n)
+    type(coef_t), intent(inout) :: coef
+    type(bc_list_t), intent(inout) :: blst
+    type(gs_t), intent(inout) :: gs_h
+    integer, optional, intent(in) :: niter
+    type(ksp_monitor_t) :: ksp_results
+
+    ! TODO: Implement the Krylov iteration and return its monitor data.
+    call neko_error('krylov_solver_template: solve is not implemented')
+  end function krylov_solver_template_solve
+
+  function krylov_solver_template_solve_coupled(this, Ax, x, y, z, fx, fy, fz, &
+       n, coef, blstx, blsty, blstz, gs_h, niter) result(ksp_results)
+    class(krylov_solver_template_t), intent(inout) :: this
+    class(ax_t), intent(in) :: Ax
+    type(field_t), intent(inout) :: x, y, z
+    integer, intent(in) :: n
+    real(kind=rp), intent(in) :: fx(n), fy(n), fz(n)
+    type(coef_t), intent(inout) :: coef
+    type(bc_list_t), intent(inout) :: blstx, blsty, blstz
+    type(gs_t), intent(inout) :: gs_h
+    integer, optional, intent(in) :: niter
+    type(ksp_monitor_t) :: ksp_results(3)
+
+    ! A valid default when a solver applies independently to each component.
+    ksp_results(1) = this%solve(Ax, x, fx, n, coef, blstx, gs_h, niter)
+    ksp_results(2) = this%solve(Ax, y, fy, n, coef, blsty, gs_h, niter)
+    ksp_results(3) = this%solve(Ax, z, fz, n, coef, blstz, gs_h, niter)
+  end function krylov_solver_template_solve_coupled
+
+  subroutine krylov_solver_template_register_types()
+    procedure(krylov_allocate), pointer :: allocator
+    allocator => krylov_solver_template_allocate
+    call register_krylov('krylov_solver_template', allocator)
+  end subroutine krylov_solver_template_register_types
+
+  subroutine krylov_solver_template_allocate(obj)
+    class(ksp_t), allocatable, intent(inout) :: obj
+    allocate(krylov_solver_template_t :: obj)
+  end subroutine krylov_solver_template_allocate
+end module krylov_solver_template

--- a/examples/programming/user_type_templates/les_model_template.f90
+++ b/examples/programming/user_type_templates/les_model_template.f90
@@ -1,0 +1,60 @@
+!> Template for a user-defined LES model.
+module les_model_template
+  use fluid_scheme_base, only : fluid_scheme_base_t
+  use json_module, only : json_file
+  use json_utils, only : json_get_or_default
+  use les_model, only : les_model_t, les_model_allocate, register_les_model
+  use num_types, only : rp
+  implicit none
+  private
+
+  type, extends(les_model_t) :: les_model_template_t
+   contains
+     procedure :: init => les_model_template_init
+     procedure :: free => les_model_template_free
+     procedure :: compute => les_model_template_compute
+  end type les_model_template_t
+
+  public :: les_model_template_register_types
+
+contains
+
+  subroutine les_model_template_init(this, fluid, json)
+    class(les_model_template_t), intent(inout) :: this
+    class(fluid_scheme_base_t), target, intent(inout) :: fluid
+    type(json_file), intent(inout) :: json
+    character(len=:), allocatable :: nut_name, delta_type
+    logical :: extrapolation
+
+    call json_get_or_default(json, 'nut_field', nut_name, 'nut')
+    call json_get_or_default(json, 'delta_type', delta_type, 'pointwise')
+    call json_get_or_default(json, 'extrapolation', extrapolation, .false.)
+    call this%free()
+    call this%init_base(fluid, nut_name, delta_type, extrapolation)
+    ! TODO: Read model-specific parameters from json.
+  end subroutine les_model_template_init
+
+  subroutine les_model_template_free(this)
+    class(les_model_template_t), intent(inout) :: this
+    ! TODO: Release fields owned by this derived type.
+    call this%free_base()
+  end subroutine les_model_template_free
+
+  subroutine les_model_template_compute(this, t, tstep)
+    class(les_model_template_t), intent(inout) :: this
+    real(kind=rp), intent(in) :: t
+    integer, intent(in) :: tstep
+    ! TODO: Compute this%nut from the resolved flow field.
+  end subroutine les_model_template_compute
+
+  subroutine les_model_template_register_types()
+    procedure(les_model_allocate), pointer :: allocator
+    allocator => les_model_template_allocate
+    call register_les_model('les_model_template', allocator)
+  end subroutine les_model_template_register_types
+
+  subroutine les_model_template_allocate(obj)
+    class(les_model_t), allocatable, intent(inout) :: obj
+    allocate(les_model_template_t :: obj)
+  end subroutine les_model_template_allocate
+end module les_model_template

--- a/examples/programming/user_type_templates/point_zone_template.f90
+++ b/examples/programming/user_type_templates/point_zone_template.f90
@@ -1,0 +1,62 @@
+!> Template for a user-defined point zone.
+module point_zone_template
+  use json_module, only : json_file
+  use json_utils, only : json_get, json_get_or_default
+  use num_types, only : rp
+  use point_zone, only : point_zone_t, point_zone_allocate, &
+       register_point_zone
+  implicit none
+  private
+
+  type, extends(point_zone_t) :: point_zone_template_t
+   contains
+     procedure :: init => point_zone_template_init
+     procedure :: free => point_zone_template_free
+     procedure :: criterion => point_zone_template_criterion
+  end type point_zone_template_t
+
+  public :: point_zone_template_register_types
+
+contains
+
+  subroutine point_zone_template_init(this, json, size)
+    class(point_zone_template_t), intent(inout) :: this
+    type(json_file), intent(inout) :: json
+    integer, intent(in) :: size
+    character(len=:), allocatable :: name
+    logical :: invert, full_elements
+
+    call json_get(json, 'name', name)
+    call json_get_or_default(json, 'invert', invert, .false.)
+    call json_get_or_default(json, 'full_elements', full_elements, .false.)
+    call this%init_base(size, name, invert, full_elements)
+    ! TODO: Read criterion-specific parameters from json.
+  end subroutine point_zone_template_init
+
+  subroutine point_zone_template_free(this)
+    class(point_zone_template_t), intent(inout) :: this
+    ! TODO: Release fields owned by this derived type.
+    call this%free_base()
+  end subroutine point_zone_template_free
+
+  pure function point_zone_template_criterion(this, x, y, z, j, k, l, e) &
+       result(is_inside)
+    class(point_zone_template_t), intent(in) :: this
+    real(kind=rp), intent(in) :: x, y, z
+    integer, intent(in) :: j, k, l, e
+    logical :: is_inside
+    ! TODO: Replace with the point-selection criterion.
+    is_inside = .false.
+  end function point_zone_template_criterion
+
+  subroutine point_zone_template_register_types()
+    procedure(point_zone_allocate), pointer :: allocator
+    allocator => point_zone_template_allocate
+    call register_point_zone('point_zone_template', allocator)
+  end subroutine point_zone_template_register_types
+
+  subroutine point_zone_template_allocate(obj)
+    class(point_zone_t), allocatable, intent(inout) :: obj
+    allocate(point_zone_template_t :: obj)
+  end subroutine point_zone_template_allocate
+end module point_zone_template

--- a/examples/programming/user_type_templates/preconditioner_template.f90
+++ b/examples/programming/user_type_templates/preconditioner_template.f90
@@ -1,0 +1,41 @@
+!> Template for a user-defined Krylov preconditioner.
+module preconditioner_template
+  use num_types, only : rp
+  use precon, only : pc_t, precon_allocate, register_precon
+  implicit none
+  private
+
+  type, extends(pc_t) :: preconditioner_template_t
+   contains
+     procedure :: solve => preconditioner_template_solve
+     procedure :: update => preconditioner_template_update
+  end type preconditioner_template_t
+
+  public :: preconditioner_template_register_types
+
+contains
+
+  subroutine preconditioner_template_solve(this, z, r, n)
+    class(preconditioner_template_t), intent(inout) :: this
+    integer, intent(in) :: n
+    real(kind=rp), intent(inout) :: z(n), r(n)
+    ! TODO: Replace the identity operation with M z = r.
+    z = r
+  end subroutine preconditioner_template_solve
+
+  subroutine preconditioner_template_update(this)
+    class(preconditioner_template_t), intent(inout) :: this
+    ! TODO: Update state after a change in geometry or operator coefficients.
+  end subroutine preconditioner_template_update
+
+  subroutine preconditioner_template_register_types()
+    procedure(precon_allocate), pointer :: allocator
+    allocator => preconditioner_template_allocate
+    call register_precon('preconditioner_template', allocator)
+  end subroutine preconditioner_template_register_types
+
+  subroutine preconditioner_template_allocate(obj)
+    class(pc_t), allocatable, intent(inout) :: obj
+    allocate(preconditioner_template_t :: obj)
+  end subroutine preconditioner_template_allocate
+end module preconditioner_template

--- a/examples/programming/user_type_templates/scalar_scheme_template.f90
+++ b/examples/programming/user_type_templates/scalar_scheme_template.f90
@@ -1,0 +1,88 @@
+!> Template for a user-defined scalar scheme.
+module scalar_scheme_template
+  use checkpoint, only : chkp_t
+  use coefs, only : coef_t
+  use field, only : field_t
+  use field_series, only : field_series_t
+  use gather_scatter, only : gs_t
+  use json_module, only : json_file
+  use krylov, only : ksp_monitor_t
+  use mesh, only : mesh_t
+  use scalar_scheme, only : scalar_scheme_t, scalar_scheme_allocate, &
+       register_scalar_scheme
+  use time_scheme_controller, only : time_scheme_controller_t
+  use time_state, only : time_state_t
+  use time_step_controller, only : time_step_controller_t
+  use user_intf, only : user_t
+  use utils, only : neko_error
+  implicit none
+  private
+
+  type, extends(scalar_scheme_t) :: scalar_scheme_template_t
+   contains
+     procedure :: init => scalar_scheme_template_init
+     procedure :: free => scalar_scheme_template_free
+     procedure :: step => scalar_scheme_template_step
+     procedure :: restart => scalar_scheme_template_restart
+  end type scalar_scheme_template_t
+
+  public :: scalar_scheme_template_register_types
+
+contains
+
+  subroutine scalar_scheme_template_init(this, msh, coef, gs, params, &
+       numerics_params, user, chkp, ulag, vlag, wlag, time_scheme, rho)
+    class(scalar_scheme_template_t), target, intent(inout) :: this
+    type(mesh_t), target, intent(in) :: msh
+    type(coef_t), target, intent(in) :: coef
+    type(gs_t), target, intent(inout) :: gs
+    type(json_file), target, intent(inout) :: params, numerics_params
+    type(user_t), target, intent(in) :: user
+    type(chkp_t), target, intent(inout) :: chkp
+    type(field_series_t), target, intent(in) :: ulag, vlag, wlag
+    type(time_scheme_controller_t), target, intent(in) :: time_scheme
+    type(field_t), target, intent(in) :: rho
+
+    ! `scheme_init` sets up common fields, material properties, source terms,
+    ! and the configured Krylov solver/preconditioner.
+    call this%scheme_init(msh, coef, gs, params, 'scalar_scheme_template', &
+         user, rho)
+    ! TODO: Construct this scheme's operators and use numerics_params,
+    !       lagged velocities, time_scheme, and chkp as needed.
+  end subroutine scalar_scheme_template_init
+
+  subroutine scalar_scheme_template_free(this)
+    class(scalar_scheme_template_t), intent(inout) :: this
+    ! TODO: Release operators and state owned by this derived type.
+    call this%scheme_free()
+  end subroutine scalar_scheme_template_free
+
+  subroutine scalar_scheme_template_step(this, time, ext_bdf, dt_controller, &
+       ksp_results)
+    class(scalar_scheme_template_t), intent(inout) :: this
+    type(time_state_t), intent(in) :: time
+    type(time_scheme_controller_t), intent(in) :: ext_bdf
+    type(time_step_controller_t), intent(in) :: dt_controller
+    type(ksp_monitor_t), intent(inout) :: ksp_results
+
+    ! TODO: Assemble and solve one scalar time step.
+    call neko_error('scalar_scheme_template: step is not implemented')
+  end subroutine scalar_scheme_template_step
+
+  subroutine scalar_scheme_template_restart(this, chkp)
+    class(scalar_scheme_template_t), target, intent(inout) :: this
+    type(chkp_t), intent(inout) :: chkp
+    ! TODO: Restore scheme-specific checkpoint state.
+  end subroutine scalar_scheme_template_restart
+
+  subroutine scalar_scheme_template_register_types()
+    procedure(scalar_scheme_allocate), pointer :: allocator
+    allocator => scalar_scheme_template_allocate
+    call register_scalar_scheme('scalar_scheme_template', allocator)
+  end subroutine scalar_scheme_template_register_types
+
+  subroutine scalar_scheme_template_allocate(obj)
+    class(scalar_scheme_t), allocatable, intent(inout) :: obj
+    allocate(scalar_scheme_template_t :: obj)
+  end subroutine scalar_scheme_template_allocate
+end module scalar_scheme_template

--- a/examples/programming/user_type_templates/simulation_component_template.f90
+++ b/examples/programming/user_type_templates/simulation_component_template.f90
@@ -1,0 +1,57 @@
+!> Template for a user-defined simulation component.
+module simulation_component_template
+  use case, only : case_t
+  use json_module, only : json_file
+  use json_utils, only : json_get_or_default
+  use simulation_component, only : simulation_component_t, &
+       simulation_component_allocate, register_simulation_component
+  use time_state, only : time_state_t
+  implicit none
+  private
+
+  type, extends(simulation_component_t) :: simulation_component_template_t
+   contains
+     procedure :: init => simulation_component_template_init
+     procedure :: free => simulation_component_template_free
+     procedure :: compute_ => simulation_component_template_compute
+  end type simulation_component_template_t
+
+  public :: simulation_component_template_register_types
+
+contains
+
+  subroutine simulation_component_template_init(this, json, case)
+    class(simulation_component_template_t), target, intent(inout) :: this
+    type(json_file), intent(inout) :: json
+    class(case_t), target, intent(inout) :: case
+
+    call this%init_base(json, case)
+    call json_get_or_default(json, 'name', this%name, &
+         'simulation_component_template')
+    ! TODO: Read component-specific parameters from json.
+  end subroutine simulation_component_template_init
+
+  subroutine simulation_component_template_free(this)
+    class(simulation_component_template_t), intent(inout) :: this
+    ! TODO: Release fields owned by this derived type.
+    call this%free_base()
+  end subroutine simulation_component_template_free
+
+  subroutine simulation_component_template_compute(this, time)
+    class(simulation_component_template_t), intent(inout) :: this
+    type(time_state_t), intent(in) :: time
+    ! TODO: Implement the component's scheduled action.
+  end subroutine simulation_component_template_compute
+
+  subroutine simulation_component_template_register_types()
+    procedure(simulation_component_allocate), pointer :: allocator
+    allocator => simulation_component_template_allocate
+    call register_simulation_component('simulation_component_template', &
+         allocator)
+  end subroutine simulation_component_template_register_types
+
+  subroutine simulation_component_template_allocate(obj)
+    class(simulation_component_t), allocatable, intent(inout) :: obj
+    allocate(simulation_component_template_t :: obj)
+  end subroutine simulation_component_template_allocate
+end module simulation_component_template

--- a/examples/programming/user_type_templates/source_term_template.f90
+++ b/examples/programming/user_type_templates/source_term_template.f90
@@ -1,0 +1,58 @@
+!> Template for a user-defined source term.
+module source_term_template
+  use coefs, only : coef_t
+  use field_list, only : field_list_t
+  use json_module, only : json_file
+  use num_types, only : rp
+  use source_term, only : source_term_t, source_term_allocate, &
+       register_source_term
+  use time_state, only : time_state_t
+  implicit none
+  private
+
+  type, extends(source_term_t) :: source_term_template_t
+   contains
+     procedure :: init => source_term_template_init
+     procedure :: free => source_term_template_free
+     procedure :: compute_ => source_term_template_compute
+  end type source_term_template_t
+
+  public :: source_term_template_register_types
+
+contains
+
+  subroutine source_term_template_init(this, json, fields, coef, variable_name)
+    class(source_term_template_t), intent(inout) :: this
+    type(json_file), intent(inout) :: json
+    type(field_list_t), target, intent(in) :: fields
+    type(coef_t), target, intent(in) :: coef
+    character(len=*), intent(in) :: variable_name
+
+    call this%free()
+    ! TODO: Read source-term-specific parameters from json.
+    call this%init_base(fields, coef, 0.0_rp, huge(0.0_rp))
+  end subroutine source_term_template_init
+
+  subroutine source_term_template_free(this)
+    class(source_term_template_t), intent(inout) :: this
+    ! TODO: Release fields owned by this derived type.
+    call this%free_base()
+  end subroutine source_term_template_free
+
+  subroutine source_term_template_compute(this, time)
+    class(source_term_template_t), intent(inout) :: this
+    type(time_state_t), intent(in) :: time
+    ! TODO: Add this source term to this%fields.
+  end subroutine source_term_template_compute
+
+  subroutine source_term_template_register_types()
+    procedure(source_term_allocate), pointer :: allocator
+    allocator => source_term_template_allocate
+    call register_source_term('source_term_template', allocator)
+  end subroutine source_term_template_register_types
+
+  subroutine source_term_template_allocate(obj)
+    class(source_term_t), allocatable, intent(inout) :: obj
+    allocate(source_term_template_t :: obj)
+  end subroutine source_term_template_allocate
+end module source_term_template

--- a/examples/programming/user_type_templates/wall_model_template.f90
+++ b/examples/programming/user_type_templates/wall_model_template.f90
@@ -1,0 +1,86 @@
+!> Template for a user-defined wall model.
+module wall_model_template
+  use coefs, only : coef_t
+  use json_module, only : json_file
+  use num_types, only : rp
+  use user_intf, only : user_t
+  use wall_model, only : wall_model_t, wall_model_allocate, &
+       register_wall_model
+  implicit none
+  private
+
+  type, extends(wall_model_t) :: wall_model_template_t
+   contains
+     procedure :: init => wall_model_template_init
+     procedure :: partial_init => wall_model_template_partial_init
+     procedure :: finalize => wall_model_template_finalize
+     procedure :: free => wall_model_template_free
+     procedure :: compute => wall_model_template_compute
+  end type wall_model_template_t
+
+  public :: wall_model_template_register_types
+
+contains
+
+  subroutine wall_model_template_init(this, scheme_name, coef, msk, facet, json)
+    class(wall_model_template_t), intent(inout) :: this
+    character(len=*), intent(in) :: scheme_name
+    type(coef_t), intent(in) :: coef
+    integer, intent(in) :: msk(:), facet(:)
+    type(json_file), intent(inout) :: json
+
+    call this%partial_init(coef, scheme_name, json)
+    call this%finalize(msk, facet)
+  end subroutine wall_model_template_init
+
+  subroutine wall_model_template_partial_init(this, coef, scheme_name, json)
+    class(wall_model_template_t), intent(inout) :: this
+    type(coef_t), intent(in) :: coef
+    character(len=*), intent(in) :: scheme_name
+    type(json_file), intent(inout) :: json
+
+    call this%partial_init_base(coef, scheme_name, json)
+    ! TODO: Read wall-model-specific parameters from json.
+  end subroutine wall_model_template_partial_init
+
+  subroutine wall_model_template_finalize(this, msk, facet, bc_name, user)
+    class(wall_model_template_t), intent(inout) :: this
+    integer, intent(in) :: msk(:), facet(:)
+    character(len=*), optional, intent(in) :: bc_name
+    type(user_t), target, optional, intent(in) :: user
+
+    if (present(bc_name) .and. present(user)) then
+       call this%finalize_base(msk, facet, bc_name, user)
+    else if (present(bc_name)) then
+       call this%finalize_base(msk, facet, bc_name)
+    else
+       call this%finalize_base(msk, facet)
+    end if
+    ! TODO: Initialize arrays which depend on this%n_nodes.
+  end subroutine wall_model_template_finalize
+
+  subroutine wall_model_template_free(this)
+    class(wall_model_template_t), intent(inout) :: this
+    ! TODO: Release fields owned by this derived type.
+    call this%free_base()
+  end subroutine wall_model_template_free
+
+  subroutine wall_model_template_compute(this, t, tstep)
+    class(wall_model_template_t), intent(inout) :: this
+    real(kind=rp), intent(in) :: t
+    integer, intent(in) :: tstep
+    ! TODO: Fill this%tau_x, this%tau_y, and this%tau_z.
+    call this%compute_mag_field()
+  end subroutine wall_model_template_compute
+
+  subroutine wall_model_template_register_types()
+    procedure(wall_model_allocate), pointer :: allocator
+    allocator => wall_model_template_allocate
+    call register_wall_model('wall_model_template', allocator)
+  end subroutine wall_model_template_register_types
+
+  subroutine wall_model_template_allocate(obj)
+    class(wall_model_t), allocatable, intent(inout) :: obj
+    allocate(wall_model_template_t :: obj)
+  end subroutine wall_model_template_allocate
+end module wall_model_template

--- a/tests/integration/tests/test_examples/test_examples.py
+++ b/tests/integration/tests/test_examples/test_examples.py
@@ -16,6 +16,7 @@ turboneko = get_neko()
 class NekoTestCase:
     case_file: str = None
     user_file: str = None
+    user_files: tuple[str, ...] = None
     mesh_file: str = None
 
 examples_dir = join(neko_dir, "examples")
@@ -122,6 +123,21 @@ examples = {
     "programming_user_file_template": NekoTestCase(
         user_file=join(examples_dir, "programming", "user_file_template.f90")
     ),
+    "programming_user_type_templates": NekoTestCase(
+        user_files=tuple(
+            join(examples_dir, "programming", "user_type_templates", filename)
+            for filename in (
+                "source_term_template.f90",
+                "point_zone_template.f90",
+                "simulation_component_template.f90",
+                "les_model_template.f90",
+                "wall_model_template.f90",
+                "preconditioner_template.f90",
+                "krylov_solver_template.f90",
+                "scalar_scheme_template.f90",
+            )
+        )
+    ),
 }
 
 
@@ -196,7 +212,10 @@ def test_example_smoke(example, launcher_script, request, log_file, tmp_path):
     ), f"neko process failed with exit code {result.returncode}"
 
 
-@pytest.mark.parametrize("example", [key for key in examples.keys() if examples[key].user_file])
+@pytest.mark.parametrize(
+    "example",
+    [key for key in examples.keys() if examples[key].user_file or examples[key].user_files],
+)
 def test_example_compile(example, log_file):
     """Compile all examples that have a user file.
 
@@ -204,9 +223,10 @@ def test_example_compile(example, log_file):
 
     makeneko = get_makeneko()
 
+    user_files = examples[example].user_files or (examples[example].user_file,)
     with open(log_file, "w") as f:
         result = subprocess.run(
-            [makeneko, examples[example].user_file],
+            [makeneko, *user_files],
             stdout=f,
             stderr=subprocess.STDOUT,
             text=True)


### PR DESCRIPTION
I thought it would be nice to have ready-made templates for all the possible user-injectable types. This way instead of "cleaning" up a copied existing type in neko, one can start with a fresh, empty, but compilable template.
The template compilation is added to the CI.