### PR TITLE
Ensure subvariants of each autotuning instance is tested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@
   staged (`DMMA_TMA`) formulations to the `opgrad`, `dudxyz`, `conv1` and
   `cdtp` operators, again as auto-tuner candidates selected per operator,
   polynomial order and element count.
+- *BREAKING* `NEKO_AUTOTUNE` now narrows the SEM operator search to the named
+  formulation instead of skipping the search outright. The geometry of that
+  formulation --- chunk size, elements per block, warps or wavefronts per
+  block --- is still swept and reported, where pinning a formulation used to
+  silently fix it at candidate 0. `NEKO_EB`, `NEKO_CHUNKS`, `NEKO_DMMA_NW`,
+  `NEKO_DMMA_TMA_NW` and `NEKO_MFMA_NWF` now pin that geometry whenever their
+  formulation is measured, rather than only when it is the pinned one, and
+  setting one alongside `NEKO_AUTOTUNE` leaves nothing to measure and skips
+  the search as before. So an A/B run of two formulations compares each at its
+  own best geometry; to get the old behaviour, set the geometry variable too.
 - *BREAKING* The `ax_helm_factory` is renamed to `ax_helm_allocator`. It now
   selects matrix-vector product types by name instead of a `full_formulation`
   logical argument, and supports runtime registration of user-defined `ax_t`

--- a/doc/man/neko.1.in
+++ b/doc/man/neko.1.in
@@ -119,9 +119,13 @@ treated as fatal errors. If unset, they are reported as warnings.
 Indentation width used by the logger.
 .TP
 .B NEKO_AUTOTUNE
-Pins the kernel formulation used by the spectral element operators on the
-CUDA and HIP backends, skipping the auto-tuning search that otherwise runs
-on the first call of each operator. Accepted values are
+Restricts the auto-tuning search run by the spectral element operators on the
+CUDA and HIP backends to a single kernel formulation. The geometry within that
+formulation is still measured: the search is narrowed, not skipped, and it
+takes the formulation's own selector
+.RB ( NEKO_CHUNKS ", " NEKO_EB ", " NEKO_DMMA_NW ", " NEKO_DMMA_TMA_NW
+.RB " or " NEKO_MFMA_NWF )
+to fix that too, which then leaves nothing to measure. Accepted values are
 .BR 1D ", " KSTEP ", " DMMA ", " DMMA_TMA ", " DMMA_TMA_BATCH " and " MFMA .
 .B DMMA
 is a CUDA only variant, available for the Helmholtz operator
@@ -175,67 +179,54 @@ to keep it out of the sweep;
 still pins it explicitly.
 .TP
 .B NEKO_EB
-Selects the elements-per-block candidate used when the kstep formulation
-is pinned with
-.BR NEKO_AUTOTUNE=KSTEP .
-Candidate
+Pins the elements-per-block candidate of the kstep formulation, which the
+auto-tuner sweeps when this is unset. Candidate
 .B 0
 is one element per block, i.e. the unblocked geometry. Values outside the
 valid range fall back to
 .BR 0 .
-Defaults to
-.BR 0 .
+Unset by default, i.e. swept.
 .TP
 .B NEKO_CHUNKS
-Selects the chunk size candidate used when the 1d formulation is pinned
-with
-.BR NEKO_AUTOTUNE=1D .
-Candidates
+Pins the chunk size candidate of the 1d formulation, which the auto-tuner
+sweeps when this is unset. Candidates
 .BR 0 " to " 3
 are 1024, 512, 256 and 128 threads per block; candidate
 .B 0
 is the historical value. A candidate smaller than one derivative matrix
-is invalid and falls back to 1024. Defaults to
-.BR 0 .
+is invalid and falls back to 1024. Unset by default, i.e. swept.
 .TP
 .B NEKO_DMMA_NW
-Selects the warps-per-block candidate used when the fp64 tensor core
-formulation is pinned with
-.BR NEKO_AUTOTUNE=DMMA .
-Candidates
+Pins the warps-per-block candidate of the fp64 tensor core formulation,
+which the auto-tuner sweeps when this is unset. Candidates
 .BR 0 ", " 1 " and " 2
 are 2, 4 and 8 warps per block. Values outside the valid range fall back to
 .BR 0 .
-Defaults to
-.BR 0 .
+Unset by default, i.e. swept.
 .TP
 .B NEKO_DMMA_TMA_NW
-Selects the warps-per-block candidate used when a TMA staged tensor core
-formulation is pinned with
-.BR NEKO_AUTOTUNE=DMMA_TMA " or " NEKO_AUTOTUNE=DMMA_TMA_BATCH .
-Candidates
+Pins the warps-per-block candidate of the TMA staged tensor core
+formulations, which the auto-tuner sweeps when this is unset. Candidates
 .BR 0 ", " 1 " and " 2
 are 2, 4 and 8 warps per block, as for
 .BR NEKO_DMMA_NW ,
-and both variants read this one variable. Values outside the valid range fall
+and both
+.BR DMMA_TMA " and " DMMA_TMA_BATCH
+read this one variable. Values outside the valid range fall
 back to
 .BR 0 .
-Defaults to
-.BR 0 .
+Unset by default, i.e. swept.
 .TP
 .B NEKO_MFMA_NWF
-Selects the wavefronts-per-block candidate used when the matrix core
-formulation is pinned with
-.BR NEKO_AUTOTUNE=MFMA .
-Candidates
+Pins the wavefronts-per-block candidate of the matrix core formulation,
+which the auto-tuner sweeps when this is unset. Candidates
 .BR 0 " to " 3
 are 1, 2, 4 and 8 wavefronts per block. The count also fixes the elements per
 block: the block covers as many elements as the ceil(lx*lx/16) column groups
 leave wavefronts for, rounded down to a power of two, and the remaining
 wavefronts cooperate on each. Values outside the valid range fall back to
 .BR 0 .
-Defaults to
-.BR 0 .
+Unset by default, i.e. swept.
 .TP
 .B NEKO_TUNE_ROUNDS
 Number of interleaved sampling rounds used by the operator auto-tuner. Each

--- a/doc/pages/appendices.md
+++ b/doc/pages/appendices.md
@@ -16,13 +16,13 @@ of the code. But can be useful for users and developers alike.
 
 | Name                     | Description                                                           | Default value |
 | ------------------------ | --------------------------------------------------------------------- | ------------- |
-| `NEKO_AUTOTUNE`          | Force SEM operator kernel formulation (``'1D'``,``'KSTEP'``,``'DMMA'``,``'DMMA_TMA'``,``'DMMA_TMA_BATCH'``,``'MFMA'``) | Unset |
+| `NEKO_AUTOTUNE`          | Restrict the SEM operator search to one kernel formulation (``'1D'``,``'KSTEP'``,``'DMMA'``,``'DMMA_TMA'``,``'DMMA_TMA_BATCH'``,``'MFMA'``) | Unset |
 | `NEKO_EB_TUNE`           | Sweep elements per block for the kstep kernels (boolean)              | 1             |
-| `NEKO_EB`                | Elements per block candidate when `NEKO_AUTOTUNE=KSTEP` (0, 1 or 2)   | 0             |
-| `NEKO_CHUNKS`            | Chunk size candidate when `NEKO_AUTOTUNE=1D` (0 to 3)                 | 0             |
-| `NEKO_DMMA_NW`           | Warps per block candidate when `NEKO_AUTOTUNE=DMMA` (0, 1 or 2)       | 0             |
-| `NEKO_DMMA_TMA_NW`       | Warps per block candidate when `NEKO_AUTOTUNE=DMMA_TMA` or `DMMA_TMA_BATCH` (0, 1 or 2) | 0 |
-| `NEKO_MFMA_NWF`          | Wavefronts per block candidate when `NEKO_AUTOTUNE=MFMA` (0 to 3)     | 0             |
+| `NEKO_EB`                | Pin the kstep elements per block candidate (0, 1 or 2)                | Unset (swept) |
+| `NEKO_CHUNKS`            | Pin the 1d chunk size candidate (0 to 3)                              | Unset (swept) |
+| `NEKO_DMMA_NW`           | Pin the `DMMA` warps per block candidate (0, 1 or 2)                  | Unset (swept) |
+| `NEKO_DMMA_TMA_NW`       | Pin the `DMMA_TMA` / `DMMA_TMA_BATCH` warps per block candidate (0, 1 or 2) | Unset (swept) |
+| `NEKO_MFMA_NWF`          | Pin the `MFMA` wavefronts per block candidate (0 to 3)                | Unset (swept) |
 | `NEKO_MFMA_TUNE`         | Sweep the matrix core variants on the HIP backend (boolean)           | 1             |
 | `NEKO_TUNE_ROUNDS`       | Interleaved sampling rounds used by the operator auto-tuner           | 3             |
 | `NEKO_TUNE_ITERS`        | Kernel launches timed per candidate per round                        | 100           |
@@ -47,24 +47,31 @@ its available kernel formulations on first call and caches the winner
 for the rest of the run; see @ref performance-operator-autotuning for
 what is measured and why the defaults differ between vendors.
 
-`NEKO_AUTOTUNE` pins a formulation and skips the search:
+`NEKO_AUTOTUNE` narrows the search to one formulation. It does not decide
+the geometry within that formulation: the chunk sizes, elements per block
+or warps per block of the named variant are still measured against each
+other and reported, and it takes that variant's own selector
+(`NEKO_CHUNKS`, `NEKO_EB`, `NEKO_DMMA_NW`, `NEKO_DMMA_TMA_NW`,
+`NEKO_MFMA_NWF`) to fix the geometry as well. With both set there is
+nothing left to measure and the search is skipped outright.
 
-- `NEKO_AUTOTUNE=1D`    : always use the 1d variant, with the chunk size
-  given by `NEKO_CHUNKS`.
-- `NEKO_AUTOTUNE=KSTEP` : always use the kstep variant, with the
-  elements per block given by `NEKO_EB`.
-- `NEKO_AUTOTUNE=DMMA`  : always use the fp64 tensor core variant, with
-  the warps per block given by `NEKO_DMMA_NW`. Available on CUDA for the
-  Helmholtz operator `Ax` (scalar and vector), `opgrad`, `dudxyz`,
-  `conv1` and `cdtp`. Double precision only, `2 <= lx <= 8` except for
-  the vector `Ax`, which is `4 <= lx <= 8`, on an sm_80 or sm_90 device.
+- `NEKO_AUTOTUNE=1D`    : always use the 1d variant, sweeping its chunk
+  sizes unless `NEKO_CHUNKS` pins one.
+- `NEKO_AUTOTUNE=KSTEP` : always use the kstep variant, sweeping its
+  elements per block unless `NEKO_EB` pins one.
+- `NEKO_AUTOTUNE=DMMA`  : always use the fp64 tensor core variant,
+  sweeping its warps per block unless `NEKO_DMMA_NW` pins one. Available
+  on CUDA for the Helmholtz operator `Ax` (scalar and vector), `opgrad`,
+  `dudxyz`, `conv1` and `cdtp`. Double precision only, `2 <= lx <= 8`
+  except for the vector `Ax`, which is `4 <= lx <= 8`, on an sm_80 or
+  sm_90 device.
   `convect_scalar` and `lambda2` have no such variant and keep tuning as
   usual.
 - `NEKO_AUTOTUNE=DMMA_TMA` : always use the TMA staged form of that
-  variant, for every operator that has one, with the warps per block
-  given by `NEKO_DMMA_TMA_NW`. Double precision and `lx = 8` only, on an
-  sm_90 device, and needs a CUDA 12 or later toolkit. The `opgrad` and
-  `conv1` forms stage past 48 kB and additionally need a device that will
+  variant, for every operator that has one, sweeping its warps per block
+  unless `NEKO_DMMA_TMA_NW` pins one. Double precision and `lx = 8` only,
+  on an sm_90 device, and needs a CUDA 12 or later toolkit. The `opgrad`
+  and `conv1` forms stage past 48 kB and additionally need a device that will
   grant a block 54800 B and 71184 B respectively.
 - `NEKO_AUTOTUNE=DMMA_TMA_BATCH` : the batched form of the TMA variant,
   which stages all ten input cubes of an element at once. Same scope and
@@ -72,10 +79,10 @@ what is measured and why the defaults differ between vendors.
   scalar operator has no such variant and reports the value as invalid.
 
 - `NEKO_AUTOTUNE=MFMA`  : the HIP counterpart of `DMMA` --- always use the
-  matrix core variant, with the wavefronts per block given by
-  `NEKO_MFMA_NWF`. Available for the Helmholtz operator `Ax` (scalar only),
-  `opgrad`, `dudxyz`, `conv1` and `cdtp`. Either precision, `4 <= lx <= 12`,
-  on a gfx90a or gfx942 device.
+  matrix core variant, sweeping its wavefronts per block unless
+  `NEKO_MFMA_NWF` pins one. Available for the Helmholtz operator `Ax`
+  (scalar only), `opgrad`, `dudxyz`, `conv1` and `cdtp`. Either precision,
+  `4 <= lx <= 12`, on a gfx90a or gfx942 device.
 
 The vector Helmholtz operator has no 1d formulation, so `1D` and `KSTEP`
 both pin it to its kstep variant, and it has no matrix core variant on HIP.
@@ -105,21 +112,21 @@ and the polynomial order allow the variant at all; setting it to `0`
 keeps the strategy out of the sweep while leaving
 `NEKO_AUTOTUNE=MFMA` able to pin it explicitly.
 
-`NEKO_CHUNKS` selects among the instantiated chunk sizes when the 1d
-variant is pinned with `NEKO_AUTOTUNE=1D`. Candidates `0` to `3` are
-1024, 512, 256 and 128 threads; candidate `0` is the historical value,
-so `NEKO_AUTOTUNE=1D` on its own is the A/B baseline for the chunk
+`NEKO_CHUNKS` pins one of the instantiated chunk sizes, which the tuner
+would otherwise sweep. Candidates `0` to `3` are 1024, 512, 256 and 128
+threads; candidate `0` is the historical value, so
+`NEKO_AUTOTUNE=1D NEKO_CHUNKS=0` is the A/B baseline for the chunk
 sweep. A candidate smaller than one derivative matrix (`lx*lx`) is
-invalid and falls back to 1024.
+invalid and falls back to 1024. The variable applies whenever the 1d
+variant is measured, not only when it is the pinned one.
 
-`NEKO_EB` selects among the instantiated blocking candidates when a
-formulation is pinned with `NEKO_AUTOTUNE=KSTEP`; candidate `0` is one
-element per block, i.e. the unblocked geometry, which makes
-`NEKO_AUTOTUNE=KSTEP` on its own the A/B baseline for the blocking.
+`NEKO_EB` pins one of the instantiated blocking candidates; candidate `0`
+is one element per block, i.e. the unblocked geometry, which makes
+`NEKO_AUTOTUNE=KSTEP NEKO_EB=0` the A/B baseline for the blocking.
 Values outside the valid range fall back to `0`.
 
-`NEKO_DMMA_NW` selects among the instantiated warps per block candidates
-when the tensor core variant is pinned with `NEKO_AUTOTUNE=DMMA`;
+`NEKO_DMMA_NW` pins one of the instantiated warps per block candidates
+of the tensor core variant;
 candidates `0`, `1` and `2` are 2, 4 and 8 warps. Values outside the
 valid range fall back to `0`. `NEKO_DMMA_TMA_NW` is the same selector for
 the two TMA staged variants, with the same three candidates, and is read

--- a/doc/pages/user-guide/performance.md
+++ b/doc/pages/user-guide/performance.md
@@ -435,11 +435,13 @@ turns the sweep off if the extra tuning time is not wanted.
 
 The tuning behaviour is controlled by the environment variables
 described in the @ref appendices_env-var reference: `NEKO_AUTOTUNE`
-pins a formulation and skips the search entirely, `NEKO_EB_TUNE` and
+narrows the search to one formulation, whose geometry is still swept,
+`NEKO_EB_TUNE` and
 `NEKO_MFMA_TUNE` enable or disable the elements per block and matrix
 core sweeps, `NEKO_EB`, `NEKO_CHUNKS`, `NEKO_DMMA_NW`,
-`NEKO_DMMA_TMA_NW` and `NEKO_MFMA_NWF` force a particular geometry when a
-formulation is pinned, and
+`NEKO_DMMA_TMA_NW` and `NEKO_MFMA_NWF` pin a particular geometry instead
+of sweeping it --- pinning both leaves nothing to measure and skips the
+search --- and
 `NEKO_TUNE_ROUNDS` / `NEKO_TUNE_ITERS` control the sampling of both
 sweeps. All
 of them are useful mainly for A/B testing; the defaults are intended to

--- a/src/math/bcknd/device/cuda/ax_helm.cu
+++ b/src/math/bcknd/device/cuda/ax_helm.cu
@@ -525,7 +525,16 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
   int best4 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, one -- the unblocked shape -- when the
+     elements per block sweep is off */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int ch_pin = neko_chunks_pin();
+  const int eb_pin = neko_eb_pin();
+  const int nw_pin = neko_dmma_pin();
+  const int tw_pin = neko_dmma_tma_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier tune() returns */
+  int strat = 0;
   const bool dmma = dmma_lx_supported<LX>() && cuda_have_dmma();
   /* Whether the pointers are bulk copy aligned is a property of this call
      rather than of the kernel, so it is checked rather than assumed, see
@@ -559,50 +568,31 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
 
   *eb_sel = 0;
   *ch_sel = 0;
+  *nw_sel = 0;
   *tw_sel = 0;
 
+  /*
+   * NEKO_AUTOTUNE names a formulation, and that is all it does: the sweep
+   * below is narrowed to that one kernel family, but its geometry -- the
+   * chunk size, the elements per block, the warps per block -- is still
+   * measured candidate against candidate. A formulation this build or this
+   * device does not have is reported and ignored, leaving the full sweep.
+   */
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      *ch_sel = neko_chunks_env();
-      CASE_1D_SEL(LX, *ch_sel);
-      sprintf(neko_log_buf,"Set by env   : 1 (1D, %d chunk)",
-              NEKO_CHUNKS_SEL(LX, *ch_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 1;
+      strat = 1;
     } else if( !strcmp(env_value,"KSTEP") ) {
-      const int c = neko_eb_env();
-      *eb_sel = c;
-      CASE_KSTEP_SEL(LX, c);
-      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-              NEKO_EB_SEL(LX, c));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 2;
     } else if( !strcmp(env_value,"DMMA") ) {
       if (dmma) {
-        const int c = neko_dmma_env();
-        *nw_sel = c;
-        CASE_DMMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 3 (DMMA, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 3;
+        strat = 3;
       } else {
         sprintf(neko_log_buf, "DMMA strategy not available for this config");
         log_error(neko_log_buf);
       }
     } else if( !strcmp(env_value,"DMMA_TMA") ) {
       if (tma) {
-        const int c = neko_dmma_tma_env();
-        *tw_sel = c;
-        CASE_DMMA_TMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 4 (DMMA_TMA, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 4;
+        strat = 4;
       } else {
         sprintf(neko_log_buf,
                 "DMMA_TMA strategy not available for this config");
@@ -614,6 +604,55 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
     }
   }
 
+  /* Geometry of the pinned formulation, if its own variable fixes that too.
+     Both pinned leaves nothing to measure, so the kernel is launched once and
+     reported, which is what pinning has always done */
+  const int pin = (strat == 1) ? ch_pin : (strat == 2) ? eb_pin :
+                  (strat == 3) ? nw_pin : (strat == 4) ? tw_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 1:
+      *ch_sel = pin;
+      CASE_1D_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 1 (1D, %d chunk)",
+              NEKO_CHUNKS_SEL(LX, pin));
+      break;
+    case 2:
+      *eb_sel = pin;
+      CASE_KSTEP_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    case 3:
+      *nw_sel = pin;
+      CASE_DMMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 3 (DMMA, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    default:
+      *tw_sel = pin;
+      CASE_DMMA_TMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 4 (DMMA_TMA, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR() */
+  const bool try_1d = (strat == 0 || strat == 1);
+  const bool try_kstep = (strat == 0 || strat == 2);
+  const bool try_dmma = dmma && (strat == 0 || strat == 3);
+  const bool try_tma = tma && (strat == 0 || strat == 4);
+
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
 
@@ -621,48 +660,34 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
      be resident and the clocks at steady state, or whichever variant is
      timed first is measured on a colder part */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_1D(LX, 0);
-    CASE_1D(LX, 1);
-    CASE_1D(LX, 2);
-    CASE_1D(LX, 3);
-    CASE_KSTEP(LX, 0);
-    if (sweep) {
-      CASE_KSTEP(LX, 1);
-      CASE_KSTEP(LX, 2);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      CASE_1D_SEL(LX, c);
     }
-    if (dmma) {
-      CASE_DMMA(LX, 0);
-      CASE_DMMA(LX, 1);
-      CASE_DMMA(LX, 2);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_KSTEP_SEL(LX, c);
     }
-    if (tma) {
-      CASE_DMMA_TMA(LX, 0);
-      CASE_DMMA_TMA(LX, 1);
-      CASE_DMMA_TMA(LX, 2);
+    NEKO_TUNE_FOR(c, try_dmma, nw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_DMMA_SEL(LX, c);
+    }
+    NEKO_TUNE_FOR(c, try_tma, tw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_DMMA_TMA_SEL(LX, c);
     }
   }
 
   /* Interleaved rounds, best time per variant: timing them one after another
      in a fixed order lets clock drift bias the comparison by position */
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 0, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 1, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 2, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 3, iters);
-    NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      NEKO_TUNE_TIME(time1, CASE_1D_SEL, LX, c, iters);
     }
-    if (dmma) {
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_KSTEP_SEL, LX, c, iters);
     }
-    if (tma) {
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_dmma, nw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time3, CASE_DMMA_SEL, LX, c, iters);
+    }
+    NEKO_TUNE_FOR(c, try_tma, tw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA_SEL, LX, c, iters);
     }
   }
 
@@ -746,7 +771,15 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
   int best4 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, see tune() */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int ch_pin = neko_chunks_pin();
+  const int eb_pin = neko_eb_pin();
+  const int nw_pin = neko_dmma_pin();
+  const int tw_pin = neko_dmma_tma_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier this returns */
+  int strat = 0;
   const bool dmma = dmma_lx_supported<LX>() && cuda_have_dmma();
   /* Whether the pointers are bulk copy aligned is a property of this call
      rather than of the kernel, so it is checked rather than assumed, see
@@ -780,50 +813,25 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
 
   *eb_sel = 0;
   *ch_sel = 0;
+  *nw_sel = 0;
   *tw_sel = 0;
 
+  /* NEKO_AUTOTUNE names a formulation and nothing more, see tune() */
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      *ch_sel = neko_chunks_env();
-      CASE_1D_SEL(LX, *ch_sel);
-      sprintf(neko_log_buf,"Set by env   : 1 (1D, %d chunk)",
-              NEKO_CHUNKS_SEL(LX, *ch_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 1;
-     } else if( !strcmp(env_value,"KSTEP") ) {
-      const int c = neko_eb_env();
-      *eb_sel = c;
-      CASE_KSTEP_PADDED_SEL(LX, c);
-      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-              NEKO_EB_SEL(LX, c));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 1;
+    } else if( !strcmp(env_value,"KSTEP") ) {
+      strat = 2;
     } else if( !strcmp(env_value,"DMMA") ) {
       if (dmma) {
-        const int c = neko_dmma_env();
-        *nw_sel = c;
-        CASE_DMMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 3 (DMMA, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 3;
+        strat = 3;
       } else {
         sprintf(neko_log_buf, "DMMA strategy not available for this config");
         log_error(neko_log_buf);
       }
     } else if( !strcmp(env_value,"DMMA_TMA") ) {
       if (tma) {
-        const int c = neko_dmma_tma_env();
-        *tw_sel = c;
-        CASE_DMMA_TMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 4 (DMMA_TMA, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 4;
+        strat = 4;
       } else {
         sprintf(neko_log_buf,
                 "DMMA_TMA strategy not available for this config");
@@ -835,6 +843,53 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
     }
   }
 
+  /* Formulation and geometry both pinned leaves nothing to measure */
+  const int pin = (strat == 1) ? ch_pin : (strat == 2) ? eb_pin :
+                  (strat == 3) ? nw_pin : (strat == 4) ? tw_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 1:
+      *ch_sel = pin;
+      CASE_1D_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 1 (1D, %d chunk)",
+              NEKO_CHUNKS_SEL(LX, pin));
+      break;
+    case 2:
+      *eb_sel = pin;
+      CASE_KSTEP_PADDED_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    case 3:
+      *nw_sel = pin;
+      CASE_DMMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 3 (DMMA, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    default:
+      *tw_sel = pin;
+      CASE_DMMA_TMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 4 (DMMA_TMA, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR() */
+  const bool try_1d = (strat == 0 || strat == 1);
+  const bool try_kstep = (strat == 0 || strat == 2);
+  const bool try_dmma = dmma && (strat == 0 || strat == 3);
+  const bool try_tma = tma && (strat == 0 || strat == 4);
+
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
 
@@ -842,48 +897,34 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
      be resident and the clocks at steady state, or whichever variant is
      timed first is measured on a colder part */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_1D(LX, 0);
-    CASE_1D(LX, 1);
-    CASE_1D(LX, 2);
-    CASE_1D(LX, 3);
-    CASE_KSTEP_PADDED(LX, 0);
-    if (sweep) {
-      CASE_KSTEP_PADDED(LX, 1);
-      CASE_KSTEP_PADDED(LX, 2);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      CASE_1D_SEL(LX, c);
     }
-    if (dmma) {
-      CASE_DMMA(LX, 0);
-      CASE_DMMA(LX, 1);
-      CASE_DMMA(LX, 2);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_KSTEP_PADDED_SEL(LX, c);
     }
-    if (tma) {
-      CASE_DMMA_TMA(LX, 0);
-      CASE_DMMA_TMA(LX, 1);
-      CASE_DMMA_TMA(LX, 2);
+    NEKO_TUNE_FOR(c, try_dmma, nw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_DMMA_SEL(LX, c);
+    }
+    NEKO_TUNE_FOR(c, try_tma, tw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_DMMA_TMA_SEL(LX, c);
     }
   }
 
   /* Interleaved rounds, best time per variant: timing them one after another
      in a fixed order lets clock drift bias the comparison by position */
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 0, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 1, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 2, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 3, iters);
-    NEKO_TUNE_TIME(time2, CASE_KSTEP_PADDED, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_KSTEP_PADDED, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_KSTEP_PADDED, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      NEKO_TUNE_TIME(time1, CASE_1D_SEL, LX, c, iters);
     }
-    if (dmma) {
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_KSTEP_PADDED_SEL, LX, c, iters);
     }
-    if (tma) {
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_dmma, nw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time3, CASE_DMMA_SEL, LX, c, iters);
+    }
+    NEKO_TUNE_FOR(c, try_tma, tw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA_SEL, LX, c, iters);
     }
   }
 
@@ -984,7 +1025,14 @@ int tune_vector(void *au, void *av, void *aw, void *u, void *v, void *w,
   int best5 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, see tune() */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int eb_pin = neko_eb_pin();
+  const int nw_pin = neko_dmma_pin();
+  const int tw_pin = neko_dmma_tma_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier this returns */
+  int strat = 0;
   const bool dmma = dmma_vector_lx_supported<LX>() && cuda_have_dmma();
   /* Whether the pointers are bulk copy aligned is a property of this call
      rather than of the kernel, see dmma_tma_vector_aligned() */
@@ -1019,45 +1067,26 @@ int tune_vector(void *au, void *av, void *aw, void *u, void *v, void *w,
   sprintf(neko_log_buf, "Autotune Ax vector (lx: %d)", *lx);
   log_section(neko_log_buf);
 
+  *eb_sel = 0;
   *nw_sel = 0;
   *tw_sel = 0;
   *bw_sel = 0;
 
+  /* NEKO_AUTOTUNE names a formulation and nothing more, see tune() */
   if(env_value) {
     if( !strcmp(env_value,"KSTEP") || !strcmp(env_value,"1D") ) {
       /* No 1d variant here, so either pin lands on kstep */
-      const int c = neko_eb_env();
-      *eb_sel = c;
-      CASE_VECTOR_KSTEP_SEL(LX, c);
-      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-              NEKO_EB_SEL(LX, c));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 2;
     } else if( !strcmp(env_value,"DMMA") ) {
       if (dmma) {
-        const int c = neko_dmma_env();
-        *nw_sel = c;
-        CASE_VECTOR_DMMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 3 (DMMA, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 3;
+        strat = 3;
       } else {
         sprintf(neko_log_buf, "DMMA strategy not available for this config");
         log_error(neko_log_buf);
       }
     } else if( !strcmp(env_value,"DMMA_TMA") ) {
       if (tma) {
-        const int c = neko_dmma_tma_env();
-        *tw_sel = c;
-        CASE_VECTOR_DMMA_TMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 4 (DMMA_TMA, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 4;
+        strat = 4;
       } else {
         sprintf(neko_log_buf,
                 "DMMA_TMA strategy not available for this config");
@@ -1065,14 +1094,7 @@ int tune_vector(void *au, void *av, void *aw, void *u, void *v, void *w,
       }
     } else if( !strcmp(env_value,"DMMA_TMA_BATCH") ) {
       if (batch) {
-        const int c = neko_dmma_tma_env();
-        *bw_sel = c;
-        CASE_VECTOR_DMMA_TMA_BATCH_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 5 (DMMA_TMA_BATCH, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 5;
+        strat = 5;
       } else {
         sprintf(neko_log_buf,
                 "DMMA_TMA_BATCH strategy not available for this config");
@@ -1084,53 +1106,85 @@ int tune_vector(void *au, void *av, void *aw, void *u, void *v, void *w,
     }
   }
 
+  /* Formulation and geometry both pinned leaves nothing to measure. The two
+     TMA forms share NEKO_DMMA_TMA_NW, hence the same pin for both */
+  const int pin = (strat == 2) ? eb_pin : (strat == 3) ? nw_pin :
+                  (strat == 4 || strat == 5) ? tw_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 2:
+      *eb_sel = pin;
+      CASE_VECTOR_KSTEP_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    case 3:
+      *nw_sel = pin;
+      CASE_VECTOR_DMMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 3 (DMMA, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    case 4:
+      *tw_sel = pin;
+      CASE_VECTOR_DMMA_TMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 4 (DMMA_TMA, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    default:
+      *bw_sel = pin;
+      CASE_VECTOR_DMMA_TMA_BATCH_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 5 (DMMA_TMA_BATCH, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR() */
+  const bool try_kstep = (strat == 0 || strat == 2);
+  const bool try_dmma = dmma && (strat == 0 || strat == 3);
+  const bool try_tma = tma && (strat == 0 || strat == 4);
+  const bool try_batch = batch && (strat == 0 || strat == 5);
+
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
 
   /* Warm every variant before timing anything, see tune() */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_VECTOR_KSTEP(LX, 0);
-    if (sweep) {
-      CASE_VECTOR_KSTEP(LX, 1);
-      CASE_VECTOR_KSTEP(LX, 2);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_VECTOR_KSTEP_SEL(LX, c);
     }
-    if (dmma) {
-      CASE_VECTOR_DMMA(LX, 0);
-      CASE_VECTOR_DMMA(LX, 1);
-      CASE_VECTOR_DMMA(LX, 2);
+    NEKO_TUNE_FOR(c, try_dmma, nw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_VECTOR_DMMA_SEL(LX, c);
     }
-    if (tma) {
-      CASE_VECTOR_DMMA_TMA(LX, 0);
-      CASE_VECTOR_DMMA_TMA(LX, 1);
-      CASE_VECTOR_DMMA_TMA(LX, 2);
+    NEKO_TUNE_FOR(c, try_tma, tw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_VECTOR_DMMA_TMA_SEL(LX, c);
     }
-    if (batch) {
-      CASE_VECTOR_DMMA_TMA_BATCH(LX, 0);
-      CASE_VECTOR_DMMA_TMA_BATCH(LX, 1);
-      CASE_VECTOR_DMMA_TMA_BATCH(LX, 2);
+    NEKO_TUNE_FOR(c, try_batch, tw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_VECTOR_DMMA_TMA_BATCH_SEL(LX, c);
     }
   }
 
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time2, CASE_VECTOR_KSTEP, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_VECTOR_KSTEP, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_VECTOR_KSTEP, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_VECTOR_KSTEP_SEL, LX, c, iters);
     }
-    if (dmma) {
-      NEKO_TUNE_TIME(time3, CASE_VECTOR_DMMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time3, CASE_VECTOR_DMMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time3, CASE_VECTOR_DMMA, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_dmma, nw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time3, CASE_VECTOR_DMMA_SEL, LX, c, iters);
     }
-    if (tma) {
-      NEKO_TUNE_TIME(time4, CASE_VECTOR_DMMA_TMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time4, CASE_VECTOR_DMMA_TMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time4, CASE_VECTOR_DMMA_TMA, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_tma, tw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time4, CASE_VECTOR_DMMA_TMA_SEL, LX, c, iters);
     }
-    if (batch) {
-      NEKO_TUNE_TIME(time5, CASE_VECTOR_DMMA_TMA_BATCH, LX, 0, iters);
-      NEKO_TUNE_TIME(time5, CASE_VECTOR_DMMA_TMA_BATCH, LX, 1, iters);
-      NEKO_TUNE_TIME(time5, CASE_VECTOR_DMMA_TMA_BATCH, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_batch, tw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time5, CASE_VECTOR_DMMA_TMA_BATCH_SEL, LX, c, iters);
     }
   }
 
@@ -1209,7 +1263,14 @@ int tune_vector_padded(void *au, void *av, void *aw, void *u, void *v, void *w,
   int best5 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, see tune() */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int eb_pin = neko_eb_pin();
+  const int nw_pin = neko_dmma_pin();
+  const int tw_pin = neko_dmma_tma_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier this returns */
+  int strat = 0;
   const bool dmma = dmma_vector_lx_supported<LX>() && cuda_have_dmma();
   /* Whether the pointers are bulk copy aligned is a property of this call
      rather than of the kernel, see dmma_tma_vector_aligned() */
@@ -1244,45 +1305,26 @@ int tune_vector_padded(void *au, void *av, void *aw, void *u, void *v, void *w,
   sprintf(neko_log_buf, "Autotune Ax vector (lx: %d)", *lx);
   log_section(neko_log_buf);
 
+  *eb_sel = 0;
   *nw_sel = 0;
   *tw_sel = 0;
   *bw_sel = 0;
 
+  /* NEKO_AUTOTUNE names a formulation and nothing more, see tune() */
   if(env_value) {
     if( !strcmp(env_value,"KSTEP") || !strcmp(env_value,"1D") ) {
       /* No 1d variant here, so either pin lands on kstep */
-      const int c = neko_eb_env();
-      *eb_sel = c;
-      CASE_VECTOR_KSTEP_PADDED_SEL(LX, c);
-      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-              NEKO_EB_SEL(LX, c));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 2;
     } else if( !strcmp(env_value,"DMMA") ) {
       if (dmma) {
-        const int c = neko_dmma_env();
-        *nw_sel = c;
-        CASE_VECTOR_DMMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 3 (DMMA, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 3;
+        strat = 3;
       } else {
         sprintf(neko_log_buf, "DMMA strategy not available for this config");
         log_error(neko_log_buf);
       }
     } else if( !strcmp(env_value,"DMMA_TMA") ) {
       if (tma) {
-        const int c = neko_dmma_tma_env();
-        *tw_sel = c;
-        CASE_VECTOR_DMMA_TMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 4 (DMMA_TMA, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 4;
+        strat = 4;
       } else {
         sprintf(neko_log_buf,
                 "DMMA_TMA strategy not available for this config");
@@ -1290,14 +1332,7 @@ int tune_vector_padded(void *au, void *av, void *aw, void *u, void *v, void *w,
       }
     } else if( !strcmp(env_value,"DMMA_TMA_BATCH") ) {
       if (batch) {
-        const int c = neko_dmma_tma_env();
-        *bw_sel = c;
-        CASE_VECTOR_DMMA_TMA_BATCH_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 5 (DMMA_TMA_BATCH, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 5;
+        strat = 5;
       } else {
         sprintf(neko_log_buf,
                 "DMMA_TMA_BATCH strategy not available for this config");
@@ -1309,53 +1344,85 @@ int tune_vector_padded(void *au, void *av, void *aw, void *u, void *v, void *w,
     }
   }
 
+  /* Formulation and geometry both pinned leaves nothing to measure. The two
+     TMA forms share NEKO_DMMA_TMA_NW, hence the same pin for both */
+  const int pin = (strat == 2) ? eb_pin : (strat == 3) ? nw_pin :
+                  (strat == 4 || strat == 5) ? tw_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 2:
+      *eb_sel = pin;
+      CASE_VECTOR_KSTEP_PADDED_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    case 3:
+      *nw_sel = pin;
+      CASE_VECTOR_DMMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 3 (DMMA, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    case 4:
+      *tw_sel = pin;
+      CASE_VECTOR_DMMA_TMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 4 (DMMA_TMA, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    default:
+      *bw_sel = pin;
+      CASE_VECTOR_DMMA_TMA_BATCH_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 5 (DMMA_TMA_BATCH, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR() */
+  const bool try_kstep = (strat == 0 || strat == 2);
+  const bool try_dmma = dmma && (strat == 0 || strat == 3);
+  const bool try_tma = tma && (strat == 0 || strat == 4);
+  const bool try_batch = batch && (strat == 0 || strat == 5);
+
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
 
   /* Warm every variant before timing anything, see tune() */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_VECTOR_KSTEP_PADDED(LX, 0);
-    if (sweep) {
-      CASE_VECTOR_KSTEP_PADDED(LX, 1);
-      CASE_VECTOR_KSTEP_PADDED(LX, 2);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_VECTOR_KSTEP_PADDED_SEL(LX, c);
     }
-    if (dmma) {
-      CASE_VECTOR_DMMA(LX, 0);
-      CASE_VECTOR_DMMA(LX, 1);
-      CASE_VECTOR_DMMA(LX, 2);
+    NEKO_TUNE_FOR(c, try_dmma, nw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_VECTOR_DMMA_SEL(LX, c);
     }
-    if (tma) {
-      CASE_VECTOR_DMMA_TMA(LX, 0);
-      CASE_VECTOR_DMMA_TMA(LX, 1);
-      CASE_VECTOR_DMMA_TMA(LX, 2);
+    NEKO_TUNE_FOR(c, try_tma, tw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_VECTOR_DMMA_TMA_SEL(LX, c);
     }
-    if (batch) {
-      CASE_VECTOR_DMMA_TMA_BATCH(LX, 0);
-      CASE_VECTOR_DMMA_TMA_BATCH(LX, 1);
-      CASE_VECTOR_DMMA_TMA_BATCH(LX, 2);
+    NEKO_TUNE_FOR(c, try_batch, tw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_VECTOR_DMMA_TMA_BATCH_SEL(LX, c);
     }
   }
 
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time2, CASE_VECTOR_KSTEP_PADDED, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_VECTOR_KSTEP_PADDED, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_VECTOR_KSTEP_PADDED, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_VECTOR_KSTEP_PADDED_SEL, LX, c, iters);
     }
-    if (dmma) {
-      NEKO_TUNE_TIME(time3, CASE_VECTOR_DMMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time3, CASE_VECTOR_DMMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time3, CASE_VECTOR_DMMA, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_dmma, nw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time3, CASE_VECTOR_DMMA_SEL, LX, c, iters);
     }
-    if (tma) {
-      NEKO_TUNE_TIME(time4, CASE_VECTOR_DMMA_TMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time4, CASE_VECTOR_DMMA_TMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time4, CASE_VECTOR_DMMA_TMA, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_tma, tw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time4, CASE_VECTOR_DMMA_TMA_SEL, LX, c, iters);
     }
-    if (batch) {
-      NEKO_TUNE_TIME(time5, CASE_VECTOR_DMMA_TMA_BATCH, LX, 0, iters);
-      NEKO_TUNE_TIME(time5, CASE_VECTOR_DMMA_TMA_BATCH, LX, 1, iters);
-      NEKO_TUNE_TIME(time5, CASE_VECTOR_DMMA_TMA_BATCH, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_batch, tw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time5, CASE_VECTOR_DMMA_TMA_BATCH_SEL, LX, c, iters);
     }
   }
 

--- a/src/math/bcknd/device/cuda/dmma_kernel.h
+++ b/src/math/bcknd/device/cuda/dmma_kernel.h
@@ -150,12 +150,18 @@ enum {
 #define NEKO_DMMA_NBLCKS(NELV, LX)                                            \
   dim3(((NELV) + NEKO_DMMA_PACK(LX) - 1) / NEKO_DMMA_PACK(LX), 1, 1)
 
-/* Forced candidate, used when NEKO_AUTOTUNE pins the DMMA variant */
-static int neko_dmma_env()
+/* Warps per block candidate pinned by NEKO_DMMA_NW, or -1 to leave it to the
+   sweep, see neko_eb_pin() in elem_block_tune.h */
+static int neko_dmma_pin()
 {
   const char *v = getenv("NEKO_DMMA_NW");
-  int c = (v != NULL) ? atoi(v) : 0;
+  int c;
 
+  if (v == NULL) {
+    return -1;
+  }
+
+  c = atoi(v);
   if (c < 0 || c >= NEKO_DMMA_CANDIDATES) {
     c = 0;
   }

--- a/src/math/bcknd/device/cuda/dmma_tma_kernel.h
+++ b/src/math/bcknd/device/cuda/dmma_tma_kernel.h
@@ -550,13 +550,18 @@ static inline bool dmma_tma_conv1_aligned(const void *du, const void *u,
                                   drdz, dsdz, dtdz);
 }
 
-/* Forced candidate, used when NEKO_AUTOTUNE pins the DMMA_TMA variant. The
-   warps per block candidates are the DMMA ones, see NEKO_DMMA_NW() */
-static int neko_dmma_tma_env()
+/* Warps per block candidate pinned by NEKO_DMMA_TMA_NW, or -1 to leave it to
+   the sweep. The candidates are the DMMA ones, see NEKO_DMMA_NW() */
+static int neko_dmma_tma_pin()
 {
   const char *v = getenv("NEKO_DMMA_TMA_NW");
-  int c = (v != NULL) ? atoi(v) : 0;
+  int c;
 
+  if (v == NULL) {
+    return -1;
+  }
+
+  c = atoi(v);
   if (c < 0 || c >= NEKO_DMMA_CANDIDATES) {
     c = 0;
   }

--- a/src/math/bcknd/device/cuda/elem_block_tune.h
+++ b/src/math/bcknd/device/cuda/elem_block_tune.h
@@ -44,6 +44,13 @@
  * bias the comparison by candidate position, which no amount of extra
  * iterations removes.
  *
+ * NEKO_AUTOTUNE takes a formulation out of the tuner's hands, but only the
+ * formulation: the geometry candidates of the one it names are still measured
+ * and reported, and it takes that formulation's own variable (NEKO_EB,
+ * NEKO_CHUNKS, ...) to fix the geometry too. Pinning the formulation used to
+ * imply candidate 0, which silently answered a different question than the one
+ * an A/B run of two formulations is asking. See NEKO_TUNE_FOR() below.
+ *
  * A tune function using these macros is expected to have `start`, `stop` and
  * `stream` in scope --- and `iters` for the reporting macros --- plus a
  * CASE_1D(LX) macro and a kstep launch macro taking (LX, C).
@@ -75,24 +82,43 @@ static int neko_eb_sweep()
   return NEKO_EB_SWEEP_DEFAULT;
 }
 
-/* Forced candidate, used when NEKO_AUTOTUNE pins the kstep variant */
-static int neko_eb_env()
+/*
+ * Elements per block candidate pinned by NEKO_EB, or -1 to leave it to the
+ * sweep.
+ *
+ * NEKO_AUTOTUNE selects the formulation and nothing more -- the geometry
+ * inside it is still measured unless it is pinned here -- so "unset" has to
+ * be distinguishable from candidate 0, which is a candidate like any other.
+ * Hence the -1 rather than a plain default of 0. Out of range values clamp
+ * to 0 rather than releasing the pin, as they always have.
+ */
+static int neko_eb_pin()
 {
   const char *v = getenv("NEKO_EB");
-  int c = (v != NULL) ? atoi(v) : 0;
+  int c;
 
+  if (v == NULL) {
+    return -1;
+  }
+
+  c = atoi(v);
   if (c < 0 || c >= NEKO_EB_CANDIDATES) {
     c = 0;
   }
   return c;
 }
 
-/* Forced chunk candidate, used when NEKO_AUTOTUNE pins the 1d variant */
-static int neko_chunks_env()
+/* Chunk candidate pinned by NEKO_CHUNKS, or -1 to sweep, see neko_eb_pin() */
+static int neko_chunks_pin()
 {
   const char *v = getenv("NEKO_CHUNKS");
-  int c = (v != NULL) ? atoi(v) : 0;
+  int c;
 
+  if (v == NULL) {
+    return -1;
+  }
+
+  c = atoi(v);
   if (c < 0 || c >= NEKO_CHUNKS_CANDIDATES) {
     c = 0;
   }
@@ -114,6 +140,24 @@ static int neko_tune_iters()
 
   return (n < 1) ? 1 : n;
 }
+
+/*
+ * Loop over the candidates of one formulation, binding C to each in turn.
+ *
+ * ON gates the formulation itself: hardware support, and -- when NEKO_AUTOTUNE
+ * is set -- whether it is the formulation that was asked for. PIN is the
+ * candidate that formulation's own variable forces, or -1 to measure all N of
+ * them. So NEKO_AUTOTUNE narrows the search to one kernel family without
+ * deciding the geometry within it, which is still swept and reported.
+ *
+ * An out of play formulation yields an empty range, leaving its candidates at
+ * NEKO_TUNE_INIT so it loses the comparison at the end rather than having to
+ * be excluded from it.
+ */
+#define NEKO_TUNE_FOR(C, ON, PIN, N)                                          \
+  for (int C = (((PIN) >= 0) ? (PIN) : 0),                                    \
+       C##_last_ = ((ON) ? (((PIN) >= 0) ? (PIN) + 1 : (N)) : 0);             \
+       C < C##_last_; C++)
 
 /* One timed round of LAUNCH at candidate C, min reduced into T[C] */
 #define NEKO_TUNE_TIME(T, LAUNCH, LX, C, ITERS)                           \

--- a/src/math/bcknd/device/cuda/opr_cdtp.cu
+++ b/src/math/bcknd/device/cuda/opr_cdtp.cu
@@ -231,7 +231,16 @@ int tune_cdtp(void *dtx, void *x,
   int best4 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, one -- the unblocked shape -- when the
+     elements per block sweep is off */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int ch_pin = neko_chunks_pin();
+  const int eb_pin = neko_eb_pin();
+  const int nw_pin = neko_dmma_pin();
+  const int tw_pin = neko_dmma_tma_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier this returns */
+  int strat = 0;
   const bool dmma = dmma_lx_supported<LX>() && cuda_have_dmma();
   /* Whether the pointers are bulk copy aligned is a property of this call
      rather than of the kernel, so it is checked rather than assumed, see
@@ -271,47 +280,28 @@ int tune_cdtp(void *dtx, void *x,
   *nw_sel = 0;
   *tw_sel = 0;
 
+  /*
+   * NEKO_AUTOTUNE names a formulation, and that is all it does: the sweep
+   * below is narrowed to that one kernel family, but its geometry -- the
+   * chunk size, the elements per block, the warps per block -- is still
+   * measured candidate against candidate. A formulation this build or this
+   * device does not have is reported and ignored, leaving the full sweep.
+   */
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      *ch_sel = neko_chunks_env();
-      CASE_1D_SEL(LX, *ch_sel);
-      sprintf(neko_log_buf,"Set by env   : 1 (1D, %d chunk)",
-              NEKO_CHUNKS_SEL(LX, *ch_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 1;
+      strat = 1;
     } else if( !strcmp(env_value,"KSTEP") ) {
-      *eb_sel = neko_eb_env();
-      CASE_KSTEP_SEL(LX, *eb_sel);
-      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-              NEKO_EB_SEL(LX, *eb_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 2;
     } else if( !strcmp(env_value,"DMMA") ) {
       if (dmma) {
-        const int c = neko_dmma_env();
-        *nw_sel = c;
-        CASE_DMMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 3 (DMMA, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 3;
+        strat = 3;
       } else {
         sprintf(neko_log_buf, "DMMA strategy not available for this config");
         log_error(neko_log_buf);
       }
     } else if( !strcmp(env_value,"DMMA_TMA") ) {
       if (tma) {
-        const int c = neko_dmma_tma_env();
-        *tw_sel = c;
-        CASE_DMMA_TMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 4 (DMMA_TMA, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 4;
+        strat = 4;
       } else {
         sprintf(neko_log_buf,
                 "DMMA_TMA strategy not available for this config");
@@ -323,6 +313,55 @@ int tune_cdtp(void *dtx, void *x,
     }
   }
 
+  /* Geometry of the pinned formulation, if its own variable fixes that too.
+     Both pinned leaves nothing to measure, so the kernel is launched once and
+     reported, which is what pinning has always done */
+  const int pin = (strat == 1) ? ch_pin : (strat == 2) ? eb_pin :
+                  (strat == 3) ? nw_pin : (strat == 4) ? tw_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 1:
+      *ch_sel = pin;
+      CASE_1D_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 1 (1D, %d chunk)",
+              NEKO_CHUNKS_SEL(LX, pin));
+      break;
+    case 2:
+      *eb_sel = pin;
+      CASE_KSTEP_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    case 3:
+      *nw_sel = pin;
+      CASE_DMMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 3 (DMMA, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    default:
+      *tw_sel = pin;
+      CASE_DMMA_TMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 4 (DMMA_TMA, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR() */
+  const bool try_1d = (strat == 0 || strat == 1);
+  const bool try_kstep = (strat == 0 || strat == 2);
+  const bool try_dmma = dmma && (strat == 0 || strat == 3);
+  const bool try_tma = tma && (strat == 0 || strat == 4);
+
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
 
@@ -330,47 +369,33 @@ int tune_cdtp(void *dtx, void *x,
      resident and the clocks at steady state, or whichever is timed first is
      measured on a colder part */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_1D(LX, 0);
-    CASE_1D(LX, 1);
-    CASE_1D(LX, 2);
-    CASE_1D(LX, 3);
-    CASE_KSTEP(LX, 0);
-    if (sweep) {
-      CASE_KSTEP(LX, 1);
-      CASE_KSTEP(LX, 2);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      CASE_1D_SEL(LX, c);
     }
-    if (dmma) {
-      CASE_DMMA(LX, 0);
-      CASE_DMMA(LX, 1);
-      CASE_DMMA(LX, 2);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_KSTEP_SEL(LX, c);
     }
-    if (tma) {
-      CASE_DMMA_TMA(LX, 0);
-      CASE_DMMA_TMA(LX, 1);
-      CASE_DMMA_TMA(LX, 2);
+    NEKO_TUNE_FOR(c, try_dmma, nw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_DMMA_SEL(LX, c);
+    }
+    NEKO_TUNE_FOR(c, try_tma, tw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_DMMA_TMA_SEL(LX, c);
     }
   }
 
   /* Interleaved rounds, best time per variant */
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 0, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 1, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 2, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 3, iters);
-    NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      NEKO_TUNE_TIME(time1, CASE_1D_SEL, LX, c, iters);
     }
-    if (dmma) {
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_KSTEP_SEL, LX, c, iters);
     }
-    if (tma) {
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_dmma, nw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time3, CASE_DMMA_SEL, LX, c, iters);
+    }
+    NEKO_TUNE_FOR(c, try_tma, tw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA_SEL, LX, c, iters);
     }
   }
 

--- a/src/math/bcknd/device/cuda/opr_conv1.cu
+++ b/src/math/bcknd/device/cuda/opr_conv1.cu
@@ -257,7 +257,16 @@ int tune_conv1(void *du, void *u,
   int best4 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, one -- the unblocked shape -- when the
+     elements per block sweep is off */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int ch_pin = neko_chunks_pin();
+  const int eb_pin = neko_eb_pin();
+  const int nw_pin = neko_dmma_pin();
+  const int tw_pin = neko_dmma_tma_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier this returns */
+  int strat = 0;
   const bool dmma = dmma_lx_supported<LX>() && cuda_have_dmma();
   /* Whether the pointers are bulk copy aligned is a property of this call
      rather than of the kernel, so it is checked rather than assumed, see
@@ -301,47 +310,28 @@ int tune_conv1(void *du, void *u,
   *nw_sel = 0;
   *tw_sel = 0;
 
+  /*
+   * NEKO_AUTOTUNE names a formulation, and that is all it does: the sweep
+   * below is narrowed to that one kernel family, but its geometry -- the
+   * chunk size, the elements per block, the warps per block -- is still
+   * measured candidate against candidate. A formulation this build or this
+   * device does not have is reported and ignored, leaving the full sweep.
+   */
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      *ch_sel = neko_chunks_env();
-      CASE_1D_SEL(LX, *ch_sel);
-      sprintf(neko_log_buf,"Set by env   : 1 (1D, %d chunk)",
-              NEKO_CHUNKS_SEL(LX, *ch_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 1;
+      strat = 1;
     } else if( !strcmp(env_value,"KSTEP") ) {
-      *eb_sel = neko_eb_env();
-      CASE_KSTEP_SEL(LX, *eb_sel);
-      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-              NEKO_EB_SEL(LX, *eb_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 2;
     } else if( !strcmp(env_value,"DMMA") ) {
       if (dmma) {
-        const int c = neko_dmma_env();
-        *nw_sel = c;
-        CASE_DMMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 3 (DMMA, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 3;
+        strat = 3;
       } else {
         sprintf(neko_log_buf, "DMMA strategy not available for this config");
         log_error(neko_log_buf);
       }
     } else if( !strcmp(env_value,"DMMA_TMA") ) {
       if (tma) {
-        const int c = neko_dmma_tma_env();
-        *tw_sel = c;
-        CASE_DMMA_TMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 4 (DMMA_TMA, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 4;
+        strat = 4;
       } else {
         sprintf(neko_log_buf,
                 "DMMA_TMA strategy not available for this config");
@@ -353,6 +343,55 @@ int tune_conv1(void *du, void *u,
     }
   }
 
+  /* Geometry of the pinned formulation, if its own variable fixes that too.
+     Both pinned leaves nothing to measure, so the kernel is launched once and
+     reported, which is what pinning has always done */
+  const int pin = (strat == 1) ? ch_pin : (strat == 2) ? eb_pin :
+                  (strat == 3) ? nw_pin : (strat == 4) ? tw_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 1:
+      *ch_sel = pin;
+      CASE_1D_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 1 (1D, %d chunk)",
+              NEKO_CHUNKS_SEL(LX, pin));
+      break;
+    case 2:
+      *eb_sel = pin;
+      CASE_KSTEP_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    case 3:
+      *nw_sel = pin;
+      CASE_DMMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 3 (DMMA, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    default:
+      *tw_sel = pin;
+      CASE_DMMA_TMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 4 (DMMA_TMA, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR() */
+  const bool try_1d = (strat == 0 || strat == 1);
+  const bool try_kstep = (strat == 0 || strat == 2);
+  const bool try_dmma = dmma && (strat == 0 || strat == 3);
+  const bool try_tma = tma && (strat == 0 || strat == 4);
+
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
 
@@ -360,47 +399,33 @@ int tune_conv1(void *du, void *u,
      resident and the clocks at steady state, or whichever is timed first is
      measured on a colder part */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_1D(LX, 0);
-    CASE_1D(LX, 1);
-    CASE_1D(LX, 2);
-    CASE_1D(LX, 3);
-    CASE_KSTEP(LX, 0);
-    if (sweep) {
-      CASE_KSTEP(LX, 1);
-      CASE_KSTEP(LX, 2);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      CASE_1D_SEL(LX, c);
     }
-    if (dmma) {
-      CASE_DMMA(LX, 0);
-      CASE_DMMA(LX, 1);
-      CASE_DMMA(LX, 2);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_KSTEP_SEL(LX, c);
     }
-    if (tma) {
-      CASE_DMMA_TMA(LX, 0);
-      CASE_DMMA_TMA(LX, 1);
-      CASE_DMMA_TMA(LX, 2);
+    NEKO_TUNE_FOR(c, try_dmma, nw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_DMMA_SEL(LX, c);
+    }
+    NEKO_TUNE_FOR(c, try_tma, tw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_DMMA_TMA_SEL(LX, c);
     }
   }
 
   /* Interleaved rounds, best time per variant */
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 0, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 1, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 2, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 3, iters);
-    NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      NEKO_TUNE_TIME(time1, CASE_1D_SEL, LX, c, iters);
     }
-    if (dmma) {
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_KSTEP_SEL, LX, c, iters);
     }
-    if (tma) {
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_dmma, nw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time3, CASE_DMMA_SEL, LX, c, iters);
+    }
+    NEKO_TUNE_FOR(c, try_tma, tw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA_SEL, LX, c, iters);
     }
   }
 

--- a/src/math/bcknd/device/cuda/opr_convect_scalar.cu
+++ b/src/math/bcknd/device/cuda/opr_convect_scalar.cu
@@ -172,7 +172,14 @@ int tune_convect_scalar(void *du, void *u,
   float time2[NEKO_EB_CANDIDATES];
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, one -- the unblocked shape -- when the
+     elements per block sweep is off */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int ch_pin = neko_chunks_pin();
+  const int eb_pin = neko_eb_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier this returns */
+  int strat = 0;
   int best = 0;
   int retval;
 
@@ -199,28 +206,56 @@ int tune_convect_scalar(void *du, void *u,
   *eb_sel = 0;
   *ch_sel = 0;
 
+  /*
+   * NEKO_AUTOTUNE names a formulation, and that is all it does: the sweep
+   * below is narrowed to that one kernel family, but its geometry -- the
+   * chunk size, the elements per block -- is still measured candidate
+   * against candidate.
+   */
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      *ch_sel = neko_chunks_env();
-      CASE_1D_SEL(LX, *ch_sel);
-      sprintf(neko_log_buf,"Set by env   : 1 (1D, %d chunk)",
-              NEKO_CHUNKS_SEL(LX, *ch_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 1;
+      strat = 1;
     } else if( !strcmp(env_value,"KSTEP") ) {
-      *eb_sel = neko_eb_env();
-      CASE_KSTEP_SEL(LX, *eb_sel);
-      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-              NEKO_EB_SEL(LX, *eb_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 2;
     } else {
        sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
        log_error(neko_log_buf);
     }
   }
+
+  /* Geometry of the pinned formulation, if its own variable fixes that too.
+     Both pinned leaves nothing to measure, so the kernel is launched once and
+     reported, which is what pinning has always done */
+  const int pin = (strat == 1) ? ch_pin : (strat == 2) ? eb_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 1:
+      *ch_sel = pin;
+      CASE_1D_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 1 (1D, %d chunk)",
+              NEKO_CHUNKS_SEL(LX, pin));
+      break;
+    default:
+      *eb_sel = pin;
+      CASE_KSTEP_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR() */
+  const bool try_1d = (strat == 0 || strat == 1);
+  const bool try_kstep = (strat == 0 || strat == 2);
 
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
@@ -228,27 +263,21 @@ int tune_convect_scalar(void *du, void *u,
      resident and the clocks at steady state, or whichever is timed first is
      measured on a colder part */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_1D(LX, 0);
-    CASE_1D(LX, 1);
-    CASE_1D(LX, 2);
-    CASE_1D(LX, 3);
-    CASE_KSTEP(LX, 0);
-    if (sweep) {
-      CASE_KSTEP(LX, 1);
-      CASE_KSTEP(LX, 2);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      CASE_1D_SEL(LX, c);
+    }
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_KSTEP_SEL(LX, c);
     }
   }
 
   /* Interleaved rounds, best time per variant */
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 0, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 1, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 2, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 3, iters);
-    NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      NEKO_TUNE_TIME(time1, CASE_1D_SEL, LX, c, iters);
+    }
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_KSTEP_SEL, LX, c, iters);
     }
   }
 

--- a/src/math/bcknd/device/cuda/opr_dudxyz.cu
+++ b/src/math/bcknd/device/cuda/opr_dudxyz.cu
@@ -229,7 +229,16 @@ int tune_dudxyz(void *du, void *u,
   int best4 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, one -- the unblocked shape -- when the
+     elements per block sweep is off */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int ch_pin = neko_chunks_pin();
+  const int eb_pin = neko_eb_pin();
+  const int nw_pin = neko_dmma_pin();
+  const int tw_pin = neko_dmma_tma_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier this returns */
+  int strat = 0;
   const bool dmma = dmma_lx_supported<LX>() && cuda_have_dmma();
   /* Whether the pointers are bulk copy aligned is a property of this call
      rather than of the kernel, so it is checked rather than assumed, see
@@ -268,47 +277,28 @@ int tune_dudxyz(void *du, void *u,
   *nw_sel = 0;
   *tw_sel = 0;
 
+  /*
+   * NEKO_AUTOTUNE names a formulation, and that is all it does: the sweep
+   * below is narrowed to that one kernel family, but its geometry -- the
+   * chunk size, the elements per block, the warps per block -- is still
+   * measured candidate against candidate. A formulation this build or this
+   * device does not have is reported and ignored, leaving the full sweep.
+   */
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      *ch_sel = neko_chunks_env();
-      CASE_1D_SEL(LX, *ch_sel);
-      sprintf(neko_log_buf,"Set by env   : 1 (1D, %d chunk)",
-              NEKO_CHUNKS_SEL(LX, *ch_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 1;
+      strat = 1;
     } else if( !strcmp(env_value,"KSTEP") ) {
-      *eb_sel = neko_eb_env();
-      CASE_KSTEP_SEL(LX, *eb_sel);
-      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-              NEKO_EB_SEL(LX, *eb_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 2;
     } else if( !strcmp(env_value,"DMMA") ) {
       if (dmma) {
-        const int c = neko_dmma_env();
-        *nw_sel = c;
-        CASE_DMMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 3 (DMMA, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 3;
+        strat = 3;
       } else {
         sprintf(neko_log_buf, "DMMA strategy not available for this config");
         log_error(neko_log_buf);
       }
     } else if( !strcmp(env_value,"DMMA_TMA") ) {
       if (tma) {
-        const int c = neko_dmma_tma_env();
-        *tw_sel = c;
-        CASE_DMMA_TMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 4 (DMMA_TMA, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 4;
+        strat = 4;
       } else {
         sprintf(neko_log_buf,
                 "DMMA_TMA strategy not available for this config");
@@ -320,6 +310,55 @@ int tune_dudxyz(void *du, void *u,
     }
   }
 
+  /* Geometry of the pinned formulation, if its own variable fixes that too.
+     Both pinned leaves nothing to measure, so the kernel is launched once and
+     reported, which is what pinning has always done */
+  const int pin = (strat == 1) ? ch_pin : (strat == 2) ? eb_pin :
+                  (strat == 3) ? nw_pin : (strat == 4) ? tw_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 1:
+      *ch_sel = pin;
+      CASE_1D_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 1 (1D, %d chunk)",
+              NEKO_CHUNKS_SEL(LX, pin));
+      break;
+    case 2:
+      *eb_sel = pin;
+      CASE_KSTEP_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    case 3:
+      *nw_sel = pin;
+      CASE_DMMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 3 (DMMA, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    default:
+      *tw_sel = pin;
+      CASE_DMMA_TMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 4 (DMMA_TMA, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR() */
+  const bool try_1d = (strat == 0 || strat == 1);
+  const bool try_kstep = (strat == 0 || strat == 2);
+  const bool try_dmma = dmma && (strat == 0 || strat == 3);
+  const bool try_tma = tma && (strat == 0 || strat == 4);
+
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
 
@@ -327,47 +366,33 @@ int tune_dudxyz(void *du, void *u,
      resident and the clocks at steady state, or whichever is timed first is
      measured on a colder part */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_1D(LX, 0);
-    CASE_1D(LX, 1);
-    CASE_1D(LX, 2);
-    CASE_1D(LX, 3);
-    CASE_KSTEP(LX, 0);
-    if (sweep) {
-      CASE_KSTEP(LX, 1);
-      CASE_KSTEP(LX, 2);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      CASE_1D_SEL(LX, c);
     }
-    if (dmma) {
-      CASE_DMMA(LX, 0);
-      CASE_DMMA(LX, 1);
-      CASE_DMMA(LX, 2);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_KSTEP_SEL(LX, c);
     }
-    if (tma) {
-      CASE_DMMA_TMA(LX, 0);
-      CASE_DMMA_TMA(LX, 1);
-      CASE_DMMA_TMA(LX, 2);
+    NEKO_TUNE_FOR(c, try_dmma, nw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_DMMA_SEL(LX, c);
+    }
+    NEKO_TUNE_FOR(c, try_tma, tw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_DMMA_TMA_SEL(LX, c);
     }
   }
 
   /* Interleaved rounds, best time per variant */
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 0, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 1, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 2, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 3, iters);
-    NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      NEKO_TUNE_TIME(time1, CASE_1D_SEL, LX, c, iters);
     }
-    if (dmma) {
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_KSTEP_SEL, LX, c, iters);
     }
-    if (tma) {
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_dmma, nw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time3, CASE_DMMA_SEL, LX, c, iters);
+    }
+    NEKO_TUNE_FOR(c, try_tma, tw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA_SEL, LX, c, iters);
     }
   }
 

--- a/src/math/bcknd/device/cuda/opr_lambda2.cu
+++ b/src/math/bcknd/device/cuda/opr_lambda2.cu
@@ -166,7 +166,14 @@ int tune_lambda2(void *lambda2, void *u, void *v, void *w,
   float time2[NEKO_EB_CANDIDATES];
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, one -- the unblocked shape -- when the
+     elements per block sweep is off */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int ch_pin = neko_chunks_pin();
+  const int eb_pin = neko_eb_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier this returns */
+  int strat = 0;
   int best = 0;
   int retval;
 
@@ -190,28 +197,56 @@ int tune_lambda2(void *lambda2, void *u, void *v, void *w,
   sprintf(neko_log_buf, "Autotune lambda2 (lx: %d)", *lx);
   log_section(neko_log_buf);
   
+  /*
+   * NEKO_AUTOTUNE names a formulation, and that is all it does: the sweep
+   * below is narrowed to that one kernel family, but its geometry -- the
+   * chunk size, the elements per block -- is still measured candidate
+   * against candidate, and reported.
+   */
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      *ch_sel = neko_chunks_env();
-      CASE_1D_SEL(LX, *ch_sel);
-      sprintf(neko_log_buf,"Set by env   : 1 (1D, %d chunk)",
-              NEKO_CHUNKS_SEL(LX, *ch_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 1;
+      strat = 1;
     } else if( !strcmp(env_value,"KSTEP") ) {
-      *eb_sel = neko_eb_env();
-      CASE_KSTEP_SEL(LX, *eb_sel);
-      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-              NEKO_EB_SEL(LX, *eb_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 2;
     } else {       
        sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
        log_error(neko_log_buf);
     }
   }
+
+  /* Geometry of the pinned formulation, if its own variable fixes that too.
+     Both pinned leaves nothing to measure, so the kernel is launched once and
+     reported, which is what pinning has always done */
+  const int pin = (strat == 1) ? ch_pin : (strat == 2) ? eb_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 1:
+      *ch_sel = pin;
+      CASE_1D_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 1 (1D, %d chunk)",
+              NEKO_CHUNKS_SEL(LX, pin));
+      break;
+    default:
+      *eb_sel = pin;
+      CASE_KSTEP_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR() */
+  const bool try_1d = (strat == 0 || strat == 1);
+  const bool try_kstep = (strat == 0 || strat == 2);
 
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
@@ -219,27 +254,21 @@ int tune_lambda2(void *lambda2, void *u, void *v, void *w,
      resident and the clocks at steady state, or whichever is timed first is
      measured on a colder part */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_1D(LX, 0);
-    CASE_1D(LX, 1);
-    CASE_1D(LX, 2);
-    CASE_1D(LX, 3);
-    CASE_KSTEP(LX, 0);
-    if (sweep) {
-      CASE_KSTEP(LX, 1);
-      CASE_KSTEP(LX, 2);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      CASE_1D_SEL(LX, c);
+    }
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_KSTEP_SEL(LX, c);
     }
   }
 
   /* Interleaved rounds, best time per variant */
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 0, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 1, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 2, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 3, iters);
-    NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      NEKO_TUNE_TIME(time1, CASE_1D_SEL, LX, c, iters);
+    }
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_KSTEP_SEL, LX, c, iters);
     }
   }
 

--- a/src/math/bcknd/device/cuda/opr_opgrad.cu
+++ b/src/math/bcknd/device/cuda/opr_opgrad.cu
@@ -233,7 +233,16 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
   int best4 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, one -- the unblocked shape -- when the
+     elements per block sweep is off */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int ch_pin = neko_chunks_pin();
+  const int eb_pin = neko_eb_pin();
+  const int nw_pin = neko_dmma_pin();
+  const int tw_pin = neko_dmma_tma_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier this returns */
+  int strat = 0;
   const bool dmma = dmma_lx_supported<LX>() && cuda_have_dmma();
   /* Whether the pointers are bulk copy aligned is a property of this call
      rather than of the kernel, so it is checked rather than assumed, see
@@ -276,50 +285,28 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
   *nw_sel = 0;
   *tw_sel = 0;
 
+  /*
+   * NEKO_AUTOTUNE names a formulation, and that is all it does: the sweep
+   * below is narrowed to that one kernel family, but its geometry -- the
+   * chunk size, the elements per block, the warps per block -- is still
+   * measured candidate against candidate. A formulation this build or this
+   * device does not have is reported and ignored, leaving the full sweep.
+   */
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      *ch_sel = neko_chunks_env();
-      CASE_1D_SEL(LX, *ch_sel);
-      sprintf(neko_log_buf,"Set by env   : 1 (1D, %d chunk)",
-              NEKO_CHUNKS_SEL(LX, *ch_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 1;
+      strat = 1;
     } else if( !strcmp(env_value,"KSTEP") ) {
-      {
-        const int c = neko_eb_env();
-        *eb_sel = c;
-        CASE_KSTEP_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-                NEKO_EB_SEL(LX, c));
-      }
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 2;
     } else if( !strcmp(env_value,"DMMA") ) {
       if (dmma) {
-        const int c = neko_dmma_env();
-        *nw_sel = c;
-        CASE_DMMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 3 (DMMA, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 3;
+        strat = 3;
       } else {
         sprintf(neko_log_buf, "DMMA strategy not available for this config");
         log_error(neko_log_buf);
       }
     } else if( !strcmp(env_value,"DMMA_TMA") ) {
       if (tma) {
-        const int c = neko_dmma_tma_env();
-        *tw_sel = c;
-        CASE_DMMA_TMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 4 (DMMA_TMA, %d warps)",
-                NEKO_DMMA_NW(c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 4;
+        strat = 4;
       } else {
         sprintf(neko_log_buf,
                 "DMMA_TMA strategy not available for this config");
@@ -331,6 +318,55 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
     }
   }
 
+  /* Geometry of the pinned formulation, if its own variable fixes that too.
+     Both pinned leaves nothing to measure, so the kernel is launched once and
+     reported, which is what pinning has always done */
+  const int pin = (strat == 1) ? ch_pin : (strat == 2) ? eb_pin :
+                  (strat == 3) ? nw_pin : (strat == 4) ? tw_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 1:
+      *ch_sel = pin;
+      CASE_1D_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 1 (1D, %d chunk)",
+              NEKO_CHUNKS_SEL(LX, pin));
+      break;
+    case 2:
+      *eb_sel = pin;
+      CASE_KSTEP_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    case 3:
+      *nw_sel = pin;
+      CASE_DMMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 3 (DMMA, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    default:
+      *tw_sel = pin;
+      CASE_DMMA_TMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 4 (DMMA_TMA, %d warps)",
+              NEKO_DMMA_NW(pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR() */
+  const bool try_1d = (strat == 0 || strat == 1);
+  const bool try_kstep = (strat == 0 || strat == 2);
+  const bool try_dmma = dmma && (strat == 0 || strat == 3);
+  const bool try_tma = tma && (strat == 0 || strat == 4);
+
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
 
@@ -338,47 +374,33 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
      resident and the clocks at steady state, or whichever is timed first is
      measured on a colder part */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_1D(LX, 0);
-    CASE_1D(LX, 1);
-    CASE_1D(LX, 2);
-    CASE_1D(LX, 3);
-    CASE_KSTEP(LX, 0);
-    if (sweep) {
-      CASE_KSTEP(LX, 1);
-      CASE_KSTEP(LX, 2);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      CASE_1D_SEL(LX, c);
     }
-    if (dmma) {
-      CASE_DMMA(LX, 0);
-      CASE_DMMA(LX, 1);
-      CASE_DMMA(LX, 2);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_KSTEP_SEL(LX, c);
     }
-    if (tma) {
-      CASE_DMMA_TMA(LX, 0);
-      CASE_DMMA_TMA(LX, 1);
-      CASE_DMMA_TMA(LX, 2);
+    NEKO_TUNE_FOR(c, try_dmma, nw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_DMMA_SEL(LX, c);
+    }
+    NEKO_TUNE_FOR(c, try_tma, tw_pin, NEKO_DMMA_CANDIDATES) {
+      CASE_DMMA_TMA_SEL(LX, c);
     }
   }
 
   /* Interleaved rounds, best time per variant */
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 0, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 1, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 2, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 3, iters);
-    NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      NEKO_TUNE_TIME(time1, CASE_1D_SEL, LX, c, iters);
     }
-    if (dmma) {
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time3, CASE_DMMA, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_KSTEP_SEL, LX, c, iters);
     }
-    if (tma) {
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_dmma, nw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time3, CASE_DMMA_SEL, LX, c, iters);
+    }
+    NEKO_TUNE_FOR(c, try_tma, tw_pin, NEKO_DMMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time4, CASE_DMMA_TMA_SEL, LX, c, iters);
     }
   }
 

--- a/src/math/bcknd/device/hip/ax_helm.hip
+++ b/src/math/bcknd/device/hip/ax_helm.hip
@@ -397,11 +397,17 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
   int best3 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, one -- the unblocked shape -- when the
+     elements per block sweep is off */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int ch_pin = neko_chunks_pin();
+  const int eb_pin = neko_eb_pin();
+  const int nwf_pin = neko_mfma_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier tune() returns */
+  int strat = 0;
   /* Hardware capability, which the explicit NEKO_AUTOTUNE=MFMA pin needs */
   const bool mfma = mfma_lx_supported<LX>() && hip_have_mfma();
-  /* Whether the sweep may pick it on its own, see neko_mfma_sweep() */
-  const bool mfma_tune = mfma && neko_mfma_sweep();
   int best = 0;
   int retval;
 
@@ -429,35 +435,23 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
 
   *eb_sel = 0;
   *ch_sel = 0;
+  *nwf_sel = 0;
 
+  /*
+   * NEKO_AUTOTUNE names a formulation, and that is all it does: the sweep
+   * below is narrowed to that one kernel family, but its geometry -- the
+   * chunk size, the elements per block, the wavefronts per block -- is still
+   * measured candidate against candidate. A formulation this build or this
+   * device does not have is reported and ignored, leaving the full sweep.
+   */
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      *ch_sel = neko_chunks_env();
-      CASE_1D_SEL(LX, *ch_sel);
-      sprintf(neko_log_buf,"Set by env   : 1 (1D, %d chunk)",
-              NEKO_CHUNKS_SEL(LX, *ch_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 1;
+      strat = 1;
     } else if( !strcmp(env_value,"KSTEP") ) {
-      const int c = neko_eb_env();
-      *eb_sel = c;
-      CASE_KSTEP_SEL(LX, c);
-      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-              NEKO_EB_SEL(LX, c));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 2;
     } else if( !strcmp(env_value,"MFMA") ) {
       if (mfma) {
-        const int c = neko_mfma_env();
-        *nwf_sel = c;
-        CASE_MFMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 3 (MFMA, %d wf, %d elem/block)",
-                NEKO_MFMA_NWF(c), NEKO_MFMA_EB(LX, c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 3;
+        strat = 3;
       } else {
         sprintf(neko_log_buf, "MFMA strategy not available for this config");
         log_error(neko_log_buf);
@@ -468,6 +462,51 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
     }
   }
 
+  /* Geometry of the pinned formulation, if its own variable fixes that too.
+     Both pinned leaves nothing to measure, so the kernel is launched once and
+     reported, which is what pinning has always done */
+  const int pin = (strat == 1) ? ch_pin : (strat == 2) ? eb_pin :
+                  (strat == 3) ? nwf_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 1:
+      *ch_sel = pin;
+      CASE_1D_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 1 (1D, %d chunk)",
+              NEKO_CHUNKS_SEL(LX, pin));
+      break;
+    case 2:
+      *eb_sel = pin;
+      CASE_KSTEP_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    default:
+      *nwf_sel = pin;
+      CASE_MFMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 3 (MFMA, %d wf, %d elem/block)",
+              NEKO_MFMA_NWF(pin), NEKO_MFMA_EB(LX, pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR(). NEKO_MFMA_TUNE
+     keeps the matrix core variant out of an unpinned sweep, but naming it
+     explicitly still measures it */
+  const bool try_1d = (strat == 0 || strat == 1);
+  const bool try_kstep = (strat == 0 || strat == 2);
+  const bool try_mfma = mfma && ((strat == 3) ||
+                                 (strat == 0 && neko_mfma_sweep()));
+
   HIP_CHECK(hipEventCreate(&start));
   HIP_CHECK(hipEventCreate(&stop));
 
@@ -475,40 +514,28 @@ int tune(void *w, void *u, void *dx, void *dy, void *dz,
      be resident and the clocks at steady state, or whichever variant is
      timed first is measured on a colder part */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_1D(LX, 0);
-    CASE_1D(LX, 1);
-    CASE_1D(LX, 2);
-    CASE_1D(LX, 3);
-    CASE_KSTEP(LX, 0);
-    if (sweep) {
-      CASE_KSTEP(LX, 1);
-      CASE_KSTEP(LX, 2);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      CASE_1D_SEL(LX, c);
     }
-    if (mfma_tune) {
-      CASE_MFMA(LX, 0);
-      CASE_MFMA(LX, 1);
-      CASE_MFMA(LX, 2);
-      CASE_MFMA(LX, 3);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_KSTEP_SEL(LX, c);
+    }
+    NEKO_TUNE_FOR(c, try_mfma, nwf_pin, NEKO_MFMA_CANDIDATES) {
+      CASE_MFMA_SEL(LX, c);
     }
   }
 
   /* Interleaved rounds, best time per variant: timing them one after another
      in a fixed order lets clock drift bias the comparison by position */
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 0, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 1, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 2, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 3, iters);
-    NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      NEKO_TUNE_TIME(time1, CASE_1D_SEL, LX, c, iters);
     }
-    if (mfma_tune) {
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 2, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 3, iters);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_KSTEP_SEL, LX, c, iters);
+    }
+    NEKO_TUNE_FOR(c, try_mfma, nwf_pin, NEKO_MFMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time3, CASE_MFMA_SEL, LX, c, iters);
     }
   }
 
@@ -576,11 +603,16 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
   int best3 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, see tune() */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int ch_pin = neko_chunks_pin();
+  const int eb_pin = neko_eb_pin();
+  const int nwf_pin = neko_mfma_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier this returns */
+  int strat = 0;
   /* Hardware capability, which the explicit NEKO_AUTOTUNE=MFMA pin needs */
   const bool mfma = mfma_lx_supported<LX>() && hip_have_mfma();
-  /* Whether the sweep may pick it on its own, see neko_mfma_sweep() */
-  const bool mfma_tune = mfma && neko_mfma_sweep();
   int best = 0;
   int retval;
 
@@ -608,35 +640,17 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
 
   *eb_sel = 0;
   *ch_sel = 0;
+  *nwf_sel = 0;
 
+  /* NEKO_AUTOTUNE names a formulation and nothing more, see tune() */
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      *ch_sel = neko_chunks_env();
-      CASE_1D_SEL(LX, *ch_sel);
-      sprintf(neko_log_buf,"Set by env   : 1 (1D, %d chunk)",
-              NEKO_CHUNKS_SEL(LX, *ch_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 1;
-     } else if( !strcmp(env_value,"KSTEP") ) {
-      const int c = neko_eb_env();
-      *eb_sel = c;
-      CASE_KSTEP_PADDED_SEL(LX, c);
-      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-              NEKO_EB_SEL(LX, c));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 1;
+    } else if( !strcmp(env_value,"KSTEP") ) {
+      strat = 2;
     } else if( !strcmp(env_value,"MFMA") ) {
       if (mfma) {
-        const int c = neko_mfma_env();
-        *nwf_sel = c;
-        CASE_MFMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 3 (MFMA, %d wf, %d elem/block)",
-                NEKO_MFMA_NWF(c), NEKO_MFMA_EB(LX, c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 3;
+        strat = 3;
       } else {
         sprintf(neko_log_buf, "MFMA strategy not available for this config");
         log_error(neko_log_buf);
@@ -647,6 +661,47 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
     }
   }
 
+  /* Formulation and geometry both pinned leaves nothing to measure */
+  const int pin = (strat == 1) ? ch_pin : (strat == 2) ? eb_pin :
+                  (strat == 3) ? nwf_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 1:
+      *ch_sel = pin;
+      CASE_1D_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 1 (1D, %d chunk)",
+              NEKO_CHUNKS_SEL(LX, pin));
+      break;
+    case 2:
+      *eb_sel = pin;
+      CASE_KSTEP_PADDED_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    default:
+      *nwf_sel = pin;
+      CASE_MFMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 3 (MFMA, %d wf, %d elem/block)",
+              NEKO_MFMA_NWF(pin), NEKO_MFMA_EB(LX, pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR() */
+  const bool try_1d = (strat == 0 || strat == 1);
+  const bool try_kstep = (strat == 0 || strat == 2);
+  const bool try_mfma = mfma && ((strat == 3) ||
+                                 (strat == 0 && neko_mfma_sweep()));
+
   HIP_CHECK(hipEventCreate(&start));
   HIP_CHECK(hipEventCreate(&stop));
 
@@ -654,40 +709,28 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
      be resident and the clocks at steady state, or whichever variant is
      timed first is measured on a colder part */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_1D(LX, 0);
-    CASE_1D(LX, 1);
-    CASE_1D(LX, 2);
-    CASE_1D(LX, 3);
-    CASE_KSTEP_PADDED(LX, 0);
-    if (sweep) {
-      CASE_KSTEP_PADDED(LX, 1);
-      CASE_KSTEP_PADDED(LX, 2);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      CASE_1D_SEL(LX, c);
     }
-    if (mfma_tune) {
-      CASE_MFMA(LX, 0);
-      CASE_MFMA(LX, 1);
-      CASE_MFMA(LX, 2);
-      CASE_MFMA(LX, 3);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_KSTEP_PADDED_SEL(LX, c);
+    }
+    NEKO_TUNE_FOR(c, try_mfma, nwf_pin, NEKO_MFMA_CANDIDATES) {
+      CASE_MFMA_SEL(LX, c);
     }
   }
 
   /* Interleaved rounds, best time per variant: timing them one after another
      in a fixed order lets clock drift bias the comparison by position */
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 0, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 1, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 2, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 3, iters);
-    NEKO_TUNE_TIME(time2, CASE_KSTEP_PADDED, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_KSTEP_PADDED, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_KSTEP_PADDED, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      NEKO_TUNE_TIME(time1, CASE_1D_SEL, LX, c, iters);
     }
-    if (mfma_tune) {
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 2, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 3, iters);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_KSTEP_PADDED_SEL, LX, c, iters);
+    }
+    NEKO_TUNE_FOR(c, try_mfma, nwf_pin, NEKO_MFMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time3, CASE_MFMA_SEL, LX, c, iters);
     }
   }
 
@@ -742,9 +785,9 @@ int tune_padded(void *w, void *u, void *dx, void *dy, void *dz,
 
 /*
  * The vector Ax has no 1d variant, so these only sweep the elements per
- * block candidates. Setting NEKO_AUTOTUNE to anything pins candidate 0,
- * i.e. the one element per block shape these kernels have always had,
- * which is the A/B baseline for the blocking.
+ * block candidates. Setting NEKO_EB pins one of them, candidate 0 being the
+ * one element per block shape these kernels have always had and so the A/B
+ * baseline for the blocking.
  *
  * @note The section title has to fit the 30 character header field in
  * log_section(), which truncates rather than wraps -- hence "Ax vector"
@@ -760,6 +803,8 @@ int tune_vector(void *au, void *av, void *aw, void *u, void *v, void *w,
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
   const int sweep = neko_eb_sweep();
+  /* Elements per block pinned by NEKO_EB, -1 to sweep it */
+  const int eb_pin = neko_eb_pin();
   int best = 0;
 
   for (int c = 0; c < NEKO_EB_CANDIDATES; c++) {
@@ -778,10 +823,13 @@ int tune_vector(void *au, void *av, void *aw, void *u, void *v, void *w,
    * reach the register file limit -- and start spilling to scratch -- well
    * before a wider block can buy anything. Sweeping them by default was a
    * regression. Set NEKO_EB_TUNE=1 to opt back into the sweep
+   *
+   * NEKO_AUTOTUNE is not consulted here: it names a formulation, and the
+   * vector Ax has only the one, so naming it says nothing about the geometry.
+   * NEKO_EB still pins that, and pinning it is what skips the sweep
    */
-  if (getenv("NEKO_AUTOTUNE") ||
-      getenv("NEKO_EB") || !neko_eb_sweep()) {
-    const int c = neko_eb_env();
+  if (eb_pin >= 0 || !sweep) {
+    const int c = (eb_pin >= 0) ? eb_pin : 0;
     CASE_VECTOR_SEL(LX, c);
     sprintf(neko_log_buf, "Vector Ax    : %d elem/block (untuned)",
             NEKO_EB_SEL(LX, c));
@@ -836,6 +884,8 @@ int tune_vector_padded(void *au, void *av, void *aw,
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
   const int sweep = neko_eb_sweep();
+  /* Elements per block pinned by NEKO_EB, -1 to sweep it */
+  const int eb_pin = neko_eb_pin();
   int best = 0;
 
   for (int c = 0; c < NEKO_EB_CANDIDATES; c++) {
@@ -854,10 +904,13 @@ int tune_vector_padded(void *au, void *av, void *aw,
    * reach the register file limit -- and start spilling to scratch -- well
    * before a wider block can buy anything. Sweeping them by default was a
    * regression. Set NEKO_EB_TUNE=1 to opt back into the sweep
+   *
+   * NEKO_AUTOTUNE is not consulted here: it names a formulation, and the
+   * vector Ax has only the one, so naming it says nothing about the geometry.
+   * NEKO_EB still pins that, and pinning it is what skips the sweep
    */
-  if (getenv("NEKO_AUTOTUNE") ||
-      getenv("NEKO_EB") || !neko_eb_sweep()) {
-    const int c = neko_eb_env();
+  if (eb_pin >= 0 || !sweep) {
+    const int c = (eb_pin >= 0) ? eb_pin : 0;
     CASE_VECTOR_PADDED_SEL(LX, c);
     sprintf(neko_log_buf, "Vector Ax    : %d elem/block (untuned)",
             NEKO_EB_SEL(LX, c));

--- a/src/math/bcknd/device/hip/elem_block_tune.h
+++ b/src/math/bcknd/device/hip/elem_block_tune.h
@@ -44,6 +44,13 @@
  * bias the comparison by candidate position, which no amount of extra
  * iterations removes.
  *
+ * NEKO_AUTOTUNE takes a formulation out of the tuner's hands, but only the
+ * formulation: the geometry candidates of the one it names are still measured
+ * and reported, and it takes that formulation's own variable (NEKO_EB,
+ * NEKO_CHUNKS, ...) to fix the geometry too. Pinning the formulation used to
+ * imply candidate 0, which silently answered a different question than the one
+ * an A/B run of two formulations is asking. See NEKO_TUNE_FOR() below.
+ *
  * A tune function using these macros is expected to have `start`, `stop` and
  * `stream` in scope --- and `iters` for the reporting macros --- plus a
  * CASE_1D(LX) macro and a kstep launch macro taking (LX, C).
@@ -80,24 +87,43 @@ static int neko_eb_sweep()
   return NEKO_EB_SWEEP_DEFAULT;
 }
 
-/* Forced candidate, used when NEKO_AUTOTUNE pins the kstep variant */
-static int neko_eb_env()
+/*
+ * Elements per block candidate pinned by NEKO_EB, or -1 to leave it to the
+ * sweep.
+ *
+ * NEKO_AUTOTUNE selects the formulation and nothing more -- the geometry
+ * inside it is still measured unless it is pinned here -- so "unset" has to
+ * be distinguishable from candidate 0, which is a candidate like any other.
+ * Hence the -1 rather than a plain default of 0. Out of range values clamp
+ * to 0 rather than releasing the pin, as they always have.
+ */
+static int neko_eb_pin()
 {
   const char *v = getenv("NEKO_EB");
-  int c = (v != NULL) ? atoi(v) : 0;
+  int c;
 
+  if (v == NULL) {
+    return -1;
+  }
+
+  c = atoi(v);
   if (c < 0 || c >= NEKO_EB_CANDIDATES) {
     c = 0;
   }
   return c;
 }
 
-/* Forced chunk candidate, used when NEKO_AUTOTUNE pins the 1d variant */
-static int neko_chunks_env()
+/* Chunk candidate pinned by NEKO_CHUNKS, or -1 to sweep, see neko_eb_pin() */
+static int neko_chunks_pin()
 {
   const char *v = getenv("NEKO_CHUNKS");
-  int c = (v != NULL) ? atoi(v) : 0;
+  int c;
 
+  if (v == NULL) {
+    return -1;
+  }
+
+  c = atoi(v);
   if (c < 0 || c >= NEKO_CHUNKS_CANDIDATES) {
     c = 0;
   }
@@ -119,6 +145,24 @@ static int neko_tune_iters()
 
   return (n < 1) ? 1 : n;
 }
+
+/*
+ * Loop over the candidates of one formulation, binding C to each in turn.
+ *
+ * ON gates the formulation itself: hardware support, and -- when NEKO_AUTOTUNE
+ * is set -- whether it is the formulation that was asked for. PIN is the
+ * candidate that formulation's own variable forces, or -1 to measure all N of
+ * them. So NEKO_AUTOTUNE narrows the search to one kernel family without
+ * deciding the geometry within it, which is still swept and reported.
+ *
+ * An out of play formulation yields an empty range, leaving its candidates at
+ * NEKO_TUNE_INIT so it loses the comparison at the end rather than having to
+ * be excluded from it.
+ */
+#define NEKO_TUNE_FOR(C, ON, PIN, N)                                          \
+  for (int C = (((PIN) >= 0) ? (PIN) : 0),                                    \
+       C##_last_ = ((ON) ? (((PIN) >= 0) ? (PIN) + 1 : (N)) : 0);             \
+       C < C##_last_; C++)
 
 /* One timed round of LAUNCH at candidate C, min reduced into T[C] */
 #define NEKO_TUNE_TIME(T, LAUNCH, LX, C, ITERS)                           \

--- a/src/math/bcknd/device/hip/mfma_kernel.h
+++ b/src/math/bcknd/device/hip/mfma_kernel.h
@@ -268,12 +268,18 @@ static int neko_mfma_sweep()
   return 1;
 }
 
-/* Forced candidate, used when NEKO_AUTOTUNE pins the MFMA variant */
-static int neko_mfma_env()
+/* Wavefronts per block candidate pinned by NEKO_MFMA_NWF, or -1 to leave it
+   to the sweep, see neko_eb_pin() in elem_block_tune.h */
+static int neko_mfma_pin()
 {
   const char *v = getenv("NEKO_MFMA_NWF");
-  int c = (v != NULL) ? atoi(v) : 0;
+  int c;
 
+  if (v == NULL) {
+    return -1;
+  }
+
+  c = atoi(v);
   if (c < 0 || c >= NEKO_MFMA_CANDIDATES) {
     c = 0;
   }

--- a/src/math/bcknd/device/hip/opr_cdtp.hip
+++ b/src/math/bcknd/device/hip/opr_cdtp.hip
@@ -207,10 +207,16 @@ int tune_cdtp(void *dtx, void *x,
   int best3 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, one -- the unblocked shape -- when the
+     elements per block sweep is off */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int ch_pin = neko_chunks_pin();
+  const int eb_pin = neko_eb_pin();
+  const int nwf_pin = neko_mfma_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier this returns */
+  int strat = 0;
   const bool mfma = mfma_lx_supported<LX>() && hip_have_mfma();
-  /* Whether the sweep may pick it on its own, see neko_mfma_sweep() */
-  const bool mfma_tune = mfma && neko_mfma_sweep();
   int best = 0;
   int retval;
 
@@ -241,33 +247,20 @@ int tune_cdtp(void *dtx, void *x,
   *ch_sel = 0;
   *nwf_sel = 0;
 
+  /*
+   * NEKO_AUTOTUNE names a formulation and nothing more: the sweep below is
+   * narrowed to that kernel family, but its geometry -- the chunk size, the
+   * elements per block, the wavefronts per block -- is still measured
+   * candidate against candidate
+   */
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      *ch_sel = neko_chunks_env();
-      CASE_1D_SEL(LX, *ch_sel);
-      sprintf(neko_log_buf,"Set by env   : 1 (1D, %d chunk)",
-              NEKO_CHUNKS_SEL(LX, *ch_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 1;
+      strat = 1;
     } else if( !strcmp(env_value,"KSTEP") ) {
-      *eb_sel = neko_eb_env();
-      CASE_KSTEP_SEL(LX, *eb_sel);
-      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-              NEKO_EB_SEL(LX, *eb_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 2;
     } else if( !strcmp(env_value,"MFMA") ) {
       if (mfma) {
-        const int c = neko_mfma_env();
-        *nwf_sel = c;
-        CASE_MFMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 3 (MFMA, %d wf, %d elem/block)",
-                NEKO_MFMA_NWF(c), NEKO_MFMA_EB(LX, c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 3;
+        strat = 3;
       } else {
         sprintf(neko_log_buf, "MFMA strategy not available for this config");
         log_error(neko_log_buf);
@@ -278,6 +271,51 @@ int tune_cdtp(void *dtx, void *x,
     }
   }
 
+  /* Geometry of the pinned formulation, if its own variable fixes that too.
+     Both pinned leaves nothing to measure, so the kernel is launched once and
+     reported, which is what pinning has always done */
+  const int pin = (strat == 1) ? ch_pin : (strat == 2) ? eb_pin :
+                  (strat == 3) ? nwf_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 1:
+      *ch_sel = pin;
+      CASE_1D_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 1 (1D, %d chunk)",
+              NEKO_CHUNKS_SEL(LX, pin));
+      break;
+    case 2:
+      *eb_sel = pin;
+      CASE_KSTEP_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    default:
+      *nwf_sel = pin;
+      CASE_MFMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 3 (MFMA, %d wf, %d elem/block)",
+              NEKO_MFMA_NWF(pin), NEKO_MFMA_EB(LX, pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR(). NEKO_MFMA_TUNE
+     keeps the matrix core variant out of an unpinned sweep, but naming it
+     explicitly still measures it */
+  const bool try_1d = (strat == 0 || strat == 1);
+  const bool try_kstep = (strat == 0 || strat == 2);
+  const bool try_mfma = mfma && ((strat == 3) ||
+                                 (strat == 0 && neko_mfma_sweep()));
+
   HIP_CHECK(hipEventCreate(&start));
   HIP_CHECK(hipEventCreate(&stop));
 
@@ -285,39 +323,27 @@ int tune_cdtp(void *dtx, void *x,
      resident and the clocks at steady state, or whichever is timed first is
      measured on a colder part */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_1D(LX, 0);
-    CASE_1D(LX, 1);
-    CASE_1D(LX, 2);
-    CASE_1D(LX, 3);
-    CASE_KSTEP(LX, 0);
-    if (sweep) {
-      CASE_KSTEP(LX, 1);
-      CASE_KSTEP(LX, 2);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      CASE_1D_SEL(LX, c);
     }
-    if (mfma_tune) {
-      CASE_MFMA(LX, 0);
-      CASE_MFMA(LX, 1);
-      CASE_MFMA(LX, 2);
-      CASE_MFMA(LX, 3);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_KSTEP_SEL(LX, c);
+    }
+    NEKO_TUNE_FOR(c, try_mfma, nwf_pin, NEKO_MFMA_CANDIDATES) {
+      CASE_MFMA_SEL(LX, c);
     }
   }
 
   /* Interleaved rounds, best time per variant */
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 0, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 1, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 2, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 3, iters);
-    NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      NEKO_TUNE_TIME(time1, CASE_1D_SEL, LX, c, iters);
     }
-    if (mfma_tune) {
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 2, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 3, iters);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_KSTEP_SEL, LX, c, iters);
+    }
+    NEKO_TUNE_FOR(c, try_mfma, nwf_pin, NEKO_MFMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time3, CASE_MFMA_SEL, LX, c, iters);
     }
   }
 

--- a/src/math/bcknd/device/hip/opr_conv1.hip
+++ b/src/math/bcknd/device/hip/opr_conv1.hip
@@ -228,10 +228,17 @@ int tune_conv1(void *du, void *u,
   int best3 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, one -- the unblocked shape -- when the
+     elements per block sweep is off */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int ch_pin = neko_chunks_pin();
+  const int eb_pin = neko_eb_pin();
+  const int nwf_pin = neko_mfma_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier this returns */
+  int strat = 0;
+  /* Hardware capability, which the explicit NEKO_AUTOTUNE=MFMA pin needs */
   const bool mfma = mfma_lx_supported<LX>() && hip_have_mfma();
-  /* Whether the sweep may pick it on its own, see neko_mfma_sweep() */
-  const bool mfma_tune = mfma && neko_mfma_sweep();
   int best = 0;
   int retval;
 
@@ -262,33 +269,21 @@ int tune_conv1(void *du, void *u,
   *ch_sel = 0;
   *nwf_sel = 0;
 
+  /*
+   * NEKO_AUTOTUNE names a formulation, and that is all it does: the sweep
+   * below is narrowed to that one kernel family, but its geometry -- the
+   * chunk size, the elements per block, the wavefronts per block -- is still
+   * measured candidate against candidate. A formulation this build or this
+   * device does not have is reported and ignored, leaving the full sweep.
+   */
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      *ch_sel = neko_chunks_env();
-      CASE_1D_SEL(LX, *ch_sel);
-      sprintf(neko_log_buf,"Set by env   : 1 (1D, %d chunk)",
-              NEKO_CHUNKS_SEL(LX, *ch_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 1;
+      strat = 1;
     } else if( !strcmp(env_value,"KSTEP") ) {
-      *eb_sel = neko_eb_env();
-      CASE_KSTEP_SEL(LX, *eb_sel);
-      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-              NEKO_EB_SEL(LX, *eb_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 2;
     } else if( !strcmp(env_value,"MFMA") ) {
       if (mfma) {
-        const int c = neko_mfma_env();
-        *nwf_sel = c;
-        CASE_MFMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 3 (MFMA, %d wf, %d elem/block)",
-                NEKO_MFMA_NWF(c), NEKO_MFMA_EB(LX, c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 3;
+        strat = 3;
       } else {
         sprintf(neko_log_buf, "MFMA strategy not available for this config");
         log_error(neko_log_buf);
@@ -299,45 +294,78 @@ int tune_conv1(void *du, void *u,
     }
   }
 
+  /* Geometry of the pinned formulation, if its own variable fixes that too.
+     Both pinned leaves nothing to measure, so the kernel is launched once and
+     reported, which is what pinning has always done */
+  const int pin = (strat == 1) ? ch_pin : (strat == 2) ? eb_pin :
+                  (strat == 3) ? nwf_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 1:
+      *ch_sel = pin;
+      CASE_1D_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 1 (1D, %d chunk)",
+              NEKO_CHUNKS_SEL(LX, pin));
+      break;
+    case 2:
+      *eb_sel = pin;
+      CASE_KSTEP_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    default:
+      *nwf_sel = pin;
+      CASE_MFMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 3 (MFMA, %d wf, %d elem/block)",
+              NEKO_MFMA_NWF(pin), NEKO_MFMA_EB(LX, pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR(). NEKO_MFMA_TUNE
+     keeps the matrix core variant out of an unpinned sweep, but naming it
+     explicitly still measures it */
+  const bool try_1d = (strat == 0 || strat == 1);
+  const bool try_kstep = (strat == 0 || strat == 2);
+  const bool try_mfma = mfma && ((strat == 3) ||
+                                 (strat == 0 && neko_mfma_sweep()));
+
   HIP_CHECK(hipEventCreate(&start));
   HIP_CHECK(hipEventCreate(&stop));
   /* Warm every variant before timing anything: each specialisation has to be
      resident and the clocks at steady state, or whichever is timed first is
      measured on a colder part */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_1D(LX, 0);
-    CASE_1D(LX, 1);
-    CASE_1D(LX, 2);
-    CASE_1D(LX, 3);
-    CASE_KSTEP(LX, 0);
-    if (sweep) {
-      CASE_KSTEP(LX, 1);
-      CASE_KSTEP(LX, 2);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      CASE_1D_SEL(LX, c);
     }
-    if (mfma_tune) {
-      CASE_MFMA(LX, 0);
-      CASE_MFMA(LX, 1);
-      CASE_MFMA(LX, 2);
-      CASE_MFMA(LX, 3);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_KSTEP_SEL(LX, c);
+    }
+    NEKO_TUNE_FOR(c, try_mfma, nwf_pin, NEKO_MFMA_CANDIDATES) {
+      CASE_MFMA_SEL(LX, c);
     }
   }
 
   /* Interleaved rounds, best time per variant */
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 0, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 1, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 2, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 3, iters);
-    NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      NEKO_TUNE_TIME(time1, CASE_1D_SEL, LX, c, iters);
     }
-    if (mfma_tune) {
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 2, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 3, iters);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_KSTEP_SEL, LX, c, iters);
+    }
+    NEKO_TUNE_FOR(c, try_mfma, nwf_pin, NEKO_MFMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time3, CASE_MFMA_SEL, LX, c, iters);
     }
   }
 

--- a/src/math/bcknd/device/hip/opr_convect_scalar.hip
+++ b/src/math/bcknd/device/hip/opr_convect_scalar.hip
@@ -177,7 +177,14 @@ int tune_convect_scalar(void *du, void *u,
   float time2[NEKO_EB_CANDIDATES];
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, one -- the unblocked shape -- when the
+     elements per block sweep is off */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int ch_pin = neko_chunks_pin();
+  const int eb_pin = neko_eb_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier this returns */
+  int strat = 0;
   int best = 0;
   int retval;
 
@@ -203,28 +210,56 @@ int tune_convect_scalar(void *du, void *u,
   *eb_sel = 0;
   *ch_sel = 0;
 
+  /*
+   * NEKO_AUTOTUNE names a formulation, and that is all it does: the sweep
+   * below is narrowed to that one kernel family, but its geometry -- the
+   * chunk size, the elements per block -- is still measured candidate
+   * against candidate.
+   */
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      *ch_sel = neko_chunks_env();
-      CASE_1D_SEL(LX, *ch_sel);
-      sprintf(neko_log_buf,"Set by env   : 1 (1D, %d chunk)",
-              NEKO_CHUNKS_SEL(LX, *ch_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 1;
+      strat = 1;
     } else if( !strcmp(env_value,"KSTEP") ) {
-      *eb_sel = neko_eb_env();
-      CASE_KSTEP_SEL(LX, *eb_sel);
-      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-              NEKO_EB_SEL(LX, *eb_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 2;
     } else {
        sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
        log_error(neko_log_buf);
     }
   }
+
+  /* Geometry of the pinned formulation, if its own variable fixes that too.
+     Both pinned leaves nothing to measure, so the kernel is launched once and
+     reported, which is what pinning has always done */
+  const int pin = (strat == 1) ? ch_pin : (strat == 2) ? eb_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 1:
+      *ch_sel = pin;
+      CASE_1D_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 1 (1D, %d chunk)",
+              NEKO_CHUNKS_SEL(LX, pin));
+      break;
+    default:
+      *eb_sel = pin;
+      CASE_KSTEP_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR() */
+  const bool try_1d = (strat == 0 || strat == 1);
+  const bool try_kstep = (strat == 0 || strat == 2);
 
   HIP_CHECK(hipEventCreate(&start));
   HIP_CHECK(hipEventCreate(&stop));
@@ -232,27 +267,21 @@ int tune_convect_scalar(void *du, void *u,
      resident and the clocks at steady state, or whichever is timed first is
      measured on a colder part */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_1D(LX, 0);
-    CASE_1D(LX, 1);
-    CASE_1D(LX, 2);
-    CASE_1D(LX, 3);
-    CASE_KSTEP(LX, 0);
-    if (sweep) {
-      CASE_KSTEP(LX, 1);
-      CASE_KSTEP(LX, 2);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      CASE_1D_SEL(LX, c);
+    }
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_KSTEP_SEL(LX, c);
     }
   }
 
   /* Interleaved rounds, best time per variant */
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 0, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 1, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 2, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 3, iters);
-    NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      NEKO_TUNE_TIME(time1, CASE_1D_SEL, LX, c, iters);
+    }
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_KSTEP_SEL, LX, c, iters);
     }
   }
 

--- a/src/math/bcknd/device/hip/opr_dudxyz.hip
+++ b/src/math/bcknd/device/hip/opr_dudxyz.hip
@@ -207,10 +207,17 @@ int tune_dudxyz(void *du, void *u,
   int best3 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, one -- the unblocked shape -- when the
+     elements per block sweep is off */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int ch_pin = neko_chunks_pin();
+  const int eb_pin = neko_eb_pin();
+  const int nwf_pin = neko_mfma_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier this returns */
+  int strat = 0;
+  /* Hardware capability, which the explicit NEKO_AUTOTUNE=MFMA pin needs */
   const bool mfma = mfma_lx_supported<LX>() && hip_have_mfma();
-  /* Whether the sweep may pick it on its own, see neko_mfma_sweep() */
-  const bool mfma_tune = mfma && neko_mfma_sweep();
   int best = 0;
   int retval;
 
@@ -241,33 +248,21 @@ int tune_dudxyz(void *du, void *u,
   *ch_sel = 0;
   *nwf_sel = 0;
 
+  /*
+   * NEKO_AUTOTUNE names a formulation, and that is all it does: the sweep
+   * below is narrowed to that one kernel family, but its geometry -- the
+   * chunk size, the elements per block, the wavefronts per block -- is still
+   * measured candidate against candidate. A formulation this build or this
+   * device does not have is reported and ignored, leaving the full sweep.
+   */
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      *ch_sel = neko_chunks_env();
-      CASE_1D_SEL(LX, *ch_sel);
-      sprintf(neko_log_buf,"Set by env   : 1 (1D, %d chunk)",
-              NEKO_CHUNKS_SEL(LX, *ch_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 1;
+      strat = 1;
     } else if( !strcmp(env_value,"KSTEP") ) {
-      *eb_sel = neko_eb_env();
-      CASE_KSTEP_SEL(LX, *eb_sel);
-      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-              NEKO_EB_SEL(LX, *eb_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 2;
     } else if( !strcmp(env_value,"MFMA") ) {
       if (mfma) {
-        const int c = neko_mfma_env();
-        *nwf_sel = c;
-        CASE_MFMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 3 (MFMA, %d wf, %d elem/block)",
-                NEKO_MFMA_NWF(c), NEKO_MFMA_EB(LX, c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 3;
+        strat = 3;
       } else {
         sprintf(neko_log_buf, "MFMA strategy not available for this config");
         log_error(neko_log_buf);
@@ -278,6 +273,51 @@ int tune_dudxyz(void *du, void *u,
     }
   }
 
+  /* Geometry of the pinned formulation, if its own variable fixes that too.
+     Both pinned leaves nothing to measure, so the kernel is launched once and
+     reported, which is what pinning has always done */
+  const int pin = (strat == 1) ? ch_pin : (strat == 2) ? eb_pin :
+                  (strat == 3) ? nwf_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 1:
+      *ch_sel = pin;
+      CASE_1D_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 1 (1D, %d chunk)",
+              NEKO_CHUNKS_SEL(LX, pin));
+      break;
+    case 2:
+      *eb_sel = pin;
+      CASE_KSTEP_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    default:
+      *nwf_sel = pin;
+      CASE_MFMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 3 (MFMA, %d wf, %d elem/block)",
+              NEKO_MFMA_NWF(pin), NEKO_MFMA_EB(LX, pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR(). NEKO_MFMA_TUNE
+     keeps the matrix core variant out of an unpinned sweep, but naming it
+     explicitly still measures it */
+  const bool try_1d = (strat == 0 || strat == 1);
+  const bool try_kstep = (strat == 0 || strat == 2);
+  const bool try_mfma = mfma && ((strat == 3) ||
+                                 (strat == 0 && neko_mfma_sweep()));
+
   HIP_CHECK(hipEventCreate(&start));
   HIP_CHECK(hipEventCreate(&stop));
 
@@ -285,39 +325,27 @@ int tune_dudxyz(void *du, void *u,
      resident and the clocks at steady state, or whichever is timed first is
      measured on a colder part */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_1D(LX, 0);
-    CASE_1D(LX, 1);
-    CASE_1D(LX, 2);
-    CASE_1D(LX, 3);
-    CASE_KSTEP(LX, 0);
-    if (sweep) {
-      CASE_KSTEP(LX, 1);
-      CASE_KSTEP(LX, 2);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      CASE_1D_SEL(LX, c);
     }
-    if (mfma_tune) {
-      CASE_MFMA(LX, 0);
-      CASE_MFMA(LX, 1);
-      CASE_MFMA(LX, 2);
-      CASE_MFMA(LX, 3);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_KSTEP_SEL(LX, c);
+    }
+    NEKO_TUNE_FOR(c, try_mfma, nwf_pin, NEKO_MFMA_CANDIDATES) {
+      CASE_MFMA_SEL(LX, c);
     }
   }
 
   /* Interleaved rounds, best time per variant */
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 0, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 1, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 2, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 3, iters);
-    NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      NEKO_TUNE_TIME(time1, CASE_1D_SEL, LX, c, iters);
     }
-    if (mfma_tune) {
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 2, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 3, iters);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_KSTEP_SEL, LX, c, iters);
+    }
+    NEKO_TUNE_FOR(c, try_mfma, nwf_pin, NEKO_MFMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time3, CASE_MFMA_SEL, LX, c, iters);
     }
   }
 

--- a/src/math/bcknd/device/hip/opr_lambda2.hip
+++ b/src/math/bcknd/device/hip/opr_lambda2.hip
@@ -172,7 +172,14 @@ int tune_lambda2(void *lambda2, void *u, void *v, void *w,
   float time2[NEKO_EB_CANDIDATES];
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, one -- the unblocked shape -- when the
+     elements per block sweep is off */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int ch_pin = neko_chunks_pin();
+  const int eb_pin = neko_eb_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier this returns */
+  int strat = 0;
   int best = 0;
   int retval;
 
@@ -196,28 +203,57 @@ int tune_lambda2(void *lambda2, void *u, void *v, void *w,
   sprintf(neko_log_buf, "Autotune lambda2 (lx: %d)", *lx);
   log_section(neko_log_buf);
   
+  /*
+   * NEKO_AUTOTUNE names a formulation, and that is all it does: the sweep
+   * below is narrowed to that one kernel family, but its geometry -- the
+   * chunk size, the elements per block -- is still measured candidate
+   * against candidate. Fixing the geometry as well takes that formulation's
+   * own variable, NEKO_CHUNKS or NEKO_EB.
+   */
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      *ch_sel = neko_chunks_env();
-      CASE_1D_SEL(LX, *ch_sel);
-      sprintf(neko_log_buf,"Set by env   : 1 (1D, %d chunk)",
-              NEKO_CHUNKS_SEL(LX, *ch_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 1;
+      strat = 1;
     } else if( !strcmp(env_value,"KSTEP") ) {
-      *eb_sel = neko_eb_env();
-      CASE_KSTEP_SEL(LX, *eb_sel);
-      sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-              NEKO_EB_SEL(LX, *eb_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 2;
     } else {       
        sprintf(neko_log_buf, "Invalid value set for NEKO_AUTOTUNE");
        log_error(neko_log_buf);
     }
   }
+
+  /* Geometry of the pinned formulation, if its own variable fixes that too.
+     Both pinned leaves nothing to measure, so the kernel is launched once and
+     reported, which is what pinning has always done */
+  const int pin = (strat == 1) ? ch_pin : (strat == 2) ? eb_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 1:
+      *ch_sel = pin;
+      CASE_1D_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 1 (1D, %d chunk)",
+              NEKO_CHUNKS_SEL(LX, pin));
+      break;
+    default:
+      *eb_sel = pin;
+      CASE_KSTEP_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR() */
+  const bool try_1d = (strat == 0 || strat == 1);
+  const bool try_kstep = (strat == 0 || strat == 2);
 
   HIP_CHECK(hipEventCreate(&start));
   HIP_CHECK(hipEventCreate(&stop));
@@ -225,27 +261,21 @@ int tune_lambda2(void *lambda2, void *u, void *v, void *w,
      resident and the clocks at steady state, or whichever is timed first is
      measured on a colder part */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_1D(LX, 0);
-    CASE_1D(LX, 1);
-    CASE_1D(LX, 2);
-    CASE_1D(LX, 3);
-    CASE_KSTEP(LX, 0);
-    if (sweep) {
-      CASE_KSTEP(LX, 1);
-      CASE_KSTEP(LX, 2);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      CASE_1D_SEL(LX, c);
+    }
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_KSTEP_SEL(LX, c);
     }
   }
 
   /* Interleaved rounds, best time per variant */
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 0, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 1, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 2, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 3, iters);
-    NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      NEKO_TUNE_TIME(time1, CASE_1D_SEL, LX, c, iters);
+    }
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_KSTEP_SEL, LX, c, iters);
     }
   }
 

--- a/src/math/bcknd/device/hip/opr_opgrad.hip
+++ b/src/math/bcknd/device/hip/opr_opgrad.hip
@@ -207,10 +207,17 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
   int best3 = 0;
   const int rounds = neko_tune_rounds();
   const int iters = neko_tune_iters();
-  const int sweep = neko_eb_sweep();
+  /* Candidates of the kstep sweep, one -- the unblocked shape -- when the
+     elements per block sweep is off */
+  const int eb_cand = neko_eb_sweep() ? NEKO_EB_CANDIDATES : 1;
+  /* Geometry pinned by each formulation's own variable, -1 to sweep it */
+  const int ch_pin = neko_chunks_pin();
+  const int eb_pin = neko_eb_pin();
+  const int nwf_pin = neko_mfma_pin();
+  /* Formulation pinned by NEKO_AUTOTUNE, as the identifier this returns */
+  int strat = 0;
+  /* Hardware capability, which the explicit NEKO_AUTOTUNE=MFMA pin needs */
   const bool mfma = mfma_lx_supported<LX>() && hip_have_mfma();
-  /* Whether the sweep may pick it on its own, see neko_mfma_sweep() */
-  const bool mfma_tune = mfma && neko_mfma_sweep();
   int best = 0;
   int retval;
 
@@ -241,36 +248,21 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
   *ch_sel = 0;
   *nwf_sel = 0;
 
+  /*
+   * NEKO_AUTOTUNE names a formulation, and that is all it does: the sweep
+   * below is narrowed to that one kernel family, but its geometry -- the
+   * chunk size, the elements per block, the wavefronts per block -- is still
+   * measured candidate against candidate. A formulation this build or this
+   * device does not have is reported and ignored, leaving the full sweep.
+   */
   if(env_value) {
     if( !strcmp(env_value,"1D") ) {
-      *ch_sel = neko_chunks_env();
-      CASE_1D_SEL(LX, *ch_sel);
-      sprintf(neko_log_buf,"Set by env   : 1 (1D, %d chunk)",
-              NEKO_CHUNKS_SEL(LX, *ch_sel));
-      log_message(neko_log_buf);
-      log_end_section();
-      return 1;
+      strat = 1;
     } else if( !strcmp(env_value,"KSTEP") ) {
-      {
-        const int c = neko_eb_env();
-        *eb_sel = c;
-        CASE_KSTEP_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 2 (KSTEP, %d elem/block)",
-                NEKO_EB_SEL(LX, c));
-      }
-      log_message(neko_log_buf);
-      log_end_section();
-      return 2;
+      strat = 2;
     } else if( !strcmp(env_value,"MFMA") ) {
       if (mfma) {
-        const int c = neko_mfma_env();
-        *nwf_sel = c;
-        CASE_MFMA_SEL(LX, c);
-        sprintf(neko_log_buf,"Set by env   : 3 (MFMA, %d wf, %d elem/block)",
-                NEKO_MFMA_NWF(c), NEKO_MFMA_EB(LX, c));
-        log_message(neko_log_buf);
-        log_end_section();
-        return 3;
+        strat = 3;
       } else {
         sprintf(neko_log_buf, "MFMA strategy not available for this config");
         log_error(neko_log_buf);
@@ -281,6 +273,51 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
     }
   }
 
+  /* Geometry of the pinned formulation, if its own variable fixes that too.
+     Both pinned leaves nothing to measure, so the kernel is launched once and
+     reported, which is what pinning has always done */
+  const int pin = (strat == 1) ? ch_pin : (strat == 2) ? eb_pin :
+                  (strat == 3) ? nwf_pin : -1;
+
+  if (pin >= 0) {
+    switch (strat) {
+    case 1:
+      *ch_sel = pin;
+      CASE_1D_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 1 (1D, %d chunk)",
+              NEKO_CHUNKS_SEL(LX, pin));
+      break;
+    case 2:
+      *eb_sel = pin;
+      CASE_KSTEP_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 2 (KSTEP, %d elem/block)",
+              NEKO_EB_SEL(LX, pin));
+      break;
+    default:
+      *nwf_sel = pin;
+      CASE_MFMA_SEL(LX, pin);
+      sprintf(neko_log_buf, "Set by env   : 3 (MFMA, %d wf, %d elem/block)",
+              NEKO_MFMA_NWF(pin), NEKO_MFMA_EB(LX, pin));
+      break;
+    }
+    log_message(neko_log_buf);
+    log_end_section();
+    return strat;
+  }
+
+  if (strat) {
+    sprintf(neko_log_buf, "Set by env   : %d (%s)", strat, env_value);
+    log_message(neko_log_buf);
+  }
+
+  /* Formulations the sweep considers, see NEKO_TUNE_FOR(). NEKO_MFMA_TUNE
+     keeps the matrix core variant out of an unpinned sweep, but naming it
+     explicitly still measures it */
+  const bool try_1d = (strat == 0 || strat == 1);
+  const bool try_kstep = (strat == 0 || strat == 2);
+  const bool try_mfma = mfma && ((strat == 3) ||
+                                 (strat == 0 && neko_mfma_sweep()));
+
   HIP_CHECK(hipEventCreate(&start));
   HIP_CHECK(hipEventCreate(&stop));
 
@@ -288,39 +325,27 @@ int tune_opgrad(void *ux, void *uy, void *uz, void *u,
      resident and the clocks at steady state, or whichever is timed first is
      measured on a colder part */
   for (int i = 0; i < NEKO_TUNE_WARMUP; i++) {
-    CASE_1D(LX, 0);
-    CASE_1D(LX, 1);
-    CASE_1D(LX, 2);
-    CASE_1D(LX, 3);
-    CASE_KSTEP(LX, 0);
-    if (sweep) {
-      CASE_KSTEP(LX, 1);
-      CASE_KSTEP(LX, 2);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      CASE_1D_SEL(LX, c);
     }
-    if (mfma_tune) {
-      CASE_MFMA(LX, 0);
-      CASE_MFMA(LX, 1);
-      CASE_MFMA(LX, 2);
-      CASE_MFMA(LX, 3);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      CASE_KSTEP_SEL(LX, c);
+    }
+    NEKO_TUNE_FOR(c, try_mfma, nwf_pin, NEKO_MFMA_CANDIDATES) {
+      CASE_MFMA_SEL(LX, c);
     }
   }
 
   /* Interleaved rounds, best time per variant */
   for (int r = 0; r < rounds; r++) {
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 0, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 1, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 2, iters);
-    NEKO_TUNE_TIME(time1, CASE_1D, LX, 3, iters);
-    NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 0, iters);
-    if (sweep) {
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 1, iters);
-      NEKO_TUNE_TIME(time2, CASE_KSTEP, LX, 2, iters);
+    NEKO_TUNE_FOR(c, try_1d, ch_pin, NEKO_CHUNKS_CANDIDATES) {
+      NEKO_TUNE_TIME(time1, CASE_1D_SEL, LX, c, iters);
     }
-    if (mfma_tune) {
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 0, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 1, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 2, iters);
-      NEKO_TUNE_TIME(time3, CASE_MFMA, LX, 3, iters);
+    NEKO_TUNE_FOR(c, try_kstep, eb_pin, eb_cand) {
+      NEKO_TUNE_TIME(time2, CASE_KSTEP_SEL, LX, c, iters);
+    }
+    NEKO_TUNE_FOR(c, try_mfma, nwf_pin, NEKO_MFMA_CANDIDATES) {
+      NEKO_TUNE_TIME(time3, CASE_MFMA_SEL, LX, c, iters);
     }
   }
 


### PR DESCRIPTION
This PR fixes the issue that if a kernel strategy was provided by the environment, each sub variants were not tested (e.g. block sizes or mfma shapes)