### PR TITLE
Use the kstep layout for the coef device kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Develop
 
+- Fixed `too many resources requested for launch` from the CUDA and HIP `coef`
+  kernels, which gave each element 1024 threads. Registers are allocated per
+  block, and at 1024 threads the per-thread count of two of these kernels
+  exceeded the 65536 registers a block can be given: 70 at `lx = 2` in the
+  area and normal kernel, which the coarsest level of the HSMG pressure
+  preconditioner reaches whatever the case's polynomial order is, and 126 at
+  `lx = 16` in the `dxyz` kernel. The three per-element `coef` kernels now use
+  the kstep layout of the SEM operator kernels, one (`lx`,`lx`) thread plane
+  per element with several elements stacked per block, which holds a block at
+  or below 256 threads for every supported order.
 - Added a coupled CPU BiCGStab solver for three-component vector systems.
 - The gather-scatter comm. backend autotuning now covers the device-resident
   backends. With `NEKO_GS_COMM` unset, a CUDA or HIP build benchmarks

--- a/src/sem/bcknd/device/cuda/coef.cu
+++ b/src/sem/bcknd/device/cuda/coef.cu
@@ -50,20 +50,18 @@ extern "C" {
                               void *jacinv, void *w3, int *nel,
                               int *lx, int *gdim) {
 
-    const dim3 nthrds(1024, 1, 1);
-    const dim3 nblcks((*nel), 1, 1);
     const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
 #define GEO_CASE(LX)                                                            \
     case LX:                                                                    \
-      coef_generate_geo_kernel<real, LX, 1024>                                  \
-        <<<nblcks, nthrds, 0, stream>>>                                         \
+      coef_generate_geo_kernel<real, LX, COEF_EB(LX)>                           \
+        <<<COEF_EB_NBLCKS(*nel, LX), COEF_EB_NTHRDS(LX), 0, stream>>>           \
         ((real *) G11, (real *) G12, (real *) G13,                              \
          (real *) G22, (real *) G23, (real *) G33,                              \
          (real *) drdx, (real *) drdy, (real *) drdz,                           \
          (real *) dsdx, (real *) dsdy, (real *) dsdz,                           \
          (real *) dtdx, (real *) dtdy, (real *) dtdz,                           \
-         (real *) jacinv, (real *) w3, *gdim);                                  \
+         (real *) jacinv, (real *) w3, *nel, *gdim);                            \
       CUDA_CHECK(cudaGetLastError());                                           \
       break
 
@@ -107,19 +105,18 @@ extern "C" {
 
     const int n = (*nel) * (*lx) * (*lx) * (*lx);
     const dim3 nthrds(1024, 1, 1);
-    const dim3 nblcks_dxyz((*nel), 1, 1);
     const dim3 nblcks_drst((n + 1024 - 1)/ 1024, 1, 1);
     const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
 #define DXYZDRST_CASE(LX)					               \
     case LX:								       \
-      coef_generate_dxyz_kernel<real, LX, 1024>                                \
-	<<<nblcks_dxyz, nthrds, 0, stream>>>                                   \
+      coef_generate_dxyz_kernel<real, LX, COEF_EB(LX)>                         \
+	<<<COEF_EB_NBLCKS(*nel, LX), COEF_EB_NTHRDS(LX), 0, stream>>>          \
         ((real *) dxdr, (real *) dydr, (real *) dzdr,                          \
          (real *) dxds, (real *) dyds, (real *) dzds,                          \
          (real *) dxdt, (real *) dydt, (real *) dzdt,                          \
          (real *) dx, (real *) dy, (real *) dz,                                \
-         (real *) x, (real *) y, (real *) z);                                  \
+         (real *) x, (real *) y, (real *) z, *nel);                            \
       CUDA_CHECK(cudaGetLastError());					       \
       break
 
@@ -190,19 +187,17 @@ extern "C" {
                                           void *wx, void *wy, void *wz,
                                           int *lx, int *nel, real eps) {
 
-    const dim3 nblcks((*nel), 1, 1);
-    const dim3 nthrds(1024, 1, 1);
     const cudaStream_t stream = (cudaStream_t) glb_cmd_queue;
 
 #define AREA_CASE(LX)                                                           \
     case LX:                                                                    \
-      coef_generate_area_and_normal_kernel<real, LX>                            \
-          <<<nblcks, nthrds, 0, stream>>>                                       \
+      coef_generate_area_and_normal_kernel<real, LX, COEF_EB(LX)>               \
+          <<<COEF_EB_NBLCKS(*nel, LX), COEF_EB_NTHRDS(LX), 0, stream>>>         \
           ((real *) area, (real *) nx, (real *) ny, (real *) nz,                \
            (real *) dxdr, (real *) dydr, (real *) dzdr,                         \
            (real *) dxds, (real *) dyds, (real *) dzds,                         \
            (real *) dxdt, (real *) dydt, (real *) dzdt,                         \
-           (real *) wx, (real *) wy, (real *) wz, eps);                         \
+           (real *) wx, (real *) wy, (real *) wz, eps, *nel);                   \
       CUDA_CHECK(cudaGetLastError());                                           \
       break
 

--- a/src/sem/bcknd/device/cuda/coef_kernel.h
+++ b/src/sem/bcknd/device/cuda/coef_kernel.h
@@ -34,200 +34,238 @@
  POSSIBILITY OF SUCH DAMAGE.
 */
 
+/*
+ * Elements per thread block for the coef kstep kernels
+ *
+ * A kstep kernel gives one (LX,LX) thread plane to an element and walks the
+ * element in k, so a block holds LX*LX*EB threads for the EB elements stacked
+ * along threadIdx.z. This replaces the earlier layout of 1024 threads per
+ * element, under which the product of block size and per thread register count
+ * could exceed the 65536 registers a block can be given. Built for sm_120 with
+ * nvcc 13 in double precision, the area and normal kernel takes 70 registers
+ * per thread at LX = 2 and the dxyz kernel 126 at LX = 16, so at 1024 threads
+ * both failed to launch with "too many resources requested for launch".
+ *
+ * EB is fixed at compile time rather than tuned. The SEM operator kernels pick
+ * theirs with an autotuner (see math/bcknd/device/cuda/elem_block.h), but the
+ * coef kernels run once per mesh, and once per step only when the mesh moves,
+ * so there is nothing for a tuning sweep to amortise against. Taking the
+ * largest power of two that keeps a block at or below
+ * COEF_EB_MAX_BLOCK_THREADS threads puts every LX in 2..16 between 64 and 256
+ * threads per block.
+ */
+#define COEF_EB_MAX_BLOCK_THREADS 256
+
+template< int LX >
+struct coef_elem_block {
+  static const int raw = COEF_EB_MAX_BLOCK_THREADS / (LX * LX);
+  static const int value = (raw >= 16) ? 16 : (raw >= 8) ? 8 :
+                           (raw >= 4) ? 4 : (raw >= 2) ? 2 : 1;
+};
+
+#define COEF_EB(LX) (coef_elem_block<LX>::value)
+#define COEF_EB_NTHRDS(LX) dim3((LX), (LX), COEF_EB(LX))
+#define COEF_EB_NBLCKS(NELV, LX)                                               \
+  dim3(((NELV) + COEF_EB(LX) - 1) / COEF_EB(LX), 1, 1)
+
 /**
  * Device kernel for coef geometry
+ *
+ * Each thread owns one (i,j) column of an element and walks it in k. The
+ * quadrature weights w3 are the same for every element, so they are read from
+ * global memory at the point where they are applied; the earlier version
+ * staged them in a LX*LX*LX shared array and wrote G11..G33 twice, once
+ * without the weight and once with it.
  */
-template< typename T, const int LX, const int CHUNKS >
-__global__ void coef_generate_geo_kernel(T * __restrict__ G11,
-					 T * __restrict__ G12,
-					 T * __restrict__ G13,
-					 T * __restrict__ G22,
-					 T * __restrict__ G23,
-					 T * __restrict__ G33,
-					 const T * __restrict__ drdx,
-					 const T * __restrict__ drdy,
-					 const T * __restrict__ drdz,
-					 const T * __restrict__ dsdx,
-					 const T * __restrict__ dsdy,
-					 const T * __restrict__ dsdz,
-					 const T * __restrict__ dtdx,
-					 const T * __restrict__ dtdy,
-					 const T * __restrict__ dtdz,
-					 const T * __restrict__ jacinv,
-					 const T * __restrict__ w3,
-					 const int gdim) {
+template< typename T, const int LX, const int EB >
+__global__ void __launch_bounds__(LX * LX * EB)
+coef_generate_geo_kernel(T * __restrict__ G11,
+                         T * __restrict__ G12,
+                         T * __restrict__ G13,
+                         T * __restrict__ G22,
+                         T * __restrict__ G23,
+                         T * __restrict__ G33,
+                         const T * __restrict__ drdx,
+                         const T * __restrict__ drdy,
+                         const T * __restrict__ drdz,
+                         const T * __restrict__ dsdx,
+                         const T * __restrict__ dsdy,
+                         const T * __restrict__ dsdz,
+                         const T * __restrict__ dtdx,
+                         const T * __restrict__ dtdy,
+                         const T * __restrict__ dtdz,
+                         const T * __restrict__ jacinv,
+                         const T * __restrict__ w3,
+                         const int nelv,
+                         const int gdim) {
 
-  int i,j,k;
+  const int e = blockIdx.x * EB + ((EB == 1) ? 0 : threadIdx.z);
 
-  const int e = blockIdx.x;
-  const int iii = threadIdx.x;
-  const int nchunks = (LX * LX * LX - 1) / CHUNKS + 1;
+  /* The kernel has no barriers, so the threads of a partially filled tail
+     block can simply leave */
+  if (e >= nelv) {
+    return;
+  }
 
-  __shared__ T shw3[LX * LX * LX];
+  const int ij = threadIdx.x + threadIdx.y * LX;
+  const int ele = e * LX * LX * LX;
 
-  j = iii;
-  while( j < (LX * LX * LX)) {
-    const int i = j + e * LX * LX * LX;
-    G11[i] = (drdx[i]*drdx[i] + drdy[i]*drdy[i] + drdz[i]*drdz[i]) * jacinv[i];
-    G22[i] = (dsdx[i]*dsdx[i] + dsdy[i]*dsdy[i] + dsdz[i]*dsdz[i]) * jacinv[i];
-    G33[i] = (dtdx[i]*dtdx[i] + dtdy[i]*dtdy[i] + dtdz[i]*dtdz[i]) * jacinv[i];
+#pragma unroll
+  for (int k = 0; k < LX; ++k) {
+    const int ijk = ij + k * LX * LX;
+    const int idx = ijk + ele;
 
-    G12[i] = (drdx[i]*dsdx[i] + drdy[i]*dsdy[i] + drdz[i]*dsdz[i]) * jacinv[i];
-    G13[i] = (drdx[i]*dtdx[i] + drdy[i]*dtdy[i] + drdz[i]*dtdz[i]) * jacinv[i];
-    G23[i] = (dsdx[i]*dtdx[i] + dsdy[i]*dtdy[i] + dsdz[i]*dtdz[i]) * jacinv[i];
+    const T w = w3[ijk];
+    const T jinv = jacinv[idx];
 
-    shw3[j] = w3[j];
+    const T rx = drdx[idx];
+    const T ry = drdy[idx];
+    const T rz = drdz[idx];
+    const T sx = dsdx[idx];
+    const T sy = dsdy[idx];
+    const T sz = dsdz[idx];
+    const T tx = dtdx[idx];
+    const T ty = dtdy[idx];
+    const T tz = dtdz[idx];
 
-    j = j + CHUNKS;
+    G11[idx] = (rx*rx + ry*ry + rz*rz) * jinv * w;
+    G22[idx] = (sx*sx + sy*sy + sz*sz) * jinv * w;
+    G33[idx] = (tx*tx + ty*ty + tz*tz) * jinv * w;
+
+    G12[idx] = (rx*sx + ry*sy + rz*sz) * jinv * w;
+    G13[idx] = (rx*tx + ry*ty + rz*tz) * jinv * w;
+    G23[idx] = (sx*tx + sy*ty + sz*tz) * jinv * w;
+  }
+}
+
+/**
+ * Compute the r, s and t derivatives of one coordinate of an element
+ *
+ * Called once per coordinate by coef_generate_dxyz_kernel with the thread
+ * layout of that kernel: the caller's thread owns the (i,j) column given by
+ * ij, sh is the offset of the calling element's plane in shu, and ele is the
+ * offset of the element in the coordinate and derivative arrays. Threads of a
+ * partially filled tail block have active false; they still take part in the
+ * barriers and only their stores are dropped.
+ */
+template< typename T, const int LX >
+__device__ inline void coef_dxyz_component(T * __restrict__ dudr,
+                                           T * __restrict__ duds,
+                                           T * __restrict__ dudt,
+                                           const T * __restrict__ u,
+                                           T * shu,
+                                           const T * shdx,
+                                           const T * shdy,
+                                           const T * shdz,
+                                           const int i,
+                                           const int j,
+                                           const int sh,
+                                           const int ele,
+                                           const bool active) {
+  const int ij = i + j * LX;
+  T ru[LX];
+
+#pragma unroll LX
+  for (int k = 0; k < LX; ++k) {
+    ru[k] = u[ij + k * LX * LX + ele];
   }
 
   __syncthreads();
 
-  for (int n = 0; n < nchunks; n++) {
-    const int ijk = iii + n * CHUNKS;
-    const int jk = ijk / LX;
-    i = ijk - jk * LX;
-    k = jk / LX;
-    j = jk - k * LX;
-    if ( i < LX && j < LX && k < LX) {
-      G11[ijk + e * LX * LX * LX] *= shw3[ijk];
-      G12[ijk + e * LX * LX * LX] *= shw3[ijk];
-      G13[ijk + e * LX * LX * LX] *= shw3[ijk];
-      G22[ijk + e * LX * LX * LX] *= shw3[ijk];
-      G23[ijk + e * LX * LX * LX] *= shw3[ijk];
-      G33[ijk + e * LX * LX * LX] *= shw3[ijk];
+#pragma unroll
+  for (int k = 0; k < LX; ++k) {
+    const int ijk = ij + k * LX * LX;
+
+    /* The t derivative runs along the column this thread holds in ru */
+    T ttmp = 0.0;
+    shu[sh + ij] = ru[k];
+#pragma unroll
+    for (int l = 0; l < LX; l++) {
+      ttmp += shdz[k + l * LX] * ru[l];
     }
+
+    __syncthreads();
+
+    /* The r and s derivatives run along the k plane now in shu */
+    T rtmp = 0.0;
+    T stmp = 0.0;
+#pragma unroll
+    for (int l = 0; l < LX; l++) {
+      rtmp += shdx[i + l * LX] * shu[sh + l + j * LX];
+      stmp += shdy[j + l * LX] * shu[sh + i + l * LX];
+    }
+
+    if (active) {
+      dudr[ijk + ele] = rtmp;
+      duds[ijk + ele] = stmp;
+      dudt[ijk + ele] = ttmp;
+    }
+
+    __syncthreads();
   }
 }
 
 /**
  * Device kernel for coef dxyz
+ *
+ * Each thread owns one (i,j) column of an element and walks it in k, holding
+ * the column of the coordinate being differentiated in registers for the t
+ * derivative and staging one k plane of it in shared memory for the r and s
+ * derivatives. The three coordinates are taken in turn through the same
+ * shared plane.
  */
-template< typename T, const int LX, const int CHUNKS >
-__global__ void coef_generate_dxyz_kernel(T * __restrict__ dxdr,
-					  T * __restrict__ dydr,
-					  T * __restrict__ dzdr,
-					  T * __restrict__ dxds,
-					  T * __restrict__ dyds,
-					  T * __restrict__ dzds,
-					  T * __restrict__ dxdt,
-					  T * __restrict__ dydt,
-					  T * __restrict__ dzdt,
-					  const T * __restrict__ dx,
-					  const T * __restrict__ dy,
-					  const T * __restrict__ dz,
-					  const T * __restrict__ x,
-					  const T * __restrict__ y,
-					  const T * __restrict__ z) {
+template< typename T, const int LX, const int EB >
+__global__ void __launch_bounds__(LX * LX * EB)
+coef_generate_dxyz_kernel(T * __restrict__ dxdr,
+                          T * __restrict__ dydr,
+                          T * __restrict__ dzdr,
+                          T * __restrict__ dxds,
+                          T * __restrict__ dyds,
+                          T * __restrict__ dzds,
+                          T * __restrict__ dxdt,
+                          T * __restrict__ dydt,
+                          T * __restrict__ dzdt,
+                          const T * __restrict__ dx,
+                          const T * __restrict__ dy,
+                          const T * __restrict__ dz,
+                          const T * __restrict__ x,
+                          const T * __restrict__ y,
+                          const T * __restrict__ z,
+                          const int nelv) {
 
-  int i,j,k;
-
-  const int e = blockIdx.x;
-  const int iii = threadIdx.x;
-  const int nchunks = (LX * LX * LX - 1) / CHUNKS + 1;
-
+  /* Element independent, one copy per block */
   __shared__ T shdx[LX * LX];
   __shared__ T shdy[LX * LX];
   __shared__ T shdz[LX * LX];
 
-  __shared__ T shu[LX * LX * LX];
+  /* One k plane per element in the block */
+  __shared__ T shu[EB * LX * LX];
 
-  if (iii < (LX * LX)) {
-    shdx[iii] = dx[iii];
-    shdy[iii] = dy[iii];
-    shdz[iii] = dz[iii];
+  const int eb = (EB == 1) ? 0 : threadIdx.z;
+  const int e_blk = blockIdx.x * EB + eb;
+  /* Threads past the last element still have to reach the barriers in the k
+     loop, so clamp their reads and drop their stores rather than returning
+     early. At EB == 1 this all constant folds away */
+  const bool active = (EB == 1) ? true : (e_blk < nelv);
+  const int e = active ? e_blk : (nelv - 1);
+  const int sh = eb * LX * LX;
+  const int i = threadIdx.x;
+  const int j = threadIdx.y;
+  const int ij = i + j * LX;
+  const int ele = e * LX * LX * LX;
+
+  if (eb == 0) {
+    shdx[ij] = dx[ij];
+    shdy[ij] = dy[ij];
+    shdz[ij] = dz[ij];
   }
 
-  j = iii;
-  while(j < (LX * LX * LX)) {
-    shu[j] = x[j + e * LX * LX * LX];
-    j = j + CHUNKS;
-  }
-
-  __syncthreads();
-
-  for (int n = 0; n < nchunks; n++) {
-    const int ijk = iii + n * CHUNKS;
-    const int jk = ijk / LX;
-    i = ijk - jk * LX;
-    k = jk / LX;
-    j = jk - k * LX;
-    if ( i < LX && j < LX && k < LX) {
-      T rtmp = 0.0;
-      T stmp = 0.0;
-      T ttmp = 0.0;
-      for (int l = 0; l < LX; l++) {
-	rtmp += shdx[i + l * LX] * shu[l + j * LX + k * LX * LX];
-	stmp += shdy[j + l * LX] * shu[i + l * LX + k * LX * LX];
-	ttmp += shdz[k + l * LX] * shu[i + j * LX + l * LX * LX];
-      }
-      dxdr[ijk + e * LX * LX * LX] = rtmp;
-      dxds[ijk + e * LX * LX * LX] = stmp;
-      dxdt[ijk + e * LX * LX * LX] = ttmp;
-    }
-  }
-
-  __syncthreads();
-
-  j = iii;
-  while(j < (LX * LX * LX)) {
-    shu[j] = y[j + e * LX * LX * LX];
-    j = j + CHUNKS;
-  }
-
-  __syncthreads();
-
-  for (int n = 0; n < nchunks; n++) {
-    const int ijk = iii + n * CHUNKS;
-    const int jk = ijk / LX;
-    i = ijk - jk * LX;
-    k = jk / LX;
-    j = jk - k * LX;
-    if ( i < LX && j < LX && k < LX) {
-      T rtmp = 0.0;
-      T stmp = 0.0;
-      T ttmp = 0.0;
-      for (int l = 0; l < LX; l++) {
-	rtmp += shdx[i + l * LX] * shu[l + j * LX + k * LX * LX];
-	stmp += shdy[j + l * LX] * shu[i + l * LX + k * LX * LX];
-	ttmp += shdz[k + l * LX] * shu[i + j * LX + l * LX * LX];
-      }
-      dydr[ijk + e * LX * LX * LX] = rtmp;
-      dyds[ijk + e * LX * LX * LX] = stmp;
-      dydt[ijk + e * LX * LX * LX] = ttmp;
-    }
-  }
-
-  __syncthreads();
-
-  j = iii;
-  while(j < (LX * LX * LX)) {
-    shu[j] = z[j + e * LX * LX * LX];
-    j = j + CHUNKS;
-  }
-
-  __syncthreads();
-
-  for (int n = 0; n < nchunks; n++) {
-    const int ijk = iii + n * CHUNKS;
-    const int jk = ijk / LX;
-    i = ijk - jk * LX;
-    k = jk / LX;
-    j = jk - k * LX;
-    if ( i < LX && j < LX && k < LX) {
-      T rtmp = 0.0;
-      T stmp = 0.0;
-      T ttmp = 0.0;
-      for (int l = 0; l < LX; l++) {
-	rtmp += shdx[i + l * LX] * shu[l + j * LX + k * LX * LX];
-	stmp += shdy[j + l * LX] * shu[i + l * LX + k * LX * LX];
-	ttmp += shdz[k + l * LX] * shu[i + j * LX + l * LX * LX];
-      }
-      dzdr[ijk + e * LX * LX * LX] = rtmp;
-      dzds[ijk + e * LX * LX * LX] = stmp;
-      dzdt[ijk + e * LX * LX * LX] = ttmp;
-    }
-  }
+  coef_dxyz_component<T, LX>(dxdr, dxds, dxdt, x,
+                             shu, shdx, shdy, shdz, i, j, sh, ele, active);
+  coef_dxyz_component<T, LX>(dydr, dyds, dydt, y,
+                             shu, shdx, shdy, shdz, i, j, sh, ele, active);
+  coef_dxyz_component<T, LX>(dzdr, dzds, dzdt, z,
+                             shu, shdx, shdy, shdz, i, j, sh, ele, active);
 }
 
 /**
@@ -308,47 +346,58 @@ __global__ void coef_generate_mass_kernel(T * __restrict__ B,
 
 /**
  * Device kernel for coef_generate_area_and_normal
+ *
+ * Each thread owns one (i,j) column of an element and walks it in k, writing
+ * the facet entries its column lands on: the r facets 0 and 1 when i is 0 or
+ * LX-1, the s facets 2 and 3 when j is, and the t facets 4 and 5 when k is.
  */
-template< typename T, const int LX >
-__global__
-void coef_generate_area_and_normal_kernel(T * __restrict__ area,
-                                          T * __restrict__ nx,
-                                          T * __restrict__ ny,
-                                          T * __restrict__ nz,
-                                          const T * __restrict__ dxdr,
-                                          const T * __restrict__ dydr,
-                                          const T * __restrict__ dzdr,
-                                          const T * __restrict__ dxds,
-                                          const T * __restrict__ dyds,
-                                          const T * __restrict__ dzds,
-                                          const T * __restrict__ dxdt,
-                                          const T * __restrict__ dydt,
-                                          const T * __restrict__ dzdt,
-                                          const T * __restrict__ wx,
-                                          const T * __restrict__ wy,
-                                          const T * __restrict__ wz,
-                                          const T eps) {
-  int i, j, k;
+template< typename T, const int LX, const int EB >
+__global__ void __launch_bounds__(LX * LX * EB)
+coef_generate_area_and_normal_kernel(T * __restrict__ area,
+                                     T * __restrict__ nx,
+                                     T * __restrict__ ny,
+                                     T * __restrict__ nz,
+                                     const T * __restrict__ dxdr,
+                                     const T * __restrict__ dydr,
+                                     const T * __restrict__ dzdr,
+                                     const T * __restrict__ dxds,
+                                     const T * __restrict__ dyds,
+                                     const T * __restrict__ dzds,
+                                     const T * __restrict__ dxdt,
+                                     const T * __restrict__ dydt,
+                                     const T * __restrict__ dzdt,
+                                     const T * __restrict__ wx,
+                                     const T * __restrict__ wy,
+                                     const T * __restrict__ wz,
+                                     const T eps,
+                                     const int nelv) {
   int f, out_idx;
   const T one = 1.0;
   const T m_one = -1.0;
   T tx, ty, tz, dot, weight, length, sgn;
 
-  const int e = blockIdx.x;
-  const int iii = threadIdx.x;
+  const int e = blockIdx.x * EB + ((EB == 1) ? 0 : threadIdx.z);
+
+  /* The kernel has no barriers, so the threads of a partially filled tail
+     block can simply leave */
+  if (e >= nelv) {
+    return;
+  }
+
+  const int i = threadIdx.x;
+  const int j = threadIdx.y;
 
   const int lxyz = LX * LX * LX;
   const int lxy = LX * LX;
 
-  for (int ijk = iii; ijk < lxyz; ijk += blockDim.x) {
+  const int face_offset = e * lxy * 6;
+  const T wxi = wx[i];
+  const T wyj = wy[j];
 
-    const int jk = ijk / LX;
-    i = ijk - jk * LX;
-    k = jk / LX;
-    j = jk - k * LX;
+  for (int k = 0; k < LX; ++k) {
 
+    const int ijk = i + (j * LX) + (k * lxy);
     const int offset = ijk + (e * lxyz);
-    const int face_offset = e * lxy * 6;
 
     // ds x dt
     if (i == 0 || i == LX - 1) {
@@ -358,7 +407,7 @@ void coef_generate_area_and_normal_kernel(T * __restrict__ area,
 
       dot = tx*tx + ty*ty + tz*tz;
       length = sqrt(dot);
-      weight = wy[j] * wz[k];
+      weight = wyj * wz[k];
 
       if (i == 0) {
         f = 0;
@@ -391,7 +440,7 @@ void coef_generate_area_and_normal_kernel(T * __restrict__ area,
 
       dot = tx*tx + ty*ty + tz*tz;
       length = sqrt(dot);
-      weight = wx[i] * wz[k];
+      weight = wxi * wz[k];
 
       if (j == 0) {
         f = 2;
@@ -424,7 +473,7 @@ void coef_generate_area_and_normal_kernel(T * __restrict__ area,
 
       dot = tx*tx + ty*ty + tz*tz;
       length = sqrt(dot);
-      weight = wx[i] * wy[j];
+      weight = wxi * wyj;
 
       if (k == 0) {
         f = 4;
@@ -450,6 +499,7 @@ void coef_generate_area_and_normal_kernel(T * __restrict__ area,
     }
   }
 }
+
 
 
 template< typename T >

--- a/src/sem/bcknd/device/hip/coef.hip
+++ b/src/sem/bcknd/device/hip/coef.hip
@@ -51,20 +51,19 @@ extern "C" {
                              void *jacinv, void *w3, int *nel,
                              int *lx, int *gdim) {
 
-    const dim3 nthrds(1024, 1, 1);
-    const dim3 nblcks((*nel), 1, 1);
-
 #define GEO_CASE(LX)                                                            \
     case LX:                                                                    \
       hipLaunchKernelGGL(                                                       \
-               HIP_KERNEL_NAME(coef_generate_geo_kernel<real, LX, 1024>),       \
-               nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,                  \
+               HIP_KERNEL_NAME(coef_generate_geo_kernel<real, LX,               \
+                                                        COEF_EB(LX)>),          \
+               COEF_EB_NBLCKS(*nel, LX), COEF_EB_NTHRDS(LX), 0,                 \
+               (hipStream_t) glb_cmd_queue,                                     \
                (real *) G11, (real *) G12, (real *) G13,                        \
                (real *) G22, (real *) G23, (real *) G33,                        \
                (real *) drdx, (real *) drdy, (real *) drdz,                     \
                (real *) dsdx, (real *) dsdy, (real *) dsdz,                     \
                (real *) dtdx, (real *) dtdy, (real *) dtdz,                     \
-               (real *) jacinv, (real *) w3, *gdim);                            \
+               (real *) jacinv, (real *) w3, *nel, *gdim);                      \
       HIP_CHECK(hipGetLastError());                                             \
       break
 
@@ -108,19 +107,20 @@ extern "C" {
 
     const int n = (*nel) * (*lx) * (*lx) * (*lx);
     const dim3 nthrds(1024, 1, 1);
-    const dim3 nblcks_dxyz((*nel), 1, 1);
     const dim3 nblcks_drst((n + 1024 - 1)/ 1024, 1, 1);
 
 #define DXYZDRST_CASE(LX)					               \
     case LX:								       \
       hipLaunchKernelGGL(						       \
-               HIP_KERNEL_NAME(coef_generate_dxyz_kernel<real, LX, 1024>),     \
-	       nblcks_dxyz, nthrds, 0, (hipStream_t) glb_cmd_queue,	       \
+               HIP_KERNEL_NAME(coef_generate_dxyz_kernel<real, LX,         \
+                                                         COEF_EB(LX)>),        \
+	       COEF_EB_NBLCKS(*nel, LX), COEF_EB_NTHRDS(LX), 0,		       \
+	       (hipStream_t) glb_cmd_queue,				       \
   	       (real *) dxdr, (real *) dydr, (real *) dzdr,		       \
 	       (real *) dxds, (real *) dyds, (real *) dzds,		       \
 	       (real *) dxdt, (real *) dydt, (real *) dzdt,		       \
 	       (real *) dx, (real *) dy, (real *) dz,			       \
-	       (real *) x, (real *) y, (real *) z);			       \
+	       (real *) x, (real *) y, (real *) z, *nel);		       \
       HIP_CHECK(hipGetLastError());					       \
       break
 
@@ -190,19 +190,18 @@ extern "C" {
                                          void *wx, void *wy, void *wz,
                                          int *lx, int *nel, real eps) {
 
-    const dim3 nblcks((*nel), 1, 1);
-    const dim3 nthrds(1024, 1, 1);
-
 #define AREA_CASE(LX)                                                        \
     case LX:                                                                 \
       hipLaunchKernelGGL(                                                    \
-           HIP_KERNEL_NAME(coef_generate_area_and_normal_kernel<real, LX>),  \
-           nblcks, nthrds, 0, (hipStream_t) glb_cmd_queue,                   \
+           HIP_KERNEL_NAME(coef_generate_area_and_normal_kernel<real, LX,    \
+                                                               COEF_EB(LX)>),\
+           COEF_EB_NBLCKS(*nel, LX), COEF_EB_NTHRDS(LX), 0,                  \
+           (hipStream_t) glb_cmd_queue,                                      \
            (real *) area, (real *) nx, (real *) ny, (real *) nz,             \
            (real *) dxdr, (real *) dydr, (real *) dzdr,                      \
            (real *) dxds, (real *) dyds, (real *) dzds,                      \
            (real *) dxdt, (real *) dydt, (real *) dzdt,                      \
-           (real *) wx, (real *) wy, (real *) wz, eps);                      \
+           (real *) wx, (real *) wy, (real *) wz, eps, *nel);                \
       HIP_CHECK(hipGetLastError());                                          \
       break
 

--- a/src/sem/bcknd/device/hip/coef_kernel.h
+++ b/src/sem/bcknd/device/hip/coef_kernel.h
@@ -34,200 +34,238 @@
  POSSIBILITY OF SUCH DAMAGE.
 */
 
+/*
+ * Elements per thread block for the coef kstep kernels
+ *
+ * A kstep kernel gives one (LX,LX) thread plane to an element and walks the
+ * element in k, so a block holds LX*LX*EB threads for the EB elements stacked
+ * along threadIdx.z. This replaces the earlier layout of 1024 threads per
+ * element, under which the product of block size and per thread register count
+ * could exceed the 65536 registers a block can be given. Built for sm_120 with
+ * nvcc 13 in double precision, the area and normal kernel takes 70 registers
+ * per thread at LX = 2 and the dxyz kernel 126 at LX = 16, so at 1024 threads
+ * both failed to launch with "too many resources requested for launch".
+ *
+ * EB is fixed at compile time rather than tuned. The SEM operator kernels pick
+ * theirs with an autotuner (see math/bcknd/device/hip/elem_block.h), but the
+ * coef kernels run once per mesh, and once per step only when the mesh moves,
+ * so there is nothing for a tuning sweep to amortise against. Taking the
+ * largest power of two that keeps a block at or below
+ * COEF_EB_MAX_BLOCK_THREADS threads puts every LX in 2..16 between 64 and 256
+ * threads per block.
+ */
+#define COEF_EB_MAX_BLOCK_THREADS 256
+
+template< int LX >
+struct coef_elem_block {
+  static const int raw = COEF_EB_MAX_BLOCK_THREADS / (LX * LX);
+  static const int value = (raw >= 16) ? 16 : (raw >= 8) ? 8 :
+                           (raw >= 4) ? 4 : (raw >= 2) ? 2 : 1;
+};
+
+#define COEF_EB(LX) (coef_elem_block<LX>::value)
+#define COEF_EB_NTHRDS(LX) dim3((LX), (LX), COEF_EB(LX))
+#define COEF_EB_NBLCKS(NELV, LX)                                               \
+  dim3(((NELV) + COEF_EB(LX) - 1) / COEF_EB(LX), 1, 1)
+
 /**
  * Device kernel for coef geometry
+ *
+ * Each thread owns one (i,j) column of an element and walks it in k. The
+ * quadrature weights w3 are the same for every element, so they are read from
+ * global memory at the point where they are applied; the earlier version
+ * staged them in a LX*LX*LX shared array and wrote G11..G33 twice, once
+ * without the weight and once with it.
  */
-template< typename T, const int LX, const int CHUNKS >
-__global__ void coef_generate_geo_kernel(T * __restrict__ G11,
-					 T * __restrict__ G12,
-					 T * __restrict__ G13,
-					 T * __restrict__ G22,
-					 T * __restrict__ G23,
-					 T * __restrict__ G33,
-					 const T * __restrict__ drdx,
-					 const T * __restrict__ drdy,
-					 const T * __restrict__ drdz,
-					 const T * __restrict__ dsdx,
-					 const T * __restrict__ dsdy,
-					 const T * __restrict__ dsdz,
-					 const T * __restrict__ dtdx,
-					 const T * __restrict__ dtdy,
-					 const T * __restrict__ dtdz,
-					 const T * __restrict__ jacinv,
-					 const T * __restrict__ w3,
-					 const int gdim) {
+template< typename T, const int LX, const int EB >
+__global__ void __launch_bounds__(LX * LX * EB)
+coef_generate_geo_kernel(T * __restrict__ G11,
+                         T * __restrict__ G12,
+                         T * __restrict__ G13,
+                         T * __restrict__ G22,
+                         T * __restrict__ G23,
+                         T * __restrict__ G33,
+                         const T * __restrict__ drdx,
+                         const T * __restrict__ drdy,
+                         const T * __restrict__ drdz,
+                         const T * __restrict__ dsdx,
+                         const T * __restrict__ dsdy,
+                         const T * __restrict__ dsdz,
+                         const T * __restrict__ dtdx,
+                         const T * __restrict__ dtdy,
+                         const T * __restrict__ dtdz,
+                         const T * __restrict__ jacinv,
+                         const T * __restrict__ w3,
+                         const int nelv,
+                         const int gdim) {
 
-  int i,j,k;
+  const int e = blockIdx.x * EB + ((EB == 1) ? 0 : threadIdx.z);
 
-  const int e = blockIdx.x;
-  const int iii = threadIdx.x;
-  const int nchunks = (LX * LX * LX - 1) / CHUNKS + 1;
+  /* The kernel has no barriers, so the threads of a partially filled tail
+     block can simply leave */
+  if (e >= nelv) {
+    return;
+  }
 
-  __shared__ T shw3[LX * LX * LX];
+  const int ij = threadIdx.x + threadIdx.y * LX;
+  const int ele = e * LX * LX * LX;
 
-  j = iii;
-  while( j < (LX * LX * LX)) {
-    const int i = j + e * LX * LX * LX;
-    G11[i] = (drdx[i]*drdx[i] + drdy[i]*drdy[i] + drdz[i]*drdz[i]) * jacinv[i];
-    G22[i] = (dsdx[i]*dsdx[i] + dsdy[i]*dsdy[i] + dsdz[i]*dsdz[i]) * jacinv[i];
-    G33[i] = (dtdx[i]*dtdx[i] + dtdy[i]*dtdy[i] + dtdz[i]*dtdz[i]) * jacinv[i];
+#pragma unroll
+  for (int k = 0; k < LX; ++k) {
+    const int ijk = ij + k * LX * LX;
+    const int idx = ijk + ele;
 
-    G12[i] = (drdx[i]*dsdx[i] + drdy[i]*dsdy[i] + drdz[i]*dsdz[i]) * jacinv[i];
-    G13[i] = (drdx[i]*dtdx[i] + drdy[i]*dtdy[i] + drdz[i]*dtdz[i]) * jacinv[i];
-    G23[i] = (dsdx[i]*dtdx[i] + dsdy[i]*dtdy[i] + dsdz[i]*dtdz[i]) * jacinv[i];
+    const T w = w3[ijk];
+    const T jinv = jacinv[idx];
 
-    shw3[j] = w3[j];
+    const T rx = drdx[idx];
+    const T ry = drdy[idx];
+    const T rz = drdz[idx];
+    const T sx = dsdx[idx];
+    const T sy = dsdy[idx];
+    const T sz = dsdz[idx];
+    const T tx = dtdx[idx];
+    const T ty = dtdy[idx];
+    const T tz = dtdz[idx];
 
-    j = j + CHUNKS;
+    G11[idx] = (rx*rx + ry*ry + rz*rz) * jinv * w;
+    G22[idx] = (sx*sx + sy*sy + sz*sz) * jinv * w;
+    G33[idx] = (tx*tx + ty*ty + tz*tz) * jinv * w;
+
+    G12[idx] = (rx*sx + ry*sy + rz*sz) * jinv * w;
+    G13[idx] = (rx*tx + ry*ty + rz*tz) * jinv * w;
+    G23[idx] = (sx*tx + sy*ty + sz*tz) * jinv * w;
+  }
+}
+
+/**
+ * Compute the r, s and t derivatives of one coordinate of an element
+ *
+ * Called once per coordinate by coef_generate_dxyz_kernel with the thread
+ * layout of that kernel: the caller's thread owns the (i,j) column given by
+ * ij, sh is the offset of the calling element's plane in shu, and ele is the
+ * offset of the element in the coordinate and derivative arrays. Threads of a
+ * partially filled tail block have active false; they still take part in the
+ * barriers and only their stores are dropped.
+ */
+template< typename T, const int LX >
+__device__ inline void coef_dxyz_component(T * __restrict__ dudr,
+                                           T * __restrict__ duds,
+                                           T * __restrict__ dudt,
+                                           const T * __restrict__ u,
+                                           T * shu,
+                                           const T * shdx,
+                                           const T * shdy,
+                                           const T * shdz,
+                                           const int i,
+                                           const int j,
+                                           const int sh,
+                                           const int ele,
+                                           const bool active) {
+  const int ij = i + j * LX;
+  T ru[LX];
+
+#pragma unroll LX
+  for (int k = 0; k < LX; ++k) {
+    ru[k] = u[ij + k * LX * LX + ele];
   }
 
   __syncthreads();
 
-  for (int n = 0; n < nchunks; n++) {
-    const int ijk = iii + n * CHUNKS;
-    const int jk = ijk / LX;
-    i = ijk - jk * LX;
-    k = jk / LX;
-    j = jk - k * LX;
-    if ( i < LX && j < LX && k < LX) {
-      G11[ijk + e * LX * LX * LX] *= shw3[ijk];
-      G12[ijk + e * LX * LX * LX] *= shw3[ijk];
-      G13[ijk + e * LX * LX * LX] *= shw3[ijk];
-      G22[ijk + e * LX * LX * LX] *= shw3[ijk];
-      G23[ijk + e * LX * LX * LX] *= shw3[ijk];
-      G33[ijk + e * LX * LX * LX] *= shw3[ijk];
+#pragma unroll
+  for (int k = 0; k < LX; ++k) {
+    const int ijk = ij + k * LX * LX;
+
+    /* The t derivative runs along the column this thread holds in ru */
+    T ttmp = 0.0;
+    shu[sh + ij] = ru[k];
+#pragma unroll
+    for (int l = 0; l < LX; l++) {
+      ttmp += shdz[k + l * LX] * ru[l];
     }
+
+    __syncthreads();
+
+    /* The r and s derivatives run along the k plane now in shu */
+    T rtmp = 0.0;
+    T stmp = 0.0;
+#pragma unroll
+    for (int l = 0; l < LX; l++) {
+      rtmp += shdx[i + l * LX] * shu[sh + l + j * LX];
+      stmp += shdy[j + l * LX] * shu[sh + i + l * LX];
+    }
+
+    if (active) {
+      dudr[ijk + ele] = rtmp;
+      duds[ijk + ele] = stmp;
+      dudt[ijk + ele] = ttmp;
+    }
+
+    __syncthreads();
   }
 }
 
 /**
  * Device kernel for coef dxyz
+ *
+ * Each thread owns one (i,j) column of an element and walks it in k, holding
+ * the column of the coordinate being differentiated in registers for the t
+ * derivative and staging one k plane of it in shared memory for the r and s
+ * derivatives. The three coordinates are taken in turn through the same
+ * shared plane.
  */
-template< typename T, const int LX, const int CHUNKS >
-__global__ void coef_generate_dxyz_kernel(T * __restrict__ dxdr,
-					  T * __restrict__ dydr,
-					  T * __restrict__ dzdr,
-					  T * __restrict__ dxds,
-					  T * __restrict__ dyds,
-					  T * __restrict__ dzds,
-					  T * __restrict__ dxdt,
-					  T * __restrict__ dydt,
-					  T * __restrict__ dzdt,
-					  const T * __restrict__ dx,
-					  const T * __restrict__ dy,
-					  const T * __restrict__ dz,
-					  const T * __restrict__ x,
-					  const T * __restrict__ y,
-					  const T * __restrict__ z) {
+template< typename T, const int LX, const int EB >
+__global__ void __launch_bounds__(LX * LX * EB)
+coef_generate_dxyz_kernel(T * __restrict__ dxdr,
+                          T * __restrict__ dydr,
+                          T * __restrict__ dzdr,
+                          T * __restrict__ dxds,
+                          T * __restrict__ dyds,
+                          T * __restrict__ dzds,
+                          T * __restrict__ dxdt,
+                          T * __restrict__ dydt,
+                          T * __restrict__ dzdt,
+                          const T * __restrict__ dx,
+                          const T * __restrict__ dy,
+                          const T * __restrict__ dz,
+                          const T * __restrict__ x,
+                          const T * __restrict__ y,
+                          const T * __restrict__ z,
+                          const int nelv) {
 
-  int i,j,k;
-
-  const int e = blockIdx.x;
-  const int iii = threadIdx.x;
-  const int nchunks = (LX * LX * LX - 1) / CHUNKS + 1;
-
+  /* Element independent, one copy per block */
   __shared__ T shdx[LX * LX];
   __shared__ T shdy[LX * LX];
   __shared__ T shdz[LX * LX];
 
-  __shared__ T shu[LX * LX * LX];
+  /* One k plane per element in the block */
+  __shared__ T shu[EB * LX * LX];
 
-  if (iii < (LX * LX)) {
-    shdx[iii] = dx[iii];
-    shdy[iii] = dy[iii];
-    shdz[iii] = dz[iii];
+  const int eb = (EB == 1) ? 0 : threadIdx.z;
+  const int e_blk = blockIdx.x * EB + eb;
+  /* Threads past the last element still have to reach the barriers in the k
+     loop, so clamp their reads and drop their stores rather than returning
+     early. At EB == 1 this all constant folds away */
+  const bool active = (EB == 1) ? true : (e_blk < nelv);
+  const int e = active ? e_blk : (nelv - 1);
+  const int sh = eb * LX * LX;
+  const int i = threadIdx.x;
+  const int j = threadIdx.y;
+  const int ij = i + j * LX;
+  const int ele = e * LX * LX * LX;
+
+  if (eb == 0) {
+    shdx[ij] = dx[ij];
+    shdy[ij] = dy[ij];
+    shdz[ij] = dz[ij];
   }
 
-  j = iii;
-  while(j < (LX * LX * LX)) {
-    shu[j] = x[j + e * LX * LX * LX];
-    j = j + CHUNKS;
-  }
-
-  __syncthreads();
-
-  for (int n = 0; n < nchunks; n++) {
-    const int ijk = iii + n * CHUNKS;
-    const int jk = ijk / LX;
-    i = ijk - jk * LX;
-    k = jk / LX;
-    j = jk - k * LX;
-    if ( i < LX && j < LX && k < LX) {
-      T rtmp = 0.0;
-      T stmp = 0.0;
-      T ttmp = 0.0;
-      for (int l = 0; l < LX; l++) {
-	rtmp += shdx[i + l * LX] * shu[l + j * LX + k * LX * LX];
-	stmp += shdy[j + l * LX] * shu[i + l * LX + k * LX * LX];
-	ttmp += shdz[k + l * LX] * shu[i + j * LX + l * LX * LX];
-      }
-      dxdr[ijk + e * LX * LX * LX] = rtmp;
-      dxds[ijk + e * LX * LX * LX] = stmp;
-      dxdt[ijk + e * LX * LX * LX] = ttmp;
-    }
-  }
-
-  __syncthreads();
-
-  j = iii;
-  while(j < (LX * LX * LX)) {
-    shu[j] = y[j + e * LX * LX * LX];
-    j = j + CHUNKS;
-  }
-
-  __syncthreads();
-
-  for (int n = 0; n < nchunks; n++) {
-    const int ijk = iii + n * CHUNKS;
-    const int jk = ijk / LX;
-    i = ijk - jk * LX;
-    k = jk / LX;
-    j = jk - k * LX;
-    if ( i < LX && j < LX && k < LX) {
-      T rtmp = 0.0;
-      T stmp = 0.0;
-      T ttmp = 0.0;
-      for (int l = 0; l < LX; l++) {
-	rtmp += shdx[i + l * LX] * shu[l + j * LX + k * LX * LX];
-	stmp += shdy[j + l * LX] * shu[i + l * LX + k * LX * LX];
-	ttmp += shdz[k + l * LX] * shu[i + j * LX + l * LX * LX];
-      }
-      dydr[ijk + e * LX * LX * LX] = rtmp;
-      dyds[ijk + e * LX * LX * LX] = stmp;
-      dydt[ijk + e * LX * LX * LX] = ttmp;
-    }
-  }
-
-  __syncthreads();
-
-  j = iii;
-  while(j < (LX * LX * LX)) {
-    shu[j] = z[j + e * LX * LX * LX];
-    j = j + CHUNKS;
-  }
-
-  __syncthreads();
-
-  for (int n = 0; n < nchunks; n++) {
-    const int ijk = iii + n * CHUNKS;
-    const int jk = ijk / LX;
-    i = ijk - jk * LX;
-    k = jk / LX;
-    j = jk - k * LX;
-    if ( i < LX && j < LX && k < LX) {
-      T rtmp = 0.0;
-      T stmp = 0.0;
-      T ttmp = 0.0;
-      for (int l = 0; l < LX; l++) {
-	rtmp += shdx[i + l * LX] * shu[l + j * LX + k * LX * LX];
-	stmp += shdy[j + l * LX] * shu[i + l * LX + k * LX * LX];
-	ttmp += shdz[k + l * LX] * shu[i + j * LX + l * LX * LX];
-      }
-      dzdr[ijk + e * LX * LX * LX] = rtmp;
-      dzds[ijk + e * LX * LX * LX] = stmp;
-      dzdt[ijk + e * LX * LX * LX] = ttmp;
-    }
-  }
+  coef_dxyz_component<T, LX>(dxdr, dxds, dxdt, x,
+                             shu, shdx, shdy, shdz, i, j, sh, ele, active);
+  coef_dxyz_component<T, LX>(dydr, dyds, dydt, y,
+                             shu, shdx, shdy, shdz, i, j, sh, ele, active);
+  coef_dxyz_component<T, LX>(dzdr, dzds, dzdt, z,
+                             shu, shdx, shdy, shdz, i, j, sh, ele, active);
 }
 
 /**
@@ -308,47 +346,58 @@ __global__ void coef_generate_mass_kernel(T * __restrict__ B,
 
 /**
  * Device kernel for coef_generate_area_and_normal
+ *
+ * Each thread owns one (i,j) column of an element and walks it in k, writing
+ * the facet entries its column lands on: the r facets 0 and 1 when i is 0 or
+ * LX-1, the s facets 2 and 3 when j is, and the t facets 4 and 5 when k is.
  */
-template< typename T, const int LX >
-__global__ void coef_generate_area_and_normal_kernel(T* __restrict__ area,
-                                                     T* __restrict__ nx,
-                                                     T* __restrict__ ny,
-                                                     T* __restrict__ nz,
-                                                     const T* __restrict__ dxdr,
-                                                     const T* __restrict__ dydr,
-                                                     const T* __restrict__ dzdr,
-                                                     const T* __restrict__ dxds,
-                                                     const T* __restrict__ dyds,
-                                                     const T* __restrict__ dzds,
-                                                     const T* __restrict__ dxdt,
-                                                     const T* __restrict__ dydt,
-                                                     const T* __restrict__ dzdt,
-                                                     const T* __restrict__ wx,
-                                                     const T* __restrict__ wy,
-                                                     const T* __restrict__ wz,
-                                                     const T eps) {
-
-  int i, j, k;
+template< typename T, const int LX, const int EB >
+__global__ void __launch_bounds__(LX * LX * EB)
+coef_generate_area_and_normal_kernel(T * __restrict__ area,
+                                     T * __restrict__ nx,
+                                     T * __restrict__ ny,
+                                     T * __restrict__ nz,
+                                     const T * __restrict__ dxdr,
+                                     const T * __restrict__ dydr,
+                                     const T * __restrict__ dzdr,
+                                     const T * __restrict__ dxds,
+                                     const T * __restrict__ dyds,
+                                     const T * __restrict__ dzds,
+                                     const T * __restrict__ dxdt,
+                                     const T * __restrict__ dydt,
+                                     const T * __restrict__ dzdt,
+                                     const T * __restrict__ wx,
+                                     const T * __restrict__ wy,
+                                     const T * __restrict__ wz,
+                                     const T eps,
+                                     const int nelv) {
   int f, out_idx;
   const T one = 1.0;
   const T m_one = -1.0;
   T tx, ty, tz, dot, weight, length, sgn;
 
-  const int e = blockIdx.x;
-  const int iii = threadIdx.x;
+  const int e = blockIdx.x * EB + ((EB == 1) ? 0 : threadIdx.z);
+
+  /* The kernel has no barriers, so the threads of a partially filled tail
+     block can simply leave */
+  if (e >= nelv) {
+    return;
+  }
+
+  const int i = threadIdx.x;
+  const int j = threadIdx.y;
 
   const int lxyz = LX * LX * LX;
   const int lxy = LX * LX;
 
-  for (int ijk = iii; ijk < lxyz; ijk += blockDim.x) {
+  const int face_offset = e * lxy * 6;
+  const T wxi = wx[i];
+  const T wyj = wy[j];
 
-    const int jk = ijk / LX;
-    i = ijk - jk * LX;
-    k = jk / LX;
-    j = jk - k * LX;
+  for (int k = 0; k < LX; ++k) {
 
+    const int ijk = i + (j * LX) + (k * lxy);
     const int offset = ijk + (e * lxyz);
-    const int face_offset = e * lxy * 6;
 
     // ds x dt
     if (i == 0 || i == LX - 1) {
@@ -358,7 +407,7 @@ __global__ void coef_generate_area_and_normal_kernel(T* __restrict__ area,
 
       dot = tx*tx + ty*ty + tz*tz;
       length = sqrt(dot);
-      weight = wy[j] * wz[k];
+      weight = wyj * wz[k];
 
       if (i == 0) {
         f = 0;
@@ -391,7 +440,7 @@ __global__ void coef_generate_area_and_normal_kernel(T* __restrict__ area,
 
       dot = tx*tx + ty*ty + tz*tz;
       length = sqrt(dot);
-      weight = wx[i] * wz[k];
+      weight = wxi * wz[k];
 
       if (j == 0) {
         f = 2;
@@ -424,7 +473,7 @@ __global__ void coef_generate_area_and_normal_kernel(T* __restrict__ area,
 
       dot = tx*tx + ty*ty + tz*tz;
       length = sqrt(dot);
-      weight = wx[i] * wy[j];
+      weight = wxi * wyj;
 
       if (k == 0) {
         f = 4;
@@ -450,6 +499,8 @@ __global__ void coef_generate_area_and_normal_kernel(T* __restrict__ area,
     }
   }
 }
+
+
 
 template< typename T >
 __device__ inline void coef_get_normal_device(const T * __restrict__ nx,

--- a/src/sem/bcknd/device/metal/coef.m
+++ b/src/sem/bcknd/device/metal/coef.m
@@ -133,7 +133,14 @@ void metal_coef_generate_geo(void *G11, void *G12, void *G13,
   [enc setBuffer:(__bridge id<MTLBuffer>)w3     offset:0 atIndex:16];
   [enc setBytes:gdim length:sizeof(int) atIndex:17];
 
-  NSUInteger nthrds = 1024;
+  /* The threadgroup size a pipeline can be given drops below 1024 when the
+     kernel's register or threadgroup memory use is high, so ask the pipeline
+     instead of assuming. The kernel strides over the element with
+     threads_per_threadgroup, so any size is correct. */
+  NSUInteger nthrds = pso_geo[LX].maxTotalThreadsPerThreadgroup;
+  if (nthrds > 1024) {
+    nthrds = 1024;
+  }
   MTLSize groupSize = MTLSizeMake(nthrds, 1, 1);
   MTLSize numGroups = MTLSizeMake((NSUInteger)(*nel), 1, 1);
 
@@ -196,7 +203,14 @@ void metal_coef_generate_dxyzdrst(void *drdx, void *drdy, void *drdz,
     [enc setBuffer:(__bridge id<MTLBuffer>)y    offset:0 atIndex:13];
     [enc setBuffer:(__bridge id<MTLBuffer>)z    offset:0 atIndex:14];
 
-    NSUInteger nthrds = 1024;
+    /* The threadgroup size a pipeline can be given drops below 1024 when the
+       kernel's register or threadgroup memory use is high, so ask the pipeline
+       instead of assuming. The kernel strides over the element with
+       threads_per_threadgroup, so any size is correct. */
+    NSUInteger nthrds = pso_dxyz[LX].maxTotalThreadsPerThreadgroup;
+    if (nthrds > 1024) {
+      nthrds = 1024;
+    }
     MTLSize groupSize = MTLSizeMake(nthrds, 1, 1);
     MTLSize numGroups = MTLSizeMake((NSUInteger)(*nel), 1, 1);
 
@@ -342,7 +356,14 @@ void metal_coef_generate_area_and_normal(void *area, void *nx, void *ny,
   [enc setBuffer:(__bridge id<MTLBuffer>)wz   offset:0 atIndex:15];
   [enc setBytes:&eps length:sizeof(real) atIndex:16];
 
-  NSUInteger nthrds = 1024;
+  /* The threadgroup size a pipeline can be given drops below 1024 when the
+     kernel's register or threadgroup memory use is high, so ask the pipeline
+     instead of assuming. The kernel strides over the element with
+     threads_per_threadgroup, so any size is correct. */
+  NSUInteger nthrds = pso_area[LX].maxTotalThreadsPerThreadgroup;
+  if (nthrds > 1024) {
+    nthrds = 1024;
+  }
   MTLSize groupSize = MTLSizeMake(nthrds, 1, 1);
   MTLSize numGroups = MTLSizeMake((NSUInteger)(*nel), 1, 1);
 


### PR DESCRIPTION
The three per-element coef kernels gave each element a block of 1024 threads. Registers are allocated per block, so with a high enough per thread count the block asks for more than the 65536 registers it can be given and the launch fails with "too many resources requested for launch". Built for sm_120 with nvcc 13 in double precision, the area and normal kernel takes 70 registers per thread at lx = 2 and the dxyz kernel 126 at lx = 16, both past the limit at 1024 threads. The lx = 2 case is reached by the coarsest level of the HSMG pressure preconditioner whatever the case's polynomial order is, and the same 1024 threads leave most of a block idle at low order.

The CUDA and HIP kernels now use the kstep layout of the SEM operator kernels: one (lx,lx) thread plane per element walking the element in k, with several elements stacked along threadIdx.z, which holds a block between 64 and 256 threads for every supported order. Elements per block are fixed at compile time rather than picked by an autotuner as in elem_block.h, since coef runs once per mesh. Results are bitwise identical to the old kernels for lx = 2..16 in both precisions.

The Metal backend hard-codes the same 1024, where the limit surfaces as the pipeline's maxTotalThreadsPerThreadgroup rather than as a register budget; its three dispatches now clamp to what the pipeline reports. Those kernels already stride with threads_per_threadgroup, so they need no change.