### PR TITLE
Return region ID if not enabled

### DIFF
--- a/src/common/runtime_statistics.f90
+++ b/src/common/runtime_statistics.f90
@@ -300,6 +300,8 @@ contains
     integer, intent(out) :: region_id
     integer :: i
 
+    if (.not. this%enabled) return
+
     region_id = -1
 
     ! Look for the region name first

--- a/src/common/runtime_statistics.f90
+++ b/src/common/runtime_statistics.f90
@@ -300,11 +300,9 @@ contains
     integer, intent(out) :: region_id
     integer :: i
 
-
-region_id = -1
+    region_id = -1
 
     if (.not. this%enabled) return
-
 
     ! Look for the region name first
     do i = RT_STATS_RESERVED_REGIONS + 1, RT_STATS_MAX_REGIONS

--- a/src/common/runtime_statistics.f90
+++ b/src/common/runtime_statistics.f90
@@ -300,9 +300,11 @@ contains
     integer, intent(out) :: region_id
     integer :: i
 
+
+region_id = -1
+
     if (.not. this%enabled) return
 
-    region_id = -1
 
     ! Look for the region name first
     do i = RT_STATS_RESERVED_REGIONS + 1, RT_STATS_MAX_REGIONS


### PR DESCRIPTION
As the title says, if runtime stats were disabled but find_region_id was called anywhere in the code, the unallocated array `rt_stats_id` is referenced, throwing segfaults. 