### PR TITLE
Fixes importing field file data

### DIFF
--- a/doc/pages/user-guide/case-file.md
+++ b/doc/pages/user-guide/case-file.md
@@ -634,25 +634,31 @@ A more detailed description of each boundary condition is provided below.
 
   The second option is to provide the values through a field file using the
   `file_name` keyword. This is currently supported only by the axis-aligned
-  implementation. The file must contain a three-component vector field in
-  global Cartesian coordinates. Internally, only the tangential components are
-  enforced on the boundary. Optional interpolation settings are the same as for
-  other field-imported data:
+  implementation. The file must contain a three-component vector field in global
+  Cartesian coordinates. Internally, only the tangential components are enforced
+  on the boundary. The `file_name` and `mesh_file_name` values use Neko's
+  field-sample naming convention, for example `field0.f00000`. The
+  `mesh_file_name` is an optional field sample containing the source mesh
+  coordinates; it can be omitted when the source field contains its own
+  coordinates. Optional interpolation settings are the same as for other
+  field-imported data:
 
   * `interpolate`. Logical flag controlling whether interpolation is used.
-  * `mesh_file_name`. Mesh file used for interpolation when the source field is
-    defined on a different mesh.
+  * `mesh_file_name`. Optional sampled field containing the source mesh
+    coordinates when the source field is defined on a different mesh.
   * `interpolation.tolerance`. Tolerance for the interpolation search.
   * `interpolation.padding`. Padding used in the interpolation search.
 
   ```json
   {
     "type": "normal_outflow",
-    "file_name": "outlet_velocity.fld",
+    "file_name": "outlet_velocity0.f00000",
     "interpolate": true,
-    "mesh_file_name": "coarse_box.nmsh",
-    "interpolation.tolerance": 1.0e-8,
-    "interpolation.padding": 0.01,
+    "mesh_file_name": "coarse_box0.f00000",
+    "interpolation": {
+      "tolerance": 1.0e-8,
+      "padding": 0.01
+    },
     "zone_indices": [1, 2]
   }
   ```

--- a/doc/schemas/fluid-pnpn-boundary-conditions.schema.json
+++ b/doc/schemas/fluid-pnpn-boundary-conditions.schema.json
@@ -182,9 +182,7 @@
             "type": {
               "enum": [
                 "outflow",
-                "outflow+user",
-                "normal_outflow",
-                "normal_outflow+user"
+                "outflow+user"
               ]
             },
             "zone_indices": {
@@ -205,11 +203,34 @@
             "type",
             "zone_indices"
           ],
+          "oneOf": [
+            {
+              "required": [
+                "value"
+              ]
+            },
+            {
+              "required": [
+                "file_name"
+              ]
+            }
+          ],
+          "dependentRequired": {
+            "interpolate": [
+              "file_name"
+            ],
+            "mesh_file_name": [
+              "file_name"
+            ],
+            "interpolation": [
+              "file_name"
+            ]
+          },
           "properties": {
             "type": {
               "enum": [
-                "outflow+dong",
-                "normal_outflow+dong"
+                "normal_outflow",
+                "normal_outflow+user"
               ]
             },
             "zone_indices": {
@@ -220,6 +241,135 @@
             },
             "value": {
               "$ref": "urn:neko:schema:common#/$defs/vector3OrRef"
+            },
+            "file_name": {
+              "type": "string",
+              "pattern": "\\.f[0-9]{5}$"
+            },
+            "interpolate": {
+              "type": "boolean"
+            },
+            "mesh_file_name": {
+              "type": "string",
+              "pattern": "\\.f[0-9]{5}$"
+            },
+            "interpolation": {
+              "type": "object",
+              "properties": {
+                "tolerance": {
+                  "type": "number",
+                  "x-neko-real": true,
+                  "exclusiveMinimum": 0
+                },
+                "padding": {
+                  "type": "number",
+                  "x-neko-real": true,
+                  "exclusiveMinimum": 0
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "zone_indices"
+          ],
+          "properties": {
+            "type": {
+              "enum": [
+                "outflow+dong"
+              ]
+            },
+            "zone_indices": {
+              "$ref": "urn:neko:schema:common#/$defs/integerArrayOrRef"
+            },
+            "name": {
+              "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+            },
+            "value": {
+              "$ref": "urn:neko:schema:common#/$defs/vector3OrRef"
+            },
+            "delta": {
+              "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+            },
+            "velocity_scale": {
+              "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "zone_indices"
+          ],
+          "oneOf": [
+            {
+              "required": [
+                "value"
+              ]
+            },
+            {
+              "required": [
+                "file_name"
+              ]
+            }
+          ],
+          "dependentRequired": {
+            "interpolate": [
+              "file_name"
+            ],
+            "mesh_file_name": [
+              "file_name"
+            ],
+            "interpolation": [
+              "file_name"
+            ]
+          },
+          "properties": {
+            "type": {
+              "const": "normal_outflow+dong"
+            },
+            "zone_indices": {
+              "$ref": "urn:neko:schema:common#/$defs/integerArrayOrRef"
+            },
+            "name": {
+              "$ref": "urn:neko:schema:common#/$defs/nonEmptyString"
+            },
+            "value": {
+              "$ref": "urn:neko:schema:common#/$defs/vector3OrRef"
+            },
+            "file_name": {
+              "type": "string",
+              "pattern": "\\.f[0-9]{5}$"
+            },
+            "interpolate": {
+              "type": "boolean"
+            },
+            "mesh_file_name": {
+              "type": "string",
+              "pattern": "\\.f[0-9]{5}$"
+            },
+            "interpolation": {
+              "type": "object",
+              "properties": {
+                "tolerance": {
+                  "type": "number",
+                  "x-neko-real": true,
+                  "exclusiveMinimum": 0
+                },
+                "padding": {
+                  "type": "number",
+                  "x-neko-real": true,
+                  "exclusiveMinimum": 0
+                }
+              },
+              "additionalProperties": false
             },
             "delta": {
               "$ref": "urn:neko:schema:common#/$defs/positiveNumberOrRef"

--- a/src/bc/non_normal_aligned.f90
+++ b/src/bc/non_normal_aligned.f90
@@ -432,11 +432,19 @@ contains
        call neko_scratch_registry%request_field(value_z_field, scratch_idx(3), &
             .true.)
 
-       call import_fields(this%field_file_name, this%field_mesh_file_name, &
-            u = value_x_field, v = value_y_field, w = value_z_field, &
-            interpolate = this%field_interpolate, &
-            tolerance = this%field_interp_tolerance, &
-            padding = this%field_interp_padding)
+       if (trim(this%field_mesh_file_name) .eq. "none") then
+          call import_fields(this%field_file_name, &
+               u = value_x_field, v = value_y_field, w = value_z_field, &
+               interpolate = this%field_interpolate, &
+               tolerance = this%field_interp_tolerance, &
+               padding = this%field_interp_padding)
+       else
+          call import_fields(this%field_file_name, this%field_mesh_file_name, &
+               u = value_x_field, v = value_y_field, w = value_z_field, &
+               interpolate = this%field_interpolate, &
+               tolerance = this%field_interp_tolerance, &
+               padding = this%field_interp_padding)
+       end if
 
        call vector_masked_gather_copy_0(this%value_x, &
             value_x_field%x(:,1,1,1), this%bc_x%msk, value_x_field%size(), &

--- a/src/io/import_field_utils.f90
+++ b/src/io/import_field_utils.f90
@@ -156,7 +156,7 @@ contains
     real(kind=dp), intent(in), optional :: padding
 
     character(len=LOG_SIZE) :: log_buf
-    integer :: sample_idx, sample_mesh_idx, i
+    integer :: i
 
     logical :: interpolate_
 
@@ -174,11 +174,18 @@ contains
     call neko_log%message(log_buf)
 
     !
-    ! Read fld file and mesh file if specified
+    ! Read the mesh field only when interpolation is enabled and a separate
+    ! mesh field was specified. The mesh file is optional; when omitted, the
+    ! coordinates are read from the field file itself.
     !
-    if (present(mesh_fname)) then
-       call neko_log%message("Mesh file     : " // trim(mesh_fname))
-       call read_fld_file(mesh_fname, fld_data)
+    if (interpolate_) then
+       if (present(mesh_fname)) then
+          ! For scalar IC. TODO: stop using the "none" fill info in scalar.
+          if (trim(mesh_fname) .ne. "none") then
+             call neko_log%message("Mesh file     : " // trim(mesh_fname))
+             call read_fld_file(mesh_fname, fld_data)
+          end if
+       end if
     end if
 
     call read_fld_file(fname, fld_data)

--- a/tests/integration/tests/test_case_schema/test_case_schema.py
+++ b/tests/integration/tests/test_case_schema/test_case_schema.py
@@ -175,6 +175,8 @@ def test_allows_dong_outflow_parameters(tmp_path, boundary_type):
 
     boundary = data["case"]["fluid"]["boundary_conditions"][1]
     boundary["type"] = boundary_type
+    if boundary_type == "normal_outflow+dong":
+        boundary["value"] = [1.0, 0.0, 0.0]
     boundary["delta"] = 0.01
     boundary["velocity_scale"] = 1.0
 

--- a/tests/integration/tests/test_import_fields/test_import_fields.py
+++ b/tests/integration/tests/test_import_fields/test_import_fields.py
@@ -29,6 +29,7 @@ from testlib import (
 COMPONENTS = ("fluid", "scalar", "non_normal", "sponge")
 IMPORT_MODES = ("same_mesh", "embedded_mesh", "separate_mesh")
 NPROCS = 2
+INTERPOLATION_TOLERANCE = {"dp": 1.0e-8, "sp": 1.0e-4}
 VALUE_TOLERANCE = {"dp": 1.0e-8, "sp": 2.0e-4}
 
 
@@ -52,7 +53,7 @@ def _field_options(field_file, mode, mesh_field):
         options["mesh_file_name"] = str(mesh_field)
     if mode != "same_mesh":
         options["interpolation"] = {
-            "tolerance": 1.0e-8,
+            "tolerance": INTERPOLATION_TOLERANCE[conftest.RP],
             "padding": 0.05,
         }
     return options

--- a/tests/integration/tests/test_import_fields/test_import_fields.py
+++ b/tests/integration/tests/test_import_fields/test_import_fields.py
@@ -1,0 +1,342 @@
+"""Integration coverage for all case-file users of ``import_fields``.
+
+Flow and scalar initial conditions, sponge baseflows, and non-normal boundary
+data all expose field import through the case file.  Exercise each pathway on
+the original mesh and through global interpolation.  Interpolation is checked
+both with coordinates embedded in the data file and with an explicitly named
+mesh field.
+
+ALE base-shape import is the only other production caller.  It does not expose
+interpolation and its same-mesh path is covered by ``test_ale.py``.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import conftest
+from testlib import (
+    configure_nprocs,
+    get_genmeshbox,
+    get_neko,
+    run_neko,
+    which_command,
+)
+
+COMPONENTS = ("fluid", "scalar", "non_normal", "sponge")
+IMPORT_MODES = ("same_mesh", "embedded_mesh", "separate_mesh")
+NPROCS = 2
+VALUE_TOLERANCE = {"dp": 1.0e-8, "sp": 2.0e-4}
+
+
+def _solver(solver_type):
+    """Return a small, robust linear-solver configuration."""
+    return {
+        "type": solver_type,
+        "preconditioner": {"type": "jacobi"},
+        "absolute_tolerance": 1.0e-7,
+        "max_iterations": 100,
+    }
+
+
+def _field_options(field_file, mode, mesh_field):
+    """Build the shared case-file field import options."""
+    options = {
+        "file_name": str(field_file),
+        "interpolate": mode != "same_mesh",
+    }
+    if mode == "separate_mesh":
+        options["mesh_file_name"] = str(mesh_field)
+    if mode != "same_mesh":
+        options["interpolation"] = {
+            "tolerance": 1.0e-8,
+            "padding": 0.05,
+        }
+    return options
+
+
+def _fluid(initial_condition, boundary_conditions, source_terms=None):
+    """Build the fluid section shared by source and consumer cases."""
+    fluid = {
+        "scheme": "pnpn",
+        "rho": 1.0,
+        "mu": 1.0,
+        "freeze": True,
+        "initial_condition": initial_condition,
+        "velocity_solver": _solver("cg"),
+        "pressure_solver": _solver("gmres"),
+        "boundary_conditions": boundary_conditions,
+        "output_control": "never",
+    }
+    if source_terms is not None:
+        fluid["source_terms"] = source_terms
+    return fluid
+
+
+def _scalar(initial_condition):
+    """Build a passive scalar that preserves its imported constant value."""
+    return {
+        "enabled": True,
+        "name": "temperature",
+        "advection": False,
+        "lambda": 1.0,
+        "cp": 1.0,
+        "initial_condition": initial_condition,
+        "solver": _solver("cg"),
+        "boundary_conditions": [
+            {
+                "type": "neumann",
+                "zone_indices": [1, 2, 3, 4, 5, 6],
+                "flux": 0.0,
+            }
+        ],
+    }
+
+
+def _base_case(mesh, output_directory):
+    """Return the inexpensive one-step case shared by all runs."""
+    return {
+        "version": 1,
+        "case": {
+            "mesh_file": str(mesh),
+            "output_directory": str(output_directory),
+            "output_at_end": False,
+            "output_boundary": False,
+            "output_checkpoints": False,
+            "time": {"end_time": 1.0e-3, "timestep": 1.0e-3},
+            "numerics": {
+                "time_order": 1,
+                "polynomial_order": 3,
+                "dealias": False,
+            },
+        },
+    }
+
+
+def _probe(fields, output_file, coordinates):
+    """Build a one-point probe used to verify imported values."""
+    return {
+        "type": "probes",
+        "compute_control": "nsamples",
+        "compute_value": 1,
+        "append_output": False,
+        "output_file": output_file,
+        "fields": fields,
+        "points": [{"type": "points", "coordinates": coordinates}],
+    }
+
+
+def _source_case(mesh, workdir):
+    """Create velocity and scalar source data with known values."""
+    config = _base_case(mesh, workdir)
+    case = config["case"]
+    case["output_at_end"] = True
+    case["fluid"] = _fluid(
+        {
+            "type": "expression",
+            "value": ["1 + x", "2 + y", "3 + z"],
+        },
+        [
+            {
+                "type": "velocity_value",
+                "zone_indices": [1, 2, 3, 4, 5, 6],
+                "value": [1.5, 2.5, 3.5],
+            }
+        ],
+    )
+    case["fluid"]["output_filename"] = "source"
+    case["fluid"]["output_mesh_in_all_files"] = True
+    case["scalar"] = _scalar({"type": "uniform", "value": 4.0})
+    return config
+
+
+def _consumer_case(component, mode, assets, run_dir):
+    """Create one consumer case and its expected probe values."""
+    mesh = assets["source_mesh"] if mode == "same_mesh" else assets["target_mesh"]
+    options = _field_options(assets["field"], mode, assets["mesh_field"])
+    config = _base_case(mesh, run_dir)
+    case = config["case"]
+
+    no_slip = {
+        "type": "no_slip",
+        "zone_indices": [1, 2, 3, 4, 5, 6],
+    }
+    fluid_ic = {"type": "uniform", "value": [0.0, 0.0, 0.0]}
+    boundaries = [no_slip]
+    source_terms = None
+
+    if component == "fluid":
+        fluid_ic = {"type": "field", **options}
+        probe_fields = ["u", "v", "w"]
+        probe_point = [0.5, 0.5, 0.5]
+        expected = [1.5, 2.5, 3.5]
+    elif component == "scalar":
+        # The first scalar in fluid output occupies the temperature slot,
+        # whose import index is zero.
+        scalar_ic = {"type": "field", "target_index": 0, **options}
+        case["scalar"] = _scalar(scalar_ic)
+        probe_fields = ["temperature"]
+        probe_point = [0.5, 0.5, 0.5]
+        expected = [4.0]
+    elif component == "non_normal":
+        boundaries = [
+            {"type": "normal_outflow", "zone_indices": [2], **options},
+            {"type": "no_slip", "zone_indices": [1, 3, 4, 5, 6]},
+        ]
+        probe_fields = ["u", "v", "w"]
+        probe_point = [1.0, 0.5, 0.5]
+        expected = [0.0, 2.5, 3.5]
+    elif component == "sponge":
+        source_terms = [
+            {
+                "type": "sponge",
+                "amplitudes": [0.0, 0.0, 0.0],
+                "fringe_registry_name": "u",
+                "baseflow": {"method": "field", **options},
+            }
+        ]
+        probe_fields = ["sponge_bf_u", "sponge_bf_v", "sponge_bf_w"]
+        probe_point = [0.5, 0.5, 0.5]
+        expected = [1.5, 2.5, 3.5]
+    else:  # pragma: no cover - protects additions to COMPONENTS
+        raise ValueError(f"Unknown import component: {component}")
+
+    case["fluid"] = _fluid(fluid_ic, boundaries, source_terms)
+    if component == "non_normal":
+        # A frozen fluid does not apply boundary conditions during the time
+        # loop. Take one non-advecting step so the imported tangential values
+        # are observable on the boundary probe.
+        case["fluid"]["freeze"] = False
+        case["fluid"]["advection"] = False
+    probe_name = f"probe_{component}_{mode}.csv"
+    case["simulation_components"] = [_probe(probe_fields, probe_name, probe_point)]
+    return config, run_dir / probe_name, expected
+
+
+def _resolve_mesh_checker(neko):
+    """Locate mesh_checker next to Neko or on PATH."""
+    checker = which_command("mesh_checker")
+    if checker is not None:
+        return Path(checker).resolve()
+    candidate = Path(neko).resolve().with_name("mesh_checker")
+    assert candidate.is_file(), "The mesh_checker executable could not be found"
+    return candidate
+
+
+def _generate_mesh(genmeshbox, mesh_checker, workdir, name, dimensions):
+    """Generate and validate one non-periodic box mesh."""
+    result = subprocess.run(
+        [
+            str(genmeshbox),
+            "0",
+            "1",
+            "0",
+            "1",
+            "0",
+            "1",
+            *(str(value) for value in dimensions),
+            ".false.",
+            ".false.",
+            ".false.",
+        ],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout
+
+    generated = workdir / "box.nmsh"
+    mesh = workdir / name
+    generated.rename(mesh)
+    result = subprocess.run(
+        [str(mesh_checker), mesh.name],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        errors="replace",
+    )
+    assert result.returncode == 0, result.stdout
+    return mesh
+
+
+@pytest.fixture(scope="module")
+def import_assets(tmp_path_factory, request):
+    """Generate meshes and a single source field shared by the matrix."""
+    workdir = tmp_path_factory.mktemp("import_fields")
+    neko = Path(get_neko()).resolve()
+    genmeshbox = Path(get_genmeshbox()).resolve()
+    mesh_checker = _resolve_mesh_checker(neko)
+    launcher = Path(request.config.getoption("--launcher-script")).resolve()
+
+    source_mesh = _generate_mesh(
+        genmeshbox, mesh_checker, workdir, "source.nmsh", (2, 2, 2)
+    )
+    target_mesh = _generate_mesh(
+        genmeshbox, mesh_checker, workdir, "target.nmsh", (3, 2, 2)
+    )
+
+    source_case = workdir / "source.case"
+    source_case.write_text(
+        json.dumps(_source_case(source_mesh, workdir), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    source_log = workdir / "source.log"
+    result = run_neko(
+        str(launcher),
+        configure_nprocs(NPROCS),
+        str(source_case),
+        str(neko),
+        str(source_log),
+    )
+    assert result.returncode == 0, source_log.read_text(encoding="utf-8")
+
+    field = workdir / "source0.f00000"
+    assert field.is_file(), "The source run did not write source0.f00000"
+    mesh_field = workdir / "source_mesh0.f00000"
+    shutil.copyfile(field, mesh_field)
+
+    return {
+        "workdir": workdir,
+        "neko": neko,
+        "launcher": launcher,
+        "source_mesh": source_mesh,
+        "target_mesh": target_mesh,
+        "field": field,
+        "mesh_field": mesh_field,
+    }
+
+
+@pytest.mark.parametrize("component", COMPONENTS)
+@pytest.mark.parametrize("mode", IMPORT_MODES)
+def test_case_file_import_fields(component, mode, import_assets):
+    """Import known data through every case-file pathway and verify values."""
+    run_dir = import_assets["workdir"] / f"{component}_{mode}"
+    run_dir.mkdir()
+    config, probe_file, expected = _consumer_case(
+        component, mode, import_assets, run_dir
+    )
+    case_file = run_dir / "consumer.case"
+    case_file.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    log_file = run_dir / "consumer.log"
+
+    result = run_neko(
+        str(import_assets["launcher"]),
+        configure_nprocs(NPROCS),
+        str(case_file),
+        str(import_assets["neko"]),
+        str(log_file),
+    )
+    log = log_file.read_text(encoding="utf-8")
+    assert result.returncode == 0, log
+    assert "Import fields" in log
+    assert f"Interpolation : {'T' if mode != 'same_mesh' else 'F'}" in log
+    if mode == "separate_mesh":
+        assert f"Mesh file     : {import_assets['mesh_field']}" in log
+
+    values = [
+        float(value) for value in probe_file.read_text().splitlines()[-1].split(",")
+    ]
+    assert values[1:] == pytest.approx(expected, abs=VALUE_TOLERANCE[conftest.RP])


### PR DESCRIPTION
- Fixes json schema
- Adds a pytest which tests all neko components using the functionality.
- Extra guardrails in the importer code.
- For non-normal, add an if so that we simply do not pass the mesh file name when it is not configured.

The scalar ic still passes "none" instead of just omitting the argument, so we need that extra guard for "none" for now, but we should just make scalar not pass the mesh name. Didn't want to do it here coz there is an open ic-realted PR for scalars.