### PR TITLE
Refactor GS tuner with device backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,38 @@
 
 ## Develop
 
+- The gather-scatter comm. backend autotuning can now benchmark the
+  device-resident backends. `MPIGPU`, `NCCL` and `CRYSTALGPU` join the
+  candidates on CUDA and HIP builds (`NVSHMEM` only when asked for), measured
+  against the host backends, which on such a build are measured staging the
+  halo through the host as they actually run there. A build configured with
+  `--enable-device-mpi` keeps its existing default of `MPIGPU` and benchmarks
+  nothing, tuning only the synchronisation strategy as before; setting
+  `NEKO_GS_TUNE` asks for the comparison there, which is how a question with
+  no built-in answer -- `NCCL` against device MPI, or a GPU-aware MPI that
+  turns out to be nominal -- gets settled on a new machine. A CUDA or HIP
+  build *without* device-aware MPI has no such default and benchmarks as it
+  already did, now with `NCCL` among the candidates when it was built in.
+- The device MPI synchronisation strategy (`NEKO_GS_STRTGY`) is benchmarked
+  as part of measuring the `MPIGPU` candidate, so the backend is compared on
+  its best strategy's time rather than the default strategy's.
+- `NEKO_GS_TUNE` accepts the device backend names `MPIGPU`, `NCCL`,
+  `CRYSTALGPU` and `NVSHMEM`. `SHMEM` there always names the host OpenSHMEM
+  backend and `NVSHMEM` the device one, since a GPU build can have both as
+  candidates, unlike `NEKO_GS_COMM` where `SHMEM` picks one by build.
+- Fixed the gather-scatter halo staging (`gs_bcknd_t%shared_on_host`) being
+  derived from `NEKO_GS_COMM` rather than from the comm. backend actually
+  selected, which left the halo on the host when a device backend was
+  requested through the `comm_bcknd` argument of `gs%init`.
 - Added crystal router gather-scatter communication backends,
   `NEKO_GS_COMM=CRYSTAL` on the host and `CRYSTALGPU` on the device. They
   route the halo in recursive-bisection stages instead of sending one message
   per peer, trading forwarded volume for message count, which pays where
   per-message overhead dominates. The routing is worked out once at
   initialisation, so the exchange itself neither negotiates sizes nor
-  allocates. `CRYSTAL` is a candidate in the host comm. autotuning
-  (`NEKO_GS_TUNE=-CRYSTAL` drops it); `CRYSTALGPU` is selected by name.
+  allocates. `CRYSTAL` is a default candidate in the comm. autotuning
+  (`NEKO_GS_TUNE=-CRYSTAL` drops it); `CRYSTALGPU` is a candidate whenever a
+  device build runs the comparison.
 - Fixed facet masks for some simulation components.
 - *BREAKING*, normal_outflow conditions now require specifying `value`, which
   is used to set the value of the tangential components of velocity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,19 @@
 
 ## Develop
 
-- The gather-scatter comm. backend autotuning can now benchmark the
-  device-resident backends. `MPIGPU`, `NCCL` and `CRYSTALGPU` join the
-  candidates on CUDA and HIP builds (`NVSHMEM` only when asked for), measured
-  against the host backends, which on such a build are measured staging the
-  halo through the host as they actually run there. A build configured with
-  `--enable-device-mpi` keeps its existing default of `MPIGPU` and benchmarks
-  nothing, tuning only the synchronisation strategy as before; setting
-  `NEKO_GS_TUNE` asks for the comparison there, which is how a question with
-  no built-in answer -- `NCCL` against device MPI, or a GPU-aware MPI that
-  turns out to be nominal -- gets settled on a new machine. A CUDA or HIP
-  build *without* device-aware MPI has no such default and benchmarks as it
-  already did, now with `NCCL` among the candidates when it was built in.
+- The gather-scatter comm. backend autotuning now covers the device-resident
+  backends. With `NEKO_GS_COMM` unset, a CUDA or HIP build benchmarks
+  `MPIGPU`, `NCCL` and `CRYSTALGPU` (`NVSHMEM` only when asked for) alongside
+  the host backends and keeps the fastest, instead of defaulting to device
+  MPI whenever the build had it. The host backends stay in the comparison and
+  are measured staging the halo through the host, which is how they run on
+  such a build.
 - The device MPI synchronisation strategy (`NEKO_GS_STRTGY`) is benchmarked
   as part of measuring the `MPIGPU` candidate, so the backend is compared on
-  its best strategy's time rather than the default strategy's.
+  its best strategy's time rather than the default strategy's, and the
+  strategy is reported on that candidate's line of the comparison rather than
+  above it. Pinning device MPI with `NEKO_GS_COMM=MPIGPU` benchmarks no
+  backends and keeps the `Avg. strtgy` / `Env. strtgy` line as before.
 - `NEKO_GS_TUNE` accepts the device backend names `MPIGPU`, `NCCL`,
   `CRYSTALGPU` and `NVSHMEM`. `SHMEM` there always names the host OpenSHMEM
   backend and `NVSHMEM` the device one, since a GPU build can have both as
@@ -31,9 +29,8 @@
   per peer, trading forwarded volume for message count, which pays where
   per-message overhead dominates. The routing is worked out once at
   initialisation, so the exchange itself neither negotiates sizes nor
-  allocates. `CRYSTAL` is a default candidate in the comm. autotuning
-  (`NEKO_GS_TUNE=-CRYSTAL` drops it); `CRYSTALGPU` is a candidate whenever a
-  device build runs the comparison.
+  allocates. Both are default candidates in the comm. autotuning
+  (`NEKO_GS_TUNE=-CRYSTAL` and `-CRYSTALGPU` drop them).
 - Fixed facet masks for some simulation components.
 - *BREAKING*, normal_outflow conditions now require specifying `value`, which
   is used to set the value of the tangential components of velocity.

--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -31,7 +31,7 @@ of the code. But can be useful for users and developers alike.
 | `NEKO_LOG_LEVEL`         | Log verbosity level (integer > 0, default: 1)                         | Unset         |
 | `NEKO_GS_STRTGY`         | Gather-scatter device MPI sync. strategy (0 < integer < 5 )           | Unset         |
 | `NEKO_GS_COMM`           | Gather-scatter communication backend                                  | Unset         |
-| `NEKO_GS_TUNE`           | Comm. backends the gather-scatter autotuning benchmarks (list)        | Unset (all but `CAF`) |
+| `NEKO_GS_TUNE`           | Comm. backends the gather-scatter autotuning benchmarks (list); also what asks for a comparison on a device-aware MPI build | Unset (all but `CAF`, `NVSHMEM`) |
 | `NEKO_GS_CAF_SIGNALING`  | Coarray Fortran gather-scatter signaling mode                         | Unset         |
 | `NEKO_GS_RMA_FLUSH_ALL`  | Batch the MPI RMA gather-scatter payload flush (boolean)              | 1             |
 | `NEKO_COMM_ID`           | Communicator id for this process (non-negative integer)               | 0             |
@@ -177,14 +177,20 @@ A number of gather-scatter backends are supported.
   per routing stage instead of one per peer (host only). `CRYSTALGPU` is the
   device-aware variant, which keeps the halo on the GPU
 
-When `NEKO_GS_COMM` is unset and the build has no device-aware MPI,
-the host backends are benchmarked at initialisation and the fastest
-one is kept (see @ref performance-gs-autotuning). Which ones take part
-is set by `NEKO_GS_TUNE`, a list of backend names spelled as for
-`NEKO_GS_COMM` (comma or space separated, case insensitive). Unset, it
-means every host backend the build supports except `CAF`, which a
+When `NEKO_GS_COMM` is unset, the backends are benchmarked at
+initialisation and the fastest one is kept (see
+@ref performance-gs-autotuning) -- except on a build configured with
+`--enable-device-mpi`, which uses `MPIGPU` without benchmarking, and
+compares only when `NEKO_GS_TUNE` is set. Which backends take part is
+set by `NEKO_GS_TUNE`, a list of backend names spelled as for
+`NEKO_GS_COMM` (comma or space separated, case insensitive). Naming
+none, it means every backend the build supports except `CAF`, which a
 compiler can accept at configure time while still giving the job a
-single image the coarray backend cannot use.
+single image the coarray backend cannot use, and `NVSHMEM`, which aborts
+unless the peer lists come out symmetric and aligned. On a CUDA or HIP
+build the device-resident backends (`MPIGPU`, `CRYSTALGPU` and `NCCL`)
+are candidates alongside the host ones, which are then measured staging
+the halo through the host as they actually run there.
 
 - `NEKO_GS_TUNE=+CAF` adds the coarray backend to that default set,
   `NEKO_GS_TUNE=-SHMEM` removes a backend from it, and the two can be
@@ -192,8 +198,10 @@ single image the coarray backend cannot use.
 - Plain names replace the set outright: `NEKO_GS_TUNE=MPI,NEIGHBOUR`
   benchmarks those two and nothing else. A single name pins that
   backend without benchmarking anything.
-- The two forms cannot be mixed, and a name that is not a host
-  gather-scatter backend is an error.
+- The two forms cannot be mixed, and a name that is not a
+  gather-scatter backend is an error. `SHMEM` here always names the host
+  OpenSHMEM backend and `NVSHMEM` the device one, since a GPU build can
+  have both as candidates.
 
 Backends that are selected but cannot run in this build or run are
 dropped; those named explicitly are reported in the log as

--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -31,7 +31,7 @@ of the code. But can be useful for users and developers alike.
 | `NEKO_LOG_LEVEL`         | Log verbosity level (integer > 0, default: 1)                         | Unset         |
 | `NEKO_GS_STRTGY`         | Gather-scatter device MPI sync. strategy (0 < integer < 5 )           | Unset         |
 | `NEKO_GS_COMM`           | Gather-scatter communication backend                                  | Unset         |
-| `NEKO_GS_TUNE`           | Comm. backends the gather-scatter autotuning benchmarks (list); also what asks for a comparison on a device-aware MPI build | Unset (all but `CAF`, `NVSHMEM`) |
+| `NEKO_GS_TUNE`           | Comm. backends the gather-scatter autotuning benchmarks (list)        | Unset (all but `CAF`, `NVSHMEM`) |
 | `NEKO_GS_CAF_SIGNALING`  | Coarray Fortran gather-scatter signaling mode                         | Unset         |
 | `NEKO_GS_RMA_FLUSH_ALL`  | Batch the MPI RMA gather-scatter payload flush (boolean)              | 1             |
 | `NEKO_COMM_ID`           | Communicator id for this process (non-negative integer)               | 0             |
@@ -179,12 +179,10 @@ A number of gather-scatter backends are supported.
 
 When `NEKO_GS_COMM` is unset, the backends are benchmarked at
 initialisation and the fastest one is kept (see
-@ref performance-gs-autotuning) -- except on a build configured with
-`--enable-device-mpi`, which uses `MPIGPU` without benchmarking, and
-compares only when `NEKO_GS_TUNE` is set. Which backends take part is
-set by `NEKO_GS_TUNE`, a list of backend names spelled as for
-`NEKO_GS_COMM` (comma or space separated, case insensitive). Naming
-none, it means every backend the build supports except `CAF`, which a
+@ref performance-gs-autotuning). Which ones take part is set by
+`NEKO_GS_TUNE`, a list of backend names spelled as for `NEKO_GS_COMM`
+(comma or space separated, case insensitive). Unset, it means every
+backend the build supports except `CAF`, which a
 compiler can accept at configure time while still giving the job a
 single image the coarray backend cannot use, and `NVSHMEM`, which aborts
 unless the peer lists come out symmetric and aligned. On a CUDA or HIP

--- a/doc/pages/user-guide/performance.md
+++ b/doc/pages/user-guide/performance.md
@@ -488,9 +488,9 @@ implementations of the off-process gs exchange, and the right choice
 depends on the host/accelerator combination and the interconnect.
 
 The active backend can be selected at runtime via the `NEKO_GS_COMM`
-environment variable. If the variable is unset, a build with device-aware
-MPI uses `MPIGPU`; every other build picks by measurement, benchmarking
-the backends it supports at initialisation and keeping the fastest, see
+environment variable. If the variable is unset, the backend is picked by
+measurement: every backend the build supports is benchmarked at
+initialisation and the fastest one is kept, see
 @ref performance-gs-autotuning. The supported values are:
 
 | `NEKO_GS_COMM` | Backend | Requirement | Typical use |
@@ -544,28 +544,21 @@ count: it pays where per-message overhead dominates and loses where the
 halo is already large enough to be bandwidth bound. Benchmarking is the
 intended way to find out which regime a given run is in: `CRYSTAL` is a
 default candidate in the autotuning (`NEKO_GS_TUNE=-CRYSTAL` drops it),
-and `CRYSTALGPU` is one whenever a device build runs the comparison --
-which on a `--enable-device-mpi` build means when `NEKO_GS_TUNE` is set.
+and `CRYSTALGPU` is one on any device build that can drive it
+(`NEKO_GS_TUNE=-CRYSTALGPU` drops it).
 
 #### Runtime autotuning of the comm. backend {#performance-gs-autotuning}
 
 Which backend wins depends on the MPI implementation, the
-interconnect and the halo of the particular decomposition, and on most
-builds there is no defensible built-in rule, so the choice is made by
-measurement. When `NEKO_GS_COMM` is unset, no `comm_bcknd` argument is
-passed to `gs%init` and the run has more than one rank, each `gs_t`
-instance benchmarks the available backends at initialisation and keeps
-the fastest one. A candidate with a sub-choice of its own has that
-benchmarked too and contributes the winning variant's time: the device
-MPI synchronisation strategy (`NEKO_GS_STRTGY`), and the coarray
-signaling mode.
-
-The exception is a build configured with `--enable-device-mpi`, which
-does have a defensible default: `MPIGPU`. Where it has been measured it
-beat the host backends by 3-5x, so that build uses it without
-benchmarking anything, and tunes only the synchronisation strategy as it
-always has. Setting `NEKO_GS_TUNE` to anything turns the full comparison
-on there as well -- see below.
+interconnect and the halo of the particular decomposition, so the
+choice is made by measurement rather than by a built-in rule. When
+`NEKO_GS_COMM` is unset, no `comm_bcknd` argument is passed to
+`gs%init` and the run has more than one rank, each `gs_t` instance
+benchmarks the available backends at initialisation and keeps the
+fastest one. A candidate with a sub-choice of its own has that
+benchmarked too and contributes the winning variant's time, reported on
+that candidate's own line: the device MPI synchronisation strategy
+(`NEKO_GS_STRTGY`), and the coarray signaling mode.
 
 By default the candidates are every backend the build supports except
 `CAF` and `NVSHMEM`: `MPI`, `NEIGHBOUR`, `MPIRMA` and `CRYSTAL`, which
@@ -577,7 +570,7 @@ every process (`NEKO_COMM_ID`), since they address their peers by global
 PE / image number; `UTOFU` and `MPIRMA` exchange their addresses over
 `NEKO_COMM` itself and are kept in that case.
 
-On a CUDA or HIP build the device-resident backends are candidates too:
+On a CUDA or HIP build the device-resident backends join the comparison:
 `MPIGPU` and `CRYSTALGPU` when the build was configured with
 `--enable-device-mpi`, and `NCCL` when NCCL or RCCL was built in. `NCCL`
 carries the same restriction as the PE-addressed host backends and is
@@ -608,12 +601,7 @@ outright on such a system.
 
 ##### Choosing the candidates
 
-`NEKO_GS_TUNE` overrides that set, and on a `--enable-device-mpi` build
-setting it at all is what asks for a comparison in the first place:
-`NEKO_GS_TUNE=MPIGPU,NCCL` measures those two against each other, and
-`NEKO_GS_TUNE=+CAF` measures the whole default set (device backends
-included, so the incumbent defends its place) plus the coarray backend.
-It takes a list of backend names,
+`NEKO_GS_TUNE` overrides that set. It takes a list of backend names,
 spelled as for `NEKO_GS_COMM`, separated by commas or spaces and
 matched case insensitively:
 
@@ -683,20 +671,26 @@ backend that was kept:
  Tuned comm   :          MPI
 ```
 
-When a GPU build is asked for a comparison, the device candidates appear
-in the same table, below the host ones, and the strategy bound for
-`MPIGPU` is reported as part of measuring it:
+On a GPU build the device candidates appear in the same table, below the
+host ones. The device MPI row names the synchronisation strategy it was
+measured under, the way the `CAF` row names its signaling mode, since
+that is part of what was measured and is what the run goes on to use;
+`(env)` marks a strategy that came from `NEKO_GS_STRTGY` rather than from
+the benchmark:
 
 ```
  Comm         :         auto
  ...
- Avg. strtgy  :         [01]
  MPI          :  8.031E-05 s
- Device MPI   :  3.412E-05 s
+ Dev. MPI [01]:  3.412E-05 s
  NCCL         :  2.984E-05 s
  Dev. Crystal :  4.755E-05 s
  Tuned comm   :         NCCL
 ```
+
+Pinning device MPI with `NEKO_GS_COMM=MPIGPU` benchmarks no backends, so
+there the strategy keeps the line of its own it has always had,
+`Avg. strtgy` or `Env. strtgy`.
 
 Tuning is skipped, keeping the host MPI backend, if any rank holds
 zero dofs: such a rank skips the halo exchange entirely, which would

--- a/doc/pages/user-guide/performance.md
+++ b/doc/pages/user-guide/performance.md
@@ -488,11 +488,10 @@ implementations of the off-process gs exchange, and the right choice
 depends on the host/accelerator combination and the interconnect.
 
 The active backend can be selected at runtime via the `NEKO_GS_COMM`
-environment variable. If the variable is unset, a sensible default is
-chosen based on the build configuration (device-aware MPI when device
-MPI is available, and otherwise the fastest of the host backends the
-build supports, picked by the autotuner described in
-@ref performance-gs-autotuning). The supported values are:
+environment variable. If the variable is unset, a build with device-aware
+MPI uses `MPIGPU`; every other build picks by measurement, benchmarking
+the backends it supports at initialisation and keeping the fastest, see
+@ref performance-gs-autotuning. The supported values are:
 
 | `NEKO_GS_COMM` | Backend | Requirement | Typical use |
 |---|---|---|---|
@@ -542,33 +541,62 @@ crosses the network once per stage it survives and is copied locally each
 time, and the stages are dependent, so only the first one overlaps the
 local gather-scatter. This is a trade of bandwidth and latency for message
 count: it pays where per-message overhead dominates and loses where the
-halo is already large enough to be bandwidth bound. `CRYSTAL` is
-benchmarked by the autotuning like any other host candidate, which is the
-intended way to find out which regime a given run is in;
-`NEKO_GS_TUNE=-CRYSTAL` drops it. `CRYSTALGPU` is not autotuned and has to
-be asked for by name.
+halo is already large enough to be bandwidth bound. Benchmarking is the
+intended way to find out which regime a given run is in: `CRYSTAL` is a
+default candidate in the autotuning (`NEKO_GS_TUNE=-CRYSTAL` drops it),
+and `CRYSTALGPU` is one whenever a device build runs the comparison --
+which on a `--enable-device-mpi` build means when `NEKO_GS_TUNE` is set.
 
-#### Runtime autotuning of the host backend {#performance-gs-autotuning}
+#### Runtime autotuning of the comm. backend {#performance-gs-autotuning}
 
-Which host backend wins depends on the MPI implementation, the
-interconnect and the halo of the particular decomposition, so the
-choice is made by measurement rather than by a built-in rule. When
-`NEKO_GS_COMM` is unset, no `comm_bcknd` argument is passed to
-`gs%init` and the run has more than one rank, each `gs_t` instance
-benchmarks the available host backends at initialisation and keeps the
-fastest one. This mirrors the autotuning of the device MPI
-synchronisation strategy (`NEKO_GS_STRTGY`) already done on
-accelerator builds.
+Which backend wins depends on the MPI implementation, the
+interconnect and the halo of the particular decomposition, and on most
+builds there is no defensible built-in rule, so the choice is made by
+measurement. When `NEKO_GS_COMM` is unset, no `comm_bcknd` argument is
+passed to `gs%init` and the run has more than one rank, each `gs_t`
+instance benchmarks the available backends at initialisation and keeps
+the fastest one. A candidate with a sub-choice of its own has that
+benchmarked too and contributes the winning variant's time: the device
+MPI synchronisation strategy (`NEKO_GS_STRTGY`), and the coarray
+signaling mode.
 
-By default the candidates are every host backend the build supports
-except `CAF`: `MPI`, `NEIGHBOUR`, `MPIRMA` and `CRYSTAL`, which need
-nothing but MPI-3, plus `SHMEM` (OpenSHMEM) and `UTOFU` when the corresponding
-support was built in -- a backend whose support is missing aborts in
-its `init`, so it is left out of the list rather than tried. `SHMEM`
-and `CAF` are additionally skipped when `NEKO_COMM` does not span every
-process (`NEKO_COMM_ID`), since they address their peers by global PE /
-image number; `UTOFU` and `MPIRMA` exchange their addresses over
+The exception is a build configured with `--enable-device-mpi`, which
+does have a defensible default: `MPIGPU`. Where it has been measured it
+beat the host backends by 3-5x, so that build uses it without
+benchmarking anything, and tunes only the synchronisation strategy as it
+always has. Setting `NEKO_GS_TUNE` to anything turns the full comparison
+on there as well -- see below.
+
+By default the candidates are every backend the build supports except
+`CAF` and `NVSHMEM`: `MPI`, `NEIGHBOUR`, `MPIRMA` and `CRYSTAL`, which
+need nothing but MPI-3, plus `SHMEM` (OpenSHMEM) and `UTOFU` when the
+corresponding support was built in -- a backend whose support is missing
+aborts in its `init`, so it is left out of the list rather than tried.
+`SHMEM` and `CAF` are additionally skipped when `NEKO_COMM` does not span
+every process (`NEKO_COMM_ID`), since they address their peers by global
+PE / image number; `UTOFU` and `MPIRMA` exchange their addresses over
 `NEKO_COMM` itself and are kept in that case.
+
+On a CUDA or HIP build the device-resident backends are candidates too:
+`MPIGPU` and `CRYSTALGPU` when the build was configured with
+`--enable-device-mpi`, and `NCCL` when NCCL or RCCL was built in. `NCCL`
+carries the same restriction as the PE-addressed host backends and is
+skipped when `NEKO_COMM` does not span every process, since its
+communicator is built at startup from a unique id broadcast over
+`MPI_COMM_WORLD`. The host backends stay in the comparison on those
+builds and are measured as they actually run there, staging the halo
+through the host mirror of the shared buffer -- a copy in each direction
+that the device-resident backends avoid, which is precisely the trade the
+benchmark settles. Switching a candidate in also moves that staging
+(`gs_bcknd_t%shared_on_host`), so each backend is measured driving the
+exchange from the memory it was written for. OpenCL and Metal builds have
+no device-resident candidates: those backends' pack and unpack kernels
+exist for CUDA and HIP only, so such builds tune over the host backends
+alone.
+
+@note `NVSHMEM` is out of the default set because it aborts unless the
+peer lists come out symmetric and aligned, which is more than a run that
+never asked for it should risk. Add it with `NEKO_GS_TUNE=+NVSHMEM`.
 
 @note `MPIRMA` assumes the MPI implementation makes one-sided progress
 without the target entering MPI. That holds for hardware-driven
@@ -580,26 +608,37 @@ outright on such a system.
 
 ##### Choosing the candidates
 
-`NEKO_GS_TUNE` overrides that set. It takes a list of backend names,
+`NEKO_GS_TUNE` overrides that set, and on a `--enable-device-mpi` build
+setting it at all is what asks for a comparison in the first place:
+`NEKO_GS_TUNE=MPIGPU,NCCL` measures those two against each other, and
+`NEKO_GS_TUNE=+CAF` measures the whole default set (device backends
+included, so the incumbent defends its place) plus the coarray backend.
+It takes a list of backend names,
 spelled as for `NEKO_GS_COMM`, separated by commas or spaces and
 matched case insensitively:
 
 | `NEKO_GS_TUNE` | Candidates |
 |---|---|
-| unset | every supported host backend but `CAF` |
+| unset | every supported backend but `CAF` and `NVSHMEM` |
 | `+CAF` | the default set, plus the coarray backend |
+| `+NVSHMEM` | the default set, plus the NVSHMEM backend |
 | `-MPIRMA` | the default set, without the MPI one-sided backend |
 | `-CRYSTAL` | the default set, without the crystal router backend |
 | `-SHMEM` | the default set, without OpenSHMEM |
 | `+CAF,-SHMEM` | both deltas applied to the default set |
 | `MPI,NEIGHBOUR` | exactly those two, whatever the build supports |
+| `MPIGPU,NCCL` | the two device backends alone, on a GPU build |
 | `UTOFU` | uTofu alone -- nothing to compare, so it is simply used |
 
-Names prefixed with `+`/`-` modify the default set, plain names
-replace it, and mixing the two forms is an error, as is naming
-something that is not a host gather-scatter backend. Backends selected
-but unusable in this build or run are dropped from the comparison; a
-backend that was named explicitly says so in the log:
+Names are spelled as for `NEKO_GS_COMM` with one exception: `SHMEM`
+there means OpenSHMEM on a CPU build and NVSHMEM on a GPU build, while
+here the two can be candidates of the same run and are spelled apart,
+`SHMEM` for the host backend and `NVSHMEM` for the device one. Names
+prefixed with `+`/`-` modify the default set, plain names replace it,
+and mixing the two forms is an error, as is naming something that is not
+a gather-scatter backend. Backends selected but unusable in this build or
+run are dropped from the comparison; a backend that was named explicitly
+says so in the log:
 
 ```
  CAF          : unavailable
@@ -642,6 +681,21 @@ backend that was kept:
  MPI neigh.   :  6.147E-05 s
  uTofu        :  1.732E-04 s
  Tuned comm   :          MPI
+```
+
+When a GPU build is asked for a comparison, the device candidates appear
+in the same table, below the host ones, and the strategy bound for
+`MPIGPU` is reported as part of measuring it:
+
+```
+ Comm         :         auto
+ ...
+ Avg. strtgy  :         [01]
+ MPI          :  8.031E-05 s
+ Device MPI   :  3.412E-05 s
+ NCCL         :  2.984E-05 s
+ Dev. Crystal :  4.755E-05 s
+ Tuned comm   :         NCCL
 ```
 
 Tuning is skipped, keeping the host MPI backend, if any rank holds

--- a/src/.depends
+++ b/src/.depends
@@ -72,7 +72,7 @@ gs/bcknd/device/gs_device_crystal.lo : gs/bcknd/device/gs_device_crystal.F90 com
 gs/bcknd/device/gs_device_nccl.lo : gs/bcknd/device/gs_device_nccl.F90 common/utils.lo device/device.lo adt/htable.lo comm/comm.lo adt/stack.lo gs/gs_comm.lo config/num_types.lo 
 gs/bcknd/device/gs_device_shmem.lo : gs/bcknd/device/gs_device_shmem.F90 common/utils.lo comm/comm.lo device/device.lo adt/htable.lo adt/stack.lo gs/gs_comm.lo config/num_types.lo 
 gs/gather_scatter.lo : gs/gather_scatter.f90 device/device.lo common/profiler.lo common/log.lo common/utils.lo math/math.lo comm/crystal_router.lo adt/stack.lo adt/htable.lo config/num_types.lo field/field.lo sem/dofmap.lo comm/comm.lo mesh/mesh.lo gs/bcknd/device/gs_device_shmem.lo gs/bcknd/device/gs_device_nccl.lo gs/bcknd/device/gs_device_crystal.lo gs/bcknd/device/gs_device_mpi.lo gs/gs_utofu.lo gs/gs_caf.lo gs/gs_shmem.lo gs/gs_neighbour.lo gs/gs_mpi_rma.lo gs/gs_crystal.lo gs/gs_mpi.lo gs/gs_comm.lo gs/gs_ops.lo gs/bcknd/cpu/gs_cpu.lo gs/bcknd/sx/gs_sx.lo gs/bcknd/device/gs_device.lo gs/gs_bcknd.lo config/neko_config.lo 
-gs/gs_tune.lo : gs/gs_tune.f90 gs/gs_mpi_rma.lo gs/gs_utofu.lo gs/gs_caf.lo gs/gs_shmem.lo gs/gather_scatter.lo 
+gs/gs_tune.lo : gs/gs_tune.f90 config/neko_config.lo gs/bcknd/device/gs_device_shmem.lo gs/bcknd/device/gs_device_nccl.lo gs/gs_mpi_rma.lo gs/gs_utofu.lo gs/gs_caf.lo gs/gs_shmem.lo gs/gather_scatter.lo 
 mesh/entity.lo : mesh/entity.f90 
 mesh/point.lo : mesh/point.f90 mesh/entity.lo math/math.lo config/num_types.lo 
 mesh/element.lo : mesh/element.f90 mesh/point.lo adt/tuple.lo mesh/entity.lo config/num_types.lo 

--- a/src/gs/bcknd/device/gs_device_nccl.F90
+++ b/src/gs/bcknd/device/gs_device_nccl.F90
@@ -47,6 +47,15 @@ module gs_device_nccl
   implicit none
   private
 
+  !> Whether NCCL (or its ROCm equivalent RCCL) was built into this Neko
+  !! (--with-nccl / --with-rccl). Lets callers (e.g. the gs comm. autotuner)
+  !! skip the backend rather than aborting in init on builds without it.
+#if defined(HAVE_NCCL) || defined(HAVE_RCCL)
+  logical, parameter, public :: GS_DEVICE_NCCL_AVAIL = .true.
+#else
+  logical, parameter, public :: GS_DEVICE_NCCL_AVAIL = .false.
+#endif
+
   !> Buffers for non-blocking communication and packing/unpacking
   type, private :: gs_device_nccl_buf_t
      integer, allocatable :: ndofs(:) !< Number of dofs

--- a/src/gs/bcknd/device/gs_device_shmem.F90
+++ b/src/gs/bcknd/device/gs_device_shmem.F90
@@ -48,6 +48,15 @@ module gs_device_shmem
   implicit none
   private
 
+  !> Whether NVSHMEM was built into this Neko (--with-nvshmem). Lets callers
+  !! (e.g. the gs comm. autotuner) skip the backend rather than exchanging
+  !! nothing on builds without it.
+#if defined(HAVE_CUDA) && defined(HAVE_NVSHMEM)
+  logical, parameter, public :: GS_DEVICE_SHMEM_AVAIL = .true.
+#else
+  logical, parameter, public :: GS_DEVICE_SHMEM_AVAIL = .false.
+#endif
+
   !> Buffers for non-blocking communication and packing/unpacking
   type, private :: gs_device_shmem_buf_t
      integer, allocatable :: ndofs(:) !< Number of dofs

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -138,7 +138,7 @@ module gather_scatter
 
   ! These routines (used by the gs_tune submodule) have to be public
   ! since gfortran gives a private module procedure internal linkage
-  public :: gs_comm_t, gs_comm_alloc, gs_comm_name
+  public :: gs_comm_t, gs_comm_alloc, gs_comm_name, gs_comm_on_device
 
   !> Number of timed (and untimed, warm-up) gather-scatter operations per
   !! candidate in the runtime autotuning of comm. backends and device
@@ -168,6 +168,20 @@ module gather_scatter
        integer, intent(in) :: n
        integer, intent(in) :: comm_bcknd
      end subroutine gs_tune_comm
+
+     !> Bind the non-blocking synchronisation strategy of the device MPI
+     !! comm. backend held by @a gs, benchmarking the strategies unless
+     !! NEKO_GS_STRTGY names one
+     module subroutine gs_tune_dev_strtgy(gs, n)
+       type(gs_t), intent(inout) :: gs
+       integer, intent(in) :: n
+     end subroutine gs_tune_dev_strtgy
+
+     !> Whether the autotuning has been asked for explicitly, i.e. whether
+     !! NEKO_GS_TUNE is set
+     module function gs_tune_requested() result(requested)
+       logical :: requested
+     end function gs_tune_requested
   end interface
 
 contains
@@ -182,7 +196,7 @@ contains
     character(len=LOG_SIZE) :: log_buf
     character(len=20) :: bcknd_str
     integer, optional :: bcknd, comm_bcknd
-    integer :: i, ierr, bcknd_, comm_bcknd_
+    integer :: ierr, bcknd_, comm_bcknd_
     integer(i8) :: glb_nshared, glb_nlocal
     logical :: use_device_mpi, use_device_nccl, use_device_shmem, use_host_mpi
     logical :: use_host_shmem
@@ -192,12 +206,8 @@ contains
     logical :: use_mpi_rma
     logical :: use_host_crystal, use_device_crystal
     logical :: tune_comm
-    real(kind=rp), allocatable :: tmp(:)
-    type(c_ptr) :: tmp_d = C_NULL_PTR
-    integer :: strtgy(4) = [int(B'00'), int(B'01'), int(B'10'), int(B'11')]
-    integer :: avg_strtgy, env_len
-    character(len=255) :: env_strtgy, env_gscomm
-    real(kind=dp) :: strtgy_time(4)
+    integer :: env_len
+    character(len=255) :: env_gscomm
 
     call gs%free()
 
@@ -278,16 +288,23 @@ contains
        comm_bcknd_ = GS_COMM_CRYSTAL
     else if (use_device_crystal) then
        comm_bcknd_ = GS_COMM_CRYSTALGPU
+    else if (NEKO_DEVICE_MPI) then
+       ! A build with device-aware MPI has a defensible default and device
+       ! MPI is it: where it has been measured it beat the host backends by
+       ! 3-5x, which is not worth re-deriving at every startup. Setting
+       ! NEKO_GS_TUNE asks for the comparison anyway, which is how a new
+       ! machine gets its open question answered -- NCCL against device MPI,
+       ! or a GPU-aware MPI that turns out to be nominal
+       comm_bcknd_ = GS_COMM_MPIGPU
+       tune_comm = gs_tune_requested() .and. (pe_size .gt. 1)
     else
-       if (NEKO_DEVICE_MPI) then
-          comm_bcknd_ = GS_COMM_MPIGPU
-          use_device_mpi = .true.
-       else
-          ! No backend requested, benchmark the host backends once the
-          ! schedule is known and keep the fastest one (see gs_tune_comm)
-          comm_bcknd_ = GS_COMM_MPI
-          tune_comm = (pe_size .gt. 1)
-       end if
+       ! No backend requested and no obvious default: benchmark the
+       ! candidates once the schedule is known and keep the fastest one (see
+       ! gs_tune_comm). The schedule is built with the host MPI backend,
+       ! which every build can drive, and handed over to each candidate in
+       ! turn
+       comm_bcknd_ = GS_COMM_MPI
+       tune_comm = (pe_size .gt. 1)
     end if
 
     call gs_comm_alloc(gs%comm, comm_bcknd_)
@@ -378,69 +395,20 @@ contains
 
     call gs%bcknd%init(gs%nlocal, gs%nshared, gs%nlocal_blks, gs%nshared_blks)
 
-    ! Plain base-type assignment; setting this through a
-    ! select type (gs_device_t) miscompiles with CCE 21 at -O2/-O3,
-    ! silently leaving shared points on the host so that the scatter
-    ! overwrites the unpacked halo data with the stale host buffer
-    if (use_device_mpi .or. use_device_nccl .or. use_device_shmem .or. &
-         use_device_crystal) then
-       gs%bcknd%shared_on_host = .false.
+    ! Leave the gathered shared dofs where the comm. backend expects them:
+    ! in the host mirror of the shared buffer for a host backend, in device
+    ! memory for a device-resident one
+    gs%bcknd%shared_on_host = .not. gs_comm_on_device(comm_bcknd_)
+
+    ! Bind the device MPI synchronisation strategy. When the backends are
+    ! benchmarked below this is done there instead, as part of benchmarking
+    ! the device MPI candidate, so do not sweep it twice
+    if (comm_bcknd_ .eq. GS_COMM_MPIGPU .and. .not. tune_comm .and. &
+         pe_size .gt. 1) then
+       call gs_tune_dev_strtgy(gs, dofmap%size())
     end if
 
-    if (use_device_mpi) then
-       if (pe_size .gt. 1) then
-          ! Select fastest device MPI strategy at runtime
-          select type (c => gs%comm)
-          type is (gs_device_mpi_t)
-             call get_environment_variable("NEKO_GS_STRTGY", env_strtgy, &
-                  env_len)
-             if (env_len .eq. 0) then
-                allocate(tmp(dofmap%size()))
-                call device_map(tmp, tmp_d, dofmap%size())
-                tmp = 1.0_rp
-                call device_memcpy(tmp, tmp_d, dofmap%size(), &
-                     HOST_TO_DEVICE, sync = .false.)
-
-                do i = 1, size(strtgy)
-                   c%nb_strtgy = strtgy(i)
-                   strtgy_time(i) = gs_time_ops(gs, tmp, dofmap%size(), &
-                        GS_OP_ADD, GS_TUNE_NTRIALS)
-                end do
-
-                call device_unmap(tmp, tmp_d)
-                deallocate(tmp)
-
-                c%nb_strtgy = strtgy(minloc(strtgy_time, 1))
-
-                avg_strtgy = minloc(strtgy_time, 1)
-                call MPI_Allreduce(MPI_IN_PLACE, avg_strtgy, 1, &
-                     MPI_INTEGER, MPI_SUM, NEKO_COMM)
-                avg_strtgy = avg_strtgy / pe_size
-
-                write(log_buf, '(A,B0.2,A)') 'Avg. strtgy  :         [', &
-                     strtgy(avg_strtgy), ']'
-
-             else
-                read(env_strtgy(1:env_len), *) i
-
-                if (i .lt. 1 .or. i .gt. 4) then
-                   call neko_error('Invalid gs sync strtgy')
-                end if
-
-                c%nb_strtgy = strtgy(i)
-                avg_strtgy = i
-
-                write(log_buf, '(A,B0.2,A)') 'Env. strtgy  :         [', &
-                     strtgy(avg_strtgy), ']'
-             end if
-
-             call neko_log%message(log_buf)
-
-          end select
-       end if
-    end if
-
-    ! Select the fastest host comm. backend at runtime
+    ! Select the fastest comm. backend at runtime
     if (tune_comm) then
        call gs_tune_comm(gs, dofmap%size(), comm_bcknd_)
     end if
@@ -526,6 +494,27 @@ contains
     end select
 
   end function gs_comm_name
+
+  !> Whether the comm. backend @a comm_bcknd exchanges the shared dofs
+  !! straight out of device memory rather than out of the host mirror of the
+  !! shared buffer, which is what decides where the gather-scatter backend
+  !! leaves them (gs_bcknd_t%shared_on_host). A host backend on a device
+  !! build is not device-resident: it drives the exchange from the mirror,
+  !! at the price of a copy in each direction.
+  !! @param comm_bcknd comm. backend to check, one of the GS_COMM_* constants
+  !! @return whether the backend is device-resident
+  function gs_comm_on_device(comm_bcknd) result(on_device)
+    integer, intent(in) :: comm_bcknd
+    logical :: on_device
+
+    select case (comm_bcknd)
+    case (GS_COMM_MPIGPU, GS_COMM_NCCL, GS_COMM_NVSHMEM, GS_COMM_CRYSTALGPU)
+       on_device = .true.
+    case default
+       on_device = .false.
+    end select
+
+  end function gs_comm_on_device
 
   !> Deallocate a gather-scatter kernel
   subroutine gs_free(gs)

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -33,7 +33,7 @@
 !> Gather-scatter
 module gather_scatter
   use neko_config, only : NEKO_BCKND_DEVICE, NEKO_BCKND_SX, NEKO_BCKND_HIP, &
-       NEKO_BCKND_CUDA, NEKO_BCKND_OPENCL, NEKO_BCKND_METAL, NEKO_DEVICE_MPI
+       NEKO_BCKND_CUDA, NEKO_BCKND_OPENCL, NEKO_BCKND_METAL
   use gs_bcknd, only : gs_bcknd_t, GS_BCKND_CPU, GS_BCKND_SX, GS_BCKND_DEV
   use gs_device, only : gs_device_t
   use gs_sx, only : gs_sx_t
@@ -176,12 +176,6 @@ module gather_scatter
        type(gs_t), intent(inout) :: gs
        integer, intent(in) :: n
      end subroutine gs_tune_dev_strtgy
-
-     !> Whether the autotuning has been asked for explicitly, i.e. whether
-     !! NEKO_GS_TUNE is set
-     module function gs_tune_requested() result(requested)
-       logical :: requested
-     end function gs_tune_requested
   end interface
 
 contains
@@ -288,21 +282,11 @@ contains
        comm_bcknd_ = GS_COMM_CRYSTAL
     else if (use_device_crystal) then
        comm_bcknd_ = GS_COMM_CRYSTALGPU
-    else if (NEKO_DEVICE_MPI) then
-       ! A build with device-aware MPI has a defensible default and device
-       ! MPI is it: where it has been measured it beat the host backends by
-       ! 3-5x, which is not worth re-deriving at every startup. Setting
-       ! NEKO_GS_TUNE asks for the comparison anyway, which is how a new
-       ! machine gets its open question answered -- NCCL against device MPI,
-       ! or a GPU-aware MPI that turns out to be nominal
-       comm_bcknd_ = GS_COMM_MPIGPU
-       tune_comm = gs_tune_requested() .and. (pe_size .gt. 1)
     else
-       ! No backend requested and no obvious default: benchmark the
-       ! candidates once the schedule is known and keep the fastest one (see
-       ! gs_tune_comm). The schedule is built with the host MPI backend,
-       ! which every build can drive, and handed over to each candidate in
-       ! turn
+       ! No backend requested, benchmark the candidates once the schedule is
+       ! known and keep the fastest one (see gs_tune_comm). The schedule is
+       ! built with the host MPI backend, which every build can drive, and
+       ! handed over to each candidate in turn
        comm_bcknd_ = GS_COMM_MPI
        tune_comm = (pe_size .gt. 1)
     end if
@@ -400,11 +384,11 @@ contains
     ! memory for a device-resident one
     gs%bcknd%shared_on_host = .not. gs_comm_on_device(comm_bcknd_)
 
-    ! Bind the device MPI synchronisation strategy. When the backends are
-    ! benchmarked below this is done there instead, as part of benchmarking
-    ! the device MPI candidate, so do not sweep it twice
-    if (comm_bcknd_ .eq. GS_COMM_MPIGPU .and. .not. tune_comm .and. &
-         pe_size .gt. 1) then
+    ! Bind the device MPI synchronisation strategy for a run that pinned
+    ! device MPI. When the comm. backend is left to the autotuning below,
+    ! this is done there instead, as part of benchmarking the device MPI
+    ! candidate
+    if (comm_bcknd_ .eq. GS_COMM_MPIGPU .and. pe_size .gt. 1) then
        call gs_tune_dev_strtgy(gs, dofmap%size())
     end if
 

--- a/src/gs/gs_bcknd.f90
+++ b/src/gs/gs_bcknd.f90
@@ -45,8 +45,11 @@ module gs_bcknd
      type(c_ptr) :: gather_event = C_NULL_PTR
      type(c_ptr) :: scatter_event = C_NULL_PTR
      type(c_ptr) :: gs_stream = C_NULL_PTR
-     !> Shared points are handled on the host (device backends only; kept
-     !! in the base type so it can be set without a select type)
+     !> Shared points are handled on the host (device backends only). Kept
+     !! in the base type so that it can be set without a select type: a
+     !! select type (gs_device_t) assignment to it miscompiles with CCE 21
+     !! at -O2/-O3, silently leaving the shared points on the host so that
+     !! the scatter overwrites the unpacked halo with the stale host buffer
      logical :: shared_on_host = .true.
    contains
      procedure(gs_backend_init), pass(this), deferred :: init

--- a/src/gs/gs_tune.f90
+++ b/src/gs/gs_tune.f90
@@ -38,20 +38,42 @@ submodule (gather_scatter) gs_tune
        gs_caf_set_mode
   use gs_utofu, only : GS_UTOFU_AVAIL
   use gs_mpi_rma, only : GS_MPI_RMA_AVAIL
+  use gs_device_nccl, only : GS_DEVICE_NCCL_AVAIL
+  use gs_device_shmem, only : GS_DEVICE_SHMEM_AVAIL
+  use neko_config, only : NEKO_DEVICE_MPI
   implicit none
 
-  !> The host comm. backends the runtime autotuning can benchmark, in the
-  !! order they are benchmarked and reported. The device backends are not
-  !! among them: the autotuning only runs on host builds (see gs_init).
-  integer, parameter :: GS_TUNE_BCKND(7) = [GS_COMM_MPI, GS_COMM_NEIGHBOUR, &
+  !> The comm. backends the runtime autotuning can benchmark, in the order
+  !! they are benchmarked and reported: first the host backends, which on a
+  !! device build stage the halo through the host mirror of the shared
+  !! buffer, then the device-resident ones, which keep it on the device and
+  !! are candidates on CUDA and HIP builds only (see gs_comm_tunable).
+  integer, parameter :: GS_TUNE_BCKND(11) = [GS_COMM_MPI, GS_COMM_NEIGHBOUR, &
        GS_COMM_MPIRMA, GS_COMM_OPENSHMEM, GS_COMM_CAF, GS_COMM_UTOFU, &
-       GS_COMM_CRYSTAL]
+       GS_COMM_CRYSTAL, GS_COMM_MPIGPU, GS_COMM_NCCL, GS_COMM_CRYSTALGPU, &
+       GS_COMM_NVSHMEM]
 
-  !> Which of GS_TUNE_BCKND are benchmarked when NEKO_GS_TUNE is unset: all
-  !! of them the build supports but CAF, which has to be asked for (see
-  !! gs_tune_select).
-  logical, parameter :: GS_TUNE_DEFAULT(7) = [.true., .true., .true., &
-       .true., .false., .true., .true.]
+  !> Which of GS_TUNE_BCKND are benchmarked when NEKO_GS_TUNE names no
+  !! candidates of its own: all of them this build and run supports but CAF
+  !! and NVSHMEM, which have to be asked for (see gs_tune_select). A host
+  !! build drops every device backend in gs_comm_tunable, so the one set
+  !! serves both.
+  !!
+  !! @note This is the set a comparison starts from, not a statement that a
+  !! comparison happens. On a build with device-aware MPI none does unless
+  !! NEKO_GS_TUNE is set at all (see gs_tune_requested and gs_init); the
+  !! device backends are in the set so that device MPI, the default there,
+  !! defends its place once a comparison is asked for.
+  logical, parameter :: GS_TUNE_DEFAULT(11) = [.true., .true., .true., &
+       .true., .false., .true., .true., .true., .true., .true., .false.]
+
+  !> Whether this build has what the device-resident comm. backends need to
+  !! pack and unpack the halo in device memory. Their kernels are written
+  !! for CUDA and HIP only and abort on the OpenCL and Metal backends, so
+  !! those builds tune over the host backends alone, staging the halo
+  !! through the host mirror of the shared buffer as they always have.
+  logical, parameter :: GS_TUNE_DEV_AVAIL = (NEKO_BCKND_HIP .eq. 1) .or. &
+       (NEKO_BCKND_CUDA .eq. 1)
 
   !> Whether the coarray signaling mode has already been selected by the
   !! autotuner (NEKO_GS_CAF_SIGNALING=auto). The mode is a program-wide
@@ -62,16 +84,32 @@ submodule (gather_scatter) gs_tune
 
 contains
 
-  !> Host comm. backends to benchmark in the runtime autotuning: the ones
-  !! selected by NEKO_GS_TUNE (see gs_tune_select) that this run can
-  !! actually use (see gs_comm_tunable), in GS_TUNE_BCKND order. A selected
-  !! backend the run cannot use is dropped, and reported in the log if it
-  !! was named explicitly rather than merely part of the default set.
+  !> Whether the autotuning has been asked for explicitly, that is whether
+  !! NEKO_GS_TUNE is set to anything at all. What it is set to selects the
+  !! candidates (see gs_tune_select); merely being set is what turns the
+  !! benchmark on where benchmarking is not the default, namely on a build
+  !! with device-aware MPI (see gs_init).
+  !! @return whether NEKO_GS_TUNE is set
+  module function gs_tune_requested() result(requested)
+    logical :: requested
+    character(len=255) :: env_val
+    integer :: env_len
+
+    call get_environment_variable("NEKO_GS_TUNE", env_val, env_len)
+    requested = (env_len .gt. 0)
+
+  end function gs_tune_requested
+
+  !> Comm. backends to benchmark in the runtime autotuning: the ones
+  !! selected by NEKO_GS_TUNE (see gs_tune_select) that this build and run
+  !! can actually use (see gs_comm_tunable), in GS_TUNE_BCKND order. A
+  !! selected backend the run cannot use is dropped, and reported in the log
+  !! if it was named explicitly rather than merely part of the default set.
   !! @return the candidate backends, as GS_COMM_* constants. May be empty,
   !! or hold a single entry, in which case gs_tune_comm benchmarks nothing
   !! @note The list says nothing about which backend the gs kernel holds
   !! when the tuning starts; gs_tune_comm is told that separately.
-  function gs_comm_host_cand() result(cand)
+  function gs_comm_cand() result(cand)
     integer, allocatable :: cand(:)
     character(len=LOG_SIZE) :: log_buf
     character(len=13) :: label
@@ -99,12 +137,14 @@ contains
     allocate(cand(n))
     cand = c(1:n)
 
-  end function gs_comm_host_cand
+  end function gs_comm_cand
 
   !> Whether the comm. backend @a comm_bcknd can be driven by this build and
   !! this run, and may therefore be benchmarked. MPI and the neighbourhood
-  !! collective need nothing but MPI-3; the rest abort in their init unless
-  !! the corresponding support was built in.
+  !! collective need nothing but MPI-3; the rest abort in their init, or
+  !! exchange nothing, unless the corresponding support was built in. The
+  !! device-resident backends additionally need a build whose gather-scatter
+  !! kernels can pack the halo in device memory (GS_TUNE_DEV_AVAIL).
   !! @param comm_bcknd comm. backend to check, one of the GS_TUNE_BCKND
   !! entries
   !! @return whether the backend is usable as a candidate
@@ -147,6 +187,25 @@ contains
             (pe_size .eq. global_pe_size)
     case (GS_COMM_UTOFU)
        tunable = GS_UTOFU_AVAIL
+    case (GS_COMM_MPIGPU, GS_COMM_CRYSTALGPU)
+       ! Both hand device pointers straight to MPI, which only holds on a
+       ! build configured for device-aware MPI (--enable-device-mpi). They
+       ! address their peers by their rank in NEKO_COMM, so a communicator
+       ! split does not rule them out.
+       tunable = GS_TUNE_DEV_AVAIL .and. NEKO_DEVICE_MPI
+    case (GS_COMM_NCCL)
+       ! The NCCL communicator is built once at startup
+       ! (neko_comm_nccl_init) over the ranks of NEKO_COMM, but from a
+       ! unique id broadcast over MPI_COMM_WORLD, so it is only well defined
+       ! when NEKO_COMM spans every process, as for the PE addressed
+       ! backends above
+       tunable = GS_TUNE_DEV_AVAIL .and. GS_DEVICE_NCCL_AVAIL .and. &
+            (pe_size .eq. global_pe_size)
+    case (GS_COMM_NVSHMEM)
+       ! Addresses its peers by NVSHMEM PE, as OpenSHMEM does, so the same
+       ! restriction on communicator splits applies
+       tunable = GS_TUNE_DEV_AVAIL .and. GS_DEVICE_SHMEM_AVAIL .and. &
+            (pe_size .eq. global_pe_size)
     case default
        tunable = .false.
     end select
@@ -164,11 +223,13 @@ contains
   !!   (`NEKO_GS_TUNE=+CAF`).
   !!
   !! The two forms cannot be mixed. When the variable is unset the default
-  !! set GS_TUNE_DEFAULT is used, which is everything but CAF -- a compiler
-  !! may accept coarrays and still give the job a single image, and a
-  !! backend that cannot communicate is at best wasted setup, so CAF has to
-  !! be asked for. Selecting a backend outright (NEKO_GS_COMM) bypasses all
-  !! of this.
+  !! set GS_TUNE_DEFAULT is used, which is everything but CAF and NVSHMEM.
+  !! A compiler may accept coarrays and still give the job a single image,
+  !! and a backend that cannot communicate is at best wasted setup, so CAF
+  !! has to be asked for; NVSHMEM aborts outright unless the peer lists come
+  !! out symmetric and aligned, which is too much to risk on a run that
+  !! never asked for it. Selecting a backend outright (NEKO_GS_COMM)
+  !! bypasses all of this.
   !!
   !! @param sel whether each entry of GS_TUNE_BCKND was selected
   !! @param named whether each entry was named explicitly, i.e. is a request
@@ -238,8 +299,10 @@ contains
 
   !> Index into GS_TUNE_BCKND of the comm. backend named @a name, using the
   !! spellings NEKO_GS_COMM accepts, or 0 if it names no backend that takes
-  !! part in the autotuning (the device backends among them: the autotuning
-  !! only runs on host builds).
+  !! part in the autotuning. Host and device OpenSHMEM are one name to
+  !! NEKO_GS_COMM, which picks between them by build; here they can both be
+  !! candidates of the same run, so they are spelled apart: SHMEM is the
+  !! host backend and NVSHMEM the device one.
   !! @param name upper case backend name to look up
   !! @return the index into GS_TUNE_BCKND, or 0
   function gs_tune_index(name) result(idx)
@@ -261,6 +324,14 @@ contains
        bcknd = GS_COMM_MPIRMA
     case ('CRYSTAL')
        bcknd = GS_COMM_CRYSTAL
+    case ('MPIGPU')
+       bcknd = GS_COMM_MPIGPU
+    case ('NCCL', 'RCCL')
+       bcknd = GS_COMM_NCCL
+    case ('NVSHMEM')
+       bcknd = GS_COMM_NVSHMEM
+    case ('CRYSTALGPU')
+       bcknd = GS_COMM_CRYSTALGPU
     case default
        bcknd = 0
     end select
@@ -297,6 +368,10 @@ contains
   !! new backend, not recomputed). The old backend is freed before the new
   !! one is set up, so backends holding scarce resources (uTofu VCQs,
   !! symmetric memory, coarrays) never overlap.
+  !!
+  !! The gather-scatter backend is told where to leave the gathered shared
+  !! dofs to match: in the host mirror of the shared buffer for a host
+  !! backend, in device memory for a device-resident one.
   !! @param gs gather-scatter kernel whose comm. backend is replaced
   !! @param comm_bcknd comm. backend to switch to, one of the GS_COMM_*
   !! constants
@@ -312,6 +387,8 @@ contains
     deallocate(gs%comm)
     call move_alloc(comm_new, gs%comm)
     call gs%comm%init_schedule()
+
+    gs%bcknd%shared_on_host = .not. gs_comm_on_device(comm_bcknd)
 
   end subroutine gs_comm_switch
 
@@ -350,7 +427,7 @@ contains
 
   !> Select the fastest of the candidate comm. backends at runtime.
   !!
-  !! Each candidate returned by gs_comm_host_cand is benchmarked in turn on
+  !! Each candidate returned by gs_comm_cand is benchmarked in turn on
   !! a dummy vector of length @a n, reusing the schedule computed by
   !! gs_schedule (handed over from one candidate to the next, see
   !! gs_comm_t%take_schedule), and @a gs is left with the fastest backend
@@ -363,6 +440,10 @@ contains
   !! @param n length of the dummy vector to benchmark on (the dofmap size)
   !! @param comm_bcknd the comm. backend @a gs holds on entry, i.e. the one
   !! the schedule was built with, which need not be a candidate itself
+  !!
+  !! A candidate with a sub-choice of its own has it benchmarked here too,
+  !! and contributes the winning variant's time: the device MPI
+  !! synchronisation strategy, and the coarray signaling mode.
   !!
   !! @note Setting up and running a comm. backend is collective over
   !! NEKO_COMM (the neighbourhood backend builds a graph communicator, the
@@ -379,9 +460,9 @@ contains
     real(kind=dp), allocatable :: cand_time(:)
     real(kind=rp), allocatable :: tmp(:)
     type(c_ptr) :: tmp_d
-    integer :: i, best, nmin, cur
+    integer :: i, best, nmin, cur, dev_strtgy
 
-    allocate(cand, source = gs_comm_host_cand())
+    allocate(cand, source = gs_comm_cand())
 
     ! Track what gs is running as the sweep proceeds. The candidate list
     ! need neither start with the backend the schedule was built with nor
@@ -401,6 +482,9 @@ contains
        if (nmin .gt. 0 .and. size(cand) .eq. 1) then
           if (cand(1) .ne. cur) call gs_comm_switch(gs, cand(1))
           cur = cand(1)
+          ! Nothing to compare the backend against, but device MPI still has
+          ! a strategy to pick
+          if (cur .eq. GS_COMM_MPIGPU) call gs_tune_dev_strtgy(gs, n)
        end if
        call neko_log%message('Tuned comm   : ' // gs_comm_name(cur))
        return
@@ -418,6 +502,7 @@ contains
 
     ! GS_OP_MIN leaves the working vector untouched, so the benchmark can
     ! run for any number of trials without the values growing out of range
+    dev_strtgy = -1
     do i = 1, size(cand)
        if (cand(i) .eq. GS_COMM_CAF .and. gs_caf_signal_auto() .and. &
             .not. caf_signal_tuned) then
@@ -427,7 +512,16 @@ contains
           caf_signal_tuned = .true.
        else
           if (cand(i) .ne. cur) call gs_comm_switch(gs, cand(i))
-          cand_time(i) = gs_time_ops(gs, tmp, n, GS_OP_MIN, GS_TUNE_NTRIALS)
+          if (cand(i) .eq. GS_COMM_MPIGPU) then
+             ! Benchmark the synchronisation strategies as well; this leaves
+             ! the fastest one bound, and it has to be remembered in case the
+             ! sweep switches away from device MPI and back again
+             call gs_tune_strtgy(gs, tmp, n, cand_time(i))
+             dev_strtgy = gs_get_strtgy(gs)
+          else
+             cand_time(i) = gs_time_ops(gs, tmp, n, GS_OP_MIN, &
+                  GS_TUNE_NTRIALS)
+          end if
        end if
        cur = cand(i)
     end do
@@ -457,11 +551,152 @@ contains
 
     if (cand(best) .ne. cur) call gs_comm_switch(gs, cand(best))
 
+    ! A switch back to device MPI allocates a fresh backend, which comes up
+    ! with the default strategy rather than the one benchmarked above
+    if (dev_strtgy .ge. 0) call gs_set_strtgy(gs, dev_strtgy)
+
     call neko_log%message('Tuned comm   : ' // gs_comm_name(cand(best)))
 
     deallocate(cand_time)
 
   end subroutine gs_tune_comm
+
+  !> Bind the non-blocking synchronisation strategy of the device MPI comm.
+  !! backend held by @a gs, benchmarking the strategies on a dummy vector.
+  !!
+  !! Called by gs_init when device MPI was requested outright; when the
+  !! comm. backend is left to the autotuning, gs_tune_comm benchmarks the
+  !! strategies on its own working vector instead (see gs_tune_strtgy).
+  !!
+  !! @param gs gather-scatter kernel to tune, holding a device MPI comm.
+  !! backend
+  !! @param n length of the dummy vector to benchmark on (the dofmap size)
+  module subroutine gs_tune_dev_strtgy(gs, n)
+    type(gs_t), intent(inout) :: gs
+    integer, intent(in) :: n
+    real(kind=rp), allocatable :: tmp(:)
+    type(c_ptr) :: tmp_d
+
+    tmp_d = C_NULL_PTR
+    allocate(tmp(n))
+    tmp = 1.0_rp
+    call device_map(tmp, tmp_d, n)
+    call device_memcpy(tmp, tmp_d, n, HOST_TO_DEVICE, sync = .false.)
+
+    call gs_tune_strtgy(gs, tmp, n)
+
+    call device_unmap(tmp, tmp_d)
+    deallocate(tmp)
+
+  end subroutine gs_tune_dev_strtgy
+
+  !> Bind the non-blocking synchronisation strategy of the device MPI comm.
+  !! backend held by @a gs, and optionally return the average time per
+  !! gather-scatter operation under it.
+  !!
+  !! The strategy is the pair of independent choices of packing the halo per
+  !! peer or in one go, and of waiting for the incoming messages one by one
+  !! or all at once. All four are benchmarked on @a u and the fastest one is
+  !! bound, unless NEKO_GS_STRTGY names one (1-4), which is then bound and
+  !! merely timed.
+  !!
+  !! Unlike the comm. backend itself this is a rank-local choice -- it
+  !! changes how a rank drives its own streams, not what goes on the wire --
+  !! so every rank keeps its own winner and only the reported strategy is
+  !! averaged over the ranks.
+  !!
+  !! @param gs gather-scatter kernel to tune, holding a device MPI comm.
+  !! backend. Doing this to any other backend binds nothing and simply times
+  !! it four times over
+  !! @param u working vector to operate on
+  !! @param n length of @a u
+  !! @param t the average wall time (s) per operation under the bound
+  !! strategy
+  subroutine gs_tune_strtgy(gs, u, n, t)
+    type(gs_t), intent(inout) :: gs
+    integer, intent(in) :: n
+    real(kind=rp), dimension(n), intent(inout) :: u
+    real(kind=dp), intent(out), optional :: t
+    character(len=LOG_SIZE) :: log_buf
+    integer, parameter :: strtgy(4) = [int(B'00'), int(B'01'), int(B'10'), &
+         int(B'11')]
+    real(kind=dp) :: strtgy_time(size(strtgy))
+    character(len=255) :: env_strtgy
+    integer :: i, env_len, best, avg
+
+    call get_environment_variable("NEKO_GS_STRTGY", env_strtgy, env_len)
+
+    if (env_len .eq. 0) then
+       do i = 1, size(strtgy)
+          call gs_set_strtgy(gs, strtgy(i))
+          strtgy_time(i) = gs_time_ops(gs, u, n, GS_OP_MIN, GS_TUNE_NTRIALS)
+       end do
+
+       best = minloc(strtgy_time, 1)
+       call gs_set_strtgy(gs, strtgy(best))
+       if (present(t)) t = strtgy_time(best)
+
+       ! Each rank picked for itself, so report the average of what they
+       ! picked rather than rank 0's own choice
+       avg = best
+       call MPI_Allreduce(MPI_IN_PLACE, avg, 1, MPI_INTEGER, MPI_SUM, &
+            NEKO_COMM)
+       avg = avg / pe_size
+
+       write(log_buf, '(A,B0.2,A)') 'Avg. strtgy  :         [', &
+            strtgy(avg), ']'
+    else
+       read(env_strtgy(1:env_len), *) best
+
+       if (best .lt. 1 .or. best .gt. size(strtgy)) then
+          call neko_error('Invalid gs sync strtgy')
+       end if
+
+       call gs_set_strtgy(gs, strtgy(best))
+       if (present(t)) then
+          t = gs_time_ops(gs, u, n, GS_OP_MIN, GS_TUNE_NTRIALS)
+       end if
+
+       write(log_buf, '(A,B0.2,A)') 'Env. strtgy  :         [', &
+            strtgy(best), ']'
+    end if
+
+    call neko_log%message(log_buf)
+
+  end subroutine gs_tune_strtgy
+
+  !> Bind the non-blocking synchronisation strategy @a strtgy of the device
+  !! MPI comm. backend held by @a gs. A no-op for any other backend, so that
+  !! the caller need not know which one is in place.
+  !! @param gs gather-scatter kernel whose comm. backend is bound
+  !! @param strtgy the strategy, a two bit mask (see gs_device_mpi_t)
+  subroutine gs_set_strtgy(gs, strtgy)
+    type(gs_t), intent(inout) :: gs
+    integer, intent(in) :: strtgy
+
+    select type (c => gs%comm)
+    type is (gs_device_mpi_t)
+       c%nb_strtgy = strtgy
+    end select
+
+  end subroutine gs_set_strtgy
+
+  !> The non-blocking synchronisation strategy bound in the device MPI comm.
+  !! backend held by @a gs, or -1 if @a gs holds another backend.
+  !! @param gs gather-scatter kernel to read the strategy of
+  !! @return the strategy, a two bit mask (see gs_device_mpi_t), or -1
+  function gs_get_strtgy(gs) result(strtgy)
+    type(gs_t), intent(in) :: gs
+    integer :: strtgy
+
+    strtgy = -1
+
+    select type (c => gs%comm)
+    type is (gs_device_mpi_t)
+       strtgy = c%nb_strtgy
+    end select
+
+  end function gs_get_strtgy
 
   !> Benchmark the coarray signaling modes and bind the fastest one, leaving
   !! @a gs holding a CAF backend that runs in that mode. Returns the winning

--- a/src/gs/gs_tune.f90
+++ b/src/gs/gs_tune.f90
@@ -53,17 +53,10 @@ submodule (gather_scatter) gs_tune
        GS_COMM_CRYSTAL, GS_COMM_MPIGPU, GS_COMM_NCCL, GS_COMM_CRYSTALGPU, &
        GS_COMM_NVSHMEM]
 
-  !> Which of GS_TUNE_BCKND are benchmarked when NEKO_GS_TUNE names no
-  !! candidates of its own: all of them this build and run supports but CAF
-  !! and NVSHMEM, which have to be asked for (see gs_tune_select). A host
-  !! build drops every device backend in gs_comm_tunable, so the one set
-  !! serves both.
-  !!
-  !! @note This is the set a comparison starts from, not a statement that a
-  !! comparison happens. On a build with device-aware MPI none does unless
-  !! NEKO_GS_TUNE is set at all (see gs_tune_requested and gs_init); the
-  !! device backends are in the set so that device MPI, the default there,
-  !! defends its place once a comparison is asked for.
+  !> Which of GS_TUNE_BCKND are benchmarked when NEKO_GS_TUNE is unset: all
+  !! of them this build and run supports but CAF and NVSHMEM, which have to
+  !! be asked for (see gs_tune_select). A host build drops every device
+  !! backend in gs_comm_tunable, so the one set serves both.
   logical, parameter :: GS_TUNE_DEFAULT(11) = [.true., .true., .true., &
        .true., .false., .true., .true., .true., .true., .true., .false.]
 
@@ -83,22 +76,6 @@ submodule (gather_scatter) gs_tune
   logical, save :: caf_signal_tuned = .false.
 
 contains
-
-  !> Whether the autotuning has been asked for explicitly, that is whether
-  !! NEKO_GS_TUNE is set to anything at all. What it is set to selects the
-  !! candidates (see gs_tune_select); merely being set is what turns the
-  !! benchmark on where benchmarking is not the default, namely on a build
-  !! with device-aware MPI (see gs_init).
-  !! @return whether NEKO_GS_TUNE is set
-  module function gs_tune_requested() result(requested)
-    logical :: requested
-    character(len=255) :: env_val
-    integer :: env_len
-
-    call get_environment_variable("NEKO_GS_TUNE", env_val, env_len)
-    requested = (env_len .gt. 0)
-
-  end function gs_tune_requested
 
   !> Comm. backends to benchmark in the runtime autotuning: the ones
   !! selected by NEKO_GS_TUNE (see gs_tune_select) that this build and run
@@ -456,11 +433,13 @@ contains
     integer, intent(in) :: comm_bcknd
     character(len=LOG_SIZE) :: log_buf
     character(len=13) :: label
+    character(len=6) :: strtgy_str
     integer, allocatable :: cand(:)
     real(kind=dp), allocatable :: cand_time(:)
     real(kind=rp), allocatable :: tmp(:)
     type(c_ptr) :: tmp_d
-    integer :: i, best, nmin, cur, dev_strtgy
+    integer :: i, best, nmin, cur, dev_strtgy, dev_strtgy_avg
+    logical :: dev_strtgy_env
 
     allocate(cand, source = gs_comm_cand())
 
@@ -503,6 +482,8 @@ contains
     ! GS_OP_MIN leaves the working vector untouched, so the benchmark can
     ! run for any number of trials without the values growing out of range
     dev_strtgy = -1
+    dev_strtgy_avg = -1
+    dev_strtgy_env = .false.
     do i = 1, size(cand)
        if (cand(i) .eq. GS_COMM_CAF .and. gs_caf_signal_auto() .and. &
             .not. caf_signal_tuned) then
@@ -516,7 +497,8 @@ contains
              ! Benchmark the synchronisation strategies as well; this leaves
              ! the fastest one bound, and it has to be remembered in case the
              ! sweep switches away from device MPI and back again
-             call gs_tune_strtgy(gs, tmp, n, cand_time(i))
+             call gs_tune_strtgy(gs, tmp, n, dev_strtgy_avg, dev_strtgy_env, &
+                  cand_time(i))
              dev_strtgy = gs_get_strtgy(gs)
           else
              cand_time(i) = gs_time_ops(gs, tmp, n, GS_OP_MIN, &
@@ -543,9 +525,22 @@ contains
           label = 'CAF (' // &
                trim(adjustl(gs_caf_mode_name(gs_caf_mode_get()))) // ')'
        end if
+       ! Device MPI is likewise only as fast as the synchronisation strategy
+       ! it ran under, and that strategy is what the run goes on to use, so
+       ! name it on the line it was measured on rather than above the
+       ! comparison. 'Dev. MPI [xx]' is exactly the width of the label
+       ! field, so the column is unaffected
+       strtgy_str = ''
+       if (cand(i) .eq. GS_COMM_MPIGPU .and. dev_strtgy_avg .ge. 0) then
+          write(label, '(A,B0.2,A)') 'Dev. MPI [', dev_strtgy_avg, ']'
+          ! A strategy that was named rather than measured is not a property
+          ! of this comparison, so it is flagged instead of quietly shown
+          if (dev_strtgy_env) strtgy_str = ' (env)'
+       end if
        ! ES10.3 + ' s' fills the same 12 columns as the right-adjusted
        ! backend names, so the unit lines up with their last letter
-       write(log_buf, '(A,A,ES10.3,A)') label, ': ', cand_time(i), ' s'
+       write(log_buf, '(A,A,ES10.3,A,A)') label, ': ', cand_time(i), ' s', &
+            trim(strtgy_str)
        call neko_log%message(log_buf)
     end do
 
@@ -574,8 +569,11 @@ contains
   module subroutine gs_tune_dev_strtgy(gs, n)
     type(gs_t), intent(inout) :: gs
     integer, intent(in) :: n
+    character(len=LOG_SIZE) :: log_buf
     real(kind=rp), allocatable :: tmp(:)
     type(c_ptr) :: tmp_d
+    integer :: strtgy_avg
+    logical :: from_env
 
     tmp_d = C_NULL_PTR
     allocate(tmp(n))
@@ -583,16 +581,26 @@ contains
     call device_map(tmp, tmp_d, n)
     call device_memcpy(tmp, tmp_d, n, HOST_TO_DEVICE, sync = .false.)
 
-    call gs_tune_strtgy(gs, tmp, n)
+    call gs_tune_strtgy(gs, tmp, n, strtgy_avg, from_env)
 
     call device_unmap(tmp, tmp_d)
     deallocate(tmp)
 
+    ! Nothing else was tuned, so the strategy gets the line to itself
+    if (from_env) then
+       write(log_buf, '(A,B0.2,A)') 'Env. strtgy  :         [', strtgy_avg, ']'
+    else
+       write(log_buf, '(A,B0.2,A)') 'Avg. strtgy  :         [', strtgy_avg, ']'
+    end if
+    call neko_log%message(log_buf)
+
   end subroutine gs_tune_dev_strtgy
 
   !> Bind the non-blocking synchronisation strategy of the device MPI comm.
-  !! backend held by @a gs, and optionally return the average time per
-  !! gather-scatter operation under it.
+  !! backend held by @a gs, reporting the bound strategy back to the caller
+  !! rather than to the log: where it is one candidate among several it
+  !! belongs on that candidate's line, and where it is the only thing being
+  !! tuned it gets a line of its own (see gs_tune_dev_strtgy).
   !!
   !! The strategy is the pair of independent choices of packing the halo per
   !! peer or in one go, and of waiting for the incoming messages one by one
@@ -602,22 +610,28 @@ contains
   !!
   !! Unlike the comm. backend itself this is a rank-local choice -- it
   !! changes how a rank drives its own streams, not what goes on the wire --
-  !! so every rank keeps its own winner and only the reported strategy is
-  !! averaged over the ranks.
+  !! so every rank keeps its own winner. @a strtgy_avg is the average of
+  !! those winners, the same treatment the candidate timings get, so that
+  !! what is reported describes the run rather than rank 0.
   !!
   !! @param gs gather-scatter kernel to tune, holding a device MPI comm.
   !! backend. Doing this to any other backend binds nothing and simply times
   !! it four times over
   !! @param u working vector to operate on
   !! @param n length of @a u
+  !! @param strtgy_avg the bound strategy averaged over the ranks, as the
+  !! two bit mask to report (not an index into the strategy list)
+  !! @param from_env whether NEKO_GS_STRTGY named the strategy, rather than
+  !! it having been benchmarked
   !! @param t the average wall time (s) per operation under the bound
   !! strategy
-  subroutine gs_tune_strtgy(gs, u, n, t)
+  subroutine gs_tune_strtgy(gs, u, n, strtgy_avg, from_env, t)
     type(gs_t), intent(inout) :: gs
     integer, intent(in) :: n
     real(kind=rp), dimension(n), intent(inout) :: u
+    integer, intent(out) :: strtgy_avg
+    logical, intent(out) :: from_env
     real(kind=dp), intent(out), optional :: t
-    character(len=LOG_SIZE) :: log_buf
     integer, parameter :: strtgy(4) = [int(B'00'), int(B'01'), int(B'10'), &
          int(B'11')]
     real(kind=dp) :: strtgy_time(size(strtgy))
@@ -625,8 +639,9 @@ contains
     integer :: i, env_len, best, avg
 
     call get_environment_variable("NEKO_GS_STRTGY", env_strtgy, env_len)
+    from_env = (env_len .gt. 0)
 
-    if (env_len .eq. 0) then
+    if (.not. from_env) then
        do i = 1, size(strtgy)
           call gs_set_strtgy(gs, strtgy(i))
           strtgy_time(i) = gs_time_ops(gs, u, n, GS_OP_MIN, GS_TUNE_NTRIALS)
@@ -636,15 +651,10 @@ contains
        call gs_set_strtgy(gs, strtgy(best))
        if (present(t)) t = strtgy_time(best)
 
-       ! Each rank picked for itself, so report the average of what they
-       ! picked rather than rank 0's own choice
        avg = best
        call MPI_Allreduce(MPI_IN_PLACE, avg, 1, MPI_INTEGER, MPI_SUM, &
             NEKO_COMM)
        avg = avg / pe_size
-
-       write(log_buf, '(A,B0.2,A)') 'Avg. strtgy  :         [', &
-            strtgy(avg), ']'
     else
        read(env_strtgy(1:env_len), *) best
 
@@ -657,11 +667,11 @@ contains
           t = gs_time_ops(gs, u, n, GS_OP_MIN, GS_TUNE_NTRIALS)
        end if
 
-       write(log_buf, '(A,B0.2,A)') 'Env. strtgy  :         [', &
-            strtgy(best), ']'
+       ! Every rank was given the same one, so there is nothing to average
+       avg = best
     end if
 
-    call neko_log%message(log_buf)
+    strtgy_avg = strtgy(avg)
 
   end subroutine gs_tune_strtgy
 


### PR DESCRIPTION
This pr refactors the GS backend (init + tuner), to allow for auto tuner sweeps of all backends e.g. HOST + GPU for a GPU backend, or all possible device backends e.g. `NCCL`, `MPIGPU`,`CRYSTALGPU`.

However, the default is that the tuner is disabled for device backends (Controllable by the usual env. variables)
