### PR TITLE
Fix OpenCL CFL kernels to support FP32 if needed

### DIFF
--- a/src/math/bcknd/device/opencl/cfl_kernel.cl
+++ b/src/math/bcknd/device/opencl/cfl_kernel.cl
@@ -1,7 +1,7 @@
 #ifndef __MATH_CFL_KERNEL_CL__
 #define __MATH_CFL_KERNEL_CL__
 /*
- Copyright (c) 2022, The Neko Authors
+ Copyright (c) 2022-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -39,7 +39,7 @@
  */
 
 #define DEFINE_CFL_KERNEL(LX, CHUNKS)                                          \
-__kernel void cfl_kernel_lx##LX(const double dt,                                 \
+__kernel void cfl_kernel_lx##LX(const real_xp dt,                              \
 				__global const real * __restrict__ u,	       \
 				__global const real * __restrict__ v,	       \
 				__global const real * __restrict__ w,	       \
@@ -56,7 +56,7 @@ __kernel void cfl_kernel_lx##LX(const double dt,                                
 				__global const real * __restrict__ ds_inv,     \
 				__global const real * __restrict__ dt_inv,     \
 				__global const real * __restrict__ jacinv,     \
-				__global double * __restrict__ cfl_h) {	       \
+				__global real_xp * __restrict__ cfl_h) {       \
                                                                                \
   int i,j,k;								       \
                                                                                \
@@ -74,7 +74,7 @@ __kernel void cfl_kernel_lx##LX(const double dt,                                
                                                                                \
   __local real shjacinv[LX * LX * LX];                                         \
                                                                                \
-  __local double shcfl[256];                                                     \
+  __local real_xp shcfl[256];                                                  \
                                                                                \
   if (iii < LX) {                                                              \
     shdr_inv[iii] = dr_inv[iii];                                               \
@@ -97,7 +97,7 @@ __kernel void cfl_kernel_lx##LX(const double dt,                                
                                                                                \
   barrier(CLK_LOCAL_MEM_FENCE);                                                \
                                                                                \
-  double cfl_tmp = 0.0;                                                          \
+  real_xp cfl_tmp = 0.0;                                                       \
   for (int n = 0; n < nchunks; n++) {                                          \
     const int ijk = iii + n * CHUNKS;                                          \
     const int jk = ijk / LX;                                                   \
@@ -105,15 +105,15 @@ __kernel void cfl_kernel_lx##LX(const double dt,                                
     k = jk / LX;                                                               \
     j = jk - k * LX;                                                           \
     if ( i < LX && j < LX && k < LX) {                                         \
-      const double cflr = fabs(dt * (( shu[ijk] * drdx[ijk + e * LX * LX * LX]   \
+      const real_xp cflr = fabs(dt * (( shu[ijk] * drdx[ijk + e * LX * LX * LX]\
                                      + shv[ijk] * drdy[ijk + e * LX * LX * LX] \
                                      + shw[ijk] * drdz[ijk + e * LX * LX * LX] \
                                      ) * shjacinv[ijk]) * shdr_inv[i]);        \
-      const double cfls = fabs(dt * (( shu[ijk] * dsdx[ijk + e * LX * LX * LX]   \
+      const real_xp cfls = fabs(dt * (( shu[ijk] * dsdx[ijk + e * LX * LX * LX]\
                                      + shv[ijk] * dsdy[ijk + e * LX * LX * LX] \
                                      + shw[ijk] * dsdz[ijk + e * LX * LX * LX] \
                                      ) * shjacinv[ijk]) * shds_inv[j]);        \
-      const double cflt = fabs( dt * ( ( shu[ijk] * dtdx[ijk + e * LX * LX * LX] \
+      const real_xp cflt = fabs(dt * (( shu[ijk] * dtdx[ijk + e * LX * LX * LX]\
                                       + shv[ijk] * dtdy[ijk + e * LX * LX * LX]\
 				      + shw[ijk] * dtdz[ijk + e * LX * LX * LX]\
 				      ) * shjacinv[ijk]) * shdt_inv[k]);       \
@@ -136,7 +136,7 @@ __kernel void cfl_kernel_lx##LX(const double dt,                                
   if (get_local_id(0) == 0) {                                                  \
     cfl_h[get_group_id(0)] = shcfl[0];                                         \
   }                                                                            \
-}                                                                             
+}
 
 DEFINE_CFL_KERNEL(2, 256)
 DEFINE_CFL_KERNEL(3, 256)

--- a/src/math/bcknd/device/opencl/opr_cfl.c
+++ b/src/math/bcknd/device/opencl/opr_cfl.c
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2022-2024, The Neko Authors
+ Copyright (c) 2022-2026, The Neko Authors
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -51,7 +51,7 @@
 /**
  * Fortran wrapper for device OpenCL convective terms
  */
-double opencl_cfl(double *dt, void *u, void *v, void *w,
+real_xp opencl_cfl(real_xp *dt, void *u, void *v, void *w,
 		void *drdx, void *dsdx, void *dtdx,
 		void *drdy, void *dsdy, void *dtdy,
 		void *drdz, void *dsdz, void *dtdz,
@@ -66,9 +66,9 @@ double opencl_cfl(double *dt, void *u, void *v, void *w,
   const size_t global_item_size = 256 * (*nel);
   const size_t local_item_size = 256;
 
-  double * cfl = (double *) malloc((*nel) * sizeof(double));
+  real_xp * cfl = (real_xp *) malloc((*nel) * sizeof(real_xp));
   cl_mem cfl_d = clCreateBuffer(glb_ctx, CL_MEM_READ_WRITE,
-                                (*nel) * sizeof(double), NULL, &err);
+                                (*nel) * sizeof(real_xp), NULL, &err);
   CL_CHECK(err);
   cl_kernel kernel;
 
@@ -79,7 +79,7 @@ double opencl_cfl(double *dt, void *u, void *v, void *w,
       kernel = clCreateKernel(cfl_program, STR(cfl_kernel_lx##LX), &err);       \
       CL_CHECK(err);                                                            \
                                                                                 \
-      CL_CHECK(clSetKernelArg(kernel, 0, sizeof(double), dt));                    \
+      CL_CHECK(clSetKernelArg(kernel, 0, sizeof(real_xp), dt));                 \
       CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *) &u));         \
       CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *) &v));         \
       CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *) &w));         \
@@ -124,10 +124,10 @@ double opencl_cfl(double *dt, void *u, void *v, void *w,
   }
 
   CL_CHECK(clEnqueueReadBuffer((cl_command_queue) glb_cmd_queue,
-			       cfl_d, CL_TRUE, 0, (*nel) * sizeof(double),
+			       cfl_d, CL_TRUE, 0, (*nel) * sizeof(real_xp),
 			       cfl, 1, &kern_wait, NULL));
 
-  double cfl_max = 0.0;
+  real_xp cfl_max = 0.0;
   for (i = 0; i < (*nel); i++) {
     cfl_max = fmax(cfl_max, cfl[i]);
   }

--- a/src/math/bcknd/device/opr_device.F90
+++ b/src/math/bcknd/device/opr_device.F90
@@ -33,7 +33,7 @@
 !> Operators accelerator backends
 module opr_device
   use gather_scatter, only : GS_OP_ADD
-  use num_types, only : rp, c_rp, i8, dp, c_dp
+  use num_types, only : rp, c_rp, i8, dp, c_dp, xp, c_xp
   use device, only : device_get_ptr, device_event_sync, device_map, device_unmap
   use space, only : space_t
   use coefs, only : coef_t
@@ -380,17 +380,17 @@ module opr_device
   end interface
 
   interface
-     real(c_dp) function opencl_cfl(dt, u_d, v_d, w_d, &
+     real(c_xp) function opencl_cfl(dt, u_d, v_d, w_d, &
           drdx_d, dsdx_d, dtdx_d, drdy_d, dsdy_d, dtdy_d, &
           drdz_d, dsdz_d, dtdz_d, dr_inv_d, ds_inv_d, dt_inv_d, &
           jacinv_d, nel, lx) &
           bind(c, name = 'opencl_cfl')
        use, intrinsic :: iso_c_binding
-       import c_dp
+       import c_xp
        type(c_ptr), value :: u_d, v_d, w_d, drdx_d, dsdx_d, dtdx_d
        type(c_ptr), value :: drdy_d, dsdy_d, dtdy_d, drdz_d, dsdz_d, dtdz_d
        type(c_ptr), value :: dr_inv_d, ds_inv_d, dt_inv_d, jacinv_d
-       real(c_dp) :: dt
+       real(c_xp) :: dt
        integer(c_int) :: nel, lx
      end function opencl_cfl
   end interface
@@ -1018,6 +1018,7 @@ contains
     type(c_ptr), intent(in) :: u_d, v_d, w_d
     real(kind=dp) :: cfl
     real(kind=rp) :: cfl_rp
+    real(kind=xp) :: cfl_xp
 
 #ifdef HAVE_HIP
     cfl = hip_cfl(dt, u_d, v_d, w_d, &
@@ -1034,12 +1035,13 @@ contains
          Xh%dr_inv_d, Xh%ds_inv_d, Xh%dt_inv_d, &
          coef%jacinv_d, nelv, Xh%lx)
 #elif HAVE_OPENCL
-    cfl = opencl_cfl(dt, u_d, v_d, w_d, &
+    cfl_xp = opencl_cfl(real(dt, kind=xp), u_d, v_d, w_d, &
          coef%drdx_d, coef%dsdx_d, coef%dtdx_d, &
          coef%drdy_d, coef%dsdy_d, coef%dtdy_d, &
          coef%drdz_d, coef%dsdz_d, coef%dtdz_d, &
          Xh%dr_inv_d, Xh%ds_inv_d, Xh%dt_inv_d, &
          coef%jacinv_d, nelv, Xh%lx)
+    cfl = real(cfl_xp, kind=dp)
 #elif HAVE_METAL
     cfl_rp = metal_cfl(real(dt, kind=rp), u_d, v_d, w_d, &
          coef%drdx_d, coef%dsdx_d, coef%dtdx_d, &


### PR DESCRIPTION
This PR ensures that the CFL OpenCL backend works on devices, limited to only fp32. Fixes #2750 