### PR TITLE
Fix/mesh fname in import fields

### DIFF
--- a/src/fluid/flow_ic.f90
+++ b/src/fluid/flow_ic.f90
@@ -493,9 +493,15 @@ contains
     ws => w
     ps => p
 
+    if (trim(mesh_file_name) .eq. 'none') then
+    call import_fields(file_name, global_interp_subdict, &
+         u = us, v = vs, w = ws, p = ps, &
+         interpolate = interpolate)
+    else
     call import_fields(file_name, global_interp_subdict, mesh_file_name, &
          u = us, v = vs, w = ws, p = ps, &
          interpolate = interpolate)
+    end if
 
     nullify(us, vs, ws, ps)
 

--- a/src/fluid/flow_ic.f90
+++ b/src/fluid/flow_ic.f90
@@ -494,13 +494,13 @@ contains
     ps => p
 
     if (trim(mesh_file_name) .eq. 'none') then
-    call import_fields(file_name, global_interp_subdict, &
-         u = us, v = vs, w = ws, p = ps, &
-         interpolate = interpolate)
+       call import_fields(file_name, global_interp_subdict, &
+            u = us, v = vs, w = ws, p = ps, &
+            interpolate = interpolate)
     else
-    call import_fields(file_name, global_interp_subdict, mesh_file_name, &
-         u = us, v = vs, w = ws, p = ps, &
-         interpolate = interpolate)
+       call import_fields(file_name, global_interp_subdict, mesh_file_name, &
+            u = us, v = vs, w = ws, p = ps, &
+            interpolate = interpolate)
     end if
 
     nullify(us, vs, ws, ps)

--- a/src/source_terms/sponge_source_term.f90
+++ b/src/source_terms/sponge_source_term.f90
@@ -311,13 +311,13 @@ contains
     ! Import the u,v,w baseflows from fld
     !
     if (trim(mesh_file_name) .eq. 'none') then
-    call import_fields(file_name, interp_subdict, &
-         u = this%u_bf, v = this%v_bf, w = this%w_bf, &
-         interpolate = interpolate)
+       call import_fields(file_name, interp_subdict, &
+            u = this%u_bf, v = this%v_bf, w = this%w_bf, &
+            interpolate = interpolate)
     else
-    call import_fields(file_name, interp_subdict, mesh_file_name, &
-         u = this%u_bf, v = this%v_bf, w = this%w_bf, &
-         interpolate = interpolate)
+       call import_fields(file_name, interp_subdict, mesh_file_name, &
+            u = this%u_bf, v = this%v_bf, w = this%w_bf, &
+            interpolate = interpolate)
     end if
 
     this%baseflow_set = .true.

--- a/src/source_terms/sponge_source_term.f90
+++ b/src/source_terms/sponge_source_term.f90
@@ -310,9 +310,15 @@ contains
     !
     ! Import the u,v,w baseflows from fld
     !
+    if (trim(mesh_file_name) .eq. 'none') then
+    call import_fields(file_name, interp_subdict, &
+         u = this%u_bf, v = this%v_bf, w = this%w_bf, &
+         interpolate = interpolate)
+    else
     call import_fields(file_name, interp_subdict, mesh_file_name, &
          u = this%u_bf, v = this%v_bf, w = this%w_bf, &
          interpolate = interpolate)
+    end if
 
     this%baseflow_set = .true.
 


### PR DESCRIPTION
Do remove the mesh_fname dummy argument in calls to import fields, since now the mesh file is read everytime the argument is passed. Affects flow_ic and sponge source term