### PR TITLE
Reduce (old and new) memory spikes during gs init

### DIFF
--- a/src/gs/bcknd/device/gs_device_crystal.F90
+++ b/src/gs/bcknd/device/gs_device_crystal.F90
@@ -95,6 +95,7 @@ module gs_device_crystal
      procedure, pass(this) :: nbsend => gs_device_crystal_nbsend
      procedure, pass(this) :: nbrecv => gs_device_crystal_nbrecv
      procedure, pass(this) :: nbwait => gs_device_crystal_nbwait
+     procedure, pass(this) :: init_vec => gs_device_crystal_init_vec
      procedure, pass(this) :: nbsend_vec => gs_device_crystal_nbsend_vec
      procedure, pass(this) :: nbrecv_vec => gs_device_crystal_nbrecv_vec
      procedure, pass(this) :: nbwait_vec => gs_device_crystal_nbwait_vec
@@ -258,12 +259,6 @@ contains
     sz = c_sizeof(rp_dummy) * this%plan%nsmax
     call device_alloc(this%sbuf_d, sz)
 
-    sz = c_sizeof(rp_dummy) * GS_VEC_NC * this%plan%nwrk
-    call device_alloc(this%buf_v_d(1), sz)
-    call device_alloc(this%buf_v_d(2), sz)
-    sz = c_sizeof(rp_dummy) * GS_VEC_NC * this%plan%nsmax
-    call device_alloc(this%sbuf_v_d, sz)
-
     ! The first stage gathers straight out of the shared vector
     if (this%plan%nstage .gt. 0) then
        call cr_upload(this%pack_keep_d, this%plan%pack_keep_dof, &
@@ -300,8 +295,27 @@ contains
     end do
 
     this%vec_supported = .true.
+    this%vec_ready = .false.
 
   end subroutine gs_device_crystal_init
+
+  !> Allocate the fused vector working and send buffers in device memory,
+  !! sized for GS_VEC_NC components. Deferred to the first fused exchange,
+  !! see gs_comm_t. The nc-scaled stage index lists are uploaded separately,
+  !! on the first exchange of a given nc (see vec_nc), and the routing plan
+  !! is shared with the scalar exchange, so this stays rank local.
+  subroutine gs_device_crystal_init_vec(this)
+    class(gs_device_crystal_t), intent(inout) :: this
+    integer(c_size_t) :: sz
+    real(c_rp) :: rp_dummy
+
+    sz = c_sizeof(rp_dummy) * GS_VEC_NC * this%plan%nwrk
+    call device_alloc(this%buf_v_d(1), sz)
+    call device_alloc(this%buf_v_d(2), sz)
+    sz = c_sizeof(rp_dummy) * GS_VEC_NC * this%plan%nsmax
+    call device_alloc(this%sbuf_v_d, sz)
+
+  end subroutine gs_device_crystal_init_vec
 
   !> Deallocate crystal router based device communication
   subroutine gs_device_crystal_free(this)
@@ -333,6 +347,7 @@ contains
     if (allocated(this%send_idx_v_d)) deallocate(this%send_idx_v_d)
 
     this%vec_nc = 0
+    this%vec_ready = .false.
 
     call this%plan%free()
 

--- a/src/gs/bcknd/device/gs_device_mpi.F90
+++ b/src/gs/bcknd/device/gs_device_mpi.F90
@@ -59,6 +59,7 @@ module gs_device_mpi
      type(c_ptr) :: dof_d = C_NULL_PTR !< Dof mapping for pack/unpack
    contains
      procedure, pass(this) :: init => gs_device_mpi_buf_init
+     procedure, pass(this) :: init_vec => gs_device_mpi_buf_init_vec
      procedure, pass(this) :: free => gs_device_mpi_buf_free
   end type gs_device_mpi_buf_t
 
@@ -77,6 +78,7 @@ module gs_device_mpi
      procedure, pass(this) :: nbsend => gs_device_mpi_nbsend
      procedure, pass(this) :: nbrecv => gs_device_mpi_nbrecv
      procedure, pass(this) :: nbwait => gs_device_mpi_nbwait
+     procedure, pass(this) :: init_vec => gs_device_mpi_init_vec
      procedure, pass(this) :: nbsend_vec => gs_device_mpi_nbsend_vec
      procedure, pass(this) :: nbrecv_vec => gs_device_mpi_nbrecv_vec
      procedure, pass(this) :: nbwait_vec => gs_device_mpi_nbwait_vec
@@ -267,11 +269,6 @@ contains
     call device_alloc(this%buf_d, sz)
     call device_memset(this%buf_d, 0, sz, sync = .true.)
 
-    ! Fused vector buffer, sized for up to GS_VEC_NC components.
-    sz = c_sizeof(rp_dummy) * GS_VEC_NC * total
-    call device_alloc(this%buf_v_d, sz)
-    call device_memset(this%buf_v_d, 0, sz, sync = .true.)
-
     sz = c_sizeof(i4_dummy) * total
     call device_alloc(this%dof_d, sz)
 
@@ -314,6 +311,19 @@ contains
     call doftable%free()
 
   end subroutine gs_device_mpi_buf_init
+
+  !> Allocate this buffer's fused vector slab, sized for up to GS_VEC_NC
+  !! components. Deferred to the first fused exchange, see gs_comm_t.
+  subroutine gs_device_mpi_buf_init_vec(this)
+    class(gs_device_mpi_buf_t), intent(inout) :: this
+    integer(c_size_t) :: sz
+    real(c_rp) :: rp_dummy
+
+    sz = c_sizeof(rp_dummy) * GS_VEC_NC * this%total
+    call device_alloc(this%buf_v_d, sz)
+    call device_memset(this%buf_v_d, 0, sz, sync = .true.)
+
+  end subroutine gs_device_mpi_buf_init_vec
 
   subroutine gs_device_mpi_buf_free(this)
     class(gs_device_mpi_buf_t), intent(inout) :: this
@@ -361,8 +371,21 @@ contains
     this%nb_strtgy = 0
 
     this%vec_supported = .true.
+    this%vec_ready = .false.
 
   end subroutine gs_device_mpi_init
+
+  !> Allocate the fused vector send and receive slabs in device memory,
+  !! sized for GS_VEC_NC components. Deferred to the first fused exchange,
+  !! see gs_comm_t. The peer lists, dof maps and streams built in init are
+  !! shared with the scalar exchange, so this stays rank local.
+  subroutine gs_device_mpi_init_vec(this)
+    class(gs_device_mpi_t), intent(inout) :: this
+
+    call this%send_buf%init_vec()
+    call this%recv_buf%init_vec()
+
+  end subroutine gs_device_mpi_init_vec
 
   !> Deallocate MPI based communication method
   subroutine gs_device_mpi_free(this)
@@ -371,6 +394,7 @@ contains
 
     call this%send_buf%free()
     call this%recv_buf%free()
+    this%vec_ready = .false.
 
     call this%free_order()
     call this%free_dofs()

--- a/src/gs/bcknd/device/gs_device_nccl.F90
+++ b/src/gs/bcknd/device/gs_device_nccl.F90
@@ -66,6 +66,7 @@ module gs_device_nccl
      type(c_ptr) :: dof_d = C_NULL_PTR !< Dof mapping for pack/unpack
    contains
      procedure, pass(this) :: init => gs_device_nccl_buf_init
+     procedure, pass(this) :: init_vec => gs_device_nccl_buf_init_vec
      procedure, pass(this) :: free => gs_device_nccl_buf_free
   end type gs_device_nccl_buf_t
 
@@ -84,6 +85,7 @@ module gs_device_nccl
      procedure, pass(this) :: nbsend => gs_device_nccl_nbsend
      procedure, pass(this) :: nbrecv => gs_device_nccl_nbrecv
      procedure, pass(this) :: nbwait => gs_device_nccl_nbwait
+     procedure, pass(this) :: init_vec => gs_device_nccl_init_vec
      procedure, pass(this) :: nbsend_vec => gs_device_nccl_nbsend_vec
      procedure, pass(this) :: nbrecv_vec => gs_device_nccl_nbrecv_vec
      procedure, pass(this) :: nbwait_vec => gs_device_nccl_nbwait_vec
@@ -214,10 +216,6 @@ contains
     sz = c_sizeof(rp_dummy) * total
     call device_alloc(this%buf_d, sz)
 
-    ! Fused vector buffer, sized for up to GS_VEC_NC components.
-    sz = c_sizeof(rp_dummy) * GS_VEC_NC * total
-    call device_alloc(this%buf_v_d, sz)
-
     sz = c_sizeof(i4_dummy) * total
     call device_alloc(this%dof_d, sz)
 
@@ -257,6 +255,18 @@ contains
     call doftable%free()
 
   end subroutine gs_device_nccl_buf_init
+
+  !> Allocate this buffer's fused vector slab, sized for up to GS_VEC_NC
+  !! components. Deferred to the first fused exchange, see gs_comm_t.
+  subroutine gs_device_nccl_buf_init_vec(this)
+    class(gs_device_nccl_buf_t), intent(inout) :: this
+    integer(c_size_t) :: sz
+    real(c_rp) :: rp_dummy
+
+    sz = c_sizeof(rp_dummy) * GS_VEC_NC * this%total
+    call device_alloc(this%buf_v_d, sz)
+
+  end subroutine gs_device_nccl_buf_init_vec
 
   subroutine gs_device_nccl_buf_free(this)
     class(gs_device_nccl_buf_t), intent(inout) :: this
@@ -303,8 +313,21 @@ contains
 #endif
 
     this%vec_supported = .true.
+    this%vec_ready = .false.
 
   end subroutine gs_device_nccl_init
+
+  !> Allocate the fused vector send and receive slabs in device memory,
+  !! sized for GS_VEC_NC components. Deferred to the first fused exchange,
+  !! see gs_comm_t. The NCCL communicator is built once at startup and the
+  !! peer lists and dof maps come from init, so this stays rank local.
+  subroutine gs_device_nccl_init_vec(this)
+    class(gs_device_nccl_t), intent(inout) :: this
+
+    call this%send_buf%init_vec()
+    call this%recv_buf%init_vec()
+
+  end subroutine gs_device_nccl_init_vec
 
   !> Deallocate MPI based communication method
   subroutine gs_device_nccl_free(this)
@@ -313,6 +336,7 @@ contains
 
     call this%send_buf%free()
     call this%recv_buf%free()
+    this%vec_ready = .false.
 
     call this%free_order()
     call this%free_dofs()

--- a/src/gs/bcknd/device/gs_device_shmem.F90
+++ b/src/gs/bcknd/device/gs_device_shmem.F90
@@ -391,6 +391,11 @@ contains
 
     this%iter = 0
     this%vec_supported = .true.
+    ! The vector slabs are part of the symmetric/registered allocation
+    ! made above, which every rank has to take part in, so they cannot
+    ! be deferred to the first fused exchange: a rank with no shared
+    ! dofs never reaches it. See gs_comm_t%vec_ready.
+    this%vec_ready = .true.
 
   end subroutine gs_device_shmem_init
 

--- a/src/gs/gather_scatter.f90
+++ b/src/gs/gather_scatter.f90
@@ -605,6 +605,32 @@ contains
 
   end subroutine gs_free
 
+  !> Allocate the buffers the fused vector gather-scatter needs, on the
+  !! first gs_op_r3 that reaches the fused path.
+  !!
+  !! @param gs gather-scatter kernel to complete
+  !! @note Rank local, not collective: a rank with no shared dofs never
+  !! reaches the fused path, so neither this nor comm%init_vec may
+  !! communicate. Backends whose vector buffers come out of an allocation
+  !! the whole run agrees on make them in init instead, see gs_comm_t.
+  subroutine gs_vec_alloc(gs)
+    class(gs_t), intent(inout) :: gs
+
+    if (.not. allocated(gs%shared_gs_v)) then
+       allocate(gs%shared_gs_v(max(1, GS_VEC_NC * gs%nshared)))
+       if (NEKO_BCKND_DEVICE .eq. 1) then
+          call device_map(gs%shared_gs_v, gs%shared_gs_v_d, &
+               max(1, GS_VEC_NC * gs%nshared))
+       end if
+    end if
+
+    if (.not. gs%comm%vec_ready) then
+       call gs%comm%init_vec()
+       gs%comm%vec_ready = .true.
+    end if
+
+  end subroutine gs_vec_alloc
+
   !> Setup mapping of dofs to gather-scatter operations
   subroutine gs_init_mapping(gs)
     type(gs_t), target, intent(inout) :: gs
@@ -614,6 +640,7 @@ contains
     type(stack_i4_t), target :: local_face_dof, face_dof_local
     type(stack_i4_t), target :: shared_face_dof, face_dof_shared
     integer :: i, j, k, l, lx, ly, lz, max_id, max_sid, id, lid, dm_size
+    integer :: sdm_size
     type(htable_i8_t) :: dm !>
     type(htable_i8_t), pointer :: sdm
 
@@ -626,11 +653,16 @@ contains
     lz = dofmap%Xh%lz
     dm_size = dofmap%size()/lx
 
+    ! The shared dof table only ever receives dofs the dofmap flagged as
+    ! shared, i.e. the partition surface, which is a small fraction of the
+    ! dofmap.
+    sdm_size = min(count(dofmap%shared_dof), dofmap%size() / 2) * 2
+
     call dm%init(dm_size, i)
     !>@note this might be a bit overkill,
     !!but having many collisions makes the init take too long.
     !!This is really critical to performance of the init
-    call sdm%init(dofmap%size(), i)
+    call sdm%init(max(sdm_size, 1), i)
 
 
     call local_dof%init()
@@ -1342,13 +1374,8 @@ contains
     ! Allocate buffer for shared gs-ops
     allocate(gs%shared_gs(gs%nshared))
 
-    ! Compact multi-component shared buffer for the fused vector gs. On the
-    ! device it is mapped so the fused exchange can use its device pointer.
-    allocate(gs%shared_gs_v(max(1, GS_VEC_NC * gs%nshared)))
-    if (NEKO_BCKND_DEVICE .eq. 1) then
-       call device_map(gs%shared_gs_v, gs%shared_gs_v_d, &
-            max(1, GS_VEC_NC * gs%nshared))
-    end if
+    ! The compact multi-component shared buffer for the fused vector gs
+    ! (gs%shared_gs_v) is allocated on the first gs_op_r3, see gs_vec_alloc.
 
     if (gs%nshared .gt. 0) then
        call gs_qsort_dofmap(gs%shared_dof_gs, gs%shared_gs_dof, &
@@ -1826,6 +1853,12 @@ contains
        end if
        return
     end if
+
+    ! The fused path is the only user of the vector buffers, so they are
+    ! allocated here rather than in the setup. A rank that skips the
+    ! exchange below (no dofs, or a single rank run) needs none of them,
+    ! and gs_vec_alloc communicates nothing, so ranks may disagree.
+    if (pe_size .gt. 1 .and. n .gt. 0) call gs_vec_alloc(gs)
 
     lo = gs%local_facet_offset
     so = -gs%shared_facet_offset

--- a/src/gs/gs_caf.F90
+++ b/src/gs/gs_caf.F90
@@ -437,6 +437,11 @@ contains
        gs_caf_buf_size = GS_VEC_NC * max_total
     end if
     this%vec_supported = .true.
+    ! The vector slabs are part of the symmetric/registered allocation
+    ! made above, which every rank has to take part in, so they cannot
+    ! be deferred to the first fused exchange: a rank with no shared
+    ! dofs never reaches it. See gs_comm_t%vec_ready.
+    this%vec_ready = .true.
 
     ! Tell each sender at what offset in our recv_buf to place their slab,
     ! and learn at what offset in each receiver's recv_buf our slab should go.

--- a/src/gs/gs_comm.f90
+++ b/src/gs/gs_comm.f90
@@ -66,6 +66,17 @@ module gs_comm
      !! halo exchange (nbsend_vec/nbrecv_vec/nbwait_vec). When .false., the
      !! gs_op_r3 caller falls back to nc independent scalar exchanges.
      logical :: vec_supported = .false.
+     !> Whether the buffers the fused vector exchange needs are in place.
+     !! They are sized GS_VEC_NC times the halo, quadrupling what the
+     !! backend holds, and only gs_op_r3 ever touches them, so a backend
+     !! that can allocate them on its own defers that to the first fused
+     !! exchange (see init_vec) rather than paying for it in every run. A
+     !! backend whose vector buffers are part of an allocation the whole
+     !! run has to agree on -- symmetric memory, coarrays, registered
+     !! memory, an RMA window -- cannot defer, since a rank with no shared
+     !! dofs never reaches the first fused exchange; those allocate in init
+     !! and set this there.
+     logical :: vec_ready = .false.
    contains
      procedure(gs_comm_init), pass(this), deferred :: init
      procedure(gs_comm_free), pass(this), deferred :: free
@@ -80,6 +91,7 @@ module gs_comm
      procedure, pass(this) :: init_schedule
      !> Fused vector halo exchange. Default implementations abort; backends
      !! that set vec_supported = .true. override them.
+     procedure, pass(this) :: init_vec => gs_init_vec
      procedure, pass(this) :: nbsend_vec => gs_nbsend_vec
      procedure, pass(this) :: nbrecv_vec => gs_nbrecv_vec
      procedure, pass(this) :: nbwait_vec => gs_nbwait_vec
@@ -302,6 +314,17 @@ contains
     call recv_pe%free()
 
   end subroutine init_schedule
+
+  !> Default deferred allocation of the fused vector buffers. Reached only
+  !! on a backend that advertises vec_supported without either allocating
+  !! its vector buffers in init (setting vec_ready there) or overriding
+  !! this, which is a backend bug rather than a run-time condition.
+  !! @note Rank local by contract: a rank with no shared dofs skips the
+  !! fused exchange entirely, so an override must not communicate.
+  subroutine gs_init_vec(this)
+    class(gs_comm_t), intent(inout) :: this
+    call neko_error('Vector gather-scatter not supported by this comm backend')
+  end subroutine gs_init_vec
 
   !> Default fused vector send. Abort unless a backend overrides it.
   !! @param u compact shared buffer, component-outer: u((c-1)*n + idx)

--- a/src/gs/gs_crystal.f90
+++ b/src/gs/gs_crystal.f90
@@ -88,6 +88,7 @@ module gs_crystal
      procedure, pass(this) :: nbsend => gs_crystal_nbsend
      procedure, pass(this) :: nbrecv => gs_crystal_nbrecv
      procedure, pass(this) :: nbwait => gs_crystal_nbwait
+     procedure, pass(this) :: init_vec => gs_crystal_init_vec
      procedure, pass(this) :: nbsend_vec => gs_crystal_nbsend_vec
      procedure, pass(this) :: nbrecv_vec => gs_crystal_nbrecv_vec
      procedure, pass(this) :: nbwait_vec => gs_crystal_nbwait_vec
@@ -109,12 +110,23 @@ contains
 
     allocate(this%buf(2*this%plan%nwrk))
     allocate(this%sbuf(this%plan%nsmax))
+
+    this%vec_supported = .true.
+    this%vec_ready = .false.
+
+  end subroutine gs_crystal_init
+
+  !> Allocate the fused vector working and send buffers, sized for GS_VEC_NC
+  !! components. Deferred to the first fused exchange, see gs_comm_t. The
+  !! routing plan is shared with the scalar exchange and is not rebuilt
+  !! here, so this stays rank local.
+  subroutine gs_crystal_init_vec(this)
+    class(gs_crystal_t), intent(inout) :: this
+
     allocate(this%buf_v(2*GS_VEC_NC*this%plan%nwrk))
     allocate(this%sbuf_v(GS_VEC_NC*this%plan%nsmax))
 
-    this%vec_supported = .true.
-
-  end subroutine gs_crystal_init
+  end subroutine gs_crystal_init_vec
 
   !> Deallocate crystal router based communication method
   subroutine gs_crystal_free(this)
@@ -124,6 +136,7 @@ contains
     if (allocated(this%sbuf)) deallocate(this%sbuf)
     if (allocated(this%buf_v)) deallocate(this%buf_v)
     if (allocated(this%sbuf_v)) deallocate(this%sbuf_v)
+    this%vec_ready = .false.
 
     call this%plan%free()
 

--- a/src/gs/gs_mpi.f90
+++ b/src/gs/gs_mpi.f90
@@ -74,6 +74,7 @@ module gs_mpi
      procedure, pass(this) :: nbsend => gs_nbsend_mpi
      procedure, pass(this) :: nbrecv => gs_nbrecv_mpi
      procedure, pass(this) :: nbwait => gs_nbwait_mpi
+     procedure, pass(this) :: init_vec => gs_mpi_init_vec
      procedure, pass(this) :: nbsend_vec => gs_nbsend_vec_mpi
      procedure, pass(this) :: nbrecv_vec => gs_nbrecv_vec_mpi
      procedure, pass(this) :: nbwait_vec => gs_nbwait_vec_mpi
@@ -117,12 +118,24 @@ contains
     end do
     allocate(this%recv_buf(max(1, recv_total)))
 
-    ! Fused vector exchange buffers, sized for GS_VEC_NC components.
-    allocate(this%send_buf_v(max(1, GS_VEC_NC*send_total)))
-    allocate(this%recv_buf_v(max(1, GS_VEC_NC*recv_total)))
     this%vec_supported = .true.
+    this%vec_ready = .false.
 
   end subroutine gs_mpi_init
+
+  !> Allocate the fused vector exchange buffers, sized for GS_VEC_NC
+  !! components. Deferred to the first fused exchange, see gs_comm_t.
+  subroutine gs_mpi_init_vec(this)
+    class(gs_mpi_t), intent(inout) :: this
+    integer :: send_total, recv_total
+
+    send_total = sum(this%send_len)
+    recv_total = sum(this%recv_len)
+
+    allocate(this%send_buf_v(max(1, GS_VEC_NC*send_total)))
+    allocate(this%recv_buf_v(max(1, GS_VEC_NC*recv_total)))
+
+  end subroutine gs_mpi_init_vec
 
   !> Deallocate MPI based communication method
   subroutine gs_mpi_free(this)
@@ -175,6 +188,7 @@ contains
     if (allocated(this%recv_buf_v)) then
        deallocate(this%recv_buf_v)
     end if
+    this%vec_ready = .false.
 
     call this%free_order()
     call this%free_dofs()

--- a/src/gs/gs_mpi_rma.f90
+++ b/src/gs/gs_mpi_rma.f90
@@ -247,6 +247,11 @@ contains
 
     this%iter = 0
     this%vec_supported = .true.
+    ! The vector slabs are part of the symmetric/registered allocation
+    ! made above, which every rank has to take part in, so they cannot
+    ! be deferred to the first fused exchange: a rank with no shared
+    ! dofs never reaches it. See gs_comm_t%vec_ready.
+    this%vec_ready = .true.
 
     ! The zeroing above is a local store into window memory; no rank may
     ! issue RMA until every rank has done it.

--- a/src/gs/gs_neighbour.f90
+++ b/src/gs/gs_neighbour.f90
@@ -82,6 +82,7 @@ module gs_neighbour
      procedure, pass(this) :: nbsend => gs_nbsend_neighbour
      procedure, pass(this) :: nbrecv => gs_nbrecv_neighbour
      procedure, pass(this) :: nbwait => gs_nbwait_neighbour
+     procedure, pass(this) :: init_vec => gs_neighbour_init_vec
      procedure, pass(this) :: nbsend_vec => gs_nbsend_vec_neighbour
      procedure, pass(this) :: nbrecv_vec => gs_nbrecv_vec_neighbour
      procedure, pass(this) :: nbwait_vec => gs_nbwait_vec_neighbour
@@ -132,16 +133,8 @@ contains
     end do
     allocate(this%recv_buf(max(1, recv_total)))
 
-    ! Fused vector exchange buffers/descriptors, sized for GS_VEC_NC comps.
-    allocate(this%send_buf_v(max(1, GS_VEC_NC*send_total)))
-    allocate(this%recv_buf_v(max(1, GS_VEC_NC*recv_total)))
-    allocate(this%sendcounts_v(max(1, nsend)), this%sdispls_v(max(1, nsend)))
-    allocate(this%recvcounts_v(max(1, nrecv)), this%rdispls_v(max(1, nrecv)))
-    this%sendcounts_v = 0
-    this%sdispls_v = 0
-    this%recvcounts_v = 0
-    this%rdispls_v = 0
     this%vec_supported = .true.
+    this%vec_ready = .false.
 
     ! Build a distributed-graph communicator over the halo neighbourhood.
     ! With MPI_Dist_graph_create_adjacent and reorder = .false. the order of
@@ -158,6 +151,31 @@ contains
     deallocate(src_weights, dst_weights)
 
   end subroutine gs_neighbour_init
+
+  !> Allocate the fused vector exchange buffers and the nc-scaled collective
+  !! descriptors, sized for GS_VEC_NC components. Deferred to the first
+  !! fused exchange, see gs_comm_t. The graph communicator built in init is
+  !! shared with the scalar exchange and is not touched here, so this stays
+  !! rank local.
+  subroutine gs_neighbour_init_vec(this)
+    class(gs_neighbour_t), intent(inout) :: this
+    integer :: nsend, nrecv, send_total, recv_total
+
+    nsend = size(this%send_pe)
+    nrecv = size(this%recv_pe)
+    send_total = sum(this%sendcounts)
+    recv_total = sum(this%recvcounts)
+
+    allocate(this%send_buf_v(max(1, GS_VEC_NC*send_total)))
+    allocate(this%recv_buf_v(max(1, GS_VEC_NC*recv_total)))
+    allocate(this%sendcounts_v(max(1, nsend)), this%sdispls_v(max(1, nsend)))
+    allocate(this%recvcounts_v(max(1, nrecv)), this%rdispls_v(max(1, nrecv)))
+    this%sendcounts_v = 0
+    this%sdispls_v = 0
+    this%recvcounts_v = 0
+    this%rdispls_v = 0
+
+  end subroutine gs_neighbour_init_vec
 
   !> Deallocate the neighbourhood-collective communication method
   subroutine gs_neighbour_free(this)
@@ -177,6 +195,7 @@ contains
     if (allocated(this%sdispls_v)) deallocate(this%sdispls_v)
     if (allocated(this%recvcounts_v)) deallocate(this%recvcounts_v)
     if (allocated(this%rdispls_v)) deallocate(this%rdispls_v)
+    this%vec_ready = .false.
 
     call MPI_Comm_free(this%neigh_comm, ierr)
 

--- a/src/gs/gs_shmem.F90
+++ b/src/gs/gs_shmem.F90
@@ -275,6 +275,11 @@ contains
 
     this%iter = 0
     this%vec_supported = .true.
+    ! The vector slabs are part of the symmetric/registered allocation
+    ! made above, which every rank has to take part in, so they cannot
+    ! be deferred to the first fused exchange: a rank with no shared
+    ! dofs never reaches it. See gs_comm_t%vec_ready.
+    this%vec_ready = .true.
 
     ! Ensure all PEs have completed symmetric allocation before any
     ! one-sided communication is issued.

--- a/src/gs/gs_utofu.F90
+++ b/src/gs/gs_utofu.F90
@@ -430,6 +430,11 @@ contains
     ! The vector context stays registered either way; only its use is gated.
     call get_environment_variable("NEKO_GS_UTOFU_VEC", env_val, env_len)
     this%vec_supported = .not. (env_len .gt. 0 .and. env_val(1:1) .eq. '0')
+    ! The vector slabs are part of the symmetric/registered allocation
+    ! made above, which every rank has to take part in, so they cannot
+    ! be deferred to the first fused exchange: a rank with no shared
+    ! dofs never reaches it. See gs_comm_t%vec_ready.
+    this%vec_ready = .true.
 #else
     call neko_error("uTofu support not built; reconfigure with --with-utofu")
 #endif


### PR DESCRIPTION
This pr removes an ancient overallocation of shared dofs, and also change the vector gs buffers to be lazily allocated.